### PR TITLE
Changed include order to make tests work with libstdc++ 9,10

### DIFF
--- a/test/extensions_testsuite/binary_search_cpu.pass.cpp
+++ b/test/extensions_testsuite/binary_search_cpu.pass.cpp
@@ -13,11 +13,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/iterator>
+
+#include <iostream>
 
 int main()
 {

--- a/test/extensions_testsuite/binary_search_sycl.pass.cpp
+++ b/test/extensions_testsuite/binary_search_sycl.pass.cpp
@@ -13,13 +13,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-
-#include <CL/sycl.hpp>
-
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/iterator>
+
+#include <iostream>
+
+#include <CL/sycl.hpp>
 
 int main()
 {

--- a/test/extensions_testsuite/discard_iterator_sycl.pass.cpp
+++ b/test/extensions_testsuite/discard_iterator_sycl.pass.cpp
@@ -13,15 +13,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-#include <chrono>
-
-#include <CL/sycl.hpp>
-
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/numeric>
 #include <oneapi/dpl/iterator>
+
+#include <iostream>
+#include <chrono>
+
+#include <CL/sycl.hpp>
 
 template<typename _T1, typename _T2> void ASSERT_EQUAL(_T1&& X, _T2&& Y) {
     if(X!=Y)

--- a/test/extensions_testsuite/dpl_namespace.pass.cpp
+++ b/test/extensions_testsuite/dpl_namespace.pass.cpp
@@ -13,14 +13,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-
-#include <CL/sycl.hpp>
-
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/iterator>
 #include <oneapi/dpl/functional>
+
+#include <iostream>
+
+#include <CL/sycl.hpp>
 
 namespace sycl = cl::sycl;
 

--- a/test/extensions_testsuite/exclusive_scan_by_segment_sycl.pass.cpp
+++ b/test/extensions_testsuite/exclusive_scan_by_segment_sycl.pass.cpp
@@ -13,14 +13,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "oneapi/dpl/execution"
+#include "oneapi/dpl/algorithm"
+#include "oneapi/dpl/iterator"
+
 #include <iostream>
 #include <iomanip>
 
 #include <CL/sycl.hpp>
-
-#include "oneapi/dpl/execution"
-#include "oneapi/dpl/algorithm"
-#include "oneapi/dpl/iterator"
 
 template<typename _T1, typename _T2>
 void ASSERT_EQUAL(_T1&& X, _T2&& Y) {

--- a/test/extensions_testsuite/exclusive_scan_by_segment_usm.pass.cpp
+++ b/test/extensions_testsuite/exclusive_scan_by_segment_usm.pass.cpp
@@ -13,14 +13,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "oneapi/dpl/execution"
+#include "oneapi/dpl/algorithm"
+#include "oneapi/dpl/iterator"
+
 #include <iostream>
 #include <iomanip>
 
 #include <CL/sycl.hpp>
-
-#include "oneapi/dpl/execution"
-#include "oneapi/dpl/algorithm"
-#include "oneapi/dpl/iterator"
 
 template<typename _T1, typename _T2>
 void ASSERT_EQUAL(_T1&& X, _T2&& Y) {

--- a/test/extensions_testsuite/inclusive_scan_by_segment_sycl.pass.cpp
+++ b/test/extensions_testsuite/inclusive_scan_by_segment_sycl.pass.cpp
@@ -13,14 +13,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "oneapi/dpl/execution"
+#include "oneapi/dpl/algorithm"
+#include "oneapi/dpl/iterator"
+
 #include <iostream>
 #include <iomanip>
 
 #include <CL/sycl.hpp>
-
-#include "oneapi/dpl/execution"
-#include "oneapi/dpl/algorithm"
-#include "oneapi/dpl/iterator"
 
 template<typename _T1, typename _T2>
 void ASSERT_EQUAL(_T1&& X, _T2&& Y) {

--- a/test/extensions_testsuite/inclusive_scan_by_segment_usm.pass.cpp
+++ b/test/extensions_testsuite/inclusive_scan_by_segment_usm.pass.cpp
@@ -13,14 +13,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "oneapi/dpl/execution"
+#include "oneapi/dpl/algorithm"
+#include "oneapi/dpl/iterator"
+
 #include <iostream>
 #include <iomanip>
 
 #include <CL/sycl.hpp>
-
-#include "oneapi/dpl/execution"
-#include "oneapi/dpl/algorithm"
-#include "oneapi/dpl/iterator"
 
 template<typename _T1, typename _T2>
 void ASSERT_EQUAL(_T1&& X, _T2&& Y) {

--- a/test/extensions_testsuite/lower_bound_cpu.pass.cpp
+++ b/test/extensions_testsuite/lower_bound_cpu.pass.cpp
@@ -13,11 +13,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/iterator>
+
+#include <iostream>
 
 class binarySearch {};
 int main()

--- a/test/extensions_testsuite/lower_bound_sycl.pass.cpp
+++ b/test/extensions_testsuite/lower_bound_sycl.pass.cpp
@@ -13,13 +13,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-
-#include <CL/sycl.hpp>
-
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/iterator>
+
+#include <iostream>
+
+#include <CL/sycl.hpp>
 
 int main()
 {

--- a/test/extensions_testsuite/permutation_iterator_sycl.pass.cpp
+++ b/test/extensions_testsuite/permutation_iterator_sycl.pass.cpp
@@ -13,15 +13,15 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-#include <chrono>
-
-#include <CL/sycl.hpp>
-
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/numeric>
 #include <oneapi/dpl/iterator>
+
+#include <iostream>
+#include <chrono>
+
+#include <CL/sycl.hpp>
 
 template<typename _T1, typename _T2> void ASSERT_EQUAL(_T1&& X, _T2&& Y) {
     if(X!=Y)

--- a/test/extensions_testsuite/reduce_by_segment_cpu.pass.cpp
+++ b/test/extensions_testsuite/reduce_by_segment_cpu.pass.cpp
@@ -13,9 +13,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/algorithm>
+
+#include <iostream>
 
 template<typename _T1, typename _T2>
 void ASSERT_EQUAL(_T1&& X, _T2&& Y) {

--- a/test/extensions_testsuite/reduce_by_segment_sycl.pass.cpp
+++ b/test/extensions_testsuite/reduce_by_segment_sycl.pass.cpp
@@ -13,14 +13,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "oneapi/dpl/execution"
+#include "oneapi/dpl/algorithm"
+#include "oneapi/dpl/iterator"
+
 #include <iostream>
 #include <iomanip>
 
 #include <CL/sycl.hpp>
-
-#include "oneapi/dpl/execution"
-#include "oneapi/dpl/algorithm"
-#include "oneapi/dpl/iterator"
 
 template<typename _T1, typename _T2>
 void ASSERT_EQUAL(_T1&& X, _T2&& Y) {

--- a/test/extensions_testsuite/reduce_by_segment_usm.pass.cpp
+++ b/test/extensions_testsuite/reduce_by_segment_usm.pass.cpp
@@ -13,14 +13,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "oneapi/dpl/execution"
+#include "oneapi/dpl/algorithm"
+#include "oneapi/dpl/iterator"
+
 #include <iostream>
 #include <iomanip>
 
 #include <CL/sycl.hpp>
-
-#include "oneapi/dpl/execution"
-#include "oneapi/dpl/algorithm"
-#include "oneapi/dpl/iterator"
 
 template<typename _T1, typename _T2>
 void ASSERT_EQUAL(_T1&& X, _T2&& Y) {

--- a/test/extensions_testsuite/scan_by_segment_cpu.pass.cpp
+++ b/test/extensions_testsuite/scan_by_segment_cpu.pass.cpp
@@ -13,9 +13,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/algorithm>
+
+#include <iostream>
 
 template<typename _T1, typename _T2>
 void ASSERT_EQUAL(_T1&& X, _T2&& Y) {

--- a/test/extensions_testsuite/test_functional.cpp
+++ b/test/extensions_testsuite/test_functional.cpp
@@ -13,14 +13,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-
-#ifndef ONEDPL_STANDARD_POLICIES_ONLY
-#include <CL/sycl.hpp>
-#else
-#include <vector>
-#endif
-
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/numeric>
@@ -28,6 +20,14 @@
 #include <oneapi/dpl/iterator>
 
 #include <oneapi/dpl/functional>
+
+#include <iostream>
+
+#ifndef ONEDPL_STANDARD_POLICIES_ONLY
+#include <CL/sycl.hpp>
+#else
+#include <vector>
+#endif
 
 template<typename Iterator, typename T>
 bool check_values(Iterator first, Iterator last, const T& val)

--- a/test/extensions_testsuite/upper_bound_cpu.pass.cpp
+++ b/test/extensions_testsuite/upper_bound_cpu.pass.cpp
@@ -13,11 +13,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/iterator>
+
+#include <iostream>
 
 class binarySearch {};
 int main()

--- a/test/extensions_testsuite/upper_bound_sycl.pass.cpp
+++ b/test/extensions_testsuite/upper_bound_sycl.pass.cpp
@@ -13,13 +13,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-
-#include <CL/sycl.hpp>
-
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/iterator>
+
+#include <iostream>
+
+#include <CL/sycl.hpp>
 
 class binarySearch {};
 int main()

--- a/test/general/lambda_naming.pass.cpp
+++ b/test/general/lambda_naming.pass.cpp
@@ -13,9 +13,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if _ONEDPL_BACKEND_SYCL
-#    include <CL/sycl.hpp>
-#endif
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
@@ -24,6 +21,10 @@
 #include _PSTL_TEST_HEADER(iterator)
 
 #include "support/utils.h"
+
+#if _ONEDPL_BACKEND_SYCL
+#    include <CL/sycl.hpp>
+#endif
 
 using namespace TestUtils;
 

--- a/test/general/lambda_naming.pass.cpp
+++ b/test/general/lambda_naming.pass.cpp
@@ -17,12 +17,13 @@
 #    include <CL/sycl.hpp>
 #endif
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
 #include _PSTL_TEST_HEADER(numeric)
 #include _PSTL_TEST_HEADER(iterator)
+
+#include "support/utils.h"
 
 using namespace TestUtils;
 

--- a/test/general/sycl_iterator.pass.cpp
+++ b/test/general/sycl_iterator.pass.cpp
@@ -18,14 +18,13 @@
 
 #include "support/pstl_test_config.h"
 
-#include "support/utils.h"
-
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
 #include _PSTL_TEST_HEADER(numeric)
 #include _PSTL_TEST_HEADER(memory)
 #include _PSTL_TEST_HEADER(iterator)
 
+#include "support/utils.h"
 #include "oneapi/dpl/pstl/utils.h"
 
 using namespace TestUtils;

--- a/test/general/sycl_iterator.pass.cpp
+++ b/test/general/sycl_iterator.pass.cpp
@@ -13,9 +13,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <cmath>
-#include <type_traits>
-
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
@@ -26,6 +23,9 @@
 
 #include "support/utils.h"
 #include "oneapi/dpl/pstl/utils.h"
+
+#include <cmath>
+#include <type_traits>
 
 using namespace TestUtils;
 

--- a/test/general/sycl_policy.pass.cpp
+++ b/test/general/sycl_policy.pass.cpp
@@ -21,10 +21,11 @@
 #endif
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 #if _ONEDPL_BACKEND_SYCL
 template<typename Policy>

--- a/test/general/sycl_policy.pass.cpp
+++ b/test/general/sycl_policy.pass.cpp
@@ -13,19 +13,19 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-#include <vector>
-
-#if _ONEDPL_BACKEND_SYCL
-#include <CL/sycl.hpp>
-#endif
-
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
 
 #include "support/utils.h"
+
+#include <iostream>
+#include <vector>
+
+#if _ONEDPL_BACKEND_SYCL
+#include <CL/sycl.hpp>
+#endif
 
 #if _ONEDPL_BACKEND_SYCL
 template<typename Policy>

--- a/test/general/type_requirements.pass.cpp
+++ b/test/general/type_requirements.pass.cpp
@@ -14,7 +14,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
+
+#include _PSTL_TEST_HEADER(execution)
 
 #if _ONEDPL_BACKEND_SYCL
 
@@ -28,6 +29,7 @@ void CheckTuple() {
 
 #endif
 
+#include "support/utils.h"
 
 int main() {
 #if _ONEDPL_BACKEND_SYCL

--- a/test/general/version.pass.cpp
+++ b/test/general/version.pass.cpp
@@ -13,10 +13,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/pstl/onedpl_config.h>
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
+
+#include <oneapi/dpl/pstl/onedpl_config.h>
 
 #include "support/utils.h"
 

--- a/test/parallel_api/algorithm/alg.merge/inplace_merge.pass.cpp
+++ b/test/parallel_api/algorithm/alg.merge/inplace_merge.pass.cpp
@@ -14,10 +14,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 using namespace TestUtils;
 

--- a/test/parallel_api/algorithm/alg.merge/merge.pass.cpp
+++ b/test/parallel_api/algorithm/alg.merge/merge.pass.cpp
@@ -14,10 +14,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 #include <functional>
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.copy/copy_if.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.copy/copy_if.pass.cpp
@@ -15,10 +15,11 @@
 
 // Tests for copy_if and remove_copy_if
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 #if  !defined(_PSTL_TEST_COPY_IF) && !defined(_PSTL_TEST_REMOVE_COPY_IF)
 #define _PSTL_TEST_COPY_IF

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/is_partitioned.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/is_partitioned.pass.cpp
@@ -14,10 +14,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 using namespace TestUtils;
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition.pass.cpp
@@ -15,10 +15,11 @@
 
 // Tests for and partition
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 #include <iterator>
 #include <type_traits>

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition_copy.pass.cpp
@@ -15,10 +15,11 @@
 
 // Tests for stable_partition and partition_copy
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 #include <cstdlib>
 #include <iterator>

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/stable_partition.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/stable_partition.pass.cpp
@@ -15,10 +15,11 @@
 
 // Tests for stable_partition
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 #include <iterator>
 #include <type_traits>

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse.pass.cpp
@@ -14,10 +14,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 #include <iterator>
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse_copy.pass.cpp
@@ -14,10 +14,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 #include <iterator>
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/copy_move.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/copy_move.pass.cpp
@@ -16,10 +16,11 @@
 // Tests for copy, move and copy_n
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 #if  !defined(_PSTL_TEST_COPY) && !defined(_PSTL_TEST_COPY_N) && !defined(_PSTL_TEST_MOVE)
 #define _PSTL_TEST_COPY

--- a/test/parallel_api/algorithm/alg.modifying.operations/fill.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/fill.pass.cpp
@@ -14,10 +14,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 #if  !defined(_PSTL_TEST_FILL) && !defined(_PSTL_TEST_FILL_N)
 #define _PSTL_TEST_FILL

--- a/test/parallel_api/algorithm/alg.modifying.operations/generate.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/generate.pass.cpp
@@ -14,10 +14,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 #include <atomic>
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/remove.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/remove.pass.cpp
@@ -15,10 +15,11 @@
 
 // Test for remove, remove_if
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 #if  !defined(_PSTL_TEST_REMOVE) && !defined(_PSTL_TEST_REMOVE_IF)
 #define _PSTL_TEST_REMOVE

--- a/test/parallel_api/algorithm/alg.modifying.operations/remove_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/remove_copy.pass.cpp
@@ -14,10 +14,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 using namespace TestUtils;
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/replace.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/replace.pass.cpp
@@ -14,10 +14,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 #if  !defined(_PSTL_TEST_REPLACE) && !defined(_PSTL_TEST_REPLACE_IF)
 #define _PSTL_TEST_REPLACE

--- a/test/parallel_api/algorithm/alg.modifying.operations/replace_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/replace_copy.pass.cpp
@@ -16,10 +16,11 @@
 // Tests for replace_copy and replace_copy_if
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 #if  !defined(_PSTL_TEST_REPLACE_COPY) && !defined(_PSTL_TEST_REPLACE_COPY_IF)
 #define _PSTL_TEST_REPLACE_COPY

--- a/test/parallel_api/algorithm/alg.modifying.operations/rotate.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/rotate.pass.cpp
@@ -14,10 +14,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 #include <iterator>
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/rotate_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/rotate_copy.pass.cpp
@@ -14,10 +14,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 #include <iterator>
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/swap_ranges.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/swap_ranges.pass.cpp
@@ -14,10 +14,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 #include <iterator>
 #include <numeric>

--- a/test/parallel_api/algorithm/alg.modifying.operations/transform_binary.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/transform_binary.pass.cpp
@@ -14,10 +14,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 using namespace TestUtils;
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/transform_unary.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/transform_unary.pass.cpp
@@ -16,10 +16,11 @@
 // Tests for transform
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 using namespace TestUtils;
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/unique.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/unique.pass.cpp
@@ -15,10 +15,11 @@
 
 // Test for unique
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 using namespace TestUtils;
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/unique_copy_equal.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/unique_copy_equal.pass.cpp
@@ -15,10 +15,11 @@
 
 // Tests for unique_copy
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 using namespace TestUtils;
 

--- a/test/parallel_api/algorithm/alg.nonmodifying/adjacent_find.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/adjacent_find.pass.cpp
@@ -14,10 +14,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
+
 
 using namespace TestUtils;
 

--- a/test/parallel_api/algorithm/alg.nonmodifying/adjacent_find.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/adjacent_find.pass.cpp
@@ -20,7 +20,6 @@
 
 #include "support/utils.h"
 
-
 using namespace TestUtils;
 
 template <typename T>

--- a/test/parallel_api/algorithm/alg.nonmodifying/all_of.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/all_of.pass.cpp
@@ -14,10 +14,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 /*
   TODO: consider implementing the following tests for a better code coverage

--- a/test/parallel_api/algorithm/alg.nonmodifying/any_of.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/any_of.pass.cpp
@@ -14,10 +14,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 /*
   TODO: consider implementing the following tests for a better code coverage

--- a/test/parallel_api/algorithm/alg.nonmodifying/count.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/count.pass.cpp
@@ -15,10 +15,11 @@
 
 // Tests for count and count_if
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 #if  !defined(_PSTL_TEST_COUNT) && !defined(_PSTL_TEST_COUNT_IF)
 #define _PSTL_TEST_COUNT

--- a/test/parallel_api/algorithm/alg.nonmodifying/equal.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/equal.pass.cpp
@@ -14,10 +14,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 using namespace TestUtils;
 

--- a/test/parallel_api/algorithm/alg.nonmodifying/find.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/find.pass.cpp
@@ -15,10 +15,11 @@
 
 // Tests for find
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 using namespace TestUtils;
 

--- a/test/parallel_api/algorithm/alg.nonmodifying/find_end.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/find_end.pass.cpp
@@ -14,10 +14,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 #if  !defined(_PSTL_TEST_FIND_END) && !defined(_PSTL_TEST_SEARCH)
 #define _PSTL_TEST_FIND_END

--- a/test/parallel_api/algorithm/alg.nonmodifying/find_first_of.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/find_first_of.pass.cpp
@@ -14,10 +14,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 using namespace TestUtils;
 

--- a/test/parallel_api/algorithm/alg.nonmodifying/find_if.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/find_if.pass.cpp
@@ -15,10 +15,11 @@
 
 // Tests for find_if and find_if_not
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 #if  !defined(_PSTL_TEST_FIND_IF) && !defined(_PSTL_TEST_FIND_IF_NOT)
 #define _PSTL_TEST_FIND_IF

--- a/test/parallel_api/algorithm/alg.nonmodifying/for_each.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/for_each.pass.cpp
@@ -14,10 +14,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 #if  !defined(FOR_EACH) && !defined(FOR_EACH_N)
 #define FOR_EACH

--- a/test/parallel_api/algorithm/alg.nonmodifying/mismatch.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/mismatch.pass.cpp
@@ -14,10 +14,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 using namespace TestUtils;
 

--- a/test/parallel_api/algorithm/alg.nonmodifying/none_of.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/none_of.pass.cpp
@@ -14,10 +14,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 /*
   TODO: consider implementing the following tests for a better code coverage

--- a/test/parallel_api/algorithm/alg.nonmodifying/nth_element.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/nth_element.pass.cpp
@@ -14,10 +14,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 #include <iostream>
 

--- a/test/parallel_api/algorithm/alg.nonmodifying/search_n.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/search_n.pass.cpp
@@ -14,10 +14,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 using namespace TestUtils;
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.heap.operations/is_heap.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.heap.operations/is_heap.pass.cpp
@@ -16,10 +16,11 @@
 // Tests for is_heap, is_heap_until
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 #include <iostream>
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.lex.comparison/lexicographical_compare.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.lex.comparison/lexicographical_compare.pass.cpp
@@ -14,10 +14,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 #include <iostream>
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/minmax_element.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/minmax_element.pass.cpp
@@ -14,10 +14,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 #include <set>
 #include <cassert>

--- a/test/parallel_api/algorithm/alg.sorting/alg.set.operations/includes.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.set.operations/includes.pass.cpp
@@ -14,10 +14,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 #include <cmath>
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set.pass.cpp
@@ -14,10 +14,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 #include <cmath>
 #include <chrono>

--- a/test/parallel_api/algorithm/alg.sorting/is_sorted.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/is_sorted.pass.cpp
@@ -14,10 +14,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 using namespace TestUtils;
 

--- a/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
@@ -14,10 +14,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 #include <cmath>
 

--- a/test/parallel_api/algorithm/alg.sorting/partial_sort_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/partial_sort_copy.pass.cpp
@@ -16,10 +16,11 @@
 // Tests for partial_sort_copy
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 #include <cmath>
 

--- a/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
@@ -14,10 +14,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 #if !defined(_PSTL_TEST_SORT) && !defined(_PSTL_TEST_STABLE_SORT)
 #define _PSTL_TEST_SORT

--- a/test/parallel_api/iterator/transform_iterator.pass.cpp
+++ b/test/parallel_api/iterator/transform_iterator.pass.cpp
@@ -13,10 +13,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "support/utils.h"
+#include "support/pstl_test_config.h"
+
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
 #include _PSTL_TEST_HEADER(iterator)
+
+#include "support/utils.h"
 
 #include <tuple>
 

--- a/test/parallel_api/iterator/zip_iterator.pass.cpp
+++ b/test/parallel_api/iterator/zip_iterator.pass.cpp
@@ -13,8 +13,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <cmath>
-
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
@@ -26,6 +24,8 @@
 #include "support/utils.h"
 
 #include "oneapi/dpl/pstl/utils.h"
+
+#include <cmath>
 
 #if !defined(_PSTL_TEST_FOR_EACH) && \
     !defined(_PSTL_TEST_TRANSFORM_REDUCE_UNARY) && \

--- a/test/parallel_api/iterator/zip_iterator.pass.cpp
+++ b/test/parallel_api/iterator/zip_iterator.pass.cpp
@@ -17,13 +17,13 @@
 
 #include "support/pstl_test_config.h"
 
-#include "support/utils.h"
-
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(algorithm)
 #include _PSTL_TEST_HEADER(numeric)
 #include _PSTL_TEST_HEADER(memory)
 #include _PSTL_TEST_HEADER(iterator)
+
+#include "support/utils.h"
 
 #include "oneapi/dpl/pstl/utils.h"
 

--- a/test/parallel_api/memory/specialized.algorithms/uninitialized_construct.pass.cpp
+++ b/test/parallel_api/memory/specialized.algorithms/uninitialized_construct.pass.cpp
@@ -17,10 +17,11 @@
 //           uninitialized_value_consruct,   uninitialized_value_consruct_n
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(memory)
+
+#include "support/utils.h"
 
 #if  !defined(_PSTL_TEST_UNITIALIZED_DEFAULT_CONSTRUCT) && !defined(_PSTL_TEST_UNITIALIZED_DEFAULT_CONSTRUCT_N) &&\
      !defined(_PSTL_TEST_UNITIALIZED_VALUE_CONSTRUCT) && !defined(_PSTL_TEST_UNITIALIZED_VALUE_CONSTRUCT_N)

--- a/test/parallel_api/memory/specialized.algorithms/uninitialized_copy_move.pass.cpp
+++ b/test/parallel_api/memory/specialized.algorithms/uninitialized_copy_move.pass.cpp
@@ -16,10 +16,11 @@
 // Tests for uninitialized_copy, uninitialized_copy_n, uninitialized_move, uninitialized_move_n
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(memory)
+
+#include "support/utils.h"
 
 #if  !defined(UNITIALIZED_COPY) && !defined(UNITIALIZED_COPY_N) &&\
      !defined(UNITIALIZED_MOVE) && !defined(UNITIALIZED_MOVE_N)

--- a/test/parallel_api/memory/specialized.algorithms/uninitialized_fill_destroy.pass.cpp
+++ b/test/parallel_api/memory/specialized.algorithms/uninitialized_fill_destroy.pass.cpp
@@ -14,7 +14,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #if  !defined(_PSTL_TEST_UNITIALIZED_FILL) && !defined(_PSTL_TEST_UNITIALIZED_FILL_N) &&\
      !defined(_PSTL_TEST_UNITIALIZED_DESTROY) && !defined(_PSTL_TEST_UNITIALIZED_DESTROY_N)
@@ -26,6 +25,8 @@
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(memory)
+
+#include "support/utils.h"
 
 #include <memory>
 

--- a/test/parallel_api/numeric/numeric.ops/adjacent_difference.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/adjacent_difference.pass.cpp
@@ -14,10 +14,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(numeric)
+
+#include "support/utils.h"
 
 #include <iterator>
 

--- a/test/parallel_api/numeric/numeric.ops/reduce.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce.pass.cpp
@@ -14,10 +14,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(numeric)
+
+#include "support/utils.h"
 
 using namespace TestUtils;
 

--- a/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
@@ -14,10 +14,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(numeric)
+
+#include "support/utils.h"
 
 #if  !defined(_PSTL_TEST_INCLUSIVE_SCAN) && !defined(_PSTL_TEST_EXCLUSIVE_SCAN)
 #define _PSTL_TEST_INCLUSIVE_SCAN

--- a/test/parallel_api/numeric/numeric.ops/transform_reduce.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/transform_reduce.pass.cpp
@@ -14,10 +14,11 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(numeric)
+
+#include "support/utils.h"
 
 using namespace TestUtils;
 

--- a/test/parallel_api/numeric/numeric.ops/transform_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/transform_scan.pass.cpp
@@ -14,11 +14,12 @@
 //===----------------------------------------------------------------------===//
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(numeric)
 #include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
 
 #if  !defined(_PSTL_TEST_TRANSFORM_INCLUSIVE_SCAN) && !defined(_PSTL_TEST_TRANSFORM_EXCLUSIVE_SCAN)
 #define _PSTL_TEST_TRANSFORM_INCLUSIVE_SCAN

--- a/test/parallel_api/ranges/copy_ranges_factory_sycl.pass.cpp
+++ b/test/parallel_api/ranges/copy_ranges_factory_sycl.pass.cpp
@@ -13,8 +13,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
@@ -23,6 +21,8 @@
 #endif
 
 #include "support/utils.h"
+
+#include <iostream>
 
 int32_t
 main()

--- a/test/parallel_api/ranges/copy_ranges_factory_sycl.pass.cpp
+++ b/test/parallel_api/ranges/copy_ranges_factory_sycl.pass.cpp
@@ -16,12 +16,13 @@
 #include <iostream>
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #if _ONEDPL_USE_RANGES
 #include _PSTL_TEST_HEADER(ranges)
 #endif
+
+#include "support/utils.h"
 
 int32_t
 main()

--- a/test/parallel_api/ranges/copy_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/copy_ranges_sycl.pass.cpp
@@ -13,8 +13,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
@@ -23,6 +21,8 @@
 #endif
 
 #include "support/utils.h"
+
+#include <iostream>
 
 int32_t
 main()

--- a/test/parallel_api/ranges/copy_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/copy_ranges_sycl.pass.cpp
@@ -16,12 +16,13 @@
 #include <iostream>
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #if _ONEDPL_USE_RANGES
 #include _PSTL_TEST_HEADER(ranges)
 #endif
+
+#include "support/utils.h"
 
 int32_t
 main()

--- a/test/parallel_api/ranges/exclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/exclusive_scan_ranges_sycl.pass.cpp
@@ -13,8 +13,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
@@ -24,6 +22,8 @@
 #endif
 
 #include "support/utils.h"
+
+#include <iostream>
 
 int32_t
 main()

--- a/test/parallel_api/ranges/exclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/exclusive_scan_ranges_sycl.pass.cpp
@@ -16,13 +16,14 @@
 #include <iostream>
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(numeric)
 #if _ONEDPL_USE_RANGES
 #include _PSTL_TEST_HEADER(ranges)
 #endif
+
+#include "support/utils.h"
 
 int32_t
 main()

--- a/test/parallel_api/ranges/find_end_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/find_end_ranges_sycl.pass.cpp
@@ -13,8 +13,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
@@ -24,6 +22,8 @@
 #endif
 
 #include "support/utils.h"
+
+#include <iostream>
 
 int32_t
 main()

--- a/test/parallel_api/ranges/find_end_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/find_end_ranges_sycl.pass.cpp
@@ -16,13 +16,14 @@
 #include <iostream>
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 
 #if _ONEDPL_USE_RANGES
 #include _PSTL_TEST_HEADER(ranges)
 #endif
+
+#include "support/utils.h"
 
 int32_t
 main()

--- a/test/parallel_api/ranges/find_first_of_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/find_first_of_ranges_sycl.pass.cpp
@@ -13,8 +13,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
@@ -24,6 +22,8 @@
 #endif
 
 #include "support/utils.h
+
+#include <iostream>
 
 int32_t
 main()

--- a/test/parallel_api/ranges/find_first_of_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/find_first_of_ranges_sycl.pass.cpp
@@ -16,13 +16,14 @@
 #include <iostream>
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 
 #if _ONEDPL_USE_RANGES
 #include _PSTL_TEST_HEADER(ranges)
 #endif
+
+#include "support/utils.h
 
 int32_t
 main()

--- a/test/parallel_api/ranges/find_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/find_ranges_sycl.pass.cpp
@@ -13,8 +13,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
@@ -24,6 +22,8 @@
 #endif
 
 #include "support/utils.h"
+
+#include <iostream>
 
 int32_t
 main()

--- a/test/parallel_api/ranges/find_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/find_ranges_sycl.pass.cpp
@@ -16,13 +16,14 @@
 #include <iostream>
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 
 #if _ONEDPL_USE_RANGES
 #include _PSTL_TEST_HEADER(ranges)
 #endif
+
+#include "support/utils.h"
 
 int32_t
 main()

--- a/test/parallel_api/ranges/for_each_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/for_each_ranges_sycl.pass.cpp
@@ -13,8 +13,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
@@ -23,6 +21,8 @@
 #endif
 
 #include "support/utils.h"
+
+#include <iostream>
 
 int32_t
 main()

--- a/test/parallel_api/ranges/for_each_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/for_each_ranges_sycl.pass.cpp
@@ -16,12 +16,13 @@
 #include <iostream>
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #if _ONEDPL_USE_RANGES
 #include _PSTL_TEST_HEADER(ranges)
 #endif
+
+#include "support/utils.h"
 
 int32_t
 main()

--- a/test/parallel_api/ranges/inclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/inclusive_scan_ranges_sycl.pass.cpp
@@ -13,8 +13,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
@@ -24,6 +22,8 @@
 #endif
 
 #include "support/utils.h"
+
+#include <iostream>
 
 int32_t
 main()

--- a/test/parallel_api/ranges/inclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/inclusive_scan_ranges_sycl.pass.cpp
@@ -16,13 +16,14 @@
 #include <iostream>
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(numeric)
 #if _ONEDPL_USE_RANGES
 #include _PSTL_TEST_HEADER(ranges)
 #endif
+
+#include "support/utils.h"
 
 int32_t
 main()

--- a/test/parallel_api/ranges/is_sorted_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/is_sorted_ranges_sycl.pass.cpp
@@ -13,8 +13,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
@@ -24,6 +22,8 @@
 #endif
 
 #include "support/utils.h"
+
+#include <iostream>
 
 int32_t
 main()

--- a/test/parallel_api/ranges/is_sorted_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/is_sorted_ranges_sycl.pass.cpp
@@ -16,13 +16,14 @@
 #include <iostream>
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 
 #if _ONEDPL_USE_RANGES
 #include _PSTL_TEST_HEADER(ranges)
 #endif
+
+#include "support/utils.h"
 
 int32_t
 main()

--- a/test/parallel_api/ranges/is_sorted_until_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/is_sorted_until_ranges_sycl.pass.cpp
@@ -13,8 +13,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
@@ -24,6 +22,8 @@
 #endif
 
 #include "support/utils.h"
+
+#include <iostream>
 
 int32_t
 main()

--- a/test/parallel_api/ranges/is_sorted_until_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/is_sorted_until_ranges_sycl.pass.cpp
@@ -16,13 +16,14 @@
 #include <iostream>
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 
 #if _ONEDPL_USE_RANGES
 #include _PSTL_TEST_HEADER(ranges)
 #endif
+
+#include "support/utils.h"
 
 int32_t
 main()

--- a/test/parallel_api/ranges/minmax_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/minmax_ranges_sycl.pass.cpp
@@ -13,8 +13,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
@@ -24,6 +22,8 @@
 #endif
 
 #include "support/utils.h"
+
+#include <iostream>
 
 int32_t
 main()

--- a/test/parallel_api/ranges/minmax_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/minmax_ranges_sycl.pass.cpp
@@ -16,13 +16,14 @@
 #include <iostream>
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 
 #if _ONEDPL_USE_RANGES
 #include _PSTL_TEST_HEADER(ranges)
 #endif
+
+#include "support/utils.h"
 
 int32_t
 main()

--- a/test/parallel_api/ranges/reduce_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/reduce_ranges_sycl.pass.cpp
@@ -13,8 +13,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
@@ -23,6 +21,8 @@
 #endif
 
 #include "support/utils.h"
+
+#include <iostream>
 
 int32_t
 main()

--- a/test/parallel_api/ranges/reduce_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/reduce_ranges_sycl.pass.cpp
@@ -16,12 +16,13 @@
 #include <iostream>
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #if _ONEDPL_USE_RANGES
 #include _PSTL_TEST_HEADER(ranges)
 #endif
+
+#include "support/utils.h"
 
 int32_t
 main()

--- a/test/parallel_api/ranges/search_n_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/search_n_ranges_sycl.pass.cpp
@@ -13,8 +13,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
@@ -23,6 +21,8 @@
 #endif
 
 #include "support/utils.h"
+
+#include <iostream>
 
 int32_t
 main()

--- a/test/parallel_api/ranges/search_n_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/search_n_ranges_sycl.pass.cpp
@@ -16,12 +16,13 @@
 #include <iostream>
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #if _ONEDPL_USE_RANGES
 #include _PSTL_TEST_HEADER(ranges)
 #endif
+
+#include "support/utils.h"
 
 int32_t
 main()

--- a/test/parallel_api/ranges/search_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/search_ranges_sycl.pass.cpp
@@ -13,8 +13,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
@@ -24,6 +22,8 @@
 #endif
 
 #include "support/utils.h"
+
+#include <iostream>
 
 int32_t
 main()

--- a/test/parallel_api/ranges/search_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/search_ranges_sycl.pass.cpp
@@ -16,13 +16,14 @@
 #include <iostream>
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 
 #if _ONEDPL_USE_RANGES
 #include _PSTL_TEST_HEADER(ranges)
 #endif
+
+#include "support/utils.h"
 
 int32_t
 main()

--- a/test/parallel_api/ranges/transform2_ranges_factory_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform2_ranges_factory_sycl.pass.cpp
@@ -13,8 +13,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
@@ -23,6 +21,8 @@
 #endif
 
 #include "support/utils.h"
+
+#include <iostream>
 
 int32_t
 main()

--- a/test/parallel_api/ranges/transform2_ranges_factory_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform2_ranges_factory_sycl.pass.cpp
@@ -16,12 +16,13 @@
 #include <iostream>
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #if _ONEDPL_USE_RANGES
 #include _PSTL_TEST_HEADER(ranges)
 #endif
+
+#include "support/utils.h"
 
 int32_t
 main()

--- a/test/parallel_api/ranges/transform2_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform2_ranges_sycl.pass.cpp
@@ -13,8 +13,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
@@ -23,6 +21,8 @@
 #endif
 
 #include "support/utils.h"
+
+#include <iostream>
 
 int32_t
 main()

--- a/test/parallel_api/ranges/transform2_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform2_ranges_sycl.pass.cpp
@@ -16,12 +16,13 @@
 #include <iostream>
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #if _ONEDPL_USE_RANGES
 #include _PSTL_TEST_HEADER(ranges)
 #endif
+
+#include "support/utils.h"
 
 int32_t
 main()

--- a/test/parallel_api/ranges/transform_exclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_exclusive_scan_ranges_sycl.pass.cpp
@@ -13,8 +13,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
@@ -24,6 +22,8 @@
 #endif
 
 #include "support/utils.h"
+
+#include <iostream>
 
 int32_t
 main()

--- a/test/parallel_api/ranges/transform_exclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_exclusive_scan_ranges_sycl.pass.cpp
@@ -16,13 +16,14 @@
 #include <iostream>
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(numeric)
 #if _ONEDPL_USE_RANGES
 #include _PSTL_TEST_HEADER(ranges)
 #endif
+
+#include "support/utils.h"
 
 int32_t
 main()

--- a/test/parallel_api/ranges/transform_inclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_inclusive_scan_ranges_sycl.pass.cpp
@@ -13,8 +13,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
@@ -24,6 +22,8 @@
 #endif
 
 #include "support/utils.h"
+
+#include <iostream>
 
 int32_t
 main()

--- a/test/parallel_api/ranges/transform_inclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_inclusive_scan_ranges_sycl.pass.cpp
@@ -16,13 +16,14 @@
 #include <iostream>
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(numeric)
 #if _ONEDPL_USE_RANGES
 #include _PSTL_TEST_HEADER(ranges)
 #endif
+
+#include "support/utils.h"
 
 int32_t
 main()

--- a/test/parallel_api/ranges/transform_ranges_factory_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_ranges_factory_sycl.pass.cpp
@@ -13,8 +13,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
@@ -23,6 +21,8 @@
 #endif
 
 #include "support/utils.h"
+
+#include <iostream>
 
 int32_t
 main()

--- a/test/parallel_api/ranges/transform_ranges_factory_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_ranges_factory_sycl.pass.cpp
@@ -16,12 +16,13 @@
 #include <iostream>
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #if _ONEDPL_USE_RANGES
 #include _PSTL_TEST_HEADER(ranges)
 #endif
+
+#include "support/utils.h"
 
 int32_t
 main()

--- a/test/parallel_api/ranges/transform_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_ranges_sycl.pass.cpp
@@ -13,8 +13,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
@@ -23,6 +21,8 @@
 #endif
 
 #include "support/utils.h"
+
+#include <iostream>
 
 int32_t
 main()

--- a/test/parallel_api/ranges/transform_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_ranges_sycl.pass.cpp
@@ -16,12 +16,13 @@
 #include <iostream>
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #if _ONEDPL_USE_RANGES
 #include _PSTL_TEST_HEADER(ranges)
 #endif
+
+#include "support/utils.h"
 
 int32_t
 main()

--- a/test/parallel_api/ranges/transform_reduce_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_reduce_ranges_sycl.pass.cpp
@@ -13,8 +13,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
@@ -23,6 +21,8 @@
 #endif
 
 #include "support/utils.h"
+
+#include <iostream>
 
 int32_t
 main()

--- a/test/parallel_api/ranges/transform_reduce_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_reduce_ranges_sycl.pass.cpp
@@ -16,12 +16,13 @@
 #include <iostream>
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #include _PSTL_TEST_HEADER(execution)
 #if _ONEDPL_USE_RANGES
 #include _PSTL_TEST_HEADER(ranges)
 #endif
+
+#include "support/utils.h"
 
 int32_t
 main()

--- a/test/parallel_api/ranges/zip_view.pass.cpp
+++ b/test/parallel_api/ranges/zip_view.pass.cpp
@@ -13,15 +13,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-
 #include "support/pstl_test_config.h"
 
+#include _PSTL_TEST_HEADER(execution)
 #if _ONEDPL_USE_RANGES
 #include _PSTL_TEST_HEADER(ranges)
 #endif
 
 #include "support/utils.h"
+
+#include <iostream>
 
 int32_t
 main()

--- a/test/parallel_api/ranges/zip_view.pass.cpp
+++ b/test/parallel_api/ranges/zip_view.pass.cpp
@@ -16,11 +16,12 @@
 #include <iostream>
 
 #include "support/pstl_test_config.h"
-#include "support/utils.h"
 
 #if _ONEDPL_USE_RANGES
 #include _PSTL_TEST_HEADER(ranges)
 #endif
+
+#include "support/utils.h"
 
 int32_t
 main()


### PR DESCRIPTION
According to oneDPL and oneTBB documentation ( https://software.intel.com/content/www/us/en/develop/articles/intel-oneapi-threading-building-blocks-release-notes.html ) oneTBB interfaces incompatible with TBB 2020. It cause compilation errors, which can be fixed by changing include order (oneDPL headers should be included first)