### PR TITLE
Added a macro to disable global policy objects

### DIFF
--- a/documentation/library_guide/pstl/macros.rst
+++ b/documentation/library_guide/pstl/macros.rst
@@ -32,61 +32,68 @@ Additional Macros
 Use these macros to control aspects of oneDPL usage. You can set them in your program code
 before including oneDPL headers.
 
-================================= ==============================
-Macro                             Description
-================================= ==============================
-``PSTL_USE_NONTEMPORAL_STORES``   This macro enables the use of ``#pragma vector nontemporal``
-                                  for write-only data when algorithms such as ``std::copy``, ``std::fill``, etc.,
-                                  are executed with unsequenced policies.
-                                  For further details about the pragma,
-                                  see the `Developer Guide and Reference <https://software.intel.com/
-                                  content/www/us/en/develop/documentation/
-                                  oneapi-dpcpp-cpp-compiler-dev-guide-and-reference/top/
-                                  compiler-reference/pragmas/
-                                  intel-specific-pragma-reference/vector.html>`_.
-                                  If the macro evaluates to a non-zero value,
-                                  the use of ``#pragma vector nontemporal`` is enabled.
-                                  By default the macro is not defined.
+================================== ==============================
+Macro                              Description
+================================== ==============================
+``PSTL_USE_NONTEMPORAL_STORES``    This macro enables the use of ``#pragma vector nontemporal``
+                                   for write-only data when algorithms such as ``std::copy``, ``std::fill``, etc.,
+                                   are executed with unsequenced policies.
+                                   For further details about the pragma,
+                                   see the `Developer Guide and Reference <https://software.intel.com/
+                                   content/www/us/en/develop/documentation/
+                                   oneapi-dpcpp-cpp-compiler-dev-guide-and-reference/top/
+                                   compiler-reference/pragmas/
+                                   intel-specific-pragma-reference/vector.html>`_.
+                                   If the macro evaluates to a non-zero value,
+                                   the use of ``#pragma vector nontemporal`` is enabled.
+                                   By default the macro is not defined.
 
-                                  Using this macro may have the same effect on the implementation of parallel
-                                  algorithms in the C++ standard libraries of GCC and LLVM.
---------------------------------- ------------------------------
-``PSTL_USAGE_WARNINGS``           This macro enables Parallel STL to
-                                  emit compile-time messages, such as warnings
-                                  about an algorithm not supporting a certain execution policy.
-                                  When set to 1, the macro allows the implementation to emit
-                                  usage warnings. When the macro is not defined (by default)
-                                  or evaluates to zero, usage warnings are disabled.
+                                   Using this macro may have the same effect on the implementation of parallel
+                                   algorithms in the C++ standard libraries of GCC and LLVM.
+---------------------------------- ------------------------------
+``PSTL_USAGE_WARNINGS``            This macro enables Parallel STL to
+                                   emit compile-time messages, such as warnings
+                                   about an algorithm not supporting a certain execution policy.
+                                   When set to 1, the macro allows the implementation to emit
+                                   usage warnings. When the macro is not defined (by default)
+                                   or evaluates to zero, usage warnings are disabled.
 
