### PR TITLE
Fix the issue of missing terminating '"' character for 'find_first_of…

### DIFF
--- a/test/parallel_api/ranges/find_first_of_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/find_first_of_ranges_sycl.pass.cpp
@@ -21,7 +21,7 @@
 #include _PSTL_TEST_HEADER(ranges)
 #endif
 
-#include "support/utils.h
+#include "support/utils.h"
 
 #include <iostream>
 


### PR DESCRIPTION
Fix the issue of missing terminating '"' character for 'find_first_of_ranges_sycl' test source file.