### PR TITLE
[RNG][Tests] Add tests skipping for non-SYCL compilers + reduce test scope

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -74,7 +74,7 @@ macro(onedpl_add_test test_source_file)
     add_dependencies(build-all ${_test_name})
 endmacro()
 
-set(_skip_regex_for_not_dpcpp "(rng_testsuite|extensions_testsuite)")
+set(_skip_regex_for_not_dpcpp "(extensions_testsuite)")
 file(GLOB_RECURSE UNIT_TESTS "*.pass.cpp")
 foreach (_file IN LISTS UNIT_TESTS)
     if (_file MATCHES "${_skip_regex_for_not_dpcpp}" AND NOT ONEDPL_BACKEND MATCHES "^(dpcpp|dpcpp_only)$")

--- a/test/rng_testsuite/conformance_tests/common_for_conformance_tests.hpp
+++ b/test/rng_testsuite/conformance_tests/common_for_conformance_tests.hpp
@@ -20,7 +20,6 @@
 #ifndef DPSTD_RANDOM_CONFORMANCE_TESTS_COMMON
 #define DPSTD_RANDOM_CONFORMANCE_TESTS_COMMON
 
-#include <iostream>
 #include <vector>
 #include <CL/sycl.hpp>
 #include <random>

--- a/test/rng_testsuite/conformance_tests/minstd_rand_rand0_test.pass.cpp
+++ b/test/rng_testsuite/conformance_tests/minstd_rand_rand0_test.pass.cpp
@@ -29,14 +29,14 @@
 
 #include <iostream>
 
-#if ONEDPL_USE_DPCPP_BACKEND
+#if _ONEDPL_BACKEND_SYCL
 #include "common_for_conformance_tests.hpp"
 #include <oneapi/dpl/random>
