### PR TITLE
CMake/make: fix after renaming test/pstl_testsuite

### DIFF
--- a/make/Makefile
+++ b/make/Makefile
@@ -30,7 +30,7 @@ BENCH_MAKEFILE = $(proj_root)/make/Makefile.bench
 
 recursive_wildcard = $(wildcard $(1)$(2)) $(foreach d,$(wildcard $(1)*),$(call recursive_wildcard,$(d)/,$(2)))
 
-test_hdr = $(wildcard $(proj_root)/test/pstl_testsuite/support/*.h)
+test_hdr = $(wildcard $(proj_root)/test/support/*.h)
 test_src_all = $(call recursive_wildcard,$(proj_root)/test/,*.pass.cpp)
 ifdef exclude_test_dirs
     ifdef include_test_dirs

--- a/make/Makefile.common
+++ b/make/Makefile.common
@@ -109,7 +109,7 @@ ifdef extra_def_macros
     EXTRA_DEF_MACROS = $(patsubst %,$(KEY)D%, $(extra_def_macros))
 endif
 
-override INCLUDES += $(KEY)I$(proj_root)/include $(KEY)I$(proj_root)/test/pstl_testsuite $(KEY)I$(proj_root)/stdlib
+override INCLUDES += $(KEY)I$(proj_root)/include $(KEY)I$(proj_root)/test $(KEY)I$(proj_root)/stdlib
 
 TEST_MACRO += $(KEY)D_PSTL_TEST_SUCCESSFUL_KEYWORD=1
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,9 +21,6 @@ add_custom_target(run-all
     DEPENDS build-all
     COMMENT "Build and run all the unit tests.")
 
-add_library(test_support INTERFACE)
-target_include_directories(test_support INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/pstl_testsuite")
-
 macro(onedpl_add_test test_source_file)
     get_filename_component(_test_name ${test_source_file} NAME)
     string(REPLACE "\.cpp" "" _test_name ${_test_name})
@@ -34,7 +31,7 @@ macro(onedpl_add_test test_source_file)
         target_compile_options(${_test_name} PRIVATE /bigobj)
     endif()
     target_include_directories(${_test_name} PRIVATE "${CMAKE_CURRENT_LIST_DIR}")
-    target_link_libraries(${_test_name} PRIVATE oneDPL test_support)
+    target_link_libraries(${_test_name} PRIVATE oneDPL)
     set_target_properties(${_test_name} PROPERTIES CXX_EXTENSIONS NO)
     if (ONEDPL_DEVICE_TYPE)
         set(SYCL_DEVICE_TYPE ${ONEDPL_DEVICE_TYPE})
@@ -74,10 +71,6 @@ macro(onedpl_add_test test_source_file)
     endforeach()
     add_dependencies(build-all ${_test_name})
 endmacro()
-
-#add_subdirectory(pstl_testsuite)
-#add_subdirectory(extenstions_testsuite)
-#if (ONEDPL_BACKEND MATCHES "^(sycl|sycl_only)$")
 
 set(_skip_regex_for_not_sycl "(rng_testsuite|extensions_testsuite)")
 file(GLOB_RECURSE UNIT_TESTS "*.pass.cpp")


### PR DESCRIPTION
These changes fix CMake/Makefiles after #50 