### PR TITLE
CMake: fix -O0 key adding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ endif()
 if (MSVC)
     target_compile_options(oneDPL INTERFACE /Zc:__cplusplus /EHsc)
 else()
-    target_compile_options(oneDPL INTERFACE $<$<CONFIG:Debug>:-O0>)
+    set(CMAKE_CXX_FLAGS_DEBUG "-O0 ${CMAKE_CXX_FLAGS_DEBUG}")
 endif()
 
 if (ONEDPL_USE_PARALLEL_POLICIES)


### PR DESCRIPTION
Without this fix `-O0` is passed only during compilation, but not linkage, it causes problems if default optimization level is not `-O0`