-                                  Using this macro may have the same effect on the implementation of parallel
-                                  algorithms in the C++ standard libraries of GCC and LLVM.
---------------------------------- ------------------------------
-``ONEDPL_USE_TBB_BACKEND``        This macro controls the use of oneAPI Threading Building Blocks (oneTBB) or
-                                  Threading Building Blocks (TBB) for parallel policies.
-                                  When the macro is set to 0, algorithms with the ``par`` and ``par_unseq`` policies are only
-                                  executed by the calling thread. This is recommended for code that should not depend on the
-                                  presence of the oneTBB or TBB library. When the macro is not defined (by default)
-                                  or evaluates to a non-zero value,
-                                  parallel policies are executed using the oneTBB or TBB library.
---------------------------------- ------------------------------
-``ONEDPL_USE_DPCPP_BACKEND``      This macro enables the use of the DPC++ policies.
-                                  When the macro is not defined (by default)
-                                  or evaluates to non-zero, DPC++ policies are enabled.
-                                  When the macro is set to 0 there is no dependency on
-                                  the oneAPI DPC++/C++ Compiler and runtime libraries.
-                                  Trying to use DPC++ policies will lead to compilation errors.
---------------------------------- ------------------------------
-``ONEDPL_ALLOW_DEFERRED_WAITING`` This macro allows waiting for completion of certain algorithms executed with 
-                                  DPC++ policies to be deferred. (Disabled by default.)
---------------------------------- ------------------------------
-``ONEDPL_FPGA_DEVICE``            Use this macro to build your code containing oneDPL parallel
-                                  algorithms for FPGA devices. (Disabled by default.)
---------------------------------- ------------------------------
-``ONEDPL_FPGA_EMULATOR``          Use this macro to build your code containing Parallel STL
-                                  algorithms for FPGA emulation device. (Disabled by default.)
+                                   Using this macro may have the same effect on the implementation of parallel
+                                   algorithms in the C++ standard libraries of GCC and LLVM.
+---------------------------------- ------------------------------
+``ONEDPL_USE_TBB_BACKEND``         This macro controls the use of oneAPI Threading Building Blocks (oneTBB) or
+                                   Threading Building Blocks (TBB) for parallel policies.
+                                   When the macro is set to 0, algorithms with the ``par`` and ``par_unseq`` policies are only
+                                   executed by the calling thread. This is recommended for code that should not depend on the
+                                   presence of the oneTBB or TBB library. When the macro is not defined (by default)
+                                   or evaluates to a non-zero value,
+                                   parallel policies are executed using the oneTBB or TBB library.
+---------------------------------- ------------------------------
+``ONEDPL_USE_DPCPP_BACKEND``       This macro enables the use of the DPC++ policies.
+                                   When the macro is not defined (by default)
+                                   or evaluates to non-zero, DPC++ policies are enabled.
+                                   When the macro is set to 0 there is no dependency on
+                                   the oneAPI DPC++/C++ Compiler and runtime libraries.
+                                   Trying to use DPC++ policies will lead to compilation errors.
+---------------------------------- ------------------------------
+``ONEDPL_USE_PREDEFINED_POLICIES`` This macro enables the use of predefined policies objects,
+                                   e.g. ``dpcpp_default``, ``dpcpp_fpga``. When the macro is not defined (by default)
+                                   or evaluates to non-zero, predefined policies objects can be used.
+                                   When the macro is set to 0, predefined policies objects and make functions
+                                   without arguments, e.g. ``make_device_policy()``,
+                                   ``make_fpga_policy()``,  are not available.
+---------------------------------- ------------------------------
+``ONEDPL_ALLOW_DEFERRED_WAITING``  This macro allows waiting for completion of certain algorithms executed with 
+                                   DPC++ policies to be deferred. (Disabled by default.)
+---------------------------------- ------------------------------
+``ONEDPL_FPGA_DEVICE``             Use this macro to build your code containing oneDPL parallel
+                                   algorithms for FPGA devices. (Disabled by default.)
+---------------------------------- ------------------------------
+``ONEDPL_FPGA_EMULATOR``           Use this macro to build your code containing Parallel STL
+                                   algorithms for FPGA emulation device. (Disabled by default.)
 
-                                  Note: Define ``ONEDPL_FPGA_DEVICE`` and ``ONEDPL_FPGA_EMULATOR`` macros in the same
-                                  application to run on a FPGA emulation device.
-                                  Define only the ``ONEDPL_FPGA_DEVICE`` macro to run on a FPGA hardware device.
-================================= ==============================
+                                   Note: Define ``ONEDPL_FPGA_DEVICE`` and ``ONEDPL_FPGA_EMULATOR`` macros in the same
+                                   application to run on a FPGA emulation device.
+                                   Define only the ``ONEDPL_FPGA_DEVICE`` macro to run on a FPGA hardware device.
+================================== ==============================
 

--- a/documentation/library_guide/pstl/macros.rst
+++ b/documentation/library_guide/pstl/macros.rst
@@ -81,7 +81,7 @@ Macro                              Description
                                    or evaluates to non-zero, predefined policies objects can be used.
                                    When the macro is set to 0, predefined policies objects and make functions
                                    without arguments, e.g. ``make_device_policy()``,
-                                   ``make_fpga_policy()``,  are not available.
+                                   ``make_fpga_policy()``, are not available.
 ---------------------------------- ------------------------------
 ``ONEDPL_ALLOW_DEFERRED_WAITING``  This macro allows waiting for completion of certain algorithms executed with 
                                    DPC++ policies to be deferred. (Disabled by default.)
@@ -96,4 +96,3 @@ Macro                              Description
                                    application to run on a FPGA emulation device.
                                    Define only the ``ONEDPL_FPGA_DEVICE`` macro to run on a FPGA hardware device.
 ================================== ==============================
-

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -133,8 +133,8 @@ template <typename DeviceSelector>
 inline device_policy<>&
 __get_default_policy_object(DeviceSelector selector)
 {
-    static device_policy<> __sycl_obj(selector);
-    return __sycl_obj;
+    static device_policy<> __single_base_obj(selector);
+    return __single_base_obj;
 }
 static device_policy<> dpcpp_default{__get_default_policy_object(sycl::default_selector{})};
 