-#endif // ONEDPL_USE_DPCPP_BACKEND
+#endif // _ONEDPL_BACKEND_SYCL
 
 int main() {
 
-#if ONEDPL_USE_DPCPP_BACKEND
+#if _ONEDPL_BACKEND_SYCL
 
     // Reference values
     uint_fast32_t minstd_rand0_ref_sample = 1043618065;
@@ -98,7 +98,7 @@ int main() {
 
 #else
     std::cout << "\tTest is skipped for non-SYCL backend" << std::endl;
-#endif // ONEDPL_USE_DPCPP_BACKEND
+#endif // _ONEDPL_BACKEND_SYCL
 
     std::cout << "Test PASSED" << std::endl;
     return 0;

--- a/test/rng_testsuite/conformance_tests/minstd_rand_rand0_test.pass.cpp
+++ b/test/rng_testsuite/conformance_tests/minstd_rand_rand0_test.pass.cpp
@@ -27,20 +27,16 @@
 //     The 10000th consecutive invocation of a default-constructed object of type minstd_rand
 //     produces the value 399268537
 
-#if (!defined(_ONEDPL_BACKEND_SYCL) || (_ONEDPL_BACKEND_SYCL == 0))
 #include <iostream>
 
-int main() {
-    std::cout << "\tTest is skipped for non-SYCL backend. Passed" << std::endl;
-    return 0;
-}
-
-#else
-
+#if ONEDPL_USE_DPCPP_BACKEND
 #include "common_for_conformance_tests.hpp"
 #include <oneapi/dpl/random>
+#endif // ONEDPL_USE_DPCPP_BACKEND
 
 int main() {
+
+#if ONEDPL_USE_DPCPP_BACKEND
 
     // Reference values
     uint_fast32_t minstd_rand0_ref_sample = 1043618065;
@@ -63,15 +59,12 @@ int main() {
     std::cout << "The 10000th produced value of oneapi::dpl::minstd_rand0_vec<4> is "  << minstd_rand0_sample_vec4 << std::endl;
     std::cout << "The 10000th produced value of oneapi::dpl::minstd_rand0_vec<8> is "  << minstd_rand0_sample_vec8 << std::endl;
     std::cout << "The 10000th produced value of oneapi::dpl::minstd_rand0_vec<16> is " << minstd_rand0_sample_vec16 << std::endl;
-    if((minstd_rand0_ref_sample == minstd_rand0_sample)                   &&
-        (minstd_rand0_ref_sample == minstd_rand0_sample_vec2)             &&
-        (minstd_rand0_ref_sample == minstd_rand0_sample_vec3)             &&
-        (minstd_rand0_ref_sample == minstd_rand0_sample_vec4)             &&
-        (minstd_rand0_ref_sample == minstd_rand0_sample_vec8)             &&
-        (minstd_rand0_ref_sample == minstd_rand0_sample_vec16)) {
-        std::cout << "Test PASSED" << std::endl;
-    }
-    else {
+    if((minstd_rand0_ref_sample != minstd_rand0_sample)                   ||
+        (minstd_rand0_ref_sample != minstd_rand0_sample_vec2)             ||
+        (minstd_rand0_ref_sample != minstd_rand0_sample_vec3)             ||
+        (minstd_rand0_ref_sample != minstd_rand0_sample_vec4)             ||
+        (minstd_rand0_ref_sample != minstd_rand0_sample_vec8)             ||
+        (minstd_rand0_ref_sample != minstd_rand0_sample_vec16)) {
         std::cout << "Test FAILED" << std::endl;
         return 1;
     }
@@ -85,6 +78,7 @@ int main() {
     auto minstd_rand_sample_vec8  = test<oneapi::dpl::minstd_rand_vec<8>, 10000, 8>();
     auto minstd_rand_sample_vec16 = test<oneapi::dpl::minstd_rand_vec<16>,10000, 16>();
 
+    // Comparison
     std::cout << "\nThe 10000th reference value of minstd_rand engine is "                    << minstd_rand_ref_sample  << std::endl;
     std::cout << "The 10000th produced value of oneapi::dpl::minstd_rand is "                  << minstd_rand_sample << std::endl;
     std::cout << "The 10000th produced value of oneapi::dpl::minstd_rand_vec<2> is "           << minstd_rand_sample_vec2 << std::endl;
@@ -92,20 +86,20 @@ int main() {
     std::cout << "The 10000th produced value of oneapi::dpl::minstd_rand_vec<4> is "           << minstd_rand_sample_vec4 << std::endl;
     std::cout << "The 10000th produced value of oneapi::dpl::minstd_rand_vec<8> is "           << minstd_rand_sample_vec8 << std::endl;
     std::cout << "The 10000th produced value of oneapi::dpl::minstd_rand_vec<16> is "          << minstd_rand_sample_vec16 << std::endl;
-    if((minstd_rand_ref_sample == minstd_rand_sample)                   &&
-        (minstd_rand_ref_sample == minstd_rand_sample_vec2)             &&
-        (minstd_rand_ref_sample == minstd_rand_sample_vec3)             &&
-        (minstd_rand_ref_sample == minstd_rand_sample_vec4)             &&
-        (minstd_rand_ref_sample == minstd_rand_sample_vec8)             &&
-        (minstd_rand_ref_sample == minstd_rand_sample_vec16)) {
-        std::cout << "Test PASSED" << std::endl;
-    }
-    else {
+    if((minstd_rand_ref_sample != minstd_rand_sample)                   ||
+        (minstd_rand_ref_sample != minstd_rand_sample_vec2)             ||
+        (minstd_rand_ref_sample != minstd_rand_sample_vec3)             ||
+        (minstd_rand_ref_sample != minstd_rand_sample_vec4)             ||
+        (minstd_rand_ref_sample != minstd_rand_sample_vec8)             ||
+        (minstd_rand_ref_sample != minstd_rand_sample_vec16)) {
         std::cout << "Test FAILED" << std::endl;
         return 1;
     }
 
+#else
+    std::cout << "\tTest is skipped for non-SYCL backend" << std::endl;
+#endif // ONEDPL_USE_DPCPP_BACKEND
+
+    std::cout << "Test PASSED" << std::endl;
     return 0;
 }
-
-#endif // #if (!defined(_ONEDPL_BACKEND_SYCL) || (_ONEDPL_BACKEND_SYCL == 0))

--- a/test/rng_testsuite/conformance_tests/minstd_rand_rand0_test.pass.cpp
+++ b/test/rng_testsuite/conformance_tests/minstd_rand_rand0_test.pass.cpp
@@ -27,6 +27,15 @@
 //     The 10000th consecutive invocation of a default-constructed object of type minstd_rand
 //     produces the value 399268537
 
+#if (!defined(_ONEDPL_BACKEND_SYCL) || (_ONEDPL_BACKEND_SYCL == 0))
+#include <iostream>
+
+int main() {
+    std::cout << "\tTest is skipped for non-SYCL backend. Passed" << std::endl;
+    return 0;
+}
+
+#else
 
 #include "common_for_conformance_tests.hpp"
 #include <oneapi/dpl/random>
@@ -98,3 +107,5 @@ int main() {
 
     return 0;
 }
+
+#endif // #if (!defined(_ONEDPL_BACKEND_SYCL) || (_ONEDPL_BACKEND_SYCL == 0))

--- a/test/rng_testsuite/conformance_tests/ranlux_24_48_base_test.pass.cpp
+++ b/test/rng_testsuite/conformance_tests/ranlux_24_48_base_test.pass.cpp
@@ -27,20 +27,16 @@
 //     The 10000th consecutive invocation of a default-constructed object of type ranlux48_base
 //     produces the value 61839128582725
 
-#if (!defined(_ONEDPL_BACKEND_SYCL) || (_ONEDPL_BACKEND_SYCL == 0))
 #include <iostream>
 
-int main() {
-    std::cout << "\tTest is skipped for non-SYCL backend. Passed" << std::endl;
-    return 0;
-}
-
-#else
-
+#if ONEDPL_USE_DPCPP_BACKEND
 #include "common_for_conformance_tests.hpp"
 #include <oneapi/dpl/random>
+#endif // ONEDPL_USE_DPCPP_BACKEND
 
 int main() {
+
+#if ONEDPL_USE_DPCPP_BACKEND
 
     // Reference values
     uint_fast32_t ranlux24_base_ref_sample = 7937952;
@@ -63,19 +59,15 @@ int main() {
     std::cout << "The 10000th produced value of oneapi::dpl::ranlux24_base_vec<4> is "  << ranlux24_base_sample_vec4 << std::endl;
     std::cout << "The 10000th produced value of oneapi::dpl::ranlux24_base_vec<8> is "  << ranlux24_base_sample_vec8 << std::endl;
     std::cout << "The 10000th produced value of oneapi::dpl::ranlux24_base_vec<16> is " << ranlux24_base_sample_vec16 << std::endl;
-    if((ranlux24_base_ref_sample == ranlux24_base_sample)                   &&
-        (ranlux24_base_ref_sample == ranlux24_base_sample_vec2)             &&
-        (ranlux24_base_ref_sample == ranlux24_base_sample_vec3)             &&
-        (ranlux24_base_ref_sample == ranlux24_base_sample_vec4)             &&
-        (ranlux24_base_ref_sample == ranlux24_base_sample_vec8)             &&
-        (ranlux24_base_ref_sample == ranlux24_base_sample_vec16)) {
-        std::cout << "Test PASSED" << std::endl;
-    }
-    else {
+    if((ranlux24_base_ref_sample != ranlux24_base_sample)                   ||
+        (ranlux24_base_ref_sample != ranlux24_base_sample_vec2)             ||
+        (ranlux24_base_ref_sample != ranlux24_base_sample_vec3)             ||
+        (ranlux24_base_ref_sample != ranlux24_base_sample_vec4)             ||
+        (ranlux24_base_ref_sample != ranlux24_base_sample_vec8)             ||
+        (ranlux24_base_ref_sample != ranlux24_base_sample_vec16)) {
         std::cout << "Test FAILED" << std::endl;
         return 1;
     }
-
 
     auto ranlux48_base_sample       = test<oneapi::dpl::ranlux48_base,        10000, 1>();
     auto ranlux48_base_sample_vec2  = test<oneapi::dpl::ranlux48_base_vec<2>, 10000, 2>();
@@ -85,6 +77,7 @@ int main() {
     auto ranlux48_base_sample_vec8  = test<oneapi::dpl::ranlux48_base_vec<8>, 10000, 8>();
     auto ranlux48_base_sample_vec16 = test<oneapi::dpl::ranlux48_base_vec<16>,10000, 16>();
 
+    // Comparison
     std::cout << "\nThe 10000th reference value of ranlux48_base engine is "                    << ranlux48_base_ref_sample  << std::endl;
     std::cout << "The 10000th produced value of oneapi::dpl::ranlux48_base is "                  << ranlux48_base_sample << std::endl;
     std::cout << "The 10000th produced value of oneapi::dpl::ranlux48_base_vec<2> is "           << ranlux48_base_sample_vec2 << std::endl;
@@ -92,20 +85,20 @@ int main() {
     std::cout << "The 10000th produced value of oneapi::dpl::ranlux48_base_vec<4> is "           << ranlux48_base_sample_vec4 << std::endl;
     std::cout << "The 10000th produced value of oneapi::dpl::ranlux48_base_vec<8> is "           << ranlux48_base_sample_vec8 << std::endl;
     std::cout << "The 10000th produced value of oneapi::dpl::ranlux48_base_vec<16> is "          << ranlux48_base_sample_vec16 << std::endl;
-    if((ranlux48_base_ref_sample == ranlux48_base_sample)                   &&
-        (ranlux48_base_ref_sample == ranlux48_base_sample_vec2)             &&
-        (ranlux48_base_ref_sample == ranlux48_base_sample_vec3)             &&
-        (ranlux48_base_ref_sample == ranlux48_base_sample_vec4)             &&
-        (ranlux48_base_ref_sample == ranlux48_base_sample_vec8)             &&
-        (ranlux48_base_ref_sample == ranlux48_base_sample_vec16)) {
-        std::cout << "Test PASSED" << std::endl;
-    }
-    else {
+    if((ranlux48_base_ref_sample != ranlux48_base_sample)                   ||
+        (ranlux48_base_ref_sample != ranlux48_base_sample_vec2)             ||
+        (ranlux48_base_ref_sample != ranlux48_base_sample_vec3)             ||
+        (ranlux48_base_ref_sample != ranlux48_base_sample_vec4)             ||
+        (ranlux48_base_ref_sample != ranlux48_base_sample_vec8)             ||
+        (ranlux48_base_ref_sample != ranlux48_base_sample_vec16)) {
         std::cout << "Test FAILED" << std::endl;
         return 1;
     }
 
+#else
+    std::cout << "\tTest is skipped for non-SYCL backend" << std::endl;
+#endif // ONEDPL_USE_DPCPP_BACKEND
+
+    std::cout << "Test PASSED" << std::endl;
     return 0;
 }
-
-#endif // #if (!defined(_ONEDPL_BACKEND_SYCL) || (_ONEDPL_BACKEND_SYCL == 0))

--- a/test/rng_testsuite/conformance_tests/ranlux_24_48_base_test.pass.cpp
+++ b/test/rng_testsuite/conformance_tests/ranlux_24_48_base_test.pass.cpp
@@ -27,6 +27,15 @@
 //     The 10000th consecutive invocation of a default-constructed object of type ranlux48_base
 //     produces the value 61839128582725
 
+#if (!defined(_ONEDPL_BACKEND_SYCL) || (_ONEDPL_BACKEND_SYCL == 0))
+#include <iostream>
+
+int main() {
+    std::cout << "\tTest is skipped for non-SYCL backend. Passed" << std::endl;
+    return 0;
+}
+
+#else
 
 #include "common_for_conformance_tests.hpp"
 #include <oneapi/dpl/random>
@@ -98,3 +107,5 @@ int main() {
 
     return 0;
 }
+
+#endif // #if (!defined(_ONEDPL_BACKEND_SYCL) || (_ONEDPL_BACKEND_SYCL == 0))

--- a/test/rng_testsuite/conformance_tests/ranlux_24_48_base_test.pass.cpp
+++ b/test/rng_testsuite/conformance_tests/ranlux_24_48_base_test.pass.cpp
@@ -29,14 +29,14 @@
 
 #include <iostream>
 
-#if ONEDPL_USE_DPCPP_BACKEND
+#if _ONEDPL_BACKEND_SYCL
 #include "common_for_conformance_tests.hpp"
 #include <oneapi/dpl/random>
-#endif // ONEDPL_USE_DPCPP_BACKEND
+#endif // _ONEDPL_BACKEND_SYCL
 
 int main() {
 
-#if ONEDPL_USE_DPCPP_BACKEND
+#if _ONEDPL_BACKEND_SYCL
 
     // Reference values
     uint_fast32_t ranlux24_base_ref_sample = 7937952;
@@ -97,7 +97,7 @@ int main() {
 
 #else
     std::cout << "\tTest is skipped for non-SYCL backend" << std::endl;
-#endif // ONEDPL_USE_DPCPP_BACKEND
+#endif // _ONEDPL_BACKEND_SYCL
 
     std::cout << "Test PASSED" << std::endl;
     return 0;

--- a/test/rng_testsuite/conformance_tests/ranlux_24_48_test.pass.cpp
+++ b/test/rng_testsuite/conformance_tests/ranlux_24_48_test.pass.cpp
@@ -29,14 +29,14 @@
 
 #include <iostream>
 
-#if ONEDPL_USE_DPCPP_BACKEND
+#if _ONEDPL_BACKEND_SYCL
 #include "common_for_conformance_tests.hpp"
 #include <oneapi/dpl/random>
-#endif // ONEDPL_USE_DPCPP_BACKEND
+#endif // _ONEDPL_BACKEND_SYCL
 
 int main() {
 
-#if ONEDPL_USE_DPCPP_BACKEND
+#if _ONEDPL_BACKEND_SYCL
 
     // Reference values
     uint_fast32_t ranlux24_ref_sample = 9901578;
@@ -97,7 +97,7 @@ int main() {
 
 #else
     std::cout << "\tTest is skipped for non-SYCL backend" << std::endl;
-#endif // ONEDPL_USE_DPCPP_BACKEND
+#endif // _ONEDPL_BACKEND_SYCL
 
     std::cout << "Test PASSED" << std::endl;
     return 0;

--- a/test/rng_testsuite/conformance_tests/ranlux_24_48_test.pass.cpp
+++ b/test/rng_testsuite/conformance_tests/ranlux_24_48_test.pass.cpp
@@ -27,6 +27,16 @@
 //     The 10000th consecutive invocation of a default-constructed object of type ranlux48
 //     produces the value 249142670248501
 
+#if (!defined(_ONEDPL_BACKEND_SYCL) || (_ONEDPL_BACKEND_SYCL == 0))
+#include <iostream>
+
+int main() {
+    std::cout << "\tTest is skipped for non-SYCL backend. Passed" << std::endl;
+    return 0;
+}
+
+#else
+
 #include "common_for_conformance_tests.hpp"
 #include <oneapi/dpl/random>
 
@@ -97,3 +107,5 @@ int main() {
 
     return 0;
 }
+
+#endif // #if (!defined(_ONEDPL_BACKEND_SYCL) || (_ONEDPL_BACKEND_SYCL == 0))

--- a/test/rng_testsuite/conformance_tests/ranlux_24_48_test.pass.cpp
+++ b/test/rng_testsuite/conformance_tests/ranlux_24_48_test.pass.cpp
@@ -27,20 +27,16 @@
 //     The 10000th consecutive invocation of a default-constructed object of type ranlux48
 //     produces the value 249142670248501
 
-#if (!defined(_ONEDPL_BACKEND_SYCL) || (_ONEDPL_BACKEND_SYCL == 0))
 #include <iostream>
 
-int main() {
-    std::cout << "\tTest is skipped for non-SYCL backend. Passed" << std::endl;
-    return 0;
-}
-
-#else
-
+#if ONEDPL_USE_DPCPP_BACKEND
 #include "common_for_conformance_tests.hpp"
 #include <oneapi/dpl/random>
+#endif // ONEDPL_USE_DPCPP_BACKEND
 
 int main() {
+
+#if ONEDPL_USE_DPCPP_BACKEND
 
     // Reference values
     uint_fast32_t ranlux24_ref_sample = 9901578;
@@ -63,19 +59,15 @@ int main() {
     std::cout << "The 10000th produced value of oneapi::dpl::ranlux24_vec<4> is "  << ranlux24_sample_vec4 << std::endl;
     std::cout << "The 10000th produced value of oneapi::dpl::ranlux24_vec<8> is "  << ranlux24_sample_vec8 << std::endl;
     std::cout << "The 10000th produced value of oneapi::dpl::ranlux24_vec<16> is " << ranlux24_sample_vec16 << std::endl;
-    if((ranlux24_ref_sample == ranlux24_sample)                   &&
-        (ranlux24_ref_sample == ranlux24_sample_vec2)             &&
-        (ranlux24_ref_sample == ranlux24_sample_vec3)             &&
-        (ranlux24_ref_sample == ranlux24_sample_vec4)             &&
-        (ranlux24_ref_sample == ranlux24_sample_vec8)             &&
-        (ranlux24_ref_sample == ranlux24_sample_vec16)) {
-        std::cout << "Test PASSED" << std::endl;
-    }
-    else {
+    if((ranlux24_ref_sample != ranlux24_sample)                   ||
+        (ranlux24_ref_sample != ranlux24_sample_vec2)             ||
+        (ranlux24_ref_sample != ranlux24_sample_vec3)             ||
+        (ranlux24_ref_sample != ranlux24_sample_vec4)             ||
+        (ranlux24_ref_sample != ranlux24_sample_vec8)             ||
+        (ranlux24_ref_sample != ranlux24_sample_vec16)) {
         std::cout << "Test FAILED" << std::endl;
         return 1;
     }
-
 
     auto ranlux48_sample       = test<oneapi::dpl::ranlux48,        10000, 1>();
     auto ranlux48_sample_vec2  = test<oneapi::dpl::ranlux48_vec<2>, 10000, 2>();
@@ -85,6 +77,7 @@ int main() {
     auto ranlux48_sample_vec8  = test<oneapi::dpl::ranlux48_vec<8>, 10000, 8>();
     auto ranlux48_sample_vec16 = test<oneapi::dpl::ranlux48_vec<16>,10000, 16>();
 
+    // Comparison
     std::cout << "\nThe 10000th reference value of ranlux48 engine is "                    << ranlux48_ref_sample  << std::endl;
     std::cout << "The 10000th produced value of oneapi::dpl::ranlux48 is "                  << ranlux48_sample << std::endl;
     std::cout << "The 10000th produced value of oneapi::dpl::ranlux48_vec<2> is "           << ranlux48_sample_vec2 << std::endl;
@@ -92,20 +85,20 @@ int main() {
     std::cout << "The 10000th produced value of oneapi::dpl::ranlux48_vec<4> is "           << ranlux48_sample_vec4 << std::endl;
     std::cout << "The 10000th produced value of oneapi::dpl::ranlux48_vec<8> is "           << ranlux48_sample_vec8 << std::endl;
     std::cout << "The 10000th produced value of oneapi::dpl::ranlux48_vec<16> is "          << ranlux48_sample_vec16 << std::endl;
-    if((ranlux48_ref_sample == ranlux48_sample)                   &&
-        (ranlux48_ref_sample == ranlux48_sample_vec2)             &&
-        (ranlux48_ref_sample == ranlux48_sample_vec3)             &&
-        (ranlux48_ref_sample == ranlux48_sample_vec4)             &&
-        (ranlux48_ref_sample == ranlux48_sample_vec8)             &&
-        (ranlux48_ref_sample == ranlux48_sample_vec16)) {
-        std::cout << "Test PASSED" << std::endl;
-    }
-    else {
+    if((ranlux48_ref_sample != ranlux48_sample)                   ||
+        (ranlux48_ref_sample != ranlux48_sample_vec2)             ||
+        (ranlux48_ref_sample != ranlux48_sample_vec3)             ||
+        (ranlux48_ref_sample != ranlux48_sample_vec4)             ||
+        (ranlux48_ref_sample != ranlux48_sample_vec8)             ||
+        (ranlux48_ref_sample != ranlux48_sample_vec16)) {
         std::cout << "Test FAILED" << std::endl;
         return 1;
     }
 
+#else
+    std::cout << "\tTest is skipped for non-SYCL backend" << std::endl;
+#endif // ONEDPL_USE_DPCPP_BACKEND
+
+    std::cout << "Test PASSED" << std::endl;
     return 0;
 }
-
-#endif // #if (!defined(_ONEDPL_BACKEND_SYCL) || (_ONEDPL_BACKEND_SYCL == 0))

--- a/test/rng_testsuite/statistics_tests/normal_distribution_test.pass.cpp
+++ b/test/rng_testsuite/statistics_tests/normal_distribution_test.pass.cpp
@@ -17,6 +17,16 @@
 //
 // Test of normal_distribution - comparison with std::
 
+#if (!defined(_ONEDPL_BACKEND_SYCL) || (_ONEDPL_BACKEND_SYCL == 0))
+#include <iostream>
+
+int main() {
+    std::cout << "\tTest is skipped for non-SYCL backend. Passed" << std::endl;
+    return 0;
+}
+
+#else
+
 #include <iostream>
 #include <CL/sycl.hpp>
 #include <random>
@@ -349,3 +359,5 @@ int main() {
     std::cout << "Test PASSED" << std::endl;
     return 0;
 }
+
+#endif // #if (!defined(_ONEDPL_BACKEND_SYCL) || (_ONEDPL_BACKEND_SYCL == 0))

--- a/test/rng_testsuite/statistics_tests/normal_distribution_test.pass.cpp
+++ b/test/rng_testsuite/statistics_tests/normal_distribution_test.pass.cpp
@@ -19,7 +19,7 @@
 
 #include <iostream>
 
-#if ONEDPL_USE_DPCPP_BACKEND
+#if _ONEDPL_BACKEND_SYCL
 #include <CL/sycl.hpp>
 #include <random>
 #include <limits>
@@ -254,11 +254,11 @@ int tests_set_portion(std::int32_t nsamples, unsigned int part) {
     return 0;
 }
 
-#endif // ONEDPL_USE_DPCPP_BACKEND
+#endif // _ONEDPL_BACKEND_SYCL
 
 int main() {
 
-#if ONEDPL_USE_DPCPP_BACKEND
+#if _ONEDPL_BACKEND_SYCL
 
     constexpr int nsamples = 100;
     int err;
@@ -355,7 +355,7 @@ int main() {
 
 #else
     std::cout << "\tTest is skipped for non-SYCL backend" << std::endl;
-#endif // ONEDPL_USE_DPCPP_BACKEND
+#endif // _ONEDPL_BACKEND_SYCL
 
     std::cout << "Test PASSED" << std::endl;
     return 0;

--- a/test/rng_testsuite/statistics_tests/normal_distribution_test.pass.cpp
+++ b/test/rng_testsuite/statistics_tests/normal_distribution_test.pass.cpp
@@ -17,17 +17,9 @@
 //
 // Test of normal_distribution - comparison with std::
 
-#if (!defined(_ONEDPL_BACKEND_SYCL) || (_ONEDPL_BACKEND_SYCL == 0))
 #include <iostream>
 
-int main() {
-    std::cout << "\tTest is skipped for non-SYCL backend. Passed" << std::endl;
-    return 0;
-}
-
-#else
-
-#include <iostream>
+#if ONEDPL_USE_DPCPP_BACKEND
 #include <CL/sycl.hpp>
 #include <random>
 #include <limits>
@@ -262,7 +254,12 @@ int tests_set_portion(std::int32_t nsamples, unsigned int part) {
     return 0;
 }
 
+#endif // ONEDPL_USE_DPCPP_BACKEND
+
 int main() {
+
+#if ONEDPL_USE_DPCPP_BACKEND
+
     constexpr int nsamples = 100;
     int err;
 
@@ -356,8 +353,10 @@ int main() {
         return 1;
     }
 
+#else
+    std::cout << "\tTest is skipped for non-SYCL backend" << std::endl;
+#endif // ONEDPL_USE_DPCPP_BACKEND
+
     std::cout << "Test PASSED" << std::endl;
     return 0;
 }
-
-#endif // #if (!defined(_ONEDPL_BACKEND_SYCL) || (_ONEDPL_BACKEND_SYCL == 0))

--- a/test/rng_testsuite/statistics_tests/uniform_int_distribution_test.pass.cpp
+++ b/test/rng_testsuite/statistics_tests/uniform_int_distribution_test.pass.cpp
@@ -18,17 +18,9 @@
 // Test of uniform_int_distribution - comparison with std::
 // Note not all types can be compared with std:: implementation is different
 
-#if (!defined(_ONEDPL_BACKEND_SYCL) || (_ONEDPL_BACKEND_SYCL == 0))
 #include <iostream>
 
-int main() {
-    std::cout << "\tTest is skipped for non-SYCL backend. Passed" << std::endl;
-    return 0;
-}
-
-#else
-
-#include <iostream>
+#if ONEDPL_USE_DPCPP_BACKEND
 #include <vector>
 #include <CL/sycl.hpp>
 #include <random>
@@ -243,7 +235,12 @@ int tests_set_portion(int nsamples, unsigned int part) {
     return 0;
 }
 
+#endif // ONEDPL_USE_DPCPP_BACKEND
+
 int main() {
+
+#if ONEDPL_USE_DPCPP_BACKEND
+
     constexpr int nsamples = 100;
     int err;
 
@@ -314,8 +311,10 @@ int main() {
         return 1;
     }
 
+#else
+    std::cout << "\tTest is skipped for non-SYCL backend" << std::endl;
+#endif // ONEDPL_USE_DPCPP_BACKEND
+
     std::cout << "Test PASSED" << std::endl;
     return 0;
 }
-
-#endif // #if (!defined(_ONEDPL_BACKEND_SYCL) || (_ONEDPL_BACKEND_SYCL == 0))

--- a/test/rng_testsuite/statistics_tests/uniform_int_distribution_test.pass.cpp
+++ b/test/rng_testsuite/statistics_tests/uniform_int_distribution_test.pass.cpp
@@ -18,6 +18,16 @@
 // Test of uniform_int_distribution - comparison with std::
 // Note not all types can be compared with std:: implementation is different
 
+#if (!defined(_ONEDPL_BACKEND_SYCL) || (_ONEDPL_BACKEND_SYCL == 0))
+#include <iostream>
+
+int main() {
+    std::cout << "\tTest is skipped for non-SYCL backend. Passed" << std::endl;
+    return 0;
+}
+
+#else
+
 #include <iostream>
 #include <vector>
 #include <CL/sycl.hpp>
@@ -307,3 +317,5 @@ int main() {
     std::cout << "Test PASSED" << std::endl;
     return 0;
 }
+
+#endif // #if (!defined(_ONEDPL_BACKEND_SYCL) || (_ONEDPL_BACKEND_SYCL == 0))

--- a/test/rng_testsuite/statistics_tests/uniform_int_distribution_test.pass.cpp
+++ b/test/rng_testsuite/statistics_tests/uniform_int_distribution_test.pass.cpp
@@ -20,7 +20,7 @@
 
 #include <iostream>
 
-#if ONEDPL_USE_DPCPP_BACKEND
+#if _ONEDPL_BACKEND_SYCL
 #include <vector>
 #include <CL/sycl.hpp>
 #include <random>
@@ -235,11 +235,11 @@ int tests_set_portion(int nsamples, unsigned int part) {
     return 0;
 }
 
-#endif // ONEDPL_USE_DPCPP_BACKEND
+#endif // _ONEDPL_BACKEND_SYCL
 
 int main() {
 
-#if ONEDPL_USE_DPCPP_BACKEND
+#if _ONEDPL_BACKEND_SYCL
 
     constexpr int nsamples = 100;
     int err;
@@ -313,7 +313,7 @@ int main() {
 
 #else
     std::cout << "\tTest is skipped for non-SYCL backend" << std::endl;
-#endif // ONEDPL_USE_DPCPP_BACKEND
+#endif // _ONEDPL_BACKEND_SYCL
 
     std::cout << "Test PASSED" << std::endl;
     return 0;

--- a/test/rng_testsuite/statistics_tests/uniform_real_distribution_test.pass.cpp
+++ b/test/rng_testsuite/statistics_tests/uniform_real_distribution_test.pass.cpp
@@ -20,7 +20,7 @@
 
 #include <iostream>
 
-#if ONEDPL_USE_DPCPP_BACKEND
+#if _ONEDPL_BACKEND_SYCL
 #include <vector>
 #include <CL/sycl.hpp>
 #include <random>
@@ -191,11 +191,11 @@ int tests_set_portion(int nsamples, unsigned int part) {
     return 0;
 }
 
-#endif // ONEDPL_USE_DPCPP_BACKEND
+#endif // _ONEDPL_BACKEND_SYCL
 
 int main() {
 
-#if ONEDPL_USE_DPCPP_BACKEND
+#if _ONEDPL_BACKEND_SYCL
 
     constexpr int nsamples = 100;
     int err;
@@ -280,7 +280,7 @@ int main() {
 
 #else
     std::cout << "\tTest is skipped for non-SYCL backend" << std::endl;
-#endif // ONEDPL_USE_DPCPP_BACKEND
+#endif // _ONEDPL_BACKEND_SYCL
 
     std::cout << "Test PASSED" << std::endl;
     return 0;

--- a/test/rng_testsuite/statistics_tests/uniform_real_distribution_test.pass.cpp
+++ b/test/rng_testsuite/statistics_tests/uniform_real_distribution_test.pass.cpp
@@ -18,6 +18,16 @@
 // Test of uniform_real_distribution - comparison with std::
 // Note not all types can be compared with std:: implementation is different
 
+#if (!defined(_ONEDPL_BACKEND_SYCL) || (_ONEDPL_BACKEND_SYCL == 0))
+#include <iostream>
+
+int main() {
+    std::cout << "\tTest is skipped for non-SYCL backend. Passed" << std::endl;
+    return 0;
+}
+
+#else
+
 #include <iostream>
 #include <vector>
 #include <CL/sycl.hpp>
@@ -274,3 +284,5 @@ int main() {
     std::cout << "Test PASSED" << std::endl;
     return 0;
 }
+
+#endif // #if (!defined(_ONEDPL_BACKEND_SYCL) || (_ONEDPL_BACKEND_SYCL == 0))

--- a/test/rng_testsuite/statistics_tests/uniform_real_distribution_test.pass.cpp
+++ b/test/rng_testsuite/statistics_tests/uniform_real_distribution_test.pass.cpp
@@ -18,17 +18,9 @@
 // Test of uniform_real_distribution - comparison with std::
 // Note not all types can be compared with std:: implementation is different
 
-#if (!defined(_ONEDPL_BACKEND_SYCL) || (_ONEDPL_BACKEND_SYCL == 0))
 #include <iostream>
 
-int main() {
-    std::cout << "\tTest is skipped for non-SYCL backend. Passed" << std::endl;
-    return 0;
-}
-
-#else
-
-#include <iostream>
+#if ONEDPL_USE_DPCPP_BACKEND
 #include <vector>
 #include <CL/sycl.hpp>
 #include <random>
@@ -199,7 +191,12 @@ int tests_set_portion(int nsamples, unsigned int part) {
     return 0;
 }
 
+#endif // ONEDPL_USE_DPCPP_BACKEND
+
 int main() {
+
+#if ONEDPL_USE_DPCPP_BACKEND
+
     constexpr int nsamples = 100;
     int err;
 
@@ -281,8 +278,10 @@ int main() {
         return 1;
     }
 
+#else
+    std::cout << "\tTest is skipped for non-SYCL backend" << std::endl;
+#endif // ONEDPL_USE_DPCPP_BACKEND
+
     std::cout << "Test PASSED" << std::endl;
     return 0;
 }
-
-#endif // #if (!defined(_ONEDPL_BACKEND_SYCL) || (_ONEDPL_BACKEND_SYCL == 0))

--- a/test/rng_testsuite/template_tests/discard_block_std_template_test.pass.cpp
+++ b/test/rng_testsuite/template_tests/discard_block_std_template_test.pass.cpp
@@ -19,7 +19,7 @@
 
 #include <iostream>
 
-#if ONEDPL_USE_DPCPP_BACKEND
+#if _ONEDPL_BACKEND_SYCL
 #include <vector>
 #include <CL/sycl.hpp>
 #include <random>
@@ -172,11 +172,11 @@ int tests_set_portion(int nsamples, unsigned int part) {
     return 0;
 }
 
-#endif // ONEDPL_USE_DPCPP_BACKEND
+#endif // _ONEDPL_BACKEND_SYCL
 
 int main() {
 
-#if ONEDPL_USE_DPCPP_BACKEND
+#if _ONEDPL_BACKEND_SYCL
 
     constexpr int nsamples = 100;
     int err;
@@ -273,7 +273,7 @@ int main() {
 
 #else
     std::cout << "\tTest is skipped for non-SYCL backend" << std::endl;
-#endif // ONEDPL_USE_DPCPP_BACKEND
+#endif // _ONEDPL_BACKEND_SYCL
 
     std::cout << "Test PASSED" << std::endl;
     return 0;

--- a/test/rng_testsuite/template_tests/discard_block_std_template_test.pass.cpp
+++ b/test/rng_testsuite/template_tests/discard_block_std_template_test.pass.cpp
@@ -17,6 +17,16 @@
 //
 // Test of discard_block_engine - comparison with std::
 
+#if (!defined(_ONEDPL_BACKEND_SYCL) || (_ONEDPL_BACKEND_SYCL == 0))
+#include <iostream>
+
+int main() {
+    std::cout << "\tTest is skipped for non-SYCL backend. Passed" << std::endl;
+    return 0;
+}
+
+#else
+
 #include <iostream>
 #include <vector>
 #include <CL/sycl.hpp>
@@ -138,8 +148,8 @@ int test_portion(oneapi::dpl::internal::element_type_t<typename Engine::result_t
 
 template<class Engine, class StdEngine>
 int tests_set(int nsamples) {
-    const int nseeds = 3;
-    int64_t seed_array [nseeds] = {0, 777, 19780503u};
+    const int nseeds = 2;
+    int64_t seed_array [nseeds] = {0, 19780503u};
 
     int err;
     for(int i = 0; i < nseeds; ++i) {
@@ -155,8 +165,8 @@ int tests_set(int nsamples) {
 
 template<class Engine, class StdEngine>
 int tests_set_portion(int nsamples, unsigned int part) {
-    const int nseeds = 2;
-    int64_t seed_array [nseeds] = {0, 19780503u};
+    const int nseeds = 1;
+    int64_t seed_array [nseeds] = {19780503u};
 
     int err;
     for(int i = 0; i < nseeds; ++i) {
@@ -267,3 +277,5 @@ int main() {
     std::cout << "Test PASSED" << std::endl;
     return 0;
 }
+
+#endif // #if (!defined(_ONEDPL_BACKEND_SYCL) || (_ONEDPL_BACKEND_SYCL == 0))

--- a/test/rng_testsuite/template_tests/discard_block_std_template_test.pass.cpp
+++ b/test/rng_testsuite/template_tests/discard_block_std_template_test.pass.cpp
@@ -17,17 +17,9 @@
 //
 // Test of discard_block_engine - comparison with std::
 
-#if (!defined(_ONEDPL_BACKEND_SYCL) || (_ONEDPL_BACKEND_SYCL == 0))
 #include <iostream>
 
-int main() {
-    std::cout << "\tTest is skipped for non-SYCL backend. Passed" << std::endl;
-    return 0;
-}
-
-#else
-
-#include <iostream>
+#if ONEDPL_USE_DPCPP_BACKEND
 #include <vector>
 #include <CL/sycl.hpp>
 #include <random>
@@ -180,7 +172,12 @@ int tests_set_portion(int nsamples, unsigned int part) {
     return 0;
 }
 
+#endif // ONEDPL_USE_DPCPP_BACKEND
+
 int main() {
+
+#if ONEDPL_USE_DPCPP_BACKEND
+
     constexpr int nsamples = 100;
     int err;
 
@@ -274,8 +271,10 @@ int main() {
         return 1;
     }
 
+#else
+    std::cout << "\tTest is skipped for non-SYCL backend" << std::endl;
+#endif // ONEDPL_USE_DPCPP_BACKEND
+
     std::cout << "Test PASSED" << std::endl;
     return 0;
 }
-
-#endif // #if (!defined(_ONEDPL_BACKEND_SYCL) || (_ONEDPL_BACKEND_SYCL == 0))

--- a/test/rng_testsuite/template_tests/linear_congruential_std_template_test.pass.cpp
+++ b/test/rng_testsuite/template_tests/linear_congruential_std_template_test.pass.cpp
@@ -17,17 +17,9 @@
 //
 // Test of linear_congruential_engine - comparison with std::
 
-#if (!defined(_ONEDPL_BACKEND_SYCL) || (_ONEDPL_BACKEND_SYCL == 0))
 #include <iostream>
 
-int main() {
-    std::cout << "\tTest is skipped for non-SYCL backend. Passed" << std::endl;
-    return 0;
-}
-
-#else
-
-#include <iostream>
+#if ONEDPL_USE_DPCPP_BACKEND
 #include <vector>
 #include <CL/sycl.hpp>
 #include <random>
@@ -202,7 +194,12 @@ int tests_set_portion(int nsamples, unsigned int part) {
     return 0;
 }
 
+#endif // ONEDPL_USE_DPCPP_BACKEND
+
 int main() {
+
+#if ONEDPL_USE_DPCPP_BACKEND
+
     constexpr int nsamples = 100;
     int err;
 
@@ -308,7 +305,7 @@ int main() {
         return 1;
     }
 
-#if defined(DETAILED_TESTING)
+#if defined(_ONEDPL_RNG_DETAILED_TESTING)
 
     // testing sycl::vec<std::uint64_t, 1>
     std::cout << "-----------------------------" << std::endl;
@@ -392,10 +389,12 @@ int main() {
         return 1;
     }
 
-#endif // #if defined(DETAILED_TESTING)
+#endif // #if defined(_ONEDPL_RNG_DETAILED_TESTING)
+
+#else
+    std::cout << "\tTest is skipped for non-SYCL backend" << std::endl;
+#endif // ONEDPL_USE_DPCPP_BACKEND
 
     std::cout << "Test PASSED" << std::endl;
     return 0;
 }
-
-#endif // #if (!defined(_ONEDPL_BACKEND_SYCL) || (_ONEDPL_BACKEND_SYCL == 0))

--- a/test/rng_testsuite/template_tests/linear_congruential_std_template_test.pass.cpp
+++ b/test/rng_testsuite/template_tests/linear_congruential_std_template_test.pass.cpp
@@ -19,7 +19,7 @@
 
 #include <iostream>
 
-#if ONEDPL_USE_DPCPP_BACKEND
+#if _ONEDPL_BACKEND_SYCL
 #include <vector>
 #include <CL/sycl.hpp>
 #include <random>
@@ -194,11 +194,11 @@ int tests_set_portion(int nsamples, unsigned int part) {
     return 0;
 }
 
-#endif // ONEDPL_USE_DPCPP_BACKEND
+#endif // _ONEDPL_BACKEND_SYCL
 
 int main() {
 
-#if ONEDPL_USE_DPCPP_BACKEND
+#if _ONEDPL_BACKEND_SYCL
 
     constexpr int nsamples = 100;
     int err;
@@ -393,7 +393,7 @@ int main() {
 
 #else
     std::cout << "\tTest is skipped for non-SYCL backend" << std::endl;
-#endif // ONEDPL_USE_DPCPP_BACKEND
+#endif // _ONEDPL_BACKEND_SYCL
 
     std::cout << "Test PASSED" << std::endl;
     return 0;

--- a/test/rng_testsuite/template_tests/linear_congruential_std_template_test.pass.cpp
+++ b/test/rng_testsuite/template_tests/linear_congruential_std_template_test.pass.cpp
@@ -17,6 +17,16 @@
 //
 // Test of linear_congruential_engine - comparison with std::
 
+#if (!defined(_ONEDPL_BACKEND_SYCL) || (_ONEDPL_BACKEND_SYCL == 0))
+#include <iostream>
+
+int main() {
+    std::cout << "\tTest is skipped for non-SYCL backend. Passed" << std::endl;
+    return 0;
+}
+
+#else
+
 #include <iostream>
 #include <vector>
 #include <CL/sycl.hpp>
@@ -140,8 +150,8 @@ int test_portion(oneapi::dpl::internal::element_type_t<UIntType> seed, int nsamp
 
 template<class Type>
 int tests_set(int nsamples) {
-    const int nseeds = 3;
-    int64_t seed_array [nseeds] = {0, 777, 19780503u};
+    const int nseeds = 2;
+    int64_t seed_array [nseeds] = {0, 19780503u};
 
     int err;
     // Test for all non-zero parameters
@@ -208,7 +218,7 @@ int main() {
 
     // testing std::uint64_t
     std::cout << "-----------------------------" << std::endl;
-    std::cout << "std::uint32_t Type" << std::endl;
+    std::cout << "std::uint64_t Type" << std::endl;
     std::cout << "-----------------------------" << std::endl;
     err += tests_set<std::uint64_t>(nsamples);
     if(err) {
@@ -227,34 +237,12 @@ int main() {
         return 1;
     }
 
-    // testing sycl::vec<std::uint64_t, 1>
-    std::cout << "-----------------------------" << std::endl;
-    std::cout << "sycl::vec<std::uint64_t, 1>" << std::endl;
-    std::cout << "-----------------------------" << std::endl;
-    err += tests_set<sycl::vec<std::uint64_t, 1>>(nsamples);
-    err += tests_set_portion<sycl::vec<std::uint64_t, 1>>(nsamples, 1);
-    if(err) {
-        std::cout << "Test FAILED" << std::endl;
-        return 1;
-    }
-
     // testing sycl::vec<std::uint32_t, 2>
     std::cout << "-----------------------------" << std::endl;
     std::cout << "sycl::vec<std::uint32_t, 2>" << std::endl;
     std::cout << "-----------------------------" << std::endl;
     err += tests_set<sycl::vec<std::uint32_t, 2>>(nsamples);
     err += tests_set_portion<sycl::vec<std::uint32_t, 2>>(nsamples, 1);
-    if(err) {
-        std::cout << "Test FAILED" << std::endl;
-        return 1;
-    }
-
-    // testing sycl::vec<std::uint64_t, 2>
-    std::cout << "-----------------------------" << std::endl;
-    std::cout << "sycl::vec<std::uint64_t, 2>" << std::endl;
-    std::cout << "-----------------------------" << std::endl;
-    err += tests_set<sycl::vec<std::uint64_t, 2>>(nsamples);
-    err += tests_set_portion<sycl::vec<std::uint64_t, 2>>(nsamples, 1);
     if(err) {
         std::cout << "Test FAILED" << std::endl;
         return 1;
@@ -271,34 +259,12 @@ int main() {
         return 1;
     }
 
-    // testing sycl::vec<std::uint64_t, 3>
-    std::cout << "-----------------------------" << std::endl;
-    std::cout << "sycl::vec<std::uint64_t, 3>" << std::endl;
-    std::cout << "-----------------------------" << std::endl;
-    err += tests_set<sycl::vec<std::uint64_t, 3>>(99);
-    err += tests_set_portion<sycl::vec<std::uint64_t, 3>>(100, 2);
-    if(err) {
-        std::cout << "Test FAILED" << std::endl;
-        return 1;
-    }
-
     // testing sycl::vec<std::uint32_t, 4>
     std::cout << "-----------------------------" << std::endl;
     std::cout << "sycl::vec<std::uint32_t, 4>" << std::endl;
     std::cout << "-----------------------------" << std::endl;
     err += tests_set<sycl::vec<std::uint32_t, 4>>(100);
-    err += tests_set_portion<sycl::vec<std::uint32_t, 4>>(300, 3);
-    if(err) {
-        std::cout << "Test FAILED" << std::endl;
-        return 1;
-    }
-
-    // testing sycl::vec<std::uint64_t, 4>
-    std::cout << "-----------------------------" << std::endl;
-    std::cout << "sycl::vec<std::uint64_t, 4>" << std::endl;
-    std::cout << "-----------------------------" << std::endl;
-    err += tests_set<sycl::vec<std::uint64_t, 4>>(100);
-    err += tests_set_portion<sycl::vec<std::uint64_t, 4>>(300, 3);
+    err += tests_set_portion<sycl::vec<std::uint32_t, 4>>(99, 3);
     if(err) {
         std::cout << "Test FAILED" << std::endl;
         return 1;
@@ -308,19 +274,8 @@ int main() {
     std::cout << "-----------------------------" << std::endl;
     std::cout << "sycl::vec<std::uint32_t, 8>" << std::endl;
     std::cout << "-----------------------------" << std::endl;
-    err += tests_set<sycl::vec<std::uint32_t, 8>>(400);
-    err += tests_set_portion<sycl::vec<std::uint32_t, 8>>(400, 5);
-    if(err) {
-        std::cout << "Test FAILED" << std::endl;
-        return 1;
-    }
-
-    // testing sycl::vec<std::uint64_t, 8>
-    std::cout << "-----------------------------" << std::endl;
-    std::cout << "sycl::vec<std::uint64_t, 8>" << std::endl;
-    std::cout << "-----------------------------" << std::endl;
-    err += tests_set<sycl::vec<std::uint64_t, 8>>(400);
-    err += tests_set_portion<sycl::vec<std::uint64_t, 8>>(400, 5);
+    err += tests_set<sycl::vec<std::uint32_t, 8>>(80);
+    err += tests_set_portion<sycl::vec<std::uint32_t, 8>>(80, 5);
     if(err) {
         std::cout << "Test FAILED" << std::endl;
         return 1;
@@ -330,17 +285,17 @@ int main() {
     std::cout << "-----------------------------" << std::endl;
     std::cout << "sycl::vec<std::uint32_t, 16>" << std::endl;
     std::cout << "-----------------------------" << std::endl;
-    err += tests_set<sycl::vec<std::uint32_t, 16>>(400);
-    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(400, 1);
-    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(400, 2);
-    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(3*100, 3);
-    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(400, 4);
-    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(400, 5);
-    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(6*100, 6);
-    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(7*100, 7);
-    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(8*100, 8);
-    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(9*100, 9);
-    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(400, 10);
+    err += tests_set<sycl::vec<std::uint32_t, 16>>(160);
+    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(100, 1);
+    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(100, 2);
+    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(99, 3);
+    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(100, 4);
+    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(100, 5);
+    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(60, 6);
+    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(70, 7);
+    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(80, 8);
+    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(90, 9);
+    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(100, 10);
     err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(110, 11);
     err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(120, 12);
     err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(130, 13);
@@ -353,21 +308,78 @@ int main() {
         return 1;
     }
 
+#if defined(DETAILED_TESTING)
+
+    // testing sycl::vec<std::uint64_t, 1>
+    std::cout << "-----------------------------" << std::endl;
+    std::cout << "sycl::vec<std::uint64_t, 1>" << std::endl;
+    std::cout << "-----------------------------" << std::endl;
+    err += tests_set<sycl::vec<std::uint64_t, 1>>(nsamples);
+    err += tests_set_portion<sycl::vec<std::uint64_t, 1>>(nsamples, 1);
+    if(err) {
+        std::cout << "Test FAILED" << std::endl;
+        return 1;
+    }
+
+    // testing sycl::vec<std::uint64_t, 2>
+    std::cout << "-----------------------------" << std::endl;
+    std::cout << "sycl::vec<std::uint64_t, 2>" << std::endl;
+    std::cout << "-----------------------------" << std::endl;
+    err += tests_set<sycl::vec<std::uint64_t, 2>>(nsamples);
+    err += tests_set_portion<sycl::vec<std::uint64_t, 2>>(nsamples, 1);
+    if(err) {
+        std::cout << "Test FAILED" << std::endl;
+        return 1;
+    }
+
+    // testing sycl::vec<std::uint64_t, 3>
+    std::cout << "-----------------------------" << std::endl;
+    std::cout << "sycl::vec<std::uint64_t, 3>" << std::endl;
+    std::cout << "-----------------------------" << std::endl;
+    err += tests_set<sycl::vec<std::uint64_t, 3>>(99);
+    err += tests_set_portion<sycl::vec<std::uint64_t, 3>>(100, 2);
+    if(err) {
+        std::cout << "Test FAILED" << std::endl;
+        return 1;
+    }
+
+    // testing sycl::vec<std::uint64_t, 4>
+    std::cout << "-----------------------------" << std::endl;
+    std::cout << "sycl::vec<std::uint64_t, 4>" << std::endl;
+    std::cout << "-----------------------------" << std::endl;
+    err += tests_set<sycl::vec<std::uint64_t, 4>>(100);
+    err += tests_set_portion<sycl::vec<std::uint64_t, 4>>(99, 3);
+    if(err) {
+        std::cout << "Test FAILED" << std::endl;
+        return 1;
+    }
+
+    // testing sycl::vec<std::uint64_t, 8>
+    std::cout << "-----------------------------" << std::endl;
+    std::cout << "sycl::vec<std::uint64_t, 8>" << std::endl;
+    std::cout << "-----------------------------" << std::endl;
+    err += tests_set<sycl::vec<std::uint64_t, 8>>(80);
+    err += tests_set_portion<sycl::vec<std::uint64_t, 8>>(80, 5);
+    if(err) {
+        std::cout << "Test FAILED" << std::endl;
+        return 1;
+    }
+
     // testing sycl::vec<std::uint64_t, 16>
     std::cout << "-----------------------------" << std::endl;
     std::cout << "sycl::vec<std::uint64_t, 16>" << std::endl;
     std::cout << "-----------------------------" << std::endl;
     err += tests_set<sycl::vec<std::uint64_t, 16>>(400);
-    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(400, 1);
-    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(400, 2);
-    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(3*100, 3);
-    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(400, 4);
-    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(400, 5);
-    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(6*100, 6);
-    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(7*100, 7);
-    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(8*100, 8);
-    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(9*100, 9);
-    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(400, 10);
+    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(100, 1);
+    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(100, 2);
+    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(99, 3);
+    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(100, 4);
+    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(100, 5);
+    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(60, 6);
+    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(70, 7);
+    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(80, 8);
+    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(90, 9);
+    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(100, 10);
     err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(110, 11);
     err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(120, 12);
     err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(130, 13);
@@ -380,6 +392,10 @@ int main() {
         return 1;
     }
 
+#endif // #if defined(DETAILED_TESTING)
+
     std::cout << "Test PASSED" << std::endl;
     return 0;
 }
+
+#endif // #if (!defined(_ONEDPL_BACKEND_SYCL) || (_ONEDPL_BACKEND_SYCL == 0))

--- a/test/rng_testsuite/template_tests/subtract_with_carry_std_template_test.pass.cpp
+++ b/test/rng_testsuite/template_tests/subtract_with_carry_std_template_test.pass.cpp
@@ -17,17 +17,9 @@
 //
 // Test of subtract_with_carry_engine - comparison with std::
 
-#if (!defined(_ONEDPL_BACKEND_SYCL) || (_ONEDPL_BACKEND_SYCL == 0))
 #include <iostream>
 
-int main() {
-    std::cout << "\tTest is skipped for non-SYCL backend. Passed" << std::endl;
-    return 0;
-}
-
-#else
-
-#include <iostream>
+#if ONEDPL_USE_DPCPP_BACKEND
 #include <vector>
 #include <CL/sycl.hpp>
 #include <random>
@@ -193,7 +185,12 @@ int tests_set_portion(int nsamples, unsigned int part) {
     return 0;
 }
 
+#endif // ONEDPL_USE_DPCPP_BACKEND
+
 int main() {
+
+#if ONEDPL_USE_DPCPP_BACKEND
+
     constexpr int nsamples = 100;
     int err;
 
@@ -299,7 +296,7 @@ int main() {
         return 1;
     }
 
-#if defined(DETAILED_TESTING)
+#if defined(_ONEDPL_RNG_DETAILED_TESTING_)
 
     // testing sycl::vec<std::uint64_t, 1>
     std::cout << "-----------------------------" << std::endl;
@@ -383,10 +380,12 @@ int main() {
         return 1;
     }
 
-#endif // #if defined(DETAILED_TESTING)
+#endif // #if defined(_ONEDPL_RNG_DETAILED_TESTING_)
+
+#else
+    std::cout << "\tTest is skipped for non-SYCL backend" << std::endl;
+#endif // ONEDPL_USE_DPCPP_BACKEND
 
     std::cout << "Test PASSED" << std::endl;
     return 0;
 }
-
-#endif // #if (!defined(_ONEDPL_BACKEND_SYCL) || (_ONEDPL_BACKEND_SYCL == 0))

--- a/test/rng_testsuite/template_tests/subtract_with_carry_std_template_test.pass.cpp
+++ b/test/rng_testsuite/template_tests/subtract_with_carry_std_template_test.pass.cpp
@@ -17,6 +17,16 @@
 //
 // Test of subtract_with_carry_engine - comparison with std::
 
+#if (!defined(_ONEDPL_BACKEND_SYCL) || (_ONEDPL_BACKEND_SYCL == 0))
+#include <iostream>
+
+int main() {
+    std::cout << "\tTest is skipped for non-SYCL backend. Passed" << std::endl;
+    return 0;
+}
+
+#else
+
 #include <iostream>
 #include <vector>
 #include <CL/sycl.hpp>
@@ -140,8 +150,8 @@ int test_portion(oneapi::dpl::internal::element_type_t<UIntType> seed, int nsamp
 
 template<class Type>
 int tests_set(int nsamples) {
-    constexpr int nseeds = 3;
-    int64_t seed_array [nseeds] = {0, 777, 19780503u};
+    constexpr int nseeds = 2;
+    int64_t seed_array [nseeds] = {0, 19780503u};
 
     int err;
     // Test for all non-zero parameters
@@ -167,23 +177,14 @@ int tests_set(int nsamples) {
 
 template<class Type>
 int tests_set_portion(int nsamples, unsigned int part) {
-    constexpr int nseeds = 2;
-    int64_t seed_array [nseeds] = {0, 19780503u};
+    constexpr int nseeds = 1;
+    int64_t seed_array [nseeds] = {19780503u};
 
     int err;
     // Test for all non-zero parameters
     for(int i = 0; i < nseeds; ++i) {
         std::cout << "SWC test_portion<Type, 24u, 10u, 24u>(" << seed_array[i] << ", "<< nsamples << ", " << part << ")";
         err = test_portion<Type, 24u, 10u, 24u>(seed_array[i], nsamples, part);
-        if(err) {
-            return 1;
-        }
-    }
-
-    // Test for zero addition parameter
-    for(int i = 0; i < nseeds; ++i) {
-        std::cout << "SWC test_portion<Type, 24u, 5u, 12u>(" << seed_array[i] << ", "<< nsamples << ", " << part << ")";
-        err = test_portion<Type, 24u, 5u, 12u>(seed_array[i], nsamples, part);
         if(err) {
             return 1;
         }
@@ -208,7 +209,7 @@ int main() {
 
     // testing std::uint64_t
     std::cout << "-----------------------------" << std::endl;
-    std::cout << "std::uint32_t Type" << std::endl;
+    std::cout << "std::uint64_t Type" << std::endl;
     std::cout << "-----------------------------" << std::endl;
     err += tests_set<std::uint64_t>(nsamples);
     if(err) {
@@ -227,34 +228,12 @@ int main() {
         return 1;
     }
 
-    // testing sycl::vec<std::uint64_t, 1>
-    std::cout << "-----------------------------" << std::endl;
-    std::cout << "sycl::vec<std::uint64_t, 1>" << std::endl;
-    std::cout << "-----------------------------" << std::endl;
-    err += tests_set<sycl::vec<std::uint64_t, 1>>(nsamples);
-    err += tests_set_portion<sycl::vec<std::uint64_t, 1>>(nsamples, 1);
-    if(err) {
-        std::cout << "Test FAILED" << std::endl;
-        return 1;
-    }
-
     // testing sycl::vec<std::uint32_t, 2>
     std::cout << "-----------------------------" << std::endl;
     std::cout << "sycl::vec<std::uint32_t, 2>" << std::endl;
     std::cout << "-----------------------------" << std::endl;
     err += tests_set<sycl::vec<std::uint32_t, 2>>(nsamples);
     err += tests_set_portion<sycl::vec<std::uint32_t, 2>>(nsamples, 1);
-    if(err) {
-        std::cout << "Test FAILED" << std::endl;
-        return 1;
-    }
-
-    // testing sycl::vec<std::uint64_t, 2>
-    std::cout << "-----------------------------" << std::endl;
-    std::cout << "sycl::vec<std::uint64_t, 2>" << std::endl;
-    std::cout << "-----------------------------" << std::endl;
-    err += tests_set<sycl::vec<std::uint64_t, 2>>(nsamples);
-    err += tests_set_portion<sycl::vec<std::uint64_t, 2>>(nsamples, 1);
     if(err) {
         std::cout << "Test FAILED" << std::endl;
         return 1;
@@ -271,34 +250,12 @@ int main() {
         return 1;
     }
 
-    // testing sycl::vec<std::uint64_t, 3>
-    std::cout << "-----------------------------" << std::endl;
-    std::cout << "sycl::vec<std::uint64_t, 3>" << std::endl;
-    std::cout << "-----------------------------" << std::endl;
-    err += tests_set<sycl::vec<std::uint64_t, 3>>(99);
-    err += tests_set_portion<sycl::vec<std::uint64_t, 3>>(100, 2);
-    if(err) {
-        std::cout << "Test FAILED" << std::endl;
-        return 1;
-    }
-
     // testing sycl::vec<std::uint32_t, 4>
     std::cout << "-----------------------------" << std::endl;
     std::cout << "sycl::vec<std::uint32_t, 4>" << std::endl;
     std::cout << "-----------------------------" << std::endl;
     err += tests_set<sycl::vec<std::uint32_t, 4>>(100);
-    err += tests_set_portion<sycl::vec<std::uint32_t, 4>>(300, 3);
-    if(err) {
-        std::cout << "Test FAILED" << std::endl;
-        return 1;
-    }
-
-    // testing sycl::vec<std::uint64_t, 4>
-    std::cout << "-----------------------------" << std::endl;
-    std::cout << "sycl::vec<std::uint64_t, 4>" << std::endl;
-    std::cout << "-----------------------------" << std::endl;
-    err += tests_set<sycl::vec<std::uint64_t, 4>>(100);
-    err += tests_set_portion<sycl::vec<std::uint64_t, 4>>(300, 3);
+    err += tests_set_portion<sycl::vec<std::uint32_t, 4>>(99, 3);
     if(err) {
         std::cout << "Test FAILED" << std::endl;
         return 1;
@@ -309,18 +266,7 @@ int main() {
     std::cout << "sycl::vec<std::uint32_t, 8>" << std::endl;
     std::cout << "-----------------------------" << std::endl;
     err += tests_set<sycl::vec<std::uint32_t, 8>>(400);
-    err += tests_set_portion<sycl::vec<std::uint32_t, 8>>(400, 5);
-    if(err) {
-        std::cout << "Test FAILED" << std::endl;
-        return 1;
-    }
-
-    // testing sycl::vec<std::uint64_t, 8>
-    std::cout << "-----------------------------" << std::endl;
-    std::cout << "sycl::vec<std::uint64_t, 8>" << std::endl;
-    std::cout << "-----------------------------" << std::endl;
-    err += tests_set<sycl::vec<std::uint64_t, 8>>(400);
-    err += tests_set_portion<sycl::vec<std::uint64_t, 8>>(400, 5);
+    err += tests_set_portion<sycl::vec<std::uint32_t, 8>>(100, 5);
     if(err) {
         std::cout << "Test FAILED" << std::endl;
         return 1;
@@ -331,16 +277,16 @@ int main() {
     std::cout << "sycl::vec<std::uint32_t, 16>" << std::endl;
     std::cout << "-----------------------------" << std::endl;
     err += tests_set<sycl::vec<std::uint32_t, 16>>(400);
-    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(400, 1);
-    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(400, 2);
-    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(3*100, 3);
-    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(400, 4);
-    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(400, 5);
-    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(6*100, 6);
-    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(7*100, 7);
-    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(8*100, 8);
-    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(9*100, 9);
-    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(400, 10);
+    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(100, 1);
+    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(100, 2);
+    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(99, 3);
+    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(100, 4);
+    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(100, 5);
+    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(60, 6);
+    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(70, 7);
+    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(80, 8);
+    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(90, 9);
+    err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(100, 10);
     err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(110, 11);
     err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(120, 12);
     err += tests_set_portion<sycl::vec<std::uint32_t, 16>>(130, 13);
@@ -353,21 +299,78 @@ int main() {
         return 1;
     }
 
+#if defined(DETAILED_TESTING)
+
+    // testing sycl::vec<std::uint64_t, 1>
+    std::cout << "-----------------------------" << std::endl;
+    std::cout << "sycl::vec<std::uint64_t, 1>" << std::endl;
+    std::cout << "-----------------------------" << std::endl;
+    err += tests_set<sycl::vec<std::uint64_t, 1>>(nsamples);
+    err += tests_set_portion<sycl::vec<std::uint64_t, 1>>(nsamples, 1);
+    if(err) {
+        std::cout << "Test FAILED" << std::endl;
+        return 1;
+    }
+
+    // testing sycl::vec<std::uint64_t, 2>
+    std::cout << "-----------------------------" << std::endl;
+    std::cout << "sycl::vec<std::uint64_t, 2>" << std::endl;
+    std::cout << "-----------------------------" << std::endl;
+    err += tests_set<sycl::vec<std::uint64_t, 2>>(nsamples);
+    err += tests_set_portion<sycl::vec<std::uint64_t, 2>>(nsamples, 1);
+    if(err) {
+        std::cout << "Test FAILED" << std::endl;
+        return 1;
+    }
+
+    // testing sycl::vec<std::uint64_t, 3>
+    std::cout << "-----------------------------" << std::endl;
+    std::cout << "sycl::vec<std::uint64_t, 3>" << std::endl;
+    std::cout << "-----------------------------" << std::endl;
+    err += tests_set<sycl::vec<std::uint64_t, 3>>(99);
+    err += tests_set_portion<sycl::vec<std::uint64_t, 3>>(100, 2);
+    if(err) {
+        std::cout << "Test FAILED" << std::endl;
+        return 1;
+    }
+
+    // testing sycl::vec<std::uint64_t, 4>
+    std::cout << "-----------------------------" << std::endl;
+    std::cout << "sycl::vec<std::uint64_t, 4>" << std::endl;
+    std::cout << "-----------------------------" << std::endl;
+    err += tests_set<sycl::vec<std::uint64_t, 4>>(100);
+    err += tests_set_portion<sycl::vec<std::uint64_t, 4>>(99, 3);
+    if(err) {
+        std::cout << "Test FAILED" << std::endl;
+        return 1;
+    }
+
+    // testing sycl::vec<std::uint64_t, 8>
+    std::cout << "-----------------------------" << std::endl;
+    std::cout << "sycl::vec<std::uint64_t, 8>" << std::endl;
+    std::cout << "-----------------------------" << std::endl;
+    err += tests_set<sycl::vec<std::uint64_t, 8>>(80);
+    err += tests_set_portion<sycl::vec<std::uint64_t, 8>>(100, 5);
+    if(err) {
+        std::cout << "Test FAILED" << std::endl;
+        return 1;
+    }
+
     // testing sycl::vec<std::uint64_t, 16>
     std::cout << "-----------------------------" << std::endl;
     std::cout << "sycl::vec<std::uint64_t, 16>" << std::endl;
     std::cout << "-----------------------------" << std::endl;
     err += tests_set<sycl::vec<std::uint64_t, 16>>(400);
-    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(400, 1);
-    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(400, 2);
-    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(3*100, 3);
-    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(400, 4);
-    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(400, 5);
-    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(6*100, 6);
-    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(7*100, 7);
-    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(8*100, 8);
-    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(9*100, 9);
-    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(400, 10);
+    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(100, 1);
+    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(100, 2);
+    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(99, 3);
+    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(100, 4);
+    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(100, 5);
+    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(60, 6);
+    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(70, 7);
+    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(80, 8);
+    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(90, 9);
+    err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(100, 10);
     err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(110, 11);
     err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(120, 12);
     err += tests_set_portion<sycl::vec<std::uint64_t, 16>>(130, 13);
@@ -380,6 +383,10 @@ int main() {
         return 1;
     }
 
+#endif // #if defined(DETAILED_TESTING)
+
     std::cout << "Test PASSED" << std::endl;
     return 0;
 }
+
+#endif // #if (!defined(_ONEDPL_BACKEND_SYCL) || (_ONEDPL_BACKEND_SYCL == 0))

--- a/test/rng_testsuite/template_tests/subtract_with_carry_std_template_test.pass.cpp
+++ b/test/rng_testsuite/template_tests/subtract_with_carry_std_template_test.pass.cpp
@@ -19,7 +19,7 @@
 
 #include <iostream>
 
-#if ONEDPL_USE_DPCPP_BACKEND
+#if _ONEDPL_BACKEND_SYCL
 #include <vector>
 #include <CL/sycl.hpp>
 #include <random>
@@ -185,11 +185,11 @@ int tests_set_portion(int nsamples, unsigned int part) {
     return 0;
 }
 
-#endif // ONEDPL_USE_DPCPP_BACKEND
+#endif // _ONEDPL_BACKEND_SYCL
 
 int main() {
 
-#if ONEDPL_USE_DPCPP_BACKEND
+#if _ONEDPL_BACKEND_SYCL
 
     constexpr int nsamples = 100;
     int err;
@@ -384,7 +384,7 @@ int main() {
 
 #else
     std::cout << "\tTest is skipped for non-SYCL backend" << std::endl;
-#endif // ONEDPL_USE_DPCPP_BACKEND
+#endif // _ONEDPL_BACKEND_SYCL
 
     std::cout << "Test PASSED" << std::endl;
     return 0;


### PR DESCRIPTION
1) Template RNG test scope was reduced for regular testing procedures
2) Add tests skipping in case of non-SYCL compilers