### PR TITLE
clang-format check on pull release

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,20 @@
+BasedOnStyle: LLVM
+
+Language: Cpp
+Standard: Cpp11
+
+IndentWidth: 4
+ColumnLimit: 120
+
+AlwaysBreakTemplateDeclarations: true
+AlwaysBreakAfterReturnType: All
+PointerAlignment: Left
+AllowShortIfStatementsOnASingleLine: false
+BreakBeforeBraces: Allman
+
+# Disable formatting options which may break tests.
+SortIncludes: false
+ReflowComments: false
+
+# Indent preprocessor directives
+IndentPPDirectives: AfterHash

--- a/.github/workflows/clang-format-pull-request.yml
+++ b/.github/workflows/clang-format-pull-request.yml
@@ -1,0 +1,37 @@
+name: clang-format-pull-request
+
+on:
+  pull_request:
+    branches:
+      - release_oneDPL
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 1
+
+    - name: Get clang-format
+      run: sudo apt-get install -yqq clang-format-10
+
+    - name: Applying clang-format for changed files
+      run: |
+        URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls/${{ github.event.pull_request.number }}/files"
+        FILES=$(curl -s --request GET --get $URL |  jq -r '.[] | .filename')
+        echo $FILES | xargs -n1 -t clang-format --style=file -i
+
+    - name: Creating diff
+      run: |
+        git diff > clang-format-diff.diff
+
+    - name: Checking if diff is empty
+      run: sh -c '[ ! -s clang-format-diff.diff ]'
+
+    - uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: clang-format-result
+        path: |
+          ./clang-format-diff.diff

--- a/.github/workflows/clang-format-pull-request.yml
+++ b/.github/workflows/clang-format-pull-request.yml
@@ -7,7 +7,7 @@ on:
       - master
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     steps:
     - uses: actions/checkout@v2
       with:
@@ -31,7 +31,7 @@ jobs:
 
     - name: Print diff
       if: failure()
-      run: echo clang-format-diff.diff
+      run: cat clang-format-diff.diff
 
 #    - uses: actions/upload-artifact@v2
 #      if: failure()

--- a/.github/workflows/clang-format-pull-request.yml
+++ b/.github/workflows/clang-format-pull-request.yml
@@ -14,7 +14,7 @@ jobs:
         fetch-depth: 1
 
     - name: Get clang-format
-      run: sudo apt-get install -yqq clang-format-10
+      run: sudo apt-get install -yqq clang-format-6
 
     - name: Applying clang-format for changed files
       run: |
@@ -29,9 +29,13 @@ jobs:
     - name: Checking if diff is empty
       run: sh -c '[ ! -s clang-format-diff.diff ]'
 
-    - uses: actions/upload-artifact@v2
+    - name: Print diff
       if: failure()
-      with:
-        name: clang-format-result
-        path: |
-          ./clang-format-diff.diff
+      run: echo clang-format-diff.diff
+
+#    - uses: actions/upload-artifact@v2
+#      if: failure()
+#      with:
+#        name: clang-format-result
+#        path: |
+#          ./clang-format-diff.diff


### PR DESCRIPTION
Only files affected by pull release are checked with clang-format.
If files after applying clang-format are changed `git diff` output will be uploaded as an artifact and action will be marked as failed.