### PR TITLE
CMake: add oneDPLConfig files support

### DIFF
--- a/cmake/README.md
+++ b/cmake/README.md
@@ -47,7 +47,7 @@ For example, `<root>/test/path/to/test.pass.cpp` will have `path` and `to` label
 
 oneDPLConfig.cmake and oneDPLConfigVersion.cmake are included into oneDPL distribution.
 
-These files allow to integrate oneDPL into user project with the find_package() function. Successful invocation of `find_package(oneDPL <options>)` creates imported target `oneDPL` that can be passed to the target_link_libraries() function.
+These files allow to integrate oneDPL into user project with the [find_package](https://cmake.org/cmake/help/latest/command/find_package.html) command. Successful invocation of `find_package(oneDPL <options>)` creates imported target `oneDPL` that can be passed to the [target_link_libraries](https://cmake.org/cmake/help/latest/command/target_link_libraries.html) command.
 
 For example:
 

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -67,6 +67,24 @@ Availability of DPC++ and oneTBB backends is automatically checked during the in
 - macro `ONEDPL_USE_TBB_BACKEND` is set to `0` if oneTBB is not available;
 - macro `ONEDPL_USE_DPCPP_BACKEND` is set to `0` if DPC++ is not available.
 
+Detailed description of these and other macros is available in the [documentation](https://software.intel.com/content/www/us/en/develop/documentation/oneapi-dpcpp-library-guide/top/parallel-stl-overview/macros.html). The macros can be explicitly set from user project.
+
+For example:
+
+```cmake
+project(Foo)
+add_executable(foo foo.cpp)
+
+# Search for oneDPL
+find_package(oneDPL REQUIRED)
+
+# Connect oneDPL to foo
+target_link_libraries(foo oneDPL)
+
+# Disable TBB backend in oneDPL
+target_compile_definitions(foo PRIVATE ONEDPL_USE_TBB_BACKEND=0)
+```
+
 ### oneDPLConfig files generation
 
 `cmake/script/generate_config.cmake` is provided to generate oneDPLConfig files for oneDPL package.

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -42,3 +42,25 @@ The following targets are available for build system after configuration:
 
 Sudirectories are added as labels for each test and can be used with `ctest -L <label>`.
 For example, `<root>/test/path/to/test.pass.cpp` will have `path` and `to` labels.
+
+## oneDPLConfig files
+
+oneDPLConfig.cmake and oneDPLConfigVersion.cmake allow users to integrate oneDPL package into their CMake projects using `find_package(oneDPL <options>)`.
+
+An imported target `oneDPL` is created after successful invocation of `find_package(oneDPL <options>)`. The target can be used via `target_link_libraries` function.
+
+Example of integration:
+
+```cmake
+# Search for oneDPL 2021 or newer.
+find_package(oneDPL 2021 REQUIRED)
+
+# Integrate found oneDPL with foo.
+target_link_libraries(foo oneDPL)
+```
+
+`cmake/script/generate_config.cmake` is provided to generate oneDPLConfig files for oneDPL package.
+
+How to use:
+
+`cmake [-DOUTPUT_DIR=<output_dir>] -P cmake/script/generate_config.cmake`

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -43,21 +43,31 @@ The following targets are available for build system after configuration:
 Sudirectories are added as labels for each test and can be used with `ctest -L <label>`.
 For example, `<root>/test/path/to/test.pass.cpp` will have `path` and `to` labels.
 
-## oneDPLConfig files
+## How to use oneDPL package from CMake
 
-oneDPLConfig.cmake and oneDPLConfigVersion.cmake allow users to integrate oneDPL package into their CMake projects using `find_package(oneDPL <options>)`.
+oneDPLConfig.cmake and oneDPLConfigVersion.cmake are included into oneDPL distribution.
 
-An imported target `oneDPL` is created after successful invocation of `find_package(oneDPL <options>)`. The target can be used via `target_link_libraries` function.
+These files allow to integrate oneDPL into user project with the find_package() function. Successful invocation of `find_package(oneDPL <options>)` creates imported target `oneDPL` that can be passed to the target_link_libraries() function.
 
-Example of integration:
+For example:
 
 ```cmake
-# Search for oneDPL 2021 or newer.
-find_package(oneDPL 2021 REQUIRED)
+project(Foo)
+add_executable(foo foo.cpp)
 
-# Integrate found oneDPL with foo.
+# Search for oneDPL
+find_package(oneDPL REQUIRED)
+
+# Connect oneDPL to foo
 target_link_libraries(foo oneDPL)
 ```
+
+Availability of DPC++ and oneTBB backends is automatically checked during the invocation of `find_package(oneDPL <options>)`:
+
+- macro `ONEDPL_USE_TBB_BACKEND` is set to `0` if oneTBB is not available;
+- macro `ONEDPL_USE_DPCPP_BACKEND` is set to `0` if DPC++ is not available.
+
+### oneDPLConfig files generation
 
 `cmake/script/generate_config.cmake` is provided to generate oneDPLConfig files for oneDPL package.
 

--- a/cmake/scripts/generate_config.cmake
+++ b/cmake/scripts/generate_config.cmake
@@ -1,0 +1,35 @@
+##===----------------------------------------------------------------------===##
+#
+# Copyright (C) 2020 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# This file incorporates work covered by the following copyright and permission
+# notice:
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+#
+##===----------------------------------------------------------------------===##
+
+if (NOT OUTPUT_DIR)
+    set(OUTPUT_DIR "output")
+endif()
+
+set(ONEDPL_ROOT "${CMAKE_CURRENT_LIST_DIR}/../..")
+
+file(READ ${ONEDPL_ROOT}/include/oneapi/dpl/pstl/onedpl_config.h _onedpl_version_info LIMIT 1024)
+string(REGEX REPLACE ".*#define ONEDPL_VERSION_MAJOR ([0-9]+).*" "\\1" _onedpl_ver_major "${_onedpl_version_info}")
+string(REGEX REPLACE ".*#define ONEDPL_VERSION_MINOR ([0-9]+).*" "\\1" _onedpl_ver_minor "${_onedpl_version_info}")
+string(REGEX REPLACE ".*#define ONEDPL_VERSION_PATCH ([0-9]+).*" "\\1" _onedpl_ver_patch "${_onedpl_version_info}")
+
+set(PROJECT_VERSION "${_onedpl_ver_major}.${_onedpl_ver_minor}.${_onedpl_ver_patch}")
+
+configure_file("${ONEDPL_ROOT}/cmake/templates/oneDPLConfig.cmake.in"
+               "${OUTPUT_DIR}/oneDPLConfig.cmake"
+               COPYONLY)
+configure_file("${ONEDPL_ROOT}/cmake/templates/oneDPLConfigVersion.cmake.in"
+               "${OUTPUT_DIR}/oneDPLConfigVersion.cmake"
+               @ONLY)
+
+message(STATUS "oneDPL ${PROJECT_VERSION} configuration files were created in '${OUTPUT_DIR}'")

--- a/cmake/templates/oneDPLConfig.cmake.in
+++ b/cmake/templates/oneDPLConfig.cmake.in
@@ -1,0 +1,46 @@
+##===----------------------------------------------------------------------===##
+#
+# Copyright (C) 2020 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# This file incorporates work covered by the following copyright and permission
+# notice:
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+#
+##===----------------------------------------------------------------------===##
+
+# Installation path: <onedpl_root>/lib/cmake/oneDPL/
+get_filename_component(_onedpl_root "${CMAKE_CURRENT_LIST_DIR}" REALPATH)
+get_filename_component(_onedpl_root "${_onedpl_root}/../../../" ABSOLUTE)
+
+get_filename_component(_onedpl_headers "${_onedpl_root}/include" ABSOLUTE)
+
+if (EXISTS "${_onedpl_headers}")
+    if (NOT TARGET oneDPL)
+        add_library(oneDPL INTERFACE IMPORTED)
+        set_target_properties(oneDPL PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${_onedpl_headers}")
+
+        # Handle oneTBB backend
+        find_package(TBB 2021 QUIET COMPONENTS tbb)
+        if (NOT TBB_FOUND)
+            message(STATUS "oneDPL: oneTBB is not found, set ONEDPL_USE_TBB_BACKEND=0")
+            set_target_properties(oneDPL PROPERTIES INTERFACE_COMPILE_DEFINITIONS ONEDPL_USE_TBB_BACKEND=0)
+        else()
+            set_target_properties(oneDPL PROPERTIES INTERFACE_LINK_LIBRARIES TBB::tbb)
+        endif()
+
+        # Handle DPC++ backend
+        include(CheckCXXCompilerFlag)
+        check_cxx_compiler_flag("-fsycl" _fsycl_option)
+        if (NOT _fsycl_option)
+            message(STATUS "oneDPL: -fsycl is not supported by current compiler, set ONEDPL_USE_DPCPP_BACKEND=0")
+            set_target_properties(oneDPL PROPERTIES INTERFACE_COMPILE_DEFINITIONS ONEDPL_USE_DPCPP_BACKEND=0)
+        endif()
+    endif()
+else()
+    message(STATUS "oneDPL: headers do not exist ${_onedpl_headers}")
+    set(ONEDPL_FOUND FALSE)
+endif()

--- a/cmake/templates/oneDPLConfigVersion.cmake.in
+++ b/cmake/templates/oneDPLConfigVersion.cmake.in
@@ -1,0 +1,34 @@
+##===----------------------------------------------------------------------===##
+#
+# Copyright (C) 2020 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+#
+# This file incorporates work covered by the following copyright and permission
+# notice:
+#
+# Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+# See https://llvm.org/LICENSE.txt for license information.
+#
+##===----------------------------------------------------------------------===##
+
+set(PACKAGE_VERSION "@PROJECT_VERSION@")
+
+if (PACKAGE_FIND_VERSION_RANGE)
+  if ((PACKAGE_FIND_VERSION_RANGE_MIN STREQUAL "INCLUDE" AND PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION_MIN)
+      OR ((PACKAGE_FIND_VERSION_RANGE_MAX STREQUAL "INCLUDE" AND PACKAGE_VERSION VERSION_GREATER PACKAGE_FIND_VERSION_MAX)
+        OR (PACKAGE_FIND_VERSION_RANGE_MAX STREQUAL "EXCLUDE" AND PACKAGE_VERSION VERSION_GREATER_EQUAL PACKAGE_FIND_VERSION_MAX)))
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+  else()
+    set(PACKAGE_VERSION_COMPATIBLE TRUE)
+  endif()
+else()
+  if(PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION)
+    set(PACKAGE_VERSION_COMPATIBLE FALSE)
+  else()
+    set(PACKAGE_VERSION_COMPATIBLE TRUE)
+    if(PACKAGE_FIND_VERSION STREQUAL PACKAGE_VERSION)
+      set(PACKAGE_VERSION_EXACT TRUE)
+    endif()
+  endif()
+endif()


### PR DESCRIPTION
Documentation: https://github.com/oneapi-src/oneDPL/tree/dev/cmake-config-files/cmake#onedplconfig-files

Currently oneDPLConfig works with backends in a following way:
1. Try to find oneTBB and link it if found or set `ONEDPL_USE_TBB_BACKEND=0` otherwise.
1. Check if compiler supports `-fsycl` and set `ONEDPL_USE_DPCPP_BACKEND=0` if it is not.