### PR TITLE
Removing unused internal buffer type inclusion

### DIFF
--- a/include/oneapi/dpl/internal/function.h
+++ b/include/oneapi/dpl/internal/function.h
@@ -56,8 +56,6 @@ struct rebind_policy<oneapi::dpl::execution::fpga_policy<factor, KernelName>, Ne
 
 using oneapi::dpl::__par_backend_hetero::__internal::__buffer;
 using oneapi::dpl::__par_backend_hetero::__internal::is_hetero_iterator;
-#else
-using oneapi::dpl::__par_backend::__buffer;
 #endif
 
 #if _ONEDPL_BACKEND_SYCL


### PR DESCRIPTION
Resolves compilation error when compiling header_inclusion_order_algorithm_1.pass with a non-SYCL compiler.
Signed-off-by: Timmie Smith <timmie.smith@intel.com>