### PR TITLE
[CI]Fix CI failure in windows check

### DIFF
--- a/jenkinsfiles/Windows_Check.groovy
+++ b/jenkinsfiles/Windows_Check.groovy
@@ -271,7 +271,7 @@ pipeline {
                                                 try {
                                                     phase = "Build&Run"
                                                     bat script: """
-                                                        dpcpp /W0 /nologo /D _UNICODE /D UNICODE /Zi /WX- /EHsc /Fetest.exe /Isrc/include /Isrc/test/parallel_api $x
+                                                        dpcpp /W0 /nologo /D _UNICODE /D UNICODE /Zi /WX- /EHsc /Fetest.exe /Isrc/include /Isrc/test /Isrc/test/parallel_api $x
                                                         test.exe
                                                     """, label: "Check $x"
                                                     passCount++
@@ -326,7 +326,7 @@ pipeline {
                                                 try {
                                                     phase = "Build&Run"
                                                     bat script: """
-                                                        dpcpp /W0 /nologo /D _UNICODE /D UNICODE /Zi /WX- /EHsc /Fetest.exe /Isrc/include /Isrc/test/extensions_testsuite $x
+                                                        dpcpp /W0 /nologo /D _UNICODE /D UNICODE /Zi /WX- /EHsc /Fetest.exe /Isrc/include /Isrc/test /Isrc/test/extensions_testsuite $x
                                                         test.exe
                                                     """, label: "Check $x"
                                                     passCount++
@@ -379,7 +379,7 @@ pipeline {
                         githubStatus.setFailed(this, "Jenkins/Win_Check")
                     }
                 }
-           }
+            }
         }
     }
 


### PR DESCRIPTION
Fix CI failure in windows check --- fatal error: 'support/pstl_test_config.h' file not found.
Since the file under test/parallel_api requires to include "support/pstl_test_config.h", the windows CI script need to add /test folder in /I option when compiling. 
If not, CI will fail when compiling with following error message:

dpcpp /W0 /nologo /D _UNICODE /D UNICODE /Zi /WX- /EHsc /Fetest.exe /Isrc/include /Isrc/test/parallel_api src\test\parallel_api\algorithm\alg.modifying.operations\alg.partitions\partition.pass.cpp 
08:24:32  src\test\parallel_api\algorithm\alg.modifying.operations\alg.partitions\partition.pass.cpp(17,10): fatal error: 'support/pstl_test_config.h' file not found
08:24:32  #include "support/pstl_test_config.h"
08:24:32           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
08:24:32  1 error generated.

Signed-off-by: Xiaodong, Li <xiaodong.li@intel.com>