@@ -142,8 +142,8 @@ static device_policy<> dpcpp_default{__get_default_policy_object(sycl::default_s
 inline fpga_policy<>&
 __get_fpga_policy_object()
 {
-    static fpga_policy<> __sycl_obj{};
-    return __sycl_obj;
+    static fpga_policy<> __single_base_obj{};
+    return __single_base_obj;
 }
 static fpga_policy<> dpcpp_fpga{__get_fpga_policy_object()};
 #        endif // _ONEDPL_FPGA_DEVICE

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -42,6 +42,13 @@
 #    define _ONEDPL_FPGA_EMU ONEDPL_FPGA_EMULATOR
 #endif
 
+#if defined(ONEDPL_USE_PREDEFINED_POLICIES)
+#    undef _ONEDPL_USE_PREDEFINED_POLICIES
+#    define _ONEDPL_USE_PREDEFINED_POLICIES ONEDPL_USE_DEFAULT_POLICIES
+#elif !defined(_ONEDPL_USE_PREDEFINED_POLICIES)
+#    define _ONEDPL_USE_PREDEFINED_POLICIES 1
+#endif
+
 // macros for deprecation
 #if (__cplusplus >= 201402L)
 #    define _DPSTD_DEPRECATED [[deprecated]]

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -112,7 +112,7 @@ namespace TestUtils
     auto default_selector = sycl::default_selector{};
     auto default_dpcpp_policy =
 #if ONEDPL_USE_PREDEFINED_POLICIES
-        oneapi::dpl::execution::dpcpp_fpga;
+        oneapi::dpl::execution::dpcpp_default;
 #else
         oneapi::dpl::execution::make_device_policy(sycl::queue{default_selector});
 #endif // ONEDPL_USE_PREDEFINED_POLICIES

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -102,7 +102,7 @@ namespace TestUtils
 #else
         sycl::INTEL::fpga_selector{};
 #endif // ONEDPL_FPGA_EMULATOR
-    auto default_dpcpp_policy =
+    auto&& default_dpcpp_policy =
 #if ONEDPL_USE_PREDEFINED_POLICIES
         oneapi::dpl::execution::dpcpp_fpga;
 #else
@@ -110,7 +110,7 @@ namespace TestUtils
 #endif // ONEDPL_USE_PREDEFINED_POLICIES
 #else
     auto default_selector = sycl::default_selector{};
-    auto default_dpcpp_policy =
+    auto&& default_dpcpp_policy =
 #if ONEDPL_USE_PREDEFINED_POLICIES
         oneapi::dpl::execution::dpcpp_default;
 #else

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -95,18 +95,28 @@ namespace TestUtils
     }
 #endif
 
-#if _ONEDPL_FPGA_DEVICE
-    auto& default_dpcpp_policy = oneapi::dpl::execution::dpcpp_fpga;
+#if ONEDPL_FPGA_DEVICE
     auto default_selector =
-#if _ONEDPL_FPGA_EMU
+#if ONEDPL_FPGA_EMULATOR
         sycl::INTEL::fpga_emulator_selector{};
 #else
         sycl::INTEL::fpga_selector{};
-#endif
+#endif // ONEDPL_FPGA_EMULATOR
+    auto default_dpcpp_policy =
+#if ONEDPL_USE_PREDEFINED_POLICIES
+        oneapi::dpl::execution::dpcpp_fpga;
 #else
-    auto& default_dpcpp_policy = oneapi::dpl::execution::dpcpp_default;
+        oneapi::dpl::execution::make_fpga_policy(sycl::queue{default_selector});
+#endif // ONEDPL_USE_PREDEFINED_POLICIES
+#else
     auto default_selector = sycl::default_selector{};
-#endif
+    auto default_dpcpp_policy =
+#if ONEDPL_USE_PREDEFINED_POLICIES
+        oneapi::dpl::execution::dpcpp_fpga;
+#else
+        oneapi::dpl::execution::make_device_policy(sycl::queue{default_selector});
+#endif // ONEDPL_USE_PREDEFINED_POLICIES
+#endif // ONEDPL_FPGA_DEVICE
 
     // create the queue with custom asynchronous exceptions handler
     static auto my_queue = sycl::queue(default_selector, async_handler);


### PR DESCRIPTION
There is an issue that global policy objects presence is not needed for some cases, e.g. only oneDPL headers are included into DLL.

The patch introduces the `ONEDPL_USE_PREDEFINED_POLICIES` public macro that disables global policy objects (equal to 1 by default). Name can be changed.

The following are disabled when `ONEDPL_USE_PREDEFINED_POLICIES==0`:
* `dpcpp_default`
* `dpcpp_fpga`
* `make_device_policy()`
* `make_fpga_policy()`

**Testing**: tested when the macro is switched on (default) or is switched off (explicitly)