### PR TITLE
Fix most of -Wunused-parameter warnings.

### DIFF
--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -162,7 +162,7 @@ template <class _ExecutionPolicy, class _ForwardIterator, class _Function, class
 oneapi::dpl::__internal::__enable_if_host_execution_policy_conditional<
     _ExecutionPolicy, !__is_random_access_iterator<_ForwardIterator>::value, void>
 __pattern_walk1(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Function __f,
-                _IsVector __is_vector,
+                _IsVector,
                 /*parallel=*/::std::true_type)
 {
     typedef typename ::std::iterator_traits<_ForwardIterator>::reference _ReferenceType;
@@ -325,7 +325,7 @@ template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterato
 oneapi::dpl::__internal::__enable_if_host_execution_policy_conditional<
     _ExecutionPolicy, !__is_random_access_iterator<_ForwardIterator1, _ForwardIterator2>::value, _ForwardIterator2>
 __pattern_walk2(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
-                _ForwardIterator2 __first2, _Function __f, _IsVector __is_vector, /*parallel=*/::std::true_type)
+                _ForwardIterator2 __first2, _Function __f, _IsVector, /*parallel=*/::std::true_type)
 {
     return __internal::__except_handler([&]() {
         using _iterator_tuple = zip_forward_iterator<_ForwardIterator1, _ForwardIterator2>;
@@ -516,7 +516,7 @@ oneapi::dpl::__internal::__enable_if_host_execution_policy_conditional<
     _ExecutionPolicy, !__is_random_access_iterator<_ForwardIterator1, _ForwardIterator2, _ForwardIterator3>::value,
     _ForwardIterator3>
 __pattern_walk3(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
-                _ForwardIterator2 __first2, _ForwardIterator3 __first3, _Function __f, _IsVector __is_vector,
+                _ForwardIterator2 __first2, _ForwardIterator3 __first3, _Function __f, _IsVector,
                 /*parallel=*/::std::true_type)
 {
     return __internal::__except_handler([&]() {
@@ -2507,7 +2507,7 @@ __brick_adjacent_find(_ForwardIterator __first, _ForwardIterator __last, _Binary
 template <class _ForwardIterator, class _BinaryPredicate>
 _ForwardIterator
 __brick_adjacent_find(_ForwardIterator __first, _ForwardIterator __last, _BinaryPredicate __pred,
-                      /* IsVector = */ ::std::false_type, bool __or_semantic) noexcept
+                      /* IsVector = */ ::std::false_type, bool) noexcept
 {
     return ::std::adjacent_find(__first, __last, __pred);
 }
@@ -2962,7 +2962,7 @@ __pattern_inplace_merge(_ExecutionPolicy&& __exec, _BidirectionalIterator __firs
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Compare, class _IsVector>
 oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, bool>
-__pattern_includes(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+__pattern_includes(_ExecutionPolicy&&, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
                    _ForwardIterator2 __first2, _ForwardIterator2 __last2, _Compare __comp, _IsVector,
                    /*is_parallel=*/::std::false_type) noexcept
 {
@@ -2972,7 +2972,7 @@ __pattern_includes(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _Forwa
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Compare, class _IsVector>
 oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, bool>
 __pattern_includes(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
-                   _ForwardIterator2 __first2, _ForwardIterator2 __last2, _Compare __comp, _IsVector __is_vector,
+                   _ForwardIterator2 __first2, _ForwardIterator2 __last2, _Compare __comp, _IsVector,
                    /*is_parallel=*/::std::true_type)
 {
     if (__first2 == __last2)
@@ -3992,7 +3992,7 @@ template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterato
           class _IsParallel>
 oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, _ForwardIterator2>
 __pattern_swap(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
-               _ForwardIterator2 __first2, _Function __f, _IsVector __is_vector, _IsParallel __is_parallel)
+               _ForwardIterator2 __first2, _Function __f, _IsVector __is_vector, _IsParallel)
 {
     return __pattern_walk2(::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __f, __is_vector,
                            __is_vector);

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -161,8 +161,7 @@ __pattern_walk1(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIte
 template <class _ExecutionPolicy, class _ForwardIterator, class _Function, class _IsVector>
 oneapi::dpl::__internal::__enable_if_host_execution_policy_conditional<
     _ExecutionPolicy, !__is_random_access_iterator<_ForwardIterator>::value, void>
-__pattern_walk1(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Function __f,
-                _IsVector,
+__pattern_walk1(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Function __f, _IsVector,
                 /*parallel=*/::std::true_type)
 {
     typedef typename ::std::iterator_traits<_ForwardIterator>::reference _ReferenceType;

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -2507,7 +2507,7 @@ __brick_adjacent_find(_ForwardIterator __first, _ForwardIterator __last, _Binary
 template <class _ForwardIterator, class _BinaryPredicate>
 _ForwardIterator
 __brick_adjacent_find(_ForwardIterator __first, _ForwardIterator __last, _BinaryPredicate __pred,
-                      /* IsVector = */ ::std::false_type, bool) noexcept
+                      /* IsVector = */ ::std::false_type, bool /* __or_semantic */) noexcept
 {
     return ::std::adjacent_find(__first, __last, __pred);
 }

--- a/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
@@ -342,7 +342,7 @@ __pattern_for_loop(_ExecutionPolicy&&, _Ip __first, _Ip __last, _Function __f, _
 // Vectorized version of for_loop_n
 template <typename _ExecutionPolicy, typename _Ip, typename _Size, typename _Function, typename... _Rest>
 void
-__pattern_for_loop_n(_ExecutionPolicy&& exec, _Ip __first, _Size __n, _Function __f, __single_stride_type,
+__pattern_for_loop_n(_ExecutionPolicy&&, _Ip __first, _Size __n, _Function __f, __single_stride_type,
                      /*vector=*/::std::true_type, /*parallel=*/::std::false_type, _Rest&&... __rest) noexcept
 {
     __reduction_pack<_Rest...> __pack{__reduction_pack_tag(), ::std::forward<_Rest>(__rest)...};
@@ -356,7 +356,7 @@ __pattern_for_loop_n(_ExecutionPolicy&& exec, _Ip __first, _Size __n, _Function 
 
 template <typename _ExecutionPolicy, typename _Ip, typename _Size, typename _Function, typename _Sp, typename... _Rest>
 void
-__pattern_for_loop_n(_ExecutionPolicy&& exec, _Ip __first, _Size __n, _Function __f, _Sp __stride,
+__pattern_for_loop_n(_ExecutionPolicy&&, _Ip __first, _Size __n, _Function __f, _Sp __stride,
                      /*vector=*/::std::true_type, /*parallel=*/::std::false_type, _Rest&&... __rest) noexcept
 {
     __reduction_pack<_Rest...> __pack{__reduction_pack_tag(), ::std::forward<_Rest>(__rest)...};

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -315,7 +315,7 @@ __parallel_for(_ExecutionPolicy&& __exec, _Fp __brick, _Index __count, _Ranges&&
 template <typename _Tp, ::std::size_t __grainsize = 4, typename _ExecutionPolicy, typename _Up, typename _Cp,
           typename _Rp, typename... _Ranges>
 oneapi::dpl::__internal::__enable_if_device_execution_policy<_ExecutionPolicy, _Tp>
-__parallel_transform_reduce(_ExecutionPolicy&& __exec, _Up __u, _Cp, _Rp __brick_reduce, _Ranges&&... __rngs)
+__parallel_transform_reduce(_ExecutionPolicy&& __exec, _Up __u, _Cp __combine, _Rp __brick_reduce, _Ranges&&... __rngs)
 {
     auto __n = __get_first_range(__rngs...).size();
     assert(__n > 0);
@@ -385,14 +385,9 @@ __parallel_transform_reduce(_ExecutionPolicy&& __exec, _Up __u, _Cp, _Rp __brick
                     }
                     else
                     {
-<<<<<<< HEAD
                         // TODO: check the approach when we use grainsize here too
                         if (__global_idx < __n_items)
                             __temp_local[__local_idx] = __temp_acc[__offset_2 + __global_idx];
-=======
-                        if (__global_idx < (decltype(__global_idx))__n)
-                            __temp_local[__local_idx] = __temp_1_acc[__global_idx];
->>>>>>> Warning keys are added to CMakeLists, fixed warnings on several tests
                         __item_id.barrier(sycl::access::fence_space::local_space);
                     }
                     // 2. Reduce within work group using local memory
@@ -421,7 +416,7 @@ template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typenam
           typename _LocalScan, typename _GroupScan, typename _GlobalScan>
 oneapi::dpl::__internal::__enable_if_device_execution_policy<
     _ExecutionPolicy, ::std::pair<oneapi::dpl::__internal::__difference_t<_Range2>, typename _InitType::__value_type>>
-__parallel_transform_scan(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _BinaryOperation,
+__parallel_transform_scan(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _BinaryOperation __binary_op,
                           _InitType __init, _LocalScan __local_scan, _GroupScan __group_scan, _GlobalScan __global_scan)
 {
     using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
@@ -612,6 +607,7 @@ struct __early_exit_find_or
         using _BackwardTagType = ::std::is_same<typename _BrickTag::_Compare, oneapi::dpl::__internal::__pstl_greater>;
 
         auto __n = oneapi::dpl::__ranges::__get_first_range(__rngs...).size();
+        using _Size = decltype(__n);
 
         auto __global_idx = __item_id.get_global_id(0);
         auto __local_idx = __item_id.get_local_id(0);
@@ -623,7 +619,7 @@ struct __early_exit_find_or
         auto __init_index =
             __shift_global * __wg_size * __n_iter + __shift_local * __shift * __n_iter + __local_idx % __shift;
 
-        for (_IterSize __i = 0; __i < __n_iter; ++__i)
+        for (_Size __i = 0; __i < __n_iter; ++__i)
         {
             //in case of find-semantic __shifted_idx must be the same type as the atomic for a correct comparison
             using _ShiftedIdxType =
@@ -635,7 +631,7 @@ struct __early_exit_find_or
             _ShiftedIdxType __shifted_idx = __init_index + __current_iter * __shift;
             // TODO:[Performance] the issue with atomic load (in comparison with __shifted_idx for erly exit)
             // should be investigated later, with other HW
-            if ((decltype(__n))__shifted_idx < __n && __pred(__shifted_idx, __rngs...))
+            if (__shifted_idx < __n && __pred(__shifted_idx, __rngs...))
             {
                 oneapi::dpl::__internal::__invoke_if_else(
                     _OrTagType{}, [&__found_local]() { __found_local.store(1); },
@@ -1010,7 +1006,7 @@ struct __partial_merge_kernel
         const auto __part_end_2 = sycl::min(__start_2 + __k, __end_2);
 
         // Handle elements from p1
-        if (__global_idx >= (_Idx)__start_1 && __global_idx < (_Idx)__part_end_1)
+        if (__global_idx >= __start_1 && __global_idx < __part_end_1)
         {
             const auto __shift =
                 /* index inside p1 */ __global_idx - __start_1 +
@@ -1021,7 +1017,7 @@ struct __partial_merge_kernel
             __out_acc[__out_shift + __shift] = __in_acc1[__global_idx];
         }
         // Handle elements from p2
-        else if (__global_idx >= (_Idx)__part_end_1 && __global_idx < (_Idx)__end_1)
+        else if (__global_idx >= __part_end_1 && __global_idx < __end_1)
         {
             const auto __shift =
                 /* index inside p2 */ (__global_idx - __part_end_1) +
@@ -1029,7 +1025,7 @@ struct __partial_merge_kernel
             __out_acc[__out_shift + __shift] = __in_acc1[__global_idx];
         }
         // Handle elements from p3
-        else if (__global_idx >= (_Idx)__start_2 && __global_idx < (_Idx)__part_end_2)
+        else if (__global_idx >= __start_2 && __global_idx < __part_end_2)
         {
             const auto __shift =
                 /* index inside p3 */ __global_idx - __start_2 +
@@ -1040,7 +1036,7 @@ struct __partial_merge_kernel
             __out_acc[__out_shift + __shift] = __in_acc2[__global_idx];
         }
         // Handle elements from p4
-        else if (__global_idx >= (_Idx)__part_end_2 && __global_idx < (_Idx)__end_2)
+        else if (__global_idx >= __part_end_2 && __global_idx < __end_2)
         {
             const auto __shift =
                 /* index inside p4 + size of p3 */ __global_idx - __start_2 +

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -150,14 +150,14 @@ __internal::sycl_iterator<access_mode::read_write, T, Allocator> end(sycl::buffe
 // begin
 template <typename T, typename Allocator, access_mode Mode>
 __internal::sycl_iterator<Mode, T, Allocator> begin(sycl::buffer<T, /*dim=*/1, Allocator> buf,
-                                                    sycl::mode_tag_t<Mode> tag)
+                                                    sycl::mode_tag_t<Mode>)
 {
     return __internal::sycl_iterator<Mode, T, Allocator>{buf, 0};
 }
 
 template <typename T, typename Allocator, access_mode Mode>
 __internal::sycl_iterator<__internal::_ModeConverter<Mode>::__value, T, Allocator>
-    begin(sycl::buffer<T, /*dim=*/1, Allocator> buf, sycl::mode_tag_t<Mode> tag, sycl::property::noinit)
+    begin(sycl::buffer<T, /*dim=*/1, Allocator> buf, sycl::mode_tag_t<Mode>, sycl::property::noinit)
 {
     return __internal::sycl_iterator<__internal::_ModeConverter<Mode>::__value, T, Allocator>{buf, 0};
 }
@@ -171,14 +171,14 @@ __internal::sycl_iterator<access_mode::discard_read_write, T, Allocator>
 
 // end
 template <typename T, typename Allocator, access_mode Mode>
-__internal::sycl_iterator<Mode, T, Allocator> end(sycl::buffer<T, /*dim=*/1, Allocator> buf, sycl::mode_tag_t<Mode> tag)
+__internal::sycl_iterator<Mode, T, Allocator> end(sycl::buffer<T, /*dim=*/1, Allocator> buf, sycl::mode_tag_t<Mode>)
 {
     return __internal::sycl_iterator<Mode, T, Allocator>{buf, buf.get_count()};
 }
 
 template <typename T, typename Allocator, access_mode Mode>
 __internal::sycl_iterator<__internal::_ModeConverter<Mode>::__value, T, Allocator>
-    end(sycl::buffer<T, /*dim=*/1, Allocator> buf, sycl::mode_tag_t<Mode> tag, sycl::property::noinit)
+    end(sycl::buffer<T, /*dim=*/1, Allocator> buf, sycl::mode_tag_t<Mode>, sycl::property::noinit)
 {
     return __internal::sycl_iterator<__internal::_ModeConverter<Mode>::__value, T, Allocator>{buf, buf.get_count()};
 }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -149,8 +149,7 @@ __internal::sycl_iterator<access_mode::read_write, T, Allocator> end(sycl::buffe
 
 // begin
 template <typename T, typename Allocator, access_mode Mode>
-__internal::sycl_iterator<Mode, T, Allocator> begin(sycl::buffer<T, /*dim=*/1, Allocator> buf,
-                                                    sycl::mode_tag_t<Mode>)
+__internal::sycl_iterator<Mode, T, Allocator> begin(sycl::buffer<T, /*dim=*/1, Allocator> buf, sycl::mode_tag_t<Mode>)
 {
     return __internal::sycl_iterator<Mode, T, Allocator>{buf, 0};
 }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -451,9 +451,9 @@ struct __global_scan_functor
                _SizePerWg __size_per_wg) const
     {
         constexpr auto __shift = _Inclusive{} ? 0 : 1;
-        _Size __item_idx = __item.get_linear_id();
+        ::std::size_t __item_idx = __item.get_linear_id();
         // skip the first group scanned locally
-        if (__item_idx >= __size_per_wg && __item_idx < __n)
+        if (__item_idx >= (::std::size_t)__size_per_wg && __item_idx < (::std::size_t)__n)
         {
             auto __wg_sums_idx = __item_idx / __size_per_wg - 1;
             // an initial value preceeds the first group for the exclusive scan

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -270,8 +270,7 @@ struct __mask_assigner
 {
     template <typename _Acc, typename _OutAcc, typename _OutIdx, typename _InAcc, typename _InIdx>
     void
-    operator()(_Acc& __acc, _OutAcc&, const _OutIdx __out_idx, const _InAcc& __in_acc,
-               const _InIdx __in_idx) const
+    operator()(_Acc& __acc, _OutAcc&, const _OutIdx __out_idx, const _InAcc& __in_acc, const _InIdx __in_idx) const
     {
         using ::std::get;
         get<N>(__acc[__out_idx]) = __in_acc[__in_idx];

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -451,9 +451,9 @@ struct __global_scan_functor
                _SizePerWg __size_per_wg) const
     {
         constexpr auto __shift = _Inclusive{} ? 0 : 1;
-        ::std::size_t __item_idx = __item.get_linear_id();
+        auto __item_idx = __item.get_linear_id();
         // skip the first group scanned locally
-        if (__item_idx >= (::std::size_t)__size_per_wg && __item_idx < (::std::size_t)__n)
+        if (__item_idx >= __size_per_wg && __item_idx < __n)
         {
             auto __wg_sums_idx = __item_idx / __size_per_wg - 1;
             // an initial value preceeds the first group for the exclusive scan
@@ -497,9 +497,9 @@ struct __scan
                 __use_init(__init, __out_acc[__global_id]);
         });
 
-        _Size __adjusted_global_id = __local_id + __size_per_wg * __group_id;
+        auto __adjusted_global_id = __local_id + __size_per_wg * __group_id;
         auto __adder = __local_acc[0];
-        for (_ItersPerWG __iter = 0; __iter < __iters_per_wg; ++__iter, __adjusted_global_id += __wgroup_size)
+        for (auto __iter = 0; __iter < __iters_per_wg; ++__iter, __adjusted_global_id += __wgroup_size)
         {
             if (__adjusted_global_id < __n)
             {
@@ -514,7 +514,7 @@ struct __scan
                 __use_init(__init, __local_acc[__global_id], __bin_op);
 
             // 1. reduce
-            _WGSize __k = 1;
+            auto __k = 1;
             do
             {
                 __item.barrier(sycl::access::fence_space::local_space);
@@ -579,7 +579,7 @@ struct reduce<_ExecutionPolicy, ::std::plus<_Tp>, __enable_if_arithmetic<_Tp>>
     operator()(_NDItem __item, _GlobalIdx __global_id, _GlobalSize __n, _LocalAcc __local_mem) const
     {
         auto __local_id = __item.get_local_id(0);
-        if (__global_id >= (_GlobalIdx)__n)
+        if (__global_id >= __n)
         {
             // Fill the rest of local buffer with 0s so each of inclusive_scan method could correctly work
             // for each work-item in sub-group

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -159,10 +159,10 @@ struct __get_first_range_type
 };
 
 template <typename _Range, typename... _Ranges>
-constexpr _Range
+constexpr _Range&
 __get_first_range(_Range&& __rng, _Ranges&&...)
 {
-    return ::std::forward<_Range>(__rng);
+    return __rng;
 }
 
 template <typename _Cgh>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -162,7 +162,7 @@ template <typename _Range, typename... _Ranges>
 constexpr _Range
 __get_first_range(_Range&& __rng, _Ranges&&...)
 {
-    return __rng;
+    return ::std::forward<_Range>(__rng);
 }
 
 template <typename _Cgh>
@@ -189,7 +189,7 @@ __require_access_zip(sycl::handler& __cgh, oneapi::dpl::__ranges::zip_view<_Rang
 //__require_access utility
 
 inline void
-__require_access(sycl::handler& __cgh)
+__require_access(sycl::handler&)
 {
 }
 
@@ -209,7 +209,7 @@ __require_access_range(sycl::handler& __cgh, zip_view<_Ranges...>& zip_rng)
 
 template <typename _BaseRange>
 void
-__require_access_range(sycl::handler& __cgh, _BaseRange&)
+__require_access_range(sycl::handler&, _BaseRange&)
 {
 }
 
@@ -341,7 +341,7 @@ struct __get_sycl_range
 
     template <typename _Iter>
     buf_type<val_t<_Iter>>
-    copy_back(_Iter __first, buf_type<val_t<_Iter>> buf, /*_copy_back*/ ::std::false_type)
+    copy_back(_Iter, buf_type<val_t<_Iter>> buf, /*_copy_back*/ ::std::false_type)
     {
         return buf;
     }
@@ -432,20 +432,20 @@ struct __get_sycl_range
     }
     template <typename _Map, typename _Size>
     auto
-    __get_it_map_view(_Map __m, _Size __n) -> typename ::std::enable_if<is_map_functor<_Map>::value, _Size>::type
+    __get_it_map_view(_Map, _Size) -> typename ::std::enable_if<is_map_functor<_Map>::value, _Size>::type
     {
         return _Size(0);
     }
     template <typename _Map, typename _T>
     static auto
-    __get_all_view(_Map __m, _T __t) ->
+    __get_all_view(_Map, _T __t) ->
         typename ::std::enable_if<is_map_iterator<_Map>::value, decltype(__t.all_view())>::type
     {
         return __t.all_view();
     }
     template <typename _Map, typename _T>
     static auto
-    __get_all_view(_Map __m, _T __t) -> typename ::std::enable_if<is_map_functor<_Map>::value, _Map>::type
+    __get_all_view(_Map __m, _T) -> typename ::std::enable_if<is_map_functor<_Map>::value, _Map>::type
     {
         return __m;
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -341,7 +341,7 @@ struct __get_sycl_range
 
     template <typename _Iter>
     buf_type<val_t<_Iter>>
-    copy_back(_Iter, buf_type<val_t<_Iter>> buf, /*_copy_back*/ ::std::false_type)
+    copy_back(_Iter /*__first*/, buf_type<val_t<_Iter>> buf, /*_copy_back*/ ::std::false_type)
     {
         return buf;
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -159,7 +159,7 @@ struct __get_first_range_type
 };
 
 template <typename _Range, typename... _Ranges>
-constexpr _Range&
+constexpr _Range
 __get_first_range(_Range&& __rng, _Ranges&&...)
 {
     return __rng;
@@ -341,7 +341,7 @@ struct __get_sycl_range
 
     template <typename _Iter>
     buf_type<val_t<_Iter>>
-    copy_back(_Iter /*__first*/, buf_type<val_t<_Iter>> buf, /*_copy_back*/ ::std::false_type)
+    copy_back(_Iter __first, buf_type<val_t<_Iter>> buf, /*_copy_back*/ ::std::false_type)
     {
         return buf;
     }
@@ -432,20 +432,20 @@ struct __get_sycl_range
     }
     template <typename _Map, typename _Size>
     auto
-    __get_it_map_view(_Map, _Size) -> typename ::std::enable_if<is_map_functor<_Map>::value, _Size>::type
+    __get_it_map_view(_Map __m, _Size __n) -> typename ::std::enable_if<is_map_functor<_Map>::value, _Size>::type
     {
         return _Size(0);
     }
     template <typename _Map, typename _T>
     static auto
-    __get_all_view(_Map, _T __t) ->
+    __get_all_view(_Map __m, _T __t) ->
         typename ::std::enable_if<is_map_iterator<_Map>::value, decltype(__t.all_view())>::type
     {
         return __t.all_view();
     }
     template <typename _Map, typename _T>
     static auto
-    __get_all_view(_Map __m, _T) -> typename ::std::enable_if<is_map_functor<_Map>::value, _Map>::type
+    __get_all_view(_Map __m, _T __t) -> typename ::std::enable_if<is_map_functor<_Map>::value, _Map>::type
     {
         return __m;
     }

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -298,7 +298,7 @@ __pattern_transform_scan(_ExecutionPolicy&& __exec, _RandomAccessIterator __firs
                                           }) -
                          1);
             },
-            [](_Tp __res) {});
+            [](_Tp) {});
         return __result + (__last - __first);
     });
 }

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -374,7 +374,7 @@ __downsweep(_Index __i, _Index __m, _Index __tilesize, _Tp* __r, _Index __lastsi
 // T must have a trivial constructor and destructor.
 template <class _ExecutionPolicy, typename _Index, typename _Tp, typename _Rp, typename _Cp, typename _Sp, typename _Ap>
 void
-__parallel_strict_scan(_ExecutionPolicy&& __exec, _Index __n, _Tp __initial, _Rp __reduce, _Cp __combine, _Sp __scan,
+__parallel_strict_scan(_ExecutionPolicy&&, _Index __n, _Tp __initial, _Rp __reduce, _Cp __combine, _Sp __scan,
                        _Ap __apex)
 {
     tbb::this_task_arena::isolate([=, &__combine]() {
@@ -642,7 +642,7 @@ class __func_task : public __task
     };
 
     __task*
-    cancel(tbb::detail::d1::execution_data& __ed) override
+    cancel(tbb::detail::d1::execution_data& ) override
     {
         return finalize(nullptr);
     }
@@ -695,14 +695,14 @@ template <typename _Func>
 class __root_task : public __task
 {
     __task*
-    execute(tbb::detail::d1::execution_data& __ed) override
+    execute(tbb::detail::d1::execution_data&) override
     {
         _M_wait_object.release();
         return nullptr;
     };
 
     __task*
-    cancel(tbb::detail::d1::execution_data& __ed) override
+    cancel(tbb::detail::d1::execution_data&) override
     {
         _M_wait_object.release();
         return nullptr;
@@ -1173,7 +1173,7 @@ __stable_sort_func<_RandomAccessIterator1, _RandomAccessIterator2, _Compare, _Le
 
 template <class _ExecutionPolicy, typename _RandomAccessIterator, typename _Compare, typename _LeafSort>
 void
-__parallel_stable_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __xs, _RandomAccessIterator __xe,
+__parallel_stable_sort(_ExecutionPolicy&&, _RandomAccessIterator __xs, _RandomAccessIterator __xe,
                        _Compare __comp, _LeafSort __leaf_sort, ::std::size_t __nsort)
 {
     tbb::this_task_arena::isolate([=, &__nsort]() {

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -642,7 +642,7 @@ class __func_task : public __task
     };
 
     __task*
-    cancel(tbb::detail::d1::execution_data& ) override
+    cancel(tbb::detail::d1::execution_data&) override
     {
         return finalize(nullptr);
     }

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -1173,8 +1173,8 @@ __stable_sort_func<_RandomAccessIterator1, _RandomAccessIterator2, _Compare, _Le
 
 template <class _ExecutionPolicy, typename _RandomAccessIterator, typename _Compare, typename _LeafSort>
 void
-__parallel_stable_sort(_ExecutionPolicy&&, _RandomAccessIterator __xs, _RandomAccessIterator __xe,
-                       _Compare __comp, _LeafSort __leaf_sort, ::std::size_t __nsort)
+__parallel_stable_sort(_ExecutionPolicy&&, _RandomAccessIterator __xs, _RandomAccessIterator __xe, _Compare __comp,
+                       _LeafSort __leaf_sort, ::std::size_t __nsort)
 {
     tbb::this_task_arena::isolate([=, &__nsort]() {
         //sorting based on task tree and parallel merge

--- a/include/oneapi/dpl/pstl/tuple_impl.h
+++ b/include/oneapi/dpl/pstl/tuple_impl.h
@@ -234,6 +234,7 @@ struct __copy_assignable_holder<_Tp, false> : __value_holder<_Tp>
 {
     using __value_holder<_Tp>::__value_holder;
 
+    __copy_assignable_holder(const __copy_assignable_holder& other)=default;
     __copy_assignable_holder&
     operator=(const __copy_assignable_holder& other)
     {
@@ -368,19 +369,19 @@ struct tuple<>
     tuple&
     operator=(const tuple&) = default;
     tuple&
-    operator=(const ::std::tuple<>& other)
+    operator=(const ::std::tuple<>&)
     {
         return *this;
     }
     friend bool
-    operator==(const tuple& __lhs, const tuple& __rhs)
+    operator==(const tuple&, const tuple&)
     {
         return true;
     }
 };
 
 inline void
-swap(tuple<>& __x, tuple<>& __y)
+swap(tuple<>&, tuple<>&)
 {
 }
 

--- a/include/oneapi/dpl/pstl/tuple_impl.h
+++ b/include/oneapi/dpl/pstl/tuple_impl.h
@@ -234,7 +234,7 @@ struct __copy_assignable_holder<_Tp, false> : __value_holder<_Tp>
 {
     using __value_holder<_Tp>::__value_holder;
 
-    __copy_assignable_holder(const __copy_assignable_holder& other)=default;
+    __copy_assignable_holder(const __copy_assignable_holder& other) = default;
     __copy_assignable_holder&
     operator=(const __copy_assignable_holder& other)
     {

--- a/include/oneapi/dpl/pstl/tuple_impl.h
+++ b/include/oneapi/dpl/pstl/tuple_impl.h
@@ -369,19 +369,19 @@ struct tuple<>
     tuple&
     operator=(const tuple&) = default;
     tuple&
-    operator=(const ::std::tuple<>&)
+    operator=(const ::std::tuple<>& /*other*/)
     {
         return *this;
     }
     friend bool
-    operator==(const tuple&, const tuple&)
+    operator==(const tuple& /*__lhs*/, const tuple& /*__rhs*/)
     {
         return true;
     }
 };
 
 inline void
-swap(tuple<>&, tuple<>&)
+swap(tuple<>& /*__x*/, tuple<>& /*__y*/)
 {
 }
 

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -69,7 +69,7 @@ __invoke_if(::std::true_type, _Fp __f)
 
 template <typename _Fp>
 void
-__invoke_if(::std::false_type, _Fp __f)
+__invoke_if(::std::false_type, _Fp)
 {
 }
 
@@ -82,20 +82,20 @@ __invoke_if_not(::std::false_type, _Fp __f)
 
 template <typename _Fp>
 void
-__invoke_if_not(::std::true_type, _Fp __f)
+__invoke_if_not(::std::true_type, _Fp)
 {
 }
 
 template <typename _F1, typename _F2>
 auto
-__invoke_if_else(::std::true_type, _F1 __f1, _F2 __f2) -> decltype(__f1())
+__invoke_if_else(::std::true_type, _F1 __f1, _F2) -> decltype(__f1())
 {
     return __f1();
 }
 
 template <typename _F1, typename _F2>
 auto
-__invoke_if_else(::std::false_type, _F1 __f1, _F2 __f2) -> decltype(__f2())
+__invoke_if_else(::std::false_type, _F1, _F2 __f2) -> decltype(__f2())
 {
     return __f2();
 }

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -68,8 +68,7 @@ __invoke_if(::std::true_type, _Fp __f)
 }
 
 template <typename _Fp>
-void
-__invoke_if(::std::false_type, _Fp)
+void __invoke_if(::std::false_type, _Fp)
 {
 }
 
@@ -81,8 +80,7 @@ __invoke_if_not(::std::false_type, _Fp __f)
 }
 
 template <typename _Fp>
-void
-__invoke_if_not(::std::true_type, _Fp)
+void __invoke_if_not(::std::true_type, _Fp)
 {
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,6 +51,8 @@ macro(onedpl_add_test test_source_file)
         DEPENDS ${_test_name}
         COMMENT "Build and run test ${_test_name}")
 
+    target_compile_options(${_test_name} PRIVATE "-Wall" PRIVATE "-Wformat-security" PRIVATE "-Werror=format-security" PRIVATE "-Wno-unused-lambda-capture" PRIVATE "-Wextra")
+
     # Add labels and group targets
     file(RELATIVE_PATH _test_rel_path ${CMAKE_CURRENT_SOURCE_DIR} ${test_source_file})
     get_filename_component(_test_rel_path ${_test_rel_path} DIRECTORY)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,8 +51,6 @@ macro(onedpl_add_test test_source_file)
         DEPENDS ${_test_name}
         COMMENT "Build and run test ${_test_name}")
 
-    target_compile_options(${_test_name} PRIVATE -Wunused-parameter -Wformat-security -Werror=format-security -Wno-unused-lambda-capture)
-
     # Add labels and group targets
     file(RELATIVE_PATH _test_rel_path ${CMAKE_CURRENT_SOURCE_DIR} ${test_source_file})
     get_filename_component(_test_rel_path ${_test_rel_path} DIRECTORY)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -51,7 +51,7 @@ macro(onedpl_add_test test_source_file)
         DEPENDS ${_test_name}
         COMMENT "Build and run test ${_test_name}")
 
-    target_compile_options(${_test_name} PRIVATE "-Wall" PRIVATE "-Wformat-security" PRIVATE "-Werror=format-security" PRIVATE "-Wno-unused-lambda-capture" PRIVATE "-Wextra")
+    target_compile_options(${_test_name} PRIVATE -Wunused-parameter -Wformat-security -Werror=format-security -Wno-unused-lambda-capture)
 
     # Add labels and group targets
     file(RELATIVE_PATH _test_rel_path ${CMAKE_CURRENT_SOURCE_DIR} ${test_source_file})

--- a/test/general/sycl_iterator.pass.cpp
+++ b/test/general/sycl_iterator.pass.cpp
@@ -638,7 +638,7 @@ struct test_copy_n
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1, Iterator2 first2, Iterator2, Size n)
     {
         using IteratorValueType = typename ::std::iterator_traits<Iterator1>::value_type;
         auto value = IteratorValueType(42);

--- a/test/general/sycl_iterator.pass.cpp
+++ b/test/general/sycl_iterator.pass.cpp
@@ -112,7 +112,7 @@ struct test_uninitialized_copy
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 /* last2 */, Size n)
     {
         using IteratorValueType = typename ::std::iterator_traits<Iterator1>::value_type;
         auto host_first1 = get_host_pointer(first1);
@@ -134,7 +134,7 @@ struct test_uninitialized_copy_n
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1, Iterator2 first2, Iterator2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 /* last1 */, Iterator2 first2, Iterator2 /* last2 */, Size n)
     {
         using IteratorValueType = typename ::std::iterator_traits<Iterator1>::value_type;
         auto host_first1 = get_host_pointer(first1);
@@ -156,7 +156,7 @@ struct test_uninitialized_move
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 /* last2 */, Size n)
     {
         using IteratorValueType = typename ::std::iterator_traits<Iterator1>::value_type;
         auto host_first1 = get_host_pointer(first1);
@@ -178,7 +178,7 @@ struct test_uninitialized_move_n
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1, Iterator2 first2, Iterator2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 /* last1 */, Iterator2 first2, Iterator2 /* last2 */, Size n)
     {
         using IteratorValueType = typename ::std::iterator_traits<Iterator1>::value_type;
         auto host_first1 = get_host_pointer(first1);
@@ -200,7 +200,7 @@ struct test_uninitialized_fill
 {
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 /* last1 */, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         auto value = T1(2);
@@ -220,7 +220,7 @@ struct test_uninitialized_fill_n
 {
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 /* last1 */, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         auto value = T1(2);
@@ -238,7 +238,7 @@ struct test_uninitialized_default_construct
 {
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 /* last1 */, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         T1 exp_value; // default-constructed value
@@ -261,7 +261,7 @@ struct test_uninitialized_default_construct_n
 {
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 /* last1 */, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         T1 exp_value; // default-constructed value
@@ -284,7 +284,7 @@ struct test_uninitialized_value_construct
 {
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 /* last1 */, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         auto value = T1(2);
@@ -306,7 +306,7 @@ struct test_uninitialized_value_construct_n
 {
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 /* last1 */, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         auto value = T1(2);
@@ -327,7 +327,7 @@ struct test_destroy
 {
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 /* last1 */, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         auto value = T1{2};
@@ -350,7 +350,7 @@ struct test_destroy_n
 {
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 /* last1 */, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         auto value = T1{2};
@@ -372,7 +372,7 @@ struct test_fill
 {
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 /* last1 */, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         auto value = T1(2);
@@ -390,7 +390,7 @@ struct test_fill_n
 {
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 /* last1 */, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         auto value = T1(2);
@@ -408,7 +408,7 @@ struct test_generate
 {
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 /* last1 */, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         auto value = T1(4);
@@ -427,7 +427,7 @@ struct test_generate_n
 {
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 /* last1 */, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         auto value = T1(4);
@@ -444,7 +444,7 @@ struct test_for_each
 {
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 /* last1 */, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
 
@@ -470,7 +470,7 @@ struct test_for_each_n
 {
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 /* last1 */, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         auto value = T1(6);
@@ -490,7 +490,7 @@ struct test_transform_unary
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 /* last2 */, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         auto value = T1(2);
@@ -513,7 +513,7 @@ struct test_transform_binary
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 /* last2 */, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
 
@@ -575,7 +575,7 @@ struct test_replace_copy
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 /* last2 */, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         auto value = T1(5);
@@ -595,7 +595,7 @@ struct test_replace_copy_if
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 /* last2 */, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         auto value = T1(6);
@@ -616,7 +616,7 @@ struct test_copy
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 /* last2 */, Size n)
     {
         using IteratorValueType = typename ::std::iterator_traits<Iterator1>::value_type;
         auto value = IteratorValueType(42);
@@ -638,7 +638,7 @@ struct test_copy_n
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1, Iterator2 first2, Iterator2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1, Iterator2 first2, Iterator2 /* last2 */, Size n)
     {
         using IteratorValueType = typename ::std::iterator_traits<Iterator1>::value_type;
         auto value = IteratorValueType(42);
@@ -660,7 +660,7 @@ struct test_move
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 /* last2 */, Size n)
     {
         using IteratorValueType = typename ::std::iterator_traits<Iterator1>::value_type;
         auto value = IteratorValueType(42);
@@ -682,7 +682,7 @@ struct test_adjacent_difference
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 /* last2 */, Size n)
     {
         using Iterator1ValueType = typename ::std::iterator_traits<Iterator1>::value_type;
         using Iterator2ValueType = typename ::std::iterator_traits<Iterator2>::value_type;
@@ -733,7 +733,7 @@ struct test_reduce
 {
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 /* last1 */, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         auto host_first1 = get_host_pointer(first1);
@@ -782,7 +782,7 @@ struct test_transform_reduce_binary
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2, Iterator2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 /* firs2 */, Iterator2 /* last2 */, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         auto host_first1 = get_host_pointer(first1);
@@ -1408,7 +1408,7 @@ struct test_equal
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1, Iterator2 first2, Iterator2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 /* last1 */, Iterator2 first2, Iterator2 /* last2 */, Size n)
     {
         using T = typename ::std::iterator_traits<Iterator1>::value_type;
         auto value = T(42);
@@ -1984,7 +1984,7 @@ struct test_unique_copy
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 /* last2 */, Size n)
     {
 
         using Iterator1ValueType = typename ::std::iterator_traits<Iterator1>::value_type;
@@ -2081,8 +2081,8 @@ struct test_partition_copy
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2, Iterator3 first3,
-               Iterator3, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 /* last2 */, Iterator3 first3,
+               Iterator3 /* last3 */, Size n)
     {
 
         using Iterator1ValueType = typename ::std::iterator_traits<Iterator1>::value_type;
@@ -2329,8 +2329,8 @@ struct test_merge
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2, Iterator3 first3,
-               Iterator3, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 /* last2 */, Iterator3 first3,
+               Iterator3 /* last3 */, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         typedef typename ::std::iterator_traits<Iterator2>::value_type T2;
@@ -2461,7 +2461,7 @@ struct test_partial_sort
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2, Iterator2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 /* first1 */, Iterator2 /* last2 */, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
 
@@ -2861,7 +2861,7 @@ struct test_nth_element
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 /* last2 */, Size n)
     {
         using T1 = typename ::std::iterator_traits<Iterator1>::value_type;
         using T2 = typename ::std::iterator_traits<Iterator2>::value_type;
@@ -2927,7 +2927,7 @@ struct test_reverse_copy
 {
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator1 result_first, Iterator1, Size n)
+    operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator1 result_first, Iterator1 /* result_last */, Size n)
     {
         using IteratorValyeType = typename ::std::iterator_traits<Iterator1>::value_type;
 
@@ -2972,7 +2972,7 @@ struct test_rotate_copy
 {
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator1 result_first, Iterator1, Size n)
+    operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator1 result_first, Iterator1 /* result_last */, Size n)
     {
         using IteratorValyeType = typename ::std::iterator_traits<Iterator1>::value_type;
 
@@ -3004,7 +3004,7 @@ struct test_includes
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Size)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Size /* n */)
     {
         auto host_first1 = get_host_pointer(first1);
         auto host_first2 = get_host_pointer(first2);
@@ -3035,7 +3035,7 @@ struct test_set_intersection
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     void
     operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Iterator3 first3,
-               Iterator3 last3, Size)
+               Iterator3 last3, Size /* n */)
     {
         auto host_first1 = get_host_pointer(first1);
         auto host_first2 = get_host_pointer(first2);
@@ -3087,7 +3087,7 @@ struct test_set_difference
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     void
     operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Iterator3 first3,
-               Iterator3 last3, Size)
+               Iterator3 last3, Size /* n */)
     {
 
         auto host_first1 = get_host_pointer(first1);
@@ -3114,7 +3114,7 @@ struct test_set_union
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     void
     operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Iterator3 first3,
-               Iterator3 last3, Size)
+               Iterator3 last3, Size /* n */)
     {
         auto host_first1 = get_host_pointer(first1);
         auto host_first2 = get_host_pointer(first2);
@@ -3140,7 +3140,7 @@ struct test_set_symmetric_difference
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     void
     operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Iterator3 first3,
-               Iterator3 last3, Size)
+               Iterator3 last3, Size /* n */)
     {
         auto host_first1 = get_host_pointer(first1);
         auto host_first2 = get_host_pointer(first2);

--- a/test/general/sycl_iterator.pass.cpp
+++ b/test/general/sycl_iterator.pass.cpp
@@ -112,7 +112,7 @@ struct test_uninitialized_copy
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2, Size n)
     {
         using IteratorValueType = typename ::std::iterator_traits<Iterator1>::value_type;
         auto host_first1 = get_host_pointer(first1);
@@ -134,7 +134,7 @@ struct test_uninitialized_copy_n
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1, Iterator2 first2, Iterator2, Size n)
     {
         using IteratorValueType = typename ::std::iterator_traits<Iterator1>::value_type;
         auto host_first1 = get_host_pointer(first1);
@@ -156,7 +156,7 @@ struct test_uninitialized_move
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2, Size n)
     {
         using IteratorValueType = typename ::std::iterator_traits<Iterator1>::value_type;
         auto host_first1 = get_host_pointer(first1);
@@ -178,7 +178,7 @@ struct test_uninitialized_move_n
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1, Iterator2 first2, Iterator2, Size n)
     {
         using IteratorValueType = typename ::std::iterator_traits<Iterator1>::value_type;
         auto host_first1 = get_host_pointer(first1);
@@ -200,7 +200,7 @@ struct test_uninitialized_fill
 {
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         auto value = T1(2);
@@ -220,7 +220,7 @@ struct test_uninitialized_fill_n
 {
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         auto value = T1(2);
@@ -238,7 +238,7 @@ struct test_uninitialized_default_construct
 {
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         T1 exp_value; // default-constructed value
@@ -261,7 +261,7 @@ struct test_uninitialized_default_construct_n
 {
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         T1 exp_value; // default-constructed value
@@ -284,7 +284,7 @@ struct test_uninitialized_value_construct
 {
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         auto value = T1(2);
@@ -306,7 +306,7 @@ struct test_uninitialized_value_construct_n
 {
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         auto value = T1(2);
@@ -327,7 +327,7 @@ struct test_destroy
 {
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         auto value = T1{2};
@@ -350,7 +350,7 @@ struct test_destroy_n
 {
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         auto value = T1{2};
@@ -372,7 +372,7 @@ struct test_fill
 {
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         auto value = T1(2);
@@ -390,7 +390,7 @@ struct test_fill_n
 {
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         auto value = T1(2);
@@ -408,7 +408,7 @@ struct test_generate
 {
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         auto value = T1(4);
@@ -427,7 +427,7 @@ struct test_generate_n
 {
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         auto value = T1(4);
@@ -444,7 +444,7 @@ struct test_for_each
 {
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
 
@@ -470,7 +470,7 @@ struct test_for_each_n
 {
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         auto value = T1(6);
@@ -490,7 +490,7 @@ struct test_transform_unary
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         auto value = T1(2);
@@ -513,7 +513,7 @@ struct test_transform_binary
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
 
@@ -575,7 +575,7 @@ struct test_replace_copy
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         auto value = T1(5);
@@ -595,7 +595,7 @@ struct test_replace_copy_if
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         auto value = T1(6);
@@ -616,7 +616,7 @@ struct test_copy
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2, Size n)
     {
         using IteratorValueType = typename ::std::iterator_traits<Iterator1>::value_type;
         auto value = IteratorValueType(42);
@@ -638,7 +638,7 @@ struct test_copy_n
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2, Size n)
     {
         using IteratorValueType = typename ::std::iterator_traits<Iterator1>::value_type;
         auto value = IteratorValueType(42);
@@ -660,7 +660,7 @@ struct test_move
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2, Size n)
     {
         using IteratorValueType = typename ::std::iterator_traits<Iterator1>::value_type;
         auto value = IteratorValueType(42);
@@ -682,7 +682,7 @@ struct test_adjacent_difference
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2, Size n)
     {
         using Iterator1ValueType = typename ::std::iterator_traits<Iterator1>::value_type;
         using Iterator2ValueType = typename ::std::iterator_traits<Iterator2>::value_type;
@@ -733,7 +733,7 @@ struct test_reduce
 {
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         auto host_first1 = get_host_pointer(first1);
@@ -782,7 +782,7 @@ struct test_transform_reduce_binary
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2, Iterator2, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         auto host_first1 = get_host_pointer(first1);
@@ -1408,7 +1408,7 @@ struct test_equal
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1, Iterator2 first2, Iterator2, Size n)
     {
         using T = typename ::std::iterator_traits<Iterator1>::value_type;
         auto value = T(42);
@@ -1984,7 +1984,7 @@ struct test_unique_copy
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2, Size n)
     {
 
         using Iterator1ValueType = typename ::std::iterator_traits<Iterator1>::value_type;
@@ -2081,8 +2081,8 @@ struct test_partition_copy
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Iterator3 first3,
-               Iterator3 last3, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2, Iterator3 first3,
+               Iterator3, Size n)
     {
 
         using Iterator1ValueType = typename ::std::iterator_traits<Iterator1>::value_type;
@@ -2329,8 +2329,8 @@ struct test_merge
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Iterator3 first3,
-               Iterator3 last3, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2, Iterator3 first3,
+               Iterator3, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         typedef typename ::std::iterator_traits<Iterator2>::value_type T2;
@@ -2461,7 +2461,7 @@ struct test_partial_sort
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2, Iterator2, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
 
@@ -2861,7 +2861,7 @@ struct test_nth_element
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2, Size n)
     {
         using T1 = typename ::std::iterator_traits<Iterator1>::value_type;
         using T2 = typename ::std::iterator_traits<Iterator2>::value_type;
@@ -2927,7 +2927,7 @@ struct test_reverse_copy
 {
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator1 result_first, Iterator1 result_last, Size n)
+    operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator1 result_first, Iterator1, Size n)
     {
         using IteratorValyeType = typename ::std::iterator_traits<Iterator1>::value_type;
 
@@ -2972,7 +2972,7 @@ struct test_rotate_copy
 {
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator1 result_first, Iterator1 result_last, Size n)
+    operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator1 result_first, Iterator1, Size n)
     {
         using IteratorValyeType = typename ::std::iterator_traits<Iterator1>::value_type;
 
@@ -3004,7 +3004,7 @@ struct test_includes
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Size)
     {
         auto host_first1 = get_host_pointer(first1);
         auto host_first2 = get_host_pointer(first2);
@@ -3035,7 +3035,7 @@ struct test_set_intersection
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     void
     operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Iterator3 first3,
-               Iterator3 last3, Size n)
+               Iterator3 last3, Size)
     {
         auto host_first1 = get_host_pointer(first1);
         auto host_first2 = get_host_pointer(first2);
@@ -3087,7 +3087,7 @@ struct test_set_difference
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     void
     operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Iterator3 first3,
-               Iterator3 last3, Size n)
+               Iterator3 last3, Size)
     {
 
         auto host_first1 = get_host_pointer(first1);
@@ -3114,7 +3114,7 @@ struct test_set_union
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     void
     operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Iterator3 first3,
-               Iterator3 last3, Size n)
+               Iterator3 last3, Size)
     {
         auto host_first1 = get_host_pointer(first1);
         auto host_first2 = get_host_pointer(first2);
@@ -3140,7 +3140,7 @@ struct test_set_symmetric_difference
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     void
     operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Iterator3 first3,
-               Iterator3 last3, Size n)
+               Iterator3 last3, Size)
     {
         auto host_first1 = get_host_pointer(first1);
         auto host_first2 = get_host_pointer(first2);

--- a/test/parallel_api/algorithm/alg.merge/inplace_merge.pass.cpp
+++ b/test/parallel_api/algorithm/alg.merge/inplace_merge.pass.cpp
@@ -48,8 +48,8 @@ struct test_one_policy
     template <typename Policy, typename BiDirIt1, typename Size, typename Generator1, typename Generator2,
               typename Compare>
     typename ::std::enable_if<is_same_iterator_category<BiDirIt1, ::std::forward_iterator_tag>::value, void>::type
-    operator()(Policy&& exec, BiDirIt1 first1, BiDirIt1 last1, BiDirIt1 first2, BiDirIt1 last2, Size n, Size m,
-               Generator1 generator1, Generator2 generator2, Compare comp)
+    operator()(Policy&&, BiDirIt1, BiDirIt1, BiDirIt1, BiDirIt1, Size, Size,
+               Generator1, Generator2, Compare)
     {
     }
 };

--- a/test/parallel_api/algorithm/alg.merge/inplace_merge.pass.cpp
+++ b/test/parallel_api/algorithm/alg.merge/inplace_merge.pass.cpp
@@ -48,8 +48,8 @@ struct test_one_policy
     template <typename Policy, typename BiDirIt1, typename Size, typename Generator1, typename Generator2,
               typename Compare>
     typename ::std::enable_if<is_same_iterator_category<BiDirIt1, ::std::forward_iterator_tag>::value, void>::type
-    operator()(Policy&&, BiDirIt1, BiDirIt1, BiDirIt1, BiDirIt1, Size, Size,
-               Generator1, Generator2, Compare)
+    operator()(Policy&& /* exec */, BiDirIt1 /* first1 */, BiDirIt1 /* last1 */, BiDirIt1 /* first2 */, BiDirIt1 /* last2 */, Size /* n */, Size /* m */,
+               Generator1 /* generator1 */, Generator2 /* generator2 */, Compare /* comp */)
     {
     }
 };

--- a/test/parallel_api/algorithm/alg.merge/merge.pass.cpp
+++ b/test/parallel_api/algorithm/alg.merge/merge.pass.cpp
@@ -82,7 +82,7 @@ struct test_merge_compare
     operator()(Policy&& exec, ::std::reverse_iterator<InputIterator1> first1, ::std::reverse_iterator<InputIterator1> last1,
                ::std::reverse_iterator<InputIterator2> first2, ::std::reverse_iterator<InputIterator2> last2,
                ::std::reverse_iterator<OutputIterator> out_first, ::std::reverse_iterator<OutputIterator> out_last,
-               Compare)
+               Compare /* comp */)
     {
         using namespace std;
         typedef typename ::std::iterator_traits<::std::reverse_iterator<InputIterator1>>::value_type T;

--- a/test/parallel_api/algorithm/alg.merge/merge.pass.cpp
+++ b/test/parallel_api/algorithm/alg.merge/merge.pass.cpp
@@ -82,7 +82,7 @@ struct test_merge_compare
     operator()(Policy&& exec, ::std::reverse_iterator<InputIterator1> first1, ::std::reverse_iterator<InputIterator1> last1,
                ::std::reverse_iterator<InputIterator2> first2, ::std::reverse_iterator<InputIterator2> last2,
                ::std::reverse_iterator<OutputIterator> out_first, ::std::reverse_iterator<OutputIterator> out_last,
-               Compare comp)
+               Compare)
     {
         using namespace std;
         typedef typename ::std::iterator_traits<::std::reverse_iterator<InputIterator1>>::value_type T;

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.copy/copy_if.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.copy/copy_if.pass.cpp
@@ -54,7 +54,7 @@ struct run_copy_if
               typename Predicate, typename T>
     void
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator out_last, OutputIterator2 expected_first, OutputIterator2 expected_last, Size n,
+               OutputIterator, OutputIterator2 expected_first, OutputIterator2 expected_last, Size n,
                Predicate pred, T trash)
     {
         // Cleaning
@@ -106,7 +106,7 @@ template <typename InputIterator, typename OutputIterator, typename OutputIterat
               typename Predicate, typename T>
     void
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator out_last, OutputIterator2 expected_first, OutputIterator2 expected_last, Size n,
+               OutputIterator, OutputIterator2 expected_first, OutputIterator2 expected_last, Size n,
                Predicate pred, T trash)
     {
         // Cleaning
@@ -219,7 +219,7 @@ main()
 #if !_ONEDPL_BACKEND_SYCL
     test<Number>(Number(42, OddTag()), IsMultiple(3, OddTag()), [](int32_t j) { return Number(j, OddTag()); });
 #endif
-    test<int32_t>(-666, [](const int32_t& x) { return true; }, [](size_t j) { return j; }, false);
+    test<int32_t>(-666, [](const int32_t&) { return true; }, [](size_t j) { return j; }, false);
 
 #if defined(_PSTL_TEST_REMOVE_COPY_IF)
     test_algo_basic_double<int32_t>(run_for_rnd_fw<test_non_const_remove_copy_if>());

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.copy/copy_if.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.copy/copy_if.pass.cpp
@@ -54,7 +54,7 @@ struct run_copy_if
               typename Predicate, typename T>
     void
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator, OutputIterator2 expected_first, OutputIterator2 expected_last, Size n,
+               OutputIterator, OutputIterator2 expected_first, OutputIterator2, Size n,
                Predicate pred, T trash)
     {
         // Cleaning
@@ -106,7 +106,7 @@ template <typename InputIterator, typename OutputIterator, typename OutputIterat
               typename Predicate, typename T>
     void
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator, OutputIterator2 expected_first, OutputIterator2 expected_last, Size n,
+               OutputIterator, OutputIterator2 expected_first, OutputIterator2, Size n,
                Predicate pred, T trash)
     {
         // Cleaning

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.copy/copy_if.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.copy/copy_if.pass.cpp
@@ -54,7 +54,7 @@ struct run_copy_if
               typename Predicate, typename T>
     void
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator, OutputIterator2 expected_first, OutputIterator2, Size n,
+               OutputIterator /* out_last */, OutputIterator2 expected_first, OutputIterator2 /* expected_last */, Size n,
                Predicate pred, T trash)
     {
         // Cleaning
@@ -106,7 +106,7 @@ template <typename InputIterator, typename OutputIterator, typename OutputIterat
               typename Predicate, typename T>
     void
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator, OutputIterator2 expected_first, OutputIterator2, Size n,
+               OutputIterator /* out_last */, OutputIterator2 expected_first, OutputIterator2 /* expected_last */, Size n,
                Predicate pred, T trash)
     {
         // Cleaning

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition.pass.cpp
@@ -62,7 +62,7 @@ is_equal(Iterator first, Iterator last, Iterator d_first)
 
 template <typename Iterator>
 typename ::std::enable_if<!::std::is_trivial<typename ::std::iterator_traits<Iterator>::value_type>::value, bool>::type
-is_equal(Iterator first, Iterator last, Iterator d_first)
+is_equal(Iterator, Iterator, Iterator)
 {
     return true;
 }
@@ -72,7 +72,7 @@ struct test_partition
 {
     template <typename Policy, typename BiDirIt, typename Size, typename UnaryOp, typename Generator>
     typename ::std::enable_if<!is_same_iterator_category<BiDirIt, ::std::forward_iterator_tag>::value, void>::type
-    operator()(Policy&& exec, BiDirIt first, BiDirIt last, BiDirIt exp_first, BiDirIt exp_last, Size n,
+    operator()(Policy&& exec, BiDirIt first, BiDirIt last, BiDirIt, BiDirIt, Size,
                UnaryOp unary_op, Generator generator)
     {
         fill_data(first, last, generator);
@@ -83,8 +83,8 @@ struct test_partition
 
     template <typename Policy, typename BiDirIt, typename Size, typename UnaryOp, typename Generator>
     typename ::std::enable_if<is_same_iterator_category<BiDirIt, ::std::forward_iterator_tag>::value, void>::type
-    operator()(Policy&& exec, BiDirIt first, BiDirIt last, BiDirIt exp_first, BiDirIt exp_last, Size n,
-               UnaryOp unary_op, Generator generator)
+    operator()(Policy&&, BiDirIt, BiDirIt, BiDirIt, BiDirIt, Size,
+               UnaryOp, Generator)
     {
     }
 };

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition.pass.cpp
@@ -62,7 +62,7 @@ is_equal(Iterator first, Iterator last, Iterator d_first)
 
 template <typename Iterator>
 typename ::std::enable_if<!::std::is_trivial<typename ::std::iterator_traits<Iterator>::value_type>::value, bool>::type
-is_equal(Iterator, Iterator, Iterator)
+is_equal(Iterator /* first */, Iterator /* last */, Iterator /* d_first */)
 {
     return true;
 }
@@ -72,7 +72,7 @@ struct test_partition
 {
     template <typename Policy, typename BiDirIt, typename Size, typename UnaryOp, typename Generator>
     typename ::std::enable_if<!is_same_iterator_category<BiDirIt, ::std::forward_iterator_tag>::value, void>::type
-    operator()(Policy&& exec, BiDirIt first, BiDirIt last, BiDirIt, BiDirIt, Size,
+    operator()(Policy&& exec, BiDirIt first, BiDirIt last, BiDirIt /* exp_first */, BiDirIt /* exp_last */, Size /* n */,
                UnaryOp unary_op, Generator generator)
     {
         fill_data(first, last, generator);
@@ -83,8 +83,8 @@ struct test_partition
 
     template <typename Policy, typename BiDirIt, typename Size, typename UnaryOp, typename Generator>
     typename ::std::enable_if<is_same_iterator_category<BiDirIt, ::std::forward_iterator_tag>::value, void>::type
-    operator()(Policy&&, BiDirIt, BiDirIt, BiDirIt, BiDirIt, Size,
-               UnaryOp, Generator)
+    operator()(Policy&& /* exec */, BiDirIt /* first */, BiDirIt /* last */, BiDirIt /* exp_first */, BiDirIt /* exp_last */, Size /* n */,
+               UnaryOp /* unary_op */, Generator /* generator */)
     {
     }
 };

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition_copy.pass.cpp
@@ -33,7 +33,7 @@ struct test_partition_copy
               typename UnaryOp>
     void
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator true_first,
-               OutputIterator true_last, OutputIterator2 false_first, OutputIterator2 false_last, UnaryOp unary_op)
+               OutputIterator, OutputIterator2 false_first, OutputIterator2, UnaryOp unary_op)
     {
 
         auto actual_ret = ::std::partition_copy(exec, first, last, true_first, false_first, unary_op);
@@ -50,16 +50,16 @@ struct test_partition_copy
 template <typename InputIterator, typename OutputIterator, typename OutputIterator2,
           typename UnaryOp>
     void
-    operator()(oneapi::dpl::execution::unsequenced_policy, InputIterator first, InputIterator last, OutputIterator true_first,
-               OutputIterator true_last, OutputIterator2 false_first, OutputIterator2 false_last, UnaryOp unary_op)
+    operator()(oneapi::dpl::execution::unsequenced_policy, InputIterator, InputIterator, OutputIterator,
+               OutputIterator, OutputIterator2, OutputIterator2, UnaryOp)
     {
     }
 
     template <typename InputIterator, typename OutputIterator, typename OutputIterator2,
               typename UnaryOp>
     void
-    operator()(oneapi::dpl::execution::parallel_unsequenced_policy, InputIterator first, InputIterator last, OutputIterator true_first,
-               OutputIterator true_last, OutputIterator2 false_first, OutputIterator2 false_last, UnaryOp unary_op)
+    operator()(oneapi::dpl::execution::parallel_unsequenced_policy, InputIterator, InputIterator, OutputIterator,
+               OutputIterator, OutputIterator2, OutputIterator2, UnaryOp)
     {
     }
 #endif
@@ -106,7 +106,7 @@ int
 main()
 {
     test<int16_t>([](const int32_t value) { return value % 2 == 0; });
-    test<int32_t>([](const int32_t value) { return true; });
+    test<int32_t>([](const int32_t) { return true; });
 
 #if !_ONEDPL_FPGA_DEVICE
     test<float64_t>([](const float64_t value) { return value > 2 << 6; });

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition_copy.pass.cpp
@@ -50,16 +50,16 @@ struct test_partition_copy
 template <typename InputIterator, typename OutputIterator, typename OutputIterator2,
           typename UnaryOp>
     void
-    operator()(oneapi::dpl::execution::unsequenced_policy, InputIterator, InputIterator, OutputIterator,
-               OutputIterator, OutputIterator2, OutputIterator2, UnaryOp)
+    operator()(oneapi::dpl::execution::unsequenced_policy, InputIterator /* first */, InputIterator /* last */, OutputIterator /* true_first */,
+               OutputIterator /* true_last */, OutputIterator2 /* false_first */, OutputIterator2 /* false_last */, /* UnaryOp unary_op */)
     {
     }
 
     template <typename InputIterator, typename OutputIterator, typename OutputIterator2,
               typename UnaryOp>
     void
-    operator()(oneapi::dpl::execution::parallel_unsequenced_policy, InputIterator, InputIterator, OutputIterator,
-               OutputIterator, OutputIterator2, OutputIterator2, UnaryOp)
+    operator()(oneapi::dpl::execution::parallel_unsequenced_policy, InputIterator /* first */, InputIterator /* last */, OutputIterator /* true_first */,
+               OutputIterator /* true_last */, OutputIterator2 /* false_first */, OutputIterator2 /* false_last */, /* UnaryOp unary_op */)
     {
     }
 #endif

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/stable_partition.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/stable_partition.pass.cpp
@@ -62,7 +62,7 @@ is_equal(Iterator first, Iterator last, Iterator d_first)
 
 template <typename Iterator>
 typename ::std::enable_if<!::std::is_trivial<typename ::std::iterator_traits<Iterator>::value_type>::value, bool>::type
-is_equal(Iterator, Iterator, Iterator)
+is_equal(Iterator /* first */, Iterator /* last */, Iterator /* d_first */)
 {
     return true;
 }
@@ -72,7 +72,7 @@ struct test_stable_partition
 {
     template <typename Policy, typename BiDirIt, typename Size, typename UnaryOp, typename Generator>
     typename ::std::enable_if<!is_same_iterator_category<BiDirIt, ::std::forward_iterator_tag>::value, void>::type
-    operator()(Policy&& exec, BiDirIt first, BiDirIt last, BiDirIt exp_first, BiDirIt exp_last, Size,
+    operator()(Policy&& exec, BiDirIt first, BiDirIt last, BiDirIt exp_first, BiDirIt exp_last, Size /* n */,
                UnaryOp unary_op, Generator generator)
     {
         fill_data(exp_first, exp_last, generator);
@@ -87,8 +87,8 @@ struct test_stable_partition
 
     template <typename Policy, typename BiDirIt, typename Size, typename UnaryOp, typename Generator>
     typename ::std::enable_if<is_same_iterator_category<BiDirIt, ::std::forward_iterator_tag>::value, void>::type
-    operator()(Policy&&, BiDirIt, BiDirIt, BiDirIt, BiDirIt, Size,
-               UnaryOp, Generator)
+    operator()(Policy&& /* exec */, BiDirIt /* first */, BiDirIt /* last */, BiDirIt /* exp_first */, BiDirIt /* exp_last */, Size /* n */,
+               UnaryOp /* unary_op */, Generator /* generator */)
     {
     }
 };

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/stable_partition.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/stable_partition.pass.cpp
@@ -62,7 +62,7 @@ is_equal(Iterator first, Iterator last, Iterator d_first)
 
 template <typename Iterator>
 typename ::std::enable_if<!::std::is_trivial<typename ::std::iterator_traits<Iterator>::value_type>::value, bool>::type
-is_equal(Iterator first, Iterator last, Iterator d_first)
+is_equal(Iterator, Iterator, Iterator)
 {
     return true;
 }
@@ -72,7 +72,7 @@ struct test_stable_partition
 {
     template <typename Policy, typename BiDirIt, typename Size, typename UnaryOp, typename Generator>
     typename ::std::enable_if<!is_same_iterator_category<BiDirIt, ::std::forward_iterator_tag>::value, void>::type
-    operator()(Policy&& exec, BiDirIt first, BiDirIt last, BiDirIt exp_first, BiDirIt exp_last, Size n,
+    operator()(Policy&& exec, BiDirIt first, BiDirIt last, BiDirIt exp_first, BiDirIt exp_last, Size,
                UnaryOp unary_op, Generator generator)
     {
         fill_data(exp_first, exp_last, generator);
@@ -87,8 +87,8 @@ struct test_stable_partition
 
     template <typename Policy, typename BiDirIt, typename Size, typename UnaryOp, typename Generator>
     typename ::std::enable_if<is_same_iterator_category<BiDirIt, ::std::forward_iterator_tag>::value, void>::type
-    operator()(Policy&& exec, BiDirIt first, BiDirIt last, BiDirIt exp_first, BiDirIt exp_last, Size n,
-               UnaryOp unary_op, Generator generator)
+    operator()(Policy&&, BiDirIt, BiDirIt, BiDirIt, BiDirIt, Size,
+               UnaryOp, Generator)
     {
     }
 };

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse.pass.cpp
@@ -60,7 +60,7 @@ struct test_one_policy
 
     template <typename ExecutionPolicy, typename Iterator1, typename Iterator2>
     typename ::std::enable_if<is_same_iterator_category<Iterator1, ::std::forward_iterator_tag>::value>::type
-    operator()(ExecutionPolicy&&, Iterator1, Iterator1, Iterator2, Iterator2)
+    operator()(ExecutionPolicy&& /* exec */, Iterator1 /* data_b */, Iterator1 /* data_e */, Iterator2 /* actual_b */, Iterator2 /* actual_e */)
     {
     }
 };

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse.pass.cpp
@@ -60,7 +60,7 @@ struct test_one_policy
 
     template <typename ExecutionPolicy, typename Iterator1, typename Iterator2>
     typename ::std::enable_if<is_same_iterator_category<Iterator1, ::std::forward_iterator_tag>::value>::type
-    operator()(ExecutionPolicy&& exec, Iterator1 data_b, Iterator1 data_e, Iterator2 actual_b, Iterator2 actual_e)
+    operator()(ExecutionPolicy&&, Iterator1, Iterator1, Iterator2, Iterator2)
     {
     }
 };

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse_copy.pass.cpp
@@ -73,7 +73,7 @@ struct test_one_policy
 
     template <typename ExecutionPolicy, typename Iterator1, typename Iterator2>
     typename ::std::enable_if<is_same_iterator_category<Iterator1, ::std::forward_iterator_tag>::value>::type
-    operator()(ExecutionPolicy&& exec, Iterator1 data_b, Iterator1 data_e, Iterator2 actual_b, Iterator2 actual_e)
+    operator()(ExecutionPolicy&&, Iterator1, Iterator1, Iterator2, Iterator2)
     {
     }
 };

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse_copy.pass.cpp
@@ -73,7 +73,7 @@ struct test_one_policy
 
     template <typename ExecutionPolicy, typename Iterator1, typename Iterator2>
     typename ::std::enable_if<is_same_iterator_category<Iterator1, ::std::forward_iterator_tag>::value>::type
-    operator()(ExecutionPolicy&&, Iterator1, Iterator1, Iterator2, Iterator2)
+    operator()(ExecutionPolicy&& /* exec */, Iterator1 /* data_b */, Iterator1 /* data_e */, Iterator2 /* actual_b */, Iterator2 /* actual_e*/)
     {
     }
 };

--- a/test/parallel_api/algorithm/alg.modifying.operations/copy_move.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/copy_move.pass.cpp
@@ -36,7 +36,7 @@ struct run_copy
     template <typename Policy, typename InputIterator, typename OutputIterator, typename OutputIterator2, typename Size>
     void
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator out_last, OutputIterator2 expected_first, OutputIterator2, Size size,
+               OutputIterator out_last, OutputIterator2 expected_first, OutputIterator2 /* expected_last */, Size size,
                Size, T trash)
     {
         // Cleaning
@@ -59,7 +59,7 @@ struct run_copy_n
     template <typename Policy, typename InputIterator, typename OutputIterator, typename OutputIterator2, typename Size>
     void
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator out_last, OutputIterator2 expected_first, OutputIterator2, Size size,
+               OutputIterator out_last, OutputIterator2 expected_first, OutputIterator2 /* expected_last */, Size size,
                Size n, T trash)
     {
         // Cleaning
@@ -82,7 +82,7 @@ struct run_move
     template <typename Policy, typename InputIterator, typename OutputIterator, typename OutputIterator2, typename Size>
     void
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator out_last, OutputIterator2 expected_first, OutputIterator2, Size size,
+               OutputIterator out_last, OutputIterator2 expected_first, OutputIterator2 /* expected_last */, Size size,
                Size, T trash)
     {
         // Cleaning
@@ -105,8 +105,8 @@ struct run_move<Wrapper<T>>
     template <typename Policy, typename InputIterator, typename OutputIterator, typename OutputIterator2, typename Size>
     void
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator out_last, OutputIterator2, OutputIterator2, Size size,
-               Size, Wrapper<T> trash)
+               OutputIterator out_last, OutputIterator2 /* expected_first */, OutputIterator2 /* expected_last */, Size size,
+               Size /* n */, Wrapper<T> trash)
     {
         // Cleaning
         ::std::fill_n(out_first, size, trash);

--- a/test/parallel_api/algorithm/alg.modifying.operations/copy_move.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/copy_move.pass.cpp
@@ -36,8 +36,8 @@ struct run_copy
     template <typename Policy, typename InputIterator, typename OutputIterator, typename OutputIterator2, typename Size>
     void
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator out_last, OutputIterator2 expected_first, OutputIterator2 expected_last, Size size,
-               Size n, T trash)
+               OutputIterator out_last, OutputIterator2 expected_first, OutputIterator2, Size size,
+               Size, T trash)
     {
         // Cleaning
         ::std::fill_n(expected_first, size, trash);
@@ -59,7 +59,7 @@ struct run_copy_n
     template <typename Policy, typename InputIterator, typename OutputIterator, typename OutputIterator2, typename Size>
     void
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator out_last, OutputIterator2 expected_first, OutputIterator2 expected_last, Size size,
+               OutputIterator out_last, OutputIterator2 expected_first, OutputIterator2, Size size,
                Size n, T trash)
     {
         // Cleaning
@@ -82,7 +82,7 @@ struct run_move
     template <typename Policy, typename InputIterator, typename OutputIterator, typename OutputIterator2, typename Size>
     void
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator out_last, OutputIterator2 expected_first, OutputIterator2 expected_last, Size size,
+               OutputIterator out_last, OutputIterator2 expected_first, OutputIterator2t, Size size,
                Size n, T trash)
     {
         // Cleaning
@@ -105,8 +105,8 @@ struct run_move<Wrapper<T>>
     template <typename Policy, typename InputIterator, typename OutputIterator, typename OutputIterator2, typename Size>
     void
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator out_last, OutputIterator2 expected_first, OutputIterator2 expected_last, Size size,
-               Size n, Wrapper<T> trash)
+               OutputIterator out_last, OutputIterator2, OutputIterator2, Size size,
+               Size, Wrapper<T> trash)
     {
         // Cleaning
         ::std::fill_n(out_first, size, trash);

--- a/test/parallel_api/algorithm/alg.modifying.operations/copy_move.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/copy_move.pass.cpp
@@ -82,8 +82,8 @@ struct run_move
     template <typename Policy, typename InputIterator, typename OutputIterator, typename OutputIterator2, typename Size>
     void
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator out_last, OutputIterator2 expected_first, OutputIterator2t, Size size,
-               Size n, T trash)
+               OutputIterator out_last, OutputIterator2 expected_first, OutputIterator2, Size size,
+               Size, T trash)
     {
         // Cleaning
         ::std::fill_n(expected_first, size, trash);

--- a/test/parallel_api/algorithm/alg.modifying.operations/fill.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/fill.pass.cpp
@@ -86,7 +86,7 @@ template <typename T>
 void
 test_fill_by_type(::std::size_t n)
 {
-    Sequence<T> in(n, [](::std::size_t v) -> T { return T(0); }); //fill with zeros
+    Sequence<T> in(n, [](::std::size_t) -> T { return T(0); }); //fill with zeros
     T value = -1;
 
 #ifdef _PSTL_TEST_FILL

--- a/test/parallel_api/algorithm/alg.modifying.operations/generate.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/generate.pass.cpp
@@ -65,7 +65,7 @@ struct test_generate_n
 {
     template <typename Policy, typename Iterator, typename Size>
     void
-    operator()(Policy&& exec, Iterator first, Iterator last, Size n)
+    operator()(Policy&& exec, Iterator first, Iterator, Size n)
     {
         using namespace std;
 
@@ -84,7 +84,7 @@ test_generate_by_type()
 {
     for (size_t n = 0; n <= 100000; n = n < 16 ? n + 1 : size_t(3.1415 * n))
     {
-        Sequence<T> in(n, [](size_t v) -> T { return T(0); }); //fill by zero
+        Sequence<T> in(n, [](size_t) -> T { return T(0); }); //fill by zero
 
 #ifdef _PSTL_TEST_GENERATE
         invoke_on_all_policies<>()(test_generate<T>(), in.begin(), in.end(), in.size());

--- a/test/parallel_api/algorithm/alg.modifying.operations/generate.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/generate.pass.cpp
@@ -65,7 +65,7 @@ struct test_generate_n
 {
     template <typename Policy, typename Iterator, typename Size>
     void
-    operator()(Policy&& exec, Iterator first, Iterator, Size n)
+    operator()(Policy&& exec, Iterator first, Iterator /* last */, Size n)
     {
         using namespace std;
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/remove.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/remove.pass.cpp
@@ -113,7 +113,7 @@ int
 main()
 {
 #if !_PSTL_ICC_18_TEST_EARLY_EXIT_MONOTONIC_RELEASE_BROKEN
-    test<uint32_t>(666, 42, [](uint32_t val) { return true; }, [](size_t j) { return j; });
+    test<uint32_t>(666, 42, [](uint32_t) { return true; }, [](size_t j) { return j; });
 #endif
 
     test<int32_t>(666, 2001, [](const int32_t& val) { return val != 2001; },

--- a/test/parallel_api/algorithm/alg.modifying.operations/remove_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/remove_copy.pass.cpp
@@ -28,7 +28,7 @@ struct run_remove_copy
     template <typename Policy, typename InputIterator, typename OutputIterator, typename OutputIterator2, typename Size>
     void
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator, OutputIterator2 expected_first, OutputIterator2, Size n,
+               OutputIterator, OutputIterator2 expected_first, OutputIterator2 /* expected_last */, Size n,
                const T& value, T trash)
     {
         // Cleaning

--- a/test/parallel_api/algorithm/alg.modifying.operations/remove_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/remove_copy.pass.cpp
@@ -28,7 +28,7 @@ struct run_remove_copy
     template <typename Policy, typename InputIterator, typename OutputIterator, typename OutputIterator2, typename Size>
     void
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator out_last, OutputIterator2 expected_first, OutputIterator2 expected_last, Size n,
+               OutputIterator, OutputIterator2 expected_first, OutputIterator2, Size n,
                const T& value, T trash)
     {
         // Cleaning

--- a/test/parallel_api/algorithm/alg.modifying.operations/replace.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/replace.pass.cpp
@@ -62,7 +62,7 @@ struct test_replace
     template <typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3, typename T, typename Predicate>
     void
     operator()(ExecutionPolicy&& exec, Iterator1 expected_b, Iterator1 expected_e, Iterator2 actual_b,
-               Iterator2 actual_e, Iterator3 data_b, Iterator3 data_e, Predicate, const T& value, const T& old_value)
+               Iterator2 actual_e, Iterator3 data_b, Iterator3 data_e, Predicate /* pred */, const T& value, const T& old_value)
     {
         using namespace std;
 
@@ -97,7 +97,7 @@ struct test_replace_if
     template <typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3, typename T, typename Predicate>
     void
     operator()(ExecutionPolicy&& exec, Iterator1 expected_b, Iterator1 expected_e, Iterator2 actual_b,
-               Iterator2 actual_e, Iterator3 data_b, Iterator3 data_e, Predicate pred, const T& value, const T&)
+               Iterator2 actual_e, Iterator3 data_b, Iterator3 data_e, Predicate pred, const T& value, const T& /* old_value */)
     {
         using namespace std;
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/replace.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/replace.pass.cpp
@@ -62,7 +62,7 @@ struct test_replace
     template <typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3, typename T, typename Predicate>
     void
     operator()(ExecutionPolicy&& exec, Iterator1 expected_b, Iterator1 expected_e, Iterator2 actual_b,
-               Iterator2 actual_e, Iterator3 data_b, Iterator3 data_e, Predicate pred, const T& value, const T& old_value)
+               Iterator2 actual_e, Iterator3 data_b, Iterator3 data_e, Predicate, const T& value, const T& old_value)
     {
         using namespace std;
 
@@ -78,7 +78,7 @@ struct test_replace
 
     template <typename T, typename Iterator1>
     bool
-    check(Iterator1 b, Iterator1 e)
+    check(Iterator1, Iterator1)
     {
         return true;
     }
@@ -97,7 +97,7 @@ struct test_replace_if
     template <typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Iterator3, typename T, typename Predicate>
     void
     operator()(ExecutionPolicy&& exec, Iterator1 expected_b, Iterator1 expected_e, Iterator2 actual_b,
-               Iterator2 actual_e, Iterator3 data_b, Iterator3 data_e, Predicate pred, const T& value, const T& old_value)
+               Iterator2 actual_e, Iterator3 data_b, Iterator3 data_e, Predicate pred, const T& value, const T&)
     {
         using namespace std;
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/replace_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/replace_copy.pass.cpp
@@ -36,8 +36,8 @@ struct test_replace_copy
               typename Predicate, typename T>
     void
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator out_last, OutputIterator2 expected_first, OutputIterator2 expected_last, Size n,
-               Predicate pred, const T& old_value, const T& new_value, T trash)
+               OutputIterator out_last, OutputIterator2 expected_first, OutputIterator2, Size n,
+               Predicate, const T& old_value, const T& new_value, T trash)
     {
         // Cleaning
         ::std::fill_n(expected_first, n, trash);
@@ -57,8 +57,8 @@ struct test_replace_copy_if
               typename Predicate, typename T>
     void
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator out_last, OutputIterator2 expected_first, OutputIterator2 expected_last, Size n,
-               Predicate pred, const T& old_value, const T& new_value, T trash)
+               OutputIterator out_last, OutputIterator2 expected_first, OutputIterator2, Size n,
+               Predicate pred, const T&, const T& new_value, T trash)
     {
         // Cleaning
         ::std::fill_n(expected_first, n, trash);

--- a/test/parallel_api/algorithm/alg.modifying.operations/replace_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/replace_copy.pass.cpp
@@ -36,8 +36,8 @@ struct test_replace_copy
               typename Predicate, typename T>
     void
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator out_last, OutputIterator2 expected_first, OutputIterator2, Size n,
-               Predicate, const T& old_value, const T& new_value, T trash)
+               OutputIterator out_last, OutputIterator2 expected_first, OutputIterator2 /* expected_last */, Size n,
+               Predicate /* pred */, const T& old_value, const T& new_value, T trash)
     {
         // Cleaning
         ::std::fill_n(expected_first, n, trash);
@@ -57,8 +57,8 @@ struct test_replace_copy_if
               typename Predicate, typename T>
     void
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator out_last, OutputIterator2 expected_first, OutputIterator2, Size n,
-               Predicate pred, const T&, const T& new_value, T trash)
+               OutputIterator out_last, OutputIterator2 expected_first, OutputIterator2 /* expected_last */, Size n,
+               Predicate pred, const T& /* pld_value */, const T& new_value, T trash)
     {
         // Cleaning
         ::std::fill_n(expected_first, n, trash);

--- a/test/parallel_api/algorithm/alg.modifying.operations/rotate.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/rotate.pass.cpp
@@ -106,7 +106,7 @@ struct test_one_policy
         !::std::is_same<ExecutionPolicy, oneapi::dpl::execution::sequenced_policy>::value &&
         ::std::is_same<typename ::std::iterator_traits<Iterator>::value_type, wrapper<float32_t>>::value,
         bool>::type
-    check_move(ExecutionPolicy&& exec, Iterator b, Iterator e, Size shift)
+    check_move(ExecutionPolicy&&, Iterator b, Iterator e, Size shift)
     {
         bool result = all_of(b, e, [](wrapper<float32_t>& a) {
             bool temp = a.move_count > 0;
@@ -122,7 +122,7 @@ struct test_one_policy
         !::std::is_same<ExecutionPolicy, oneapi::dpl::execution::sequenced_policy>::value &&
         ::std::is_same<typename ::std::iterator_traits<Iterator>::value_type, wrapper<float32_t>>::value),
         bool>::type
-    check_move(ExecutionPolicy&& exec, Iterator b, Iterator e, Size shift)
+    check_move(ExecutionPolicy&&, Iterator, Iterator, Size)
     {
         return true;
     }

--- a/test/parallel_api/algorithm/alg.modifying.operations/rotate.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/rotate.pass.cpp
@@ -106,7 +106,7 @@ struct test_one_policy
         !::std::is_same<ExecutionPolicy, oneapi::dpl::execution::sequenced_policy>::value &&
         ::std::is_same<typename ::std::iterator_traits<Iterator>::value_type, wrapper<float32_t>>::value,
         bool>::type
-    check_move(ExecutionPolicy&&, Iterator b, Iterator e, Size shift)
+    check_move(ExecutionPolicy&& /* exec */, Iterator b, Iterator e, Size shift)
     {
         bool result = all_of(b, e, [](wrapper<float32_t>& a) {
             bool temp = a.move_count > 0;
@@ -122,7 +122,7 @@ struct test_one_policy
         !::std::is_same<ExecutionPolicy, oneapi::dpl::execution::sequenced_policy>::value &&
         ::std::is_same<typename ::std::iterator_traits<Iterator>::value_type, wrapper<float32_t>>::value),
         bool>::type
-    check_move(ExecutionPolicy&&, Iterator, Iterator, Size)
+    check_move(ExecutionPolicy&& /* exec */, Iterator /* b */, Iterator /* e */, Size /* shift */)
     {
         return true;
     }

--- a/test/parallel_api/algorithm/alg.modifying.operations/swap_ranges.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/swap_ranges.pass.cpp
@@ -58,7 +58,7 @@ template <typename T>
 struct check_swap
 {
     bool
-    operator()(T& a)
+    operator()(T&)
     {
         return true;
     }

--- a/test/parallel_api/algorithm/alg.modifying.operations/transform_binary.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/transform_binary.pass.cpp
@@ -67,8 +67,8 @@ struct test_one_policy
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
               typename BinaryOp>
     void
-    operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2,
-               OutputIterator out_first, OutputIterator out_last, BinaryOp op)
+    operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2,
+               OutputIterator out_first, OutputIterator, BinaryOp op)
     {
         ::std::transform(exec, first1, last1, first2, out_first, op);
         check_and_reset(first1, last1, first2, out_first);
@@ -84,7 +84,7 @@ test(Predicate pred)
         Sequence<In1> in1(n, [](size_t k) { return k % 5 != 1 ? In1(3 * k + 7) : 0; });
         Sequence<In2> in2(n, [](size_t k) { return k % 7 != 2 ? In2(5 * k + 5) : 0; });
 
-        Sequence<Out> out(n, [](size_t k) { return -1; });
+        Sequence<Out> out(n, [](size_t) { return -1; });
 
         invoke_on_all_policies<0>()(test_one_policy<In1, In2, Out>(), in1.begin(), in1.end(), in2.begin(), in2.end(),
                                     out.begin(), out.end(), pred);

--- a/test/parallel_api/algorithm/alg.modifying.operations/transform_binary.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/transform_binary.pass.cpp
@@ -67,8 +67,8 @@ struct test_one_policy
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
               typename BinaryOp>
     void
-    operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2,
-               OutputIterator out_first, OutputIterator, BinaryOp op)
+    operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 /* last2 */,
+               OutputIterator out_first, OutputIterator /* out_last */, BinaryOp op)
     {
         ::std::transform(exec, first1, last1, first2, out_first, op);
         check_and_reset(first1, last1, first2, out_first);

--- a/test/parallel_api/algorithm/alg.modifying.operations/unique_copy_equal.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/unique_copy_equal.pass.cpp
@@ -48,7 +48,7 @@ struct run_unique_copy
     template <typename Policy, typename InputIterator, typename OutputIterator, typename OutputIterator2, typename Size>
     void
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator out_last, OutputIterator2 expected_first, OutputIterator2 expected_last,
+               OutputIterator, OutputIterator2 expected_first, OutputIterator2,
                Size n, T trash)
     {
         // Cleaning
@@ -103,7 +103,7 @@ struct run_unique_copy_predicate
               typename Predicate>
     void
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator out_last, OutputIterator2 expected_first, OutputIterator2 expected_last, Size n,
+               OutputIterator, OutputIterator2 expected_first, OutputIterator2, Size n,
                Predicate pred, T trash)
     {
         // Cleaning
@@ -185,7 +185,7 @@ main()
     test<float64_t>(float64_t(42), ::std::equal_to<float64_t>(),
                     [](int32_t j) { return float64_t(5 * j / 23 ^ (j / 7)); });
 #if !_ONEDPL_FPGA_DEVICE
-    test<float32_t>(float32_t(42), [](float32_t x, float32_t y) { return false; },
+    test<float32_t>(float32_t(42), [](float32_t, float32_t) { return false; },
                     [](int32_t j) { return float32_t(j); }, false);
 #endif
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/unique_copy_equal.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/unique_copy_equal.pass.cpp
@@ -48,7 +48,7 @@ struct run_unique_copy
     template <typename Policy, typename InputIterator, typename OutputIterator, typename OutputIterator2, typename Size>
     void
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator, OutputIterator2 expected_first, OutputIterator2,
+               OutputIterator /* out_last */, OutputIterator2 expected_first, OutputIterator2 /* expected_last */,
                Size n, T trash)
     {
         // Cleaning
@@ -103,7 +103,7 @@ struct run_unique_copy_predicate
               typename Predicate>
     void
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator, OutputIterator2 expected_first, OutputIterator2, Size n,
+               OutputIterator /* out_last */, OutputIterator2 expected_first, OutputIterator2 /* expected_last */, Size n,
                Predicate pred, T trash)
     {
         // Cleaning

--- a/test/parallel_api/algorithm/alg.nonmodifying/all_of.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/all_of.pass.cpp
@@ -66,7 +66,7 @@ test(size_t bits)
     {
 
         // Sequence of odd values
-        Sequence<T> in(n, [n, bits](size_t k) { return T(2 * HashBits(n, bits - 1) ^ 1); });
+        Sequence<T> in(n, [n, bits](size_t) { return T(2 * HashBits(n, bits - 1) ^ 1); });
 
         // Even value, or false when T is bool.
         T spike(2 * HashBits(n, bits - 1));

--- a/test/parallel_api/algorithm/alg.nonmodifying/any_of.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/any_of.pass.cpp
@@ -52,7 +52,7 @@ test(size_t bits)
     {
 
         // Sequence of odd values
-        Sequence<T> in(n, [n, bits](size_t k) { return T(2 * HashBits(n, bits - 1) ^ 1); });
+        Sequence<T> in(n, [n, bits](size_t) { return T(2 * HashBits(n, bits - 1) ^ 1); });
 
         // Even value, or false when T is bool.
         T spike(2 * HashBits(n, bits - 1));

--- a/test/parallel_api/algorithm/alg.nonmodifying/count.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/count.pass.cpp
@@ -108,7 +108,7 @@ int
 main()
 {
     test<int16_t>(42, IsEqual<int16_t>(50, OddTag()), [](int16_t j) { return j; });
-    test<int32_t>(42, [](const int32_t& x) { return true; }, [](int32_t j) { return j; });
+    test<int32_t>(42, [](const int32_t&) { return true; }, [](int32_t j) { return j; });
     test<float64_t>(42, IsEqual<float64_t>(50, OddTag()), [](int32_t j) { return float64_t(j); });
 #if !_ONEDPL_BACKEND_SYCL
     test<Number>(Number(42, OddTag()), IsEqual<Number>(Number(50, OddTag()), OddTag()),

--- a/test/parallel_api/algorithm/alg.nonmodifying/find_end.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/find_end.pass.cpp
@@ -90,8 +90,8 @@ test(const ::std::size_t bits)
 
     const ::std::size_t max_n1 = 1000;
     const ::std::size_t max_n2 = (max_n1 * 10) / 8;
-    Sequence<T> in(max_n1, [max_n1, bits](::std::size_t k) { return T(2 * HashBits(max_n1, bits - 1) ^ 1); });
-    Sequence<T> sub(max_n2, [max_n1, bits](::std::size_t k) { return T(2 * HashBits(max_n1, bits - 1)); });
+    Sequence<T> in(max_n1, [max_n1, bits](::std::size_t) { return T(2 * HashBits(max_n1, bits - 1) ^ 1); });
+    Sequence<T> sub(max_n2, [max_n1, bits](::std::size_t) { return T(2 * HashBits(max_n1, bits - 1)); });
     for (::std::size_t n1 = 0; n1 <= max_n1; n1 = n1 <= 16 ? n1 + 1 : size_t(3.1415 * n1))
     {
         ::std::size_t sub_n[] = {0, 1, 3, n1, (n1 * 10) / 8};

--- a/test/parallel_api/algorithm/alg.nonmodifying/find_first_of.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/find_first_of.pass.cpp
@@ -57,8 +57,8 @@ test(Predicate pred)
 
     const ::std::size_t max_n1 = 1000;
     const ::std::size_t max_n2 = (max_n1 * 10) / 8;
-    Sequence<T> in1(max_n1, [](::std::size_t k) { return T(1); });
-    Sequence<T> in2(max_n2, [](::std::size_t k) { return T(0); });
+    Sequence<T> in1(max_n1, [](::std::size_t) { return T(1); });
+    Sequence<T> in2(max_n2, [](::std::size_t) { return T(0); });
     for (::std::size_t n1 = 0; n1 <= max_n1; n1 = n1 <= 16 ? n1 + 1 : size_t(3.1415 * n1))
     {
         ::std::size_t sub_n[] = {0, 1, n1 / 3, n1, (n1 * 10) / 8};

--- a/test/parallel_api/algorithm/alg.nonmodifying/find_if.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/find_if.pass.cpp
@@ -33,7 +33,7 @@ struct test_find_if
 {
     template <typename Policy, typename Iterator, typename Predicate, typename NotPredicate>
     void
-    operator()(Policy&& exec, Iterator first, Iterator last, Predicate pred, NotPredicate not_pred)
+    operator()(Policy&& exec, Iterator first, Iterator last, Predicate pred, NotPredicate)
     {
         auto i = ::std::find_if(first, last, pred);
         auto j = find_if(exec, first, last, pred);

--- a/test/parallel_api/algorithm/alg.nonmodifying/find_if.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/find_if.pass.cpp
@@ -33,7 +33,7 @@ struct test_find_if
 {
     template <typename Policy, typename Iterator, typename Predicate, typename NotPredicate>
     void
-    operator()(Policy&& exec, Iterator first, Iterator last, Predicate pred, NotPredicate)
+    operator()(Policy&& exec, Iterator first, Iterator last, Predicate pred, NotPredicate /* not_pred */)
     {
         auto i = ::std::find_if(first, last, pred);
         auto j = find_if(exec, first, last, pred);

--- a/test/parallel_api/algorithm/alg.nonmodifying/for_each.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/for_each.pass.cpp
@@ -70,7 +70,7 @@ struct test_for_each_n
 {
     template <typename Policy, typename Iterator, typename Size>
     void
-    operator()(Policy&& exec, Iterator first, Iterator last, Iterator expected_first, Iterator expected_last, Size n)
+    operator()(Policy&& exec, Iterator first, Iterator, Iterator expected_first, Iterator, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator>::value_type T;
 

--- a/test/parallel_api/algorithm/alg.nonmodifying/for_each.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/for_each.pass.cpp
@@ -70,7 +70,7 @@ struct test_for_each_n
 {
     template <typename Policy, typename Iterator, typename Size>
     void
-    operator()(Policy&& exec, Iterator first, Iterator, Iterator expected_first, Iterator, Size n)
+    operator()(Policy&& exec, Iterator first, Iterator, Iterator expected_first, Iterator /* expected_last */, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator>::value_type T;
 

--- a/test/parallel_api/algorithm/alg.nonmodifying/none_of.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/none_of.pass.cpp
@@ -50,7 +50,7 @@ test(size_t bits)
     for (size_t n = 0; n <= 100000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
         // Sequence of odd values
-        Sequence<T> in(n, [n, bits](size_t k) { return T(2 * HashBits(n, bits - 1) ^ 1); });
+        Sequence<T> in(n, [n, bits](size_t) { return T(2 * HashBits(n, bits - 1) ^ 1); });
 
         // Even value, or false when T is bool.
         T spike(2 * HashBits(n, bits - 1));

--- a/test/parallel_api/algorithm/alg.nonmodifying/nth_element.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/nth_element.pass.cpp
@@ -103,8 +103,8 @@ struct test_one_policy
     template <typename Policy, typename Iterator1, typename Size, typename Generator1, typename Generator2,
               typename Compare>
     typename ::std::enable_if<!is_same_iterator_category<Iterator1, ::std::random_access_iterator_tag>::value, void>::type
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator1 first2, Iterator1 last2, Size n, Size m,
-               Generator1 generator1, Generator2 generator2, Compare comp)
+    operator()(Policy&&, Iterator1, Iterator1, Iterator1, Iterator1, Size, Size,
+               Generator1, Generator2, Compare)
     {
     }
 };

--- a/test/parallel_api/algorithm/alg.nonmodifying/nth_element.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/nth_element.pass.cpp
@@ -103,8 +103,8 @@ struct test_one_policy
     template <typename Policy, typename Iterator1, typename Size, typename Generator1, typename Generator2,
               typename Compare>
     typename ::std::enable_if<!is_same_iterator_category<Iterator1, ::std::random_access_iterator_tag>::value, void>::type
-    operator()(Policy&&, Iterator1, Iterator1, Iterator1, Iterator1, Size, Size,
-               Generator1, Generator2, Compare)
+    operator()(Policy&& /* exec */, Iterator1 /* first1 */, Iterator1 /* last1 */, Iterator1 /* first2 */, Iterator1 /* last2 */, Size /* n */, Size /* m */,
+               Generator1 /* generator1 */, Generator2 /* generator2 */, Compare /* comp */)
     {
     }
 };

--- a/test/parallel_api/algorithm/alg.nonmodifying/search_n.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/search_n.pass.cpp
@@ -65,7 +65,7 @@ test()
         {
             for (auto r : res)
             {
-                Sequence<T> in(n1, [](::std::size_t k) { return T(0); });
+                Sequence<T> in(n1, [](::std::size_t) { return T(0); });
                 ::std::size_t i = r, isub = 0;
                 for (; i < n1 & isub < n2; ++i, ++isub)
                     in[i] = value;

--- a/test/parallel_api/algorithm/alg.sorting/alg.heap.operations/is_heap.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.heap.operations/is_heap.pass.cpp
@@ -60,7 +60,7 @@ struct test_is_heap
     // is_heap works only with random access iterators
     template <typename Policy, typename Iterator>
     typename ::std::enable_if<!is_same_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
-    operator()(Policy&& exec, Iterator first, Iterator last)
+    operator()(Policy&&, Iterator, Iterator)
     {
     }
 };
@@ -81,7 +81,7 @@ struct test_is_heap_predicate
     // is_heap works only with random access iterators
     template <typename Policy, typename Iterator, typename Predicate>
     typename ::std::enable_if<!is_same_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
-    operator()(Policy&& exec, Iterator first, Iterator last, Predicate pred)
+    operator()(Policy&&, Iterator, Iterator, Predicate)
     {
     }
 };
@@ -102,7 +102,7 @@ struct test_is_heap_until
     // is_heap, is_heap_until works only with random access iterators
     template <typename Policy, typename Iterator>
     typename ::std::enable_if<!is_same_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
-    operator()(Policy&& exec, Iterator first, Iterator last)
+    operator()(Policy&&, Iterator, Iterator)
     {
     }
 };
@@ -123,7 +123,7 @@ struct test_is_heap_until_predicate
     // is_heap, is_heap_until works only with random access iterators
     template <typename Policy, typename Iterator, typename Predicate>
     typename ::std::enable_if<!is_same_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
-    operator()(Policy&& exec, Iterator first, Iterator last, Predicate pred)
+    operator()(Policy&&, Iterator, Iterator, Predicate)
     {
     }
 };
@@ -175,7 +175,7 @@ test_is_heap_by_type(Comp comp)
 #endif
     }
 
-    Sequence<T> in(max_size / 10, [](size_t v) -> T { return T(1); });
+    Sequence<T> in(max_size / 10, [](size_t) -> T { return T(1); });
 #ifdef _PSTL_TEST_IS_HEAP
     invoke_on_all_policies<16>()(test_is_heap<T>(), in.begin(), in.end());
     invoke_on_all_policies<17>()(test_is_heap_predicate<T>(), in.begin(), in.end(), comp);

--- a/test/parallel_api/algorithm/alg.sorting/alg.heap.operations/is_heap.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.heap.operations/is_heap.pass.cpp
@@ -60,7 +60,7 @@ struct test_is_heap
     // is_heap works only with random access iterators
     template <typename Policy, typename Iterator>
     typename ::std::enable_if<!is_same_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
-    operator()(Policy&&, Iterator, Iterator)
+    operator()(Policy&& /* exec */, Iterator /* first */, Iterator /* last */)
     {
     }
 };
@@ -81,7 +81,7 @@ struct test_is_heap_predicate
     // is_heap works only with random access iterators
     template <typename Policy, typename Iterator, typename Predicate>
     typename ::std::enable_if<!is_same_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
-    operator()(Policy&&, Iterator, Iterator, Predicate)
+    operator()(Policy&& /* exec */, Iterator /* first */, Iterator /* last */, Predicate /* pred */)
     {
     }
 };
@@ -102,7 +102,7 @@ struct test_is_heap_until
     // is_heap, is_heap_until works only with random access iterators
     template <typename Policy, typename Iterator>
     typename ::std::enable_if<!is_same_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
-    operator()(Policy&&, Iterator, Iterator)
+    operator()(Policy&& /* exec */, Iterator /* first */, Iterator /* last */)
     {
     }
 };
@@ -123,7 +123,7 @@ struct test_is_heap_until_predicate
     // is_heap, is_heap_until works only with random access iterators
     template <typename Policy, typename Iterator, typename Predicate>
     typename ::std::enable_if<!is_same_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
-    operator()(Policy&&, Iterator, Iterator, Predicate)
+    operator()(Policy&& /* exec */, Iterator /* first */, Iterator /* last */, Predicate /* pred */)
     {
     }
 };

--- a/test/parallel_api/algorithm/alg.sorting/alg.set.operations/includes.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.set.operations/includes.pass.cpp
@@ -63,8 +63,8 @@ struct test_one_policy
 
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
     typename ::std::enable_if<TestUtils::isReverse<InputIterator1>::value, void>::type
-    operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2,
-               Compare comp)
+    operator()(Policy&&, InputIterator1, InputIterator1, InputIterator2, InputIterator2,
+               Compare)
     {
     }
 };

--- a/test/parallel_api/algorithm/alg.sorting/alg.set.operations/includes.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.set.operations/includes.pass.cpp
@@ -63,8 +63,8 @@ struct test_one_policy
 
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
     typename ::std::enable_if<TestUtils::isReverse<InputIterator1>::value, void>::type
-    operator()(Policy&&, InputIterator1, InputIterator1, InputIterator2, InputIterator2,
-               Compare)
+    operator()(Policy&& /* exec */, InputIterator1 /* first1 */, InputIterator1 /* last1 */, InputIterator2 /* first2 */, InputIterator2 /* last2 */,
+               Compare /* comp */)
     {
     }
 };

--- a/test/parallel_api/algorithm/alg.sorting/is_sorted.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/is_sorted.pass.cpp
@@ -180,7 +180,7 @@ test_is_sorted_by_type()
 #endif
 
     //non-descending order
-    Sequence<T> in1(9, [](size_t v) -> T { return T(0); });
+    Sequence<T> in1(9, [](size_t) -> T { return T(0); });
 #ifdef _PSTL_TEST_IS_SORTED
     invoke_on_all_policies<32>()(test_is_sorted<T>(), in1.begin(), in1.end());
     invoke_on_all_policies<33>()(test_is_sorted_predicate<T>(), in1.begin(), in1.end());

--- a/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
@@ -112,8 +112,8 @@ struct test_brick_partial_sort
     template <typename Policy, typename InputIterator, typename Compare>
     typename ::std::enable_if<!is_same_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value,
                             void>::type
-    operator()(Policy&&, InputIterator, InputIterator, InputIterator, InputIterator,
-               Compare)
+    operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, InputIterator /* exp_first */, InputIterator /* exp_last */,
+               Compare /* compare */)
     {
     }
 };

--- a/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
@@ -112,8 +112,8 @@ struct test_brick_partial_sort
     template <typename Policy, typename InputIterator, typename Compare>
     typename ::std::enable_if<!is_same_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value,
                             void>::type
-    operator()(Policy&& exec, InputIterator first, InputIterator last, InputIterator exp_first, InputIterator exp_last,
-               Compare compare)
+    operator()(Policy&&, InputIterator, InputIterator, InputIterator, InputIterator,
+               Compare)
     {
     }
 };

--- a/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
@@ -188,7 +188,7 @@ struct test_sort_with_compare
     typename ::std::enable_if<is_same_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value,
                             void>::type
     operator()(Policy&& exec, OutputIterator tmp_first, OutputIterator tmp_last, OutputIterator2 expected_first,
-               OutputIterator2 expected_last, InputIterator first, InputIterator, Size n, Compare compare)
+               OutputIterator2 expected_last, InputIterator first, InputIterator /* last */, Size n, Compare compare)
     {
         using namespace std;
         copy_n(first, n, expected_first);
@@ -215,8 +215,8 @@ struct test_sort_with_compare
               typename Compare>
     typename ::std::enable_if<!is_same_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value,
                             void>::type
-    operator()(Policy&&, OutputIterator, OutputIterator, OutputIterator2,
-               OutputIterator2, InputIterator, InputIterator, Size, Compare)
+    operator()(Policy&& /* exec */, OutputIterator /* tmp_first */, OutputIterator /* tmp_last */, OutputIterator2 /* expected_first */,
+               OutputIterator2 /* expected_last */, InputIterator /* first */, InputIterator /* last */, Size /* n */, Compare /* compare */)
     {
     }
 };
@@ -228,7 +228,7 @@ struct test_sort_without_compare
     typename ::std::enable_if<is_same_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value &&
                             can_use_default_less_operator<T>::value, void>::type
     operator()(Policy&& exec, OutputIterator tmp_first, OutputIterator tmp_last, OutputIterator2 expected_first,
-               OutputIterator2 expected_last, InputIterator first, InputIterator, Size n)
+               OutputIterator2 expected_last, InputIterator first, InputIterator /* last */, Size n)
     {
         using namespace std;
         copy_n(first, n, expected_first);
@@ -254,8 +254,8 @@ struct test_sort_without_compare
     template <typename Policy, typename InputIterator, typename OutputIterator, typename OutputIterator2, typename Size>
     typename ::std::enable_if<!is_same_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value ||
                             !can_use_default_less_operator<T>::value, void>::type
-    operator()(Policy&&, OutputIterator, OutputIterator, OutputIterator2,
-               OutputIterator2, InputIterator, InputIterator, Size)
+    operator()(Policy&& /* exec */, OutputIterator /* tmp_first */, OutputIterator /* tmp_last */, OutputIterator2 /* expected_first */,
+               OutputIterator2 /* expected_last */, InputIterator /* first */, InputIterator /* last */, Size /* n */)
     {
     }
 };

--- a/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
@@ -188,7 +188,7 @@ struct test_sort_with_compare
     typename ::std::enable_if<is_same_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value,
                             void>::type
     operator()(Policy&& exec, OutputIterator tmp_first, OutputIterator tmp_last, OutputIterator2 expected_first,
-               OutputIterator2 expected_last, InputIterator first, InputIterator last, Size n, Compare compare)
+               OutputIterator2 expected_last, InputIterator first, InputIterator, Size n, Compare compare)
     {
         using namespace std;
         copy_n(first, n, expected_first);
@@ -215,8 +215,8 @@ struct test_sort_with_compare
               typename Compare>
     typename ::std::enable_if<!is_same_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value,
                             void>::type
-    operator()(Policy&& exec, OutputIterator tmp_first, OutputIterator tmp_last, OutputIterator2 expected_first,
-               OutputIterator2 expected_last, InputIterator first, InputIterator last, Size n, Compare compare)
+    operator()(Policy&&, OutputIterator, OutputIterator, OutputIterator2,
+               OutputIterator2, InputIterator, InputIterator, Size, Compare)
     {
     }
 };
@@ -228,7 +228,7 @@ struct test_sort_without_compare
     typename ::std::enable_if<is_same_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value &&
                             can_use_default_less_operator<T>::value, void>::type
     operator()(Policy&& exec, OutputIterator tmp_first, OutputIterator tmp_last, OutputIterator2 expected_first,
-               OutputIterator2 expected_last, InputIterator first, InputIterator last, Size n)
+               OutputIterator2 expected_last, InputIterator first, InputIterator, Size n)
     {
         using namespace std;
         copy_n(first, n, expected_first);
@@ -254,8 +254,8 @@ struct test_sort_without_compare
     template <typename Policy, typename InputIterator, typename OutputIterator, typename OutputIterator2, typename Size>
     typename ::std::enable_if<!is_same_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value ||
                             !can_use_default_less_operator<T>::value, void>::type
-    operator()(Policy&& exec, OutputIterator tmp_first, OutputIterator tmp_last, OutputIterator2 expected_first,
-               OutputIterator2 expected_last, InputIterator first, InputIterator last, Size n)
+    operator()(Policy&&, OutputIterator, OutputIterator, OutputIterator2,
+               OutputIterator2, InputIterator, InputIterator, Size)
     {
     }
 };

--- a/test/parallel_api/experimental/for_loop.pass.cpp
+++ b/test/parallel_api/experimental/for_loop.pass.cpp
@@ -64,7 +64,7 @@ test_body_for_loop(Policy&& exec, Iterator first, Iterator last, Iterator expect
 
 template <typename Policy, typename Iterator, typename Size>
 void
-test_body_for_loop_integral(Policy&& exec, Iterator first, Iterator last, Iterator expected_first,
+test_body_for_loop_integral(Policy&& exec, Iterator first, Iterator, Iterator expected_first,
                             Iterator expected_last, Size n)
 {
     using T = typename ::std::iterator_traits<Iterator>::value_type;
@@ -127,7 +127,7 @@ test_body_for_loop_strided(Policy&& exec, Iterator first, Iterator last, Iterato
 
 template <typename Policy, typename Iterator, typename Size>
 void
-test_body_for_loop_strided_n(Policy&& exec, Iterator first, Iterator last, Iterator expected_first,
+test_body_for_loop_strided_n(Policy&& exec, Iterator first, Iterator, Iterator expected_first,
                              Iterator expected_last, Size n, size_t loop_stride)
 {
     using T = typename ::std::iterator_traits<Iterator>::value_type;
@@ -152,7 +152,7 @@ test_body_for_loop_strided_n(Policy&& exec, Iterator first, Iterator last, Itera
 
 template <typename Policy, typename Iterator, typename Size>
 void
-test_body_for_loop_strided_integral(Policy&& exec, Iterator first, Iterator last, Iterator expected_first,
+test_body_for_loop_strided_integral(Policy&& exec, Iterator first, Iterator, Iterator expected_first,
                                     Iterator expected_last, Size n, size_t loop_stride)
 {
     using T = typename ::std::iterator_traits<Iterator>::value_type;
@@ -180,7 +180,7 @@ test_body_for_loop_strided_integral(Policy&& exec, Iterator first, Iterator last
 // Test for for_loop_n_strided, it works for both positive and negative stride values.
 template <typename Policy, typename Iterator, typename Size, typename S>
 void
-test_body_for_loop_strided_n_integral(Policy&& exec, Iterator first, Iterator last, Iterator expected_first,
+test_body_for_loop_strided_n_integral(Policy&& exec, Iterator first, Iterator, Iterator expected_first,
                                       Iterator expected_last, Size n, S loop_stride)
 {
     using T = typename ::std::iterator_traits<Iterator>::value_type;
@@ -233,8 +233,8 @@ template <typename Policy, typename Iterator, typename Size, typename S>
 typename ::std::enable_if<
     !::std::is_same<typename ::std::iterator_traits<Iterator>::iterator_category, ::std::forward_iterator_tag>::value,
     void>::type
-test_body_for_loop_strided_neg(Policy&& exec, Iterator first, Iterator last, Iterator expected_first,
-                               Iterator expected_last, Size n, S loop_stride)
+test_body_for_loop_strided_neg(Policy&& exec, Iterator first, Iterator, Iterator expected_first,
+                               Iterator, Size n, S loop_stride)
 {
     assert(loop_stride < 0);
 
@@ -259,8 +259,8 @@ template <typename Policy, typename Iterator, typename Size, typename S>
 typename ::std::enable_if<
     ::std::is_same<typename ::std::iterator_traits<Iterator>::iterator_category, ::std::forward_iterator_tag>::value,
     void>::type
-test_body_for_loop_strided_neg(Policy&& exec, Iterator first, Iterator last, Iterator expected_first,
-                               Iterator expected_last, Size n, S loop_stride)
+test_body_for_loop_strided_neg(Policy&&, Iterator, Iterator, Iterator,
+                               Iterator, Size, S)
 {
     // no-op for forward iterators. As it's not possible to iterate backwards.
 }

--- a/test/parallel_api/experimental/for_loop.pass.cpp
+++ b/test/parallel_api/experimental/for_loop.pass.cpp
@@ -64,7 +64,7 @@ test_body_for_loop(Policy&& exec, Iterator first, Iterator last, Iterator expect
 
 template <typename Policy, typename Iterator, typename Size>
 void
-test_body_for_loop_integral(Policy&& exec, Iterator first, Iterator, Iterator expected_first,
+test_body_for_loop_integral(Policy&& exec, Iterator first, Iterator /* last */, Iterator expected_first,
                             Iterator expected_last, Size n)
 {
     using T = typename ::std::iterator_traits<Iterator>::value_type;
@@ -127,7 +127,7 @@ test_body_for_loop_strided(Policy&& exec, Iterator first, Iterator last, Iterato
 
 template <typename Policy, typename Iterator, typename Size>
 void
-test_body_for_loop_strided_n(Policy&& exec, Iterator first, Iterator, Iterator expected_first,
+test_body_for_loop_strided_n(Policy&& exec, Iterator first, Iterator /* last */, Iterator expected_first,
                              Iterator expected_last, Size n, size_t loop_stride)
 {
     using T = typename ::std::iterator_traits<Iterator>::value_type;
@@ -152,7 +152,7 @@ test_body_for_loop_strided_n(Policy&& exec, Iterator first, Iterator, Iterator e
 
 template <typename Policy, typename Iterator, typename Size>
 void
-test_body_for_loop_strided_integral(Policy&& exec, Iterator first, Iterator, Iterator expected_first,
+test_body_for_loop_strided_integral(Policy&& exec, Iterator first, Iterator /* last */, Iterator expected_first,
                                     Iterator expected_last, Size n, size_t loop_stride)
 {
     using T = typename ::std::iterator_traits<Iterator>::value_type;
@@ -180,7 +180,7 @@ test_body_for_loop_strided_integral(Policy&& exec, Iterator first, Iterator, Ite
 // Test for for_loop_n_strided, it works for both positive and negative stride values.
 template <typename Policy, typename Iterator, typename Size, typename S>
 void
-test_body_for_loop_strided_n_integral(Policy&& exec, Iterator first, Iterator, Iterator expected_first,
+test_body_for_loop_strided_n_integral(Policy&& exec, Iterator first, Iterator /* last */, Iterator expected_first,
                                       Iterator expected_last, Size n, S loop_stride)
 {
     using T = typename ::std::iterator_traits<Iterator>::value_type;
@@ -233,8 +233,8 @@ template <typename Policy, typename Iterator, typename Size, typename S>
 typename ::std::enable_if<
     !::std::is_same<typename ::std::iterator_traits<Iterator>::iterator_category, ::std::forward_iterator_tag>::value,
     void>::type
-test_body_for_loop_strided_neg(Policy&& exec, Iterator first, Iterator, Iterator expected_first,
-                               Iterator, Size n, S loop_stride)
+test_body_for_loop_strided_neg(Policy&& exec, Iterator first, Iterator /* last */, Iterator expected_first,
+                               Iterator /* expected_last */, Size n, S loop_stride)
 {
     assert(loop_stride < 0);
 
@@ -259,8 +259,8 @@ template <typename Policy, typename Iterator, typename Size, typename S>
 typename ::std::enable_if<
     ::std::is_same<typename ::std::iterator_traits<Iterator>::iterator_category, ::std::forward_iterator_tag>::value,
     void>::type
-test_body_for_loop_strided_neg(Policy&&, Iterator, Iterator, Iterator,
-                               Iterator, Size, S)
+test_body_for_loop_strided_neg(Policy&& /* exec */, Iterator /* first */, Iterator /* last */, Iterator /* expected_first */,
+                               Iterator /* expected_last */, Size /* n */, S /* loop_stride */)
 {
     // no-op for forward iterators. As it's not possible to iterate backwards.
 }

--- a/test/parallel_api/experimental/for_loop_induction.pass.cpp
+++ b/test/parallel_api/experimental/for_loop_induction.pass.cpp
@@ -25,7 +25,7 @@ using namespace TestUtils;
 
 template <typename Policy, typename Iterator, typename Size>
 void
-test_body_induction(Policy&& exec, Iterator, Iterator, Iterator /* expected_first */,
+test_body_induction(Policy&& exec, Iterator /* first */, Iterator /* last */, Iterator /* expected_first */,
                     Iterator /* expected_last */, Size n)
 {
     using T = typename ::std::iterator_traits<Iterator>::value_type;

--- a/test/parallel_api/experimental/for_loop_induction.pass.cpp
+++ b/test/parallel_api/experimental/for_loop_induction.pass.cpp
@@ -25,7 +25,7 @@ using namespace TestUtils;
 
 template <typename Policy, typename Iterator, typename Size>
 void
-test_body_induction(Policy&& exec, Iterator first, Iterator last, Iterator /* expected_first */,
+test_body_induction(Policy&& exec, Iterator, Iterator, Iterator /* expected_first */,
                     Iterator /* expected_last */, Size n)
 {
     using T = typename ::std::iterator_traits<Iterator>::value_type;

--- a/test/parallel_api/experimental/for_loop_reduction.pass.cpp
+++ b/test/parallel_api/experimental/for_loop_reduction.pass.cpp
@@ -86,7 +86,7 @@ struct test_body_predefined
     template <typename Policy, typename Iterator, typename Size>
     void
     operator()(Policy&& exec, Iterator first, Iterator last, Iterator /*expected_first*/, Iterator /*expected_last*/,
-               Size n)
+               Size)
     {
         using T = typename ::std::iterator_traits<Iterator>::value_type;
         static_assert(::std::is_arithmetic<T>::value, "Currently the testcase only works with arithmetic types");
@@ -129,7 +129,7 @@ struct test_body_predefined_bits
     typename ::std::enable_if<!::std::is_floating_point<typename ::std::iterator_traits<Iterator>::value_type>::value,
                             void>::type
     operator()(Policy&& exec, Iterator first, Iterator last, Iterator /*expected_first*/, Iterator /*expected_last*/,
-               Size n)
+               Size)
     {
         using T = typename ::std::iterator_traits<Iterator>::value_type;
         static_assert(::std::is_arithmetic<T>::value, "Currently the testcase only works with arithmetic types");
@@ -163,8 +163,8 @@ struct test_body_predefined_bits
     template <typename Policy, typename Iterator, typename Size>
     typename ::std::enable_if<::std::is_floating_point<typename ::std::iterator_traits<Iterator>::value_type>::value,
                             void>::type
-    operator()(Policy&& exec, Iterator first, Iterator last, Iterator /*expected_first*/, Iterator /*expected_last*/,
-               Size n)
+    operator()(Policy&&, Iterator, Iterator, Iterator /*expected_first*/, Iterator /*expected_last*/,
+               Size)
     {
         // no-op for floats
     }

--- a/test/parallel_api/experimental/for_loop_reduction.pass.cpp
+++ b/test/parallel_api/experimental/for_loop_reduction.pass.cpp
@@ -86,7 +86,7 @@ struct test_body_predefined
     template <typename Policy, typename Iterator, typename Size>
     void
     operator()(Policy&& exec, Iterator first, Iterator last, Iterator /*expected_first*/, Iterator /*expected_last*/,
-               Size)
+               Size /* n */)
     {
         using T = typename ::std::iterator_traits<Iterator>::value_type;
         static_assert(::std::is_arithmetic<T>::value, "Currently the testcase only works with arithmetic types");
@@ -129,7 +129,7 @@ struct test_body_predefined_bits
     typename ::std::enable_if<!::std::is_floating_point<typename ::std::iterator_traits<Iterator>::value_type>::value,
                             void>::type
     operator()(Policy&& exec, Iterator first, Iterator last, Iterator /*expected_first*/, Iterator /*expected_last*/,
-               Size)
+               Size /* n */)
     {
         using T = typename ::std::iterator_traits<Iterator>::value_type;
         static_assert(::std::is_arithmetic<T>::value, "Currently the testcase only works with arithmetic types");
@@ -163,8 +163,8 @@ struct test_body_predefined_bits
     template <typename Policy, typename Iterator, typename Size>
     typename ::std::enable_if<::std::is_floating_point<typename ::std::iterator_traits<Iterator>::value_type>::value,
                             void>::type
-    operator()(Policy&&, Iterator, Iterator, Iterator /*expected_first*/, Iterator /*expected_last*/,
-               Size)
+    operator()(Policy&& /* exec */, Iterator /* first */, Iterator /* last */, Iterator /*expected_first*/, Iterator /*expected_last*/,
+               Size /* n */)
     {
         // no-op for floats
     }

--- a/test/parallel_api/iterator/discard_iterator.pass.cpp
+++ b/test/parallel_api/iterator/discard_iterator.pass.cpp
@@ -68,7 +68,7 @@ struct statistics {
 
 template <typename Policy, typename Iterator>
 void evaluate(Policy&& policy, Iterator ref_begin, Iterator ref_end,
-              oneapi::dpl::discard_iterator dev_null, std::string) {
+              oneapi::dpl::discard_iterator dev_null, std::string /* test */) {
     using policy_type = typename std::decay<Policy>::type;
     using value_type = typename std::iterator_traits<Iterator>::value_type;
     using clock = std::chrono::high_resolution_clock;

--- a/test/parallel_api/iterator/discard_iterator.pass.cpp
+++ b/test/parallel_api/iterator/discard_iterator.pass.cpp
@@ -68,7 +68,7 @@ struct statistics {
 
 template <typename Policy, typename Iterator>
 void evaluate(Policy&& policy, Iterator ref_begin, Iterator ref_end,
-              oneapi::dpl::discard_iterator dev_null, std::string test) {
+              oneapi::dpl::discard_iterator dev_null, std::string) {
     using policy_type = typename std::decay<Policy>::type;
     using value_type = typename std::iterator_traits<Iterator>::value_type;
     using clock = std::chrono::high_resolution_clock;

--- a/test/parallel_api/iterator/permutation_iterator.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator.pass.cpp
@@ -69,7 +69,7 @@ struct statistics {
 
 template <typename RefPolicy, typename Policy, typename Iterator, typename IndexMap>
 void evaluate(RefPolicy&& ref_policy, Policy&& policy, Iterator ref_begin, Iterator ref_end,
-              oneapi::dpl::permutation_iterator<Iterator, IndexMap> perm_start, std::string) {
+              oneapi::dpl::permutation_iterator<Iterator, IndexMap> perm_start, std::string /* test */) {
     using value_type = typename std::iterator_traits<Iterator>::value_type;
     using clock = std::chrono::high_resolution_clock;
 

--- a/test/parallel_api/iterator/permutation_iterator.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator.pass.cpp
@@ -69,7 +69,7 @@ struct statistics {
 
 template <typename RefPolicy, typename Policy, typename Iterator, typename IndexMap>
 void evaluate(RefPolicy&& ref_policy, Policy&& policy, Iterator ref_begin, Iterator ref_end,
-              oneapi::dpl::permutation_iterator<Iterator, IndexMap> perm_start, std::string test) {
+              oneapi::dpl::permutation_iterator<Iterator, IndexMap> perm_start, std::string) {
     using value_type = typename std::iterator_traits<Iterator>::value_type;
     using clock = std::chrono::high_resolution_clock;
 

--- a/test/parallel_api/iterator/transform_iterator.pass.cpp
+++ b/test/parallel_api/iterator/transform_iterator.pass.cpp
@@ -58,7 +58,7 @@ public:
         : expected_buffer_size(buf_size), result_begin(res_begin) {}
 
     template <typename ExecutionPolicy, typename Iterator1, typename Iterator2>
-    void operator()(ExecutionPolicy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2) {
+    void operator()(ExecutionPolicy&&, Iterator1, Iterator1, Iterator2) {
         using value_type = typename ::std::iterator_traits<Iterator1>::value_type;
         auto predicate = [](value_type val) { return val <= 10; };
 

--- a/test/parallel_api/iterator/transform_iterator.pass.cpp
+++ b/test/parallel_api/iterator/transform_iterator.pass.cpp
@@ -58,7 +58,7 @@ public:
         : expected_buffer_size(buf_size), result_begin(res_begin) {}
 
     template <typename ExecutionPolicy, typename Iterator1, typename Iterator2>
-    void operator()(ExecutionPolicy&&, Iterator1, Iterator1, Iterator2) {
+    void operator()(ExecutionPolicy&& /* exec */, Iterator1 /* first1 */, Iterator1 /* last1 */, Iterator2 /* first2 */) {
         using value_type = typename ::std::iterator_traits<Iterator1>::value_type;
         auto predicate = [](value_type val) { return val <= 10; };
 

--- a/test/parallel_api/iterator/zip_iterator.pass.cpp
+++ b/test/parallel_api/iterator/zip_iterator.pass.cpp
@@ -148,7 +148,7 @@ struct test_transform_reduce_binary
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2, Iterator2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 /* first2 */, Iterator2 /* last2 */, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         auto host_first1 = get_host_pointer(first1);
@@ -238,7 +238,7 @@ struct test_equal
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 /* last2 */, Size n)
     {
         using T = typename ::std::iterator_traits<Iterator1>::value_type;
         auto value = T(42);
@@ -378,7 +378,7 @@ struct test_unique_copy
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 /* last2 */, Size n)
     {
 
         using Iterator1ValueType = typename ::std::iterator_traits<Iterator1>::value_type;
@@ -416,8 +416,8 @@ struct test_merge
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1, Iterator2 first2, Iterator2, Iterator3 first3,
-               Iterator3, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 /* last1 */, Iterator2 first2, Iterator2 /* last2 */, Iterator3 first3,
+               Iterator3 /* last3 */, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         typedef typename ::std::iterator_traits<Iterator2>::value_type T2;
@@ -547,7 +547,7 @@ struct test_counting_zip_transform
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1, Iterator2 first2, Iterator2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 /* last1 */, Iterator2 first2, Iterator2 /* last2 */, Size n)
     {
 
         using ValueType = typename ::std::iterator_traits<Iterator2>::value_type;

--- a/test/parallel_api/iterator/zip_iterator.pass.cpp
+++ b/test/parallel_api/iterator/zip_iterator.pass.cpp
@@ -75,7 +75,7 @@ struct TupleNoOp
 
     template <typename T1, typename T2>
     T2
-    operator()(const T1& t1, const T2& t2) const
+    operator()(const T1&, const T2& t2) const
     {
         return t2;
     }
@@ -148,7 +148,7 @@ struct test_transform_reduce_binary
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2, Iterator2, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         auto host_first1 = get_host_pointer(first1);
@@ -238,7 +238,7 @@ struct test_equal
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2, Size n)
     {
         using T = typename ::std::iterator_traits<Iterator1>::value_type;
         auto value = T(42);
@@ -378,7 +378,7 @@ struct test_unique_copy
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2, Size n)
     {
 
         using Iterator1ValueType = typename ::std::iterator_traits<Iterator1>::value_type;
@@ -416,8 +416,8 @@ struct test_merge
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Iterator3 first3,
-               Iterator3 last3, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1, Iterator2 first2, Iterator2, Iterator3 first3,
+               Iterator3, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type T1;
         typedef typename ::std::iterator_traits<Iterator2>::value_type T2;
@@ -547,7 +547,7 @@ struct test_counting_zip_transform
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 last2, Size n)
+    operator()(Policy&& exec, Iterator1 first1, Iterator1, Iterator2 first2, Iterator2, Size n)
     {
 
         using ValueType = typename ::std::iterator_traits<Iterator2>::value_type;

--- a/test/parallel_api/memory/specialized.algorithms/uninitialized_construct.pass.cpp
+++ b/test/parallel_api/memory/specialized.algorithms/uninitialized_construct.pass.cpp
@@ -69,7 +69,7 @@ struct test_uninit_default_construct
 
     template <typename Policy, typename Iterator>
     void
-    operator()(Policy&& exec, Iterator begin, Iterator end, size_t n, /*is_trivial<T>=*/::std::true_type)
+    operator()(Policy&& exec, Iterator begin, Iterator end, size_t, /*is_trivial<T>=*/::std::true_type)
     {
         ::std::uninitialized_default_construct(exec, begin, end);
     }
@@ -80,7 +80,7 @@ struct test_uninit_default_construct_n
 {
     template <typename Policy, typename Iterator>
     void
-    operator()(Policy&& exec, Iterator begin, Iterator end, size_t n, /*is_trivial<T>=*/::std::false_type)
+    operator()(Policy&& exec, Iterator begin, Iterator, size_t n, /*is_trivial<T>=*/::std::false_type)
     {
         typedef typename ::std::iterator_traits<Iterator>::value_type T;
         // it needs for cleaning memory that was filled by default constructors in unique_ptr<T[]> p(new T[n])
@@ -95,7 +95,7 @@ struct test_uninit_default_construct_n
 
     template <typename Policy, typename Iterator>
     void
-    operator()(Policy&& exec, Iterator begin, Iterator end, size_t n, /*is_trivial<T>=*/::std::true_type)
+    operator()(Policy&& exec, Iterator begin, Iterator, size_t n, /*is_trivial<T>=*/::std::true_type)
     {
         ::std::uninitialized_default_construct_n(exec, begin, n);
     }
@@ -121,7 +121,7 @@ struct test_uninit_value_construct
 
     template <typename Policy, typename Iterator>
     void
-    operator()(Policy&& exec, Iterator begin, Iterator end, size_t n, /*is_trivial<T>=*/::std::true_type)
+    operator()(Policy&& exec, Iterator begin, Iterator end, size_t, /*is_trivial<T>=*/::std::true_type)
     {
         typedef typename ::std::iterator_traits<Iterator>::value_type T;
 
@@ -135,7 +135,7 @@ struct test_uninit_value_construct_n
 {
     template <typename Policy, typename Iterator>
     void
-    operator()(Policy&& exec, Iterator begin, Iterator end, size_t n, /*is_trivial<T>=*/::std::false_type)
+    operator()(Policy&& exec, Iterator begin, Iterator, size_t n, /*is_trivial<T>=*/::std::false_type)
     {
         typedef typename ::std::iterator_traits<Iterator>::value_type T;
         // it needs for cleaning memory that was filled by default constructors in unique_ptr<T[]> p(new T[n])
@@ -170,7 +170,7 @@ test_uninit_construct_by_type()
         ::std::unique_ptr<T[]> p(new T[n]);
         auto p_begin = p.get();
 #else
-        Sequence<T> p(n, [](size_t k){ return T{}; });
+        Sequence<T> p(n, [](size_t){ return T{}; });
         auto p_begin = p.begin();
 #endif
         auto p_end = ::std::next(p_begin, n);

--- a/test/parallel_api/memory/specialized.algorithms/uninitialized_construct.pass.cpp
+++ b/test/parallel_api/memory/specialized.algorithms/uninitialized_construct.pass.cpp
@@ -69,7 +69,7 @@ struct test_uninit_default_construct
 
     template <typename Policy, typename Iterator>
     void
-    operator()(Policy&& exec, Iterator begin, Iterator end, size_t, /*is_trivial<T>=*/::std::true_type)
+    operator()(Policy&& exec, Iterator begin, Iterator end, size_t /* n */, /*is_trivial<T>=*/::std::true_type)
     {
         ::std::uninitialized_default_construct(exec, begin, end);
     }
@@ -80,7 +80,7 @@ struct test_uninit_default_construct_n
 {
     template <typename Policy, typename Iterator>
     void
-    operator()(Policy&& exec, Iterator begin, Iterator, size_t n, /*is_trivial<T>=*/::std::false_type)
+    operator()(Policy&& exec, Iterator begin, Iterator /* end */, size_t n, /*is_trivial<T>=*/::std::false_type)
     {
         typedef typename ::std::iterator_traits<Iterator>::value_type T;
         // it needs for cleaning memory that was filled by default constructors in unique_ptr<T[]> p(new T[n])
@@ -95,7 +95,7 @@ struct test_uninit_default_construct_n
 
     template <typename Policy, typename Iterator>
     void
-    operator()(Policy&& exec, Iterator begin, Iterator, size_t n, /*is_trivial<T>=*/::std::true_type)
+    operator()(Policy&& exec, Iterator begin, Iterator /* end */, size_t n, /*is_trivial<T>=*/::std::true_type)
     {
         ::std::uninitialized_default_construct_n(exec, begin, n);
     }
@@ -121,7 +121,7 @@ struct test_uninit_value_construct
 
     template <typename Policy, typename Iterator>
     void
-    operator()(Policy&& exec, Iterator begin, Iterator end, size_t, /*is_trivial<T>=*/::std::true_type)
+    operator()(Policy&& exec, Iterator begin, Iterator end, size_t /* n */, /*is_trivial<T>=*/::std::true_type)
     {
         typedef typename ::std::iterator_traits<Iterator>::value_type T;
 
@@ -135,7 +135,7 @@ struct test_uninit_value_construct_n
 {
     template <typename Policy, typename Iterator>
     void
-    operator()(Policy&& exec, Iterator begin, Iterator, size_t n, /*is_trivial<T>=*/::std::false_type)
+    operator()(Policy&& exec, Iterator begin, Iterator /* end */, size_t n, /*is_trivial<T>=*/::std::false_type)
     {
         typedef typename ::std::iterator_traits<Iterator>::value_type T;
         // it needs for cleaning memory that was filled by default constructors in unique_ptr<T[]> p(new T[n])

--- a/test/parallel_api/memory/specialized.algorithms/uninitialized_copy_move.pass.cpp
+++ b/test/parallel_api/memory/specialized.algorithms/uninitialized_copy_move.pass.cpp
@@ -81,7 +81,7 @@ struct test_uninitialized_copy_n
 {
     template <typename Policy, typename InputIterator, typename OutputIterator>
     void
-    operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first, size_t n,
+    operator()(Policy&& exec, InputIterator first, InputIterator, OutputIterator out_first, size_t n,
                /*is_trivial<T>=*/::std::false_type)
     {
         typedef typename ::std::iterator_traits<InputIterator>::value_type T;
@@ -97,7 +97,7 @@ struct test_uninitialized_copy_n
 
     template <typename Policy, typename InputIterator, typename OutputIterator>
     void
-    operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first, size_t n,
+    operator()(Policy&& exec, InputIterator first, InputIterator, OutputIterator out_first, size_t n,
                /*is_trivial<T>=*/::std::true_type)
     {
         ::std::uninitialized_copy_n(exec, first, n, out_first);
@@ -139,7 +139,7 @@ struct test_uninitialized_move_n
 {
     template <typename Policy, typename InputIterator, typename OutputIterator>
     void
-    operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first, size_t n,
+    operator()(Policy&& exec, InputIterator first, InputIterator, OutputIterator out_first, size_t n,
                /*is_trivial<T>=*/::std::false_type)
     {
         typedef typename ::std::iterator_traits<InputIterator>::value_type T;
@@ -155,7 +155,7 @@ struct test_uninitialized_move_n
 
     template <typename Policy, typename InputIterator, typename OutputIterator>
     void
-    operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first, size_t n,
+    operator()(Policy&& exec, InputIterator first, InputIterator, OutputIterator out_first, size_t n,
                /*is_trivial<T>=*/::std::true_type)
     {
         ::std::uninitialized_move_n(exec, first, n, out_first);
@@ -178,7 +178,7 @@ test_uninitialized_copy_move_by_type()
         // common pointers are not supported for hetero backend
         // sycl::buffer<T,1> buf(n); // async nature of buffer requires sycn before EXPECT_ macro
         // auto out_begin = oneapi::dpl::begin(buf);
-        Sequence<T> out(n, [=](size_t k) -> T { return T{}; });
+        Sequence<T> out(n, [=](size_t) -> T { return T{}; });
         auto out_begin = out.begin();
         // TODO: "memory objects" should be created in another abstraction level
         //       to avoid multiple enable/disable macro for different backends

--- a/test/parallel_api/memory/specialized.algorithms/uninitialized_copy_move.pass.cpp
+++ b/test/parallel_api/memory/specialized.algorithms/uninitialized_copy_move.pass.cpp
@@ -81,7 +81,7 @@ struct test_uninitialized_copy_n
 {
     template <typename Policy, typename InputIterator, typename OutputIterator>
     void
-    operator()(Policy&& exec, InputIterator first, InputIterator, OutputIterator out_first, size_t n,
+    operator()(Policy&& exec, InputIterator first, InputIterator /* last */, OutputIterator out_first, size_t n,
                /*is_trivial<T>=*/::std::false_type)
     {
         typedef typename ::std::iterator_traits<InputIterator>::value_type T;
@@ -97,7 +97,7 @@ struct test_uninitialized_copy_n
 
     template <typename Policy, typename InputIterator, typename OutputIterator>
     void
-    operator()(Policy&& exec, InputIterator first, InputIterator, OutputIterator out_first, size_t n,
+    operator()(Policy&& exec, InputIterator first, InputIterator /* last */, OutputIterator out_first, size_t n,
                /*is_trivial<T>=*/::std::true_type)
     {
         ::std::uninitialized_copy_n(exec, first, n, out_first);
@@ -139,7 +139,7 @@ struct test_uninitialized_move_n
 {
     template <typename Policy, typename InputIterator, typename OutputIterator>
     void
-    operator()(Policy&& exec, InputIterator first, InputIterator, OutputIterator out_first, size_t n,
+    operator()(Policy&& exec, InputIterator first, InputIterator /* last */, OutputIterator out_first, size_t n,
                /*is_trivial<T>=*/::std::false_type)
     {
         typedef typename ::std::iterator_traits<InputIterator>::value_type T;
@@ -155,7 +155,7 @@ struct test_uninitialized_move_n
 
     template <typename Policy, typename InputIterator, typename OutputIterator>
     void
-    operator()(Policy&& exec, InputIterator first, InputIterator, OutputIterator out_first, size_t n,
+    operator()(Policy&& exec, InputIterator first, InputIterator /* last */, OutputIterator out_first, size_t n,
                /*is_trivial<T>=*/::std::true_type)
     {
         ::std::uninitialized_move_n(exec, first, n, out_first);

--- a/test/parallel_api/memory/specialized.algorithms/uninitialized_fill_destroy.pass.cpp
+++ b/test/parallel_api/memory/specialized.algorithms/uninitialized_fill_destroy.pass.cpp
@@ -94,7 +94,7 @@ struct test_destroy
 {
     template <typename Policy, typename Iterator, typename T>
     void
-    operator()(Policy&& exec, Iterator first, Iterator last, const T& in, ::std::size_t, ::std::false_type)
+    operator()(Policy&& exec, Iterator first, Iterator last, const T& in, ::std::size_t /* n */, ::std::false_type)
     {
         using namespace std;
 
@@ -110,7 +110,7 @@ struct test_destroy
 
     template <typename Policy, typename Iterator, typename T>
     void
-    operator()(Policy&& exec, Iterator first, Iterator last, const T& in, ::std::size_t, ::std::true_type)
+    operator()(Policy&& exec, Iterator first, Iterator last, const T& in, ::std::size_t /* n */, ::std::true_type)
     {
         using namespace std;
 

--- a/test/parallel_api/memory/specialized.algorithms/uninitialized_fill_destroy.pass.cpp
+++ b/test/parallel_api/memory/specialized.algorithms/uninitialized_fill_destroy.pass.cpp
@@ -94,7 +94,7 @@ struct test_destroy
 {
     template <typename Policy, typename Iterator, typename T>
     void
-    operator()(Policy&& exec, Iterator first, Iterator last, const T& in, ::std::size_t n, ::std::false_type)
+    operator()(Policy&& exec, Iterator first, Iterator last, const T& in, ::std::size_t, ::std::false_type)
     {
         using namespace std;
 
@@ -110,7 +110,7 @@ struct test_destroy
 
     template <typename Policy, typename Iterator, typename T>
     void
-    operator()(Policy&& exec, Iterator first, Iterator last, const T& in, ::std::size_t n, ::std::true_type)
+    operator()(Policy&& exec, Iterator first, Iterator last, const T& in, ::std::size_t, ::std::true_type)
     {
         using namespace std;
 
@@ -176,7 +176,7 @@ test_uninitialized_fill_destroy_by_type()
         ::std::unique_ptr<T[]> p(new T[n]);
         auto p_begin = p.get();
 #else
-        Sequence<T> p(n, [](size_t k){ return T{}; });
+        Sequence<T> p(n, [](size_t){ return T{}; });
         auto p_begin = p.begin();
 #endif
         auto p_end = ::std::next(p_begin, n);

--- a/test/parallel_api/numeric/numeric.ops/adjacent_difference.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/adjacent_difference.pass.cpp
@@ -90,7 +90,7 @@ compute_and_check(Iterator1 first, Iterator1 last, Iterator2 d_first, T, Functio
 // because we can't be sure it will be strictly equal for floating point types
 template <typename Iterator1, typename Iterator2, typename T, typename Function>
 typename ::std::enable_if<::std::is_floating_point<T>::value, bool>::type
-compute_and_check(Iterator1, Iterator1, Iterator2, T, Function)
+compute_and_check(Iterator1 /* first */, Iterator1 /* last */, Iterator2 /* d_first */, T, Function)
 {
     return true;
 }

--- a/test/parallel_api/numeric/numeric.ops/adjacent_difference.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/adjacent_difference.pass.cpp
@@ -90,7 +90,7 @@ compute_and_check(Iterator1 first, Iterator1 last, Iterator2 d_first, T, Functio
 // because we can't be sure it will be strictly equal for floating point types
 template <typename Iterator1, typename Iterator2, typename T, typename Function>
 typename ::std::enable_if<::std::is_floating_point<T>::value, bool>::type
-compute_and_check(Iterator1 first, Iterator1 last, Iterator2 d_first, T, Function)
+compute_and_check(Iterator1, Iterator1, Iterator2, T, Function)
 {
     return true;
 }

--- a/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
@@ -101,7 +101,7 @@ struct test_inclusive_scan_with_plus
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T>
     void
     operator()(Policy&& exec, Iterator1 in_first, Iterator1 in_last, Iterator2 out_first, Iterator2 out_last,
-               Iterator3 expected_first, Iterator3 expected_last, Size n, T init, T trash)
+               Iterator3 expected_first, Iterator3, Size n, T, T trash)
     {
         using namespace std;
 
@@ -119,7 +119,7 @@ struct test_exclusive_scan_with_plus
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T>
     void
     operator()(Policy&& exec, Iterator1 in_first, Iterator1 in_last, Iterator2 out_first, Iterator2 out_last,
-               Iterator3 expected_first, Iterator3 expected_last, Size n, T init, T trash)
+               Iterator3 expected_first, Iterator3, Size n, T init, T trash)
     {
         using namespace std;
 
@@ -181,7 +181,7 @@ struct test_inclusive_scan_with_binary_op
               typename BinaryOp>
     typename ::std::enable_if<!TestUtils::isReverse<Iterator1>::value, void>::type
     operator()(Policy&& exec, Iterator1 in_first, Iterator1 in_last, Iterator2 out_first, Iterator2 out_last,
-               Iterator3 expected_first, Iterator3 expected_last, Size n, T init, BinaryOp binary_op, T trash)
+               Iterator3 expected_first, Iterator3, Size n, T init, BinaryOp binary_op, T trash)
     {
         using namespace std;
 
@@ -196,8 +196,8 @@ struct test_inclusive_scan_with_binary_op
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T,
               typename BinaryOp>
     typename ::std::enable_if<TestUtils::isReverse<Iterator1>::value, void>::type
-    operator()(Policy&& exec, Iterator1 in_first, Iterator1 in_last, Iterator2 out_first, Iterator2 out_last,
-               Iterator3 expected_first, Iterator3 expected_last, Size n, T init, BinaryOp binary_op, T trash)
+    operator()(Policy&&, Iterator1, Iterator1, Iterator2, Iterator2,
+               Iterator3, Iterator3, Size, T, BinaryOp, T)
     {
     }
 };
@@ -209,7 +209,7 @@ struct test_exclusive_scan_with_binary_op
               typename BinaryOp>
     typename ::std::enable_if<!TestUtils::isReverse<Iterator1>::value, void>::type
     operator()(Policy&& exec, Iterator1 in_first, Iterator1 in_last, Iterator2 out_first, Iterator2 out_last,
-               Iterator3 expected_first, Iterator3 expected_last, Size n, T init, BinaryOp binary_op, T trash)
+               Iterator3 expected_first, Iterator3, Size n, T init, BinaryOp binary_op, T trash)
     {
         using namespace std;
 
@@ -225,8 +225,8 @@ struct test_exclusive_scan_with_binary_op
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T,
               typename BinaryOp>
     typename ::std::enable_if<TestUtils::isReverse<Iterator1>::value, void>::type
-    operator()(Policy&& exec, Iterator1 in_first, Iterator1 in_last, Iterator2 out_first, Iterator2 out_last,
-               Iterator3 expected_first, Iterator3 expected_last, Size n, T init, BinaryOp binary_op, T trash)
+    operator()(Policy&&, Iterator1, Iterator1, Iterator2, Iterator2,
+               Iterator3, Iterator3, Size, T, BinaryOp, T)
     {
     }
 };

--- a/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
@@ -101,7 +101,7 @@ struct test_inclusive_scan_with_plus
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T>
     void
     operator()(Policy&& exec, Iterator1 in_first, Iterator1 in_last, Iterator2 out_first, Iterator2 out_last,
-               Iterator3 expected_first, Iterator3, Size n, T, T trash)
+               Iterator3 expected_first, Iterator3 /* expected_last */, Size n, T /* init */, T trash)
     {
         using namespace std;
 
@@ -119,7 +119,7 @@ struct test_exclusive_scan_with_plus
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T>
     void
     operator()(Policy&& exec, Iterator1 in_first, Iterator1 in_last, Iterator2 out_first, Iterator2 out_last,
-               Iterator3 expected_first, Iterator3, Size n, T init, T trash)
+               Iterator3 expected_first, Iterator3 /* expected_last */, Size n, T init, T trash)
     {
         using namespace std;
 
@@ -181,7 +181,7 @@ struct test_inclusive_scan_with_binary_op
               typename BinaryOp>
     typename ::std::enable_if<!TestUtils::isReverse<Iterator1>::value, void>::type
     operator()(Policy&& exec, Iterator1 in_first, Iterator1 in_last, Iterator2 out_first, Iterator2 out_last,
-               Iterator3 expected_first, Iterator3, Size n, T init, BinaryOp binary_op, T trash)
+               Iterator3 expected_first, Iterator3 /* expected_last */, Size n, T init, BinaryOp binary_op, T trash)
     {
         using namespace std;
 
@@ -196,8 +196,8 @@ struct test_inclusive_scan_with_binary_op
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T,
               typename BinaryOp>
     typename ::std::enable_if<TestUtils::isReverse<Iterator1>::value, void>::type
-    operator()(Policy&&, Iterator1, Iterator1, Iterator2, Iterator2,
-               Iterator3, Iterator3, Size, T, BinaryOp, T)
+    operator()(Policy&& /* exec */, Iterator1 /* in_first */, Iterator1 /* in_last */, Iterator2 /* out_first */, Iterator2 /* out_last */,
+               Iterator3 /* expected_first */, Iterator3 /* expected_last */, Size /* n */, T /* init */, BinaryOp /* binary_op */, T /* trash */)
     {
     }
 };
@@ -209,7 +209,7 @@ struct test_exclusive_scan_with_binary_op
               typename BinaryOp>
     typename ::std::enable_if<!TestUtils::isReverse<Iterator1>::value, void>::type
     operator()(Policy&& exec, Iterator1 in_first, Iterator1 in_last, Iterator2 out_first, Iterator2 out_last,
-               Iterator3 expected_first, Iterator3, Size n, T init, BinaryOp binary_op, T trash)
+               Iterator3 expected_first, Iterator3 /* expected_last */, Size n, T init, BinaryOp binary_op, T trash)
     {
         using namespace std;
 
@@ -225,8 +225,8 @@ struct test_exclusive_scan_with_binary_op
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T,
               typename BinaryOp>
     typename ::std::enable_if<TestUtils::isReverse<Iterator1>::value, void>::type
-    operator()(Policy&&, Iterator1, Iterator1, Iterator2, Iterator2,
-               Iterator3, Iterator3, Size, T, BinaryOp, T)
+    operator()(Policy&& /* exec */, Iterator1 /* in_first */, Iterator1 /* in_last */, Iterator2 /* out_first */, Iterator2 /* out_last */,
+               Iterator3 /* expected_first */, Iterator3 /* expected_last */, Size /* n */, T /* init */, BinaryOp /* binary_op */, T /* trash */)
     {
     }
 };

--- a/test/parallel_api/numeric/numeric.ops/transform_reduce.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/transform_reduce.pass.cpp
@@ -79,7 +79,7 @@ CheckResults(const T& expected, const T& in)
 // We need to check correctness only for "int" (for example) except cases
 // if we have "floating-point type"-specialization
 void
-CheckResults(const float32_t&, const float32_t&)
+CheckResults(const float32_t& /* expected */, const float32_t& /* in */)
 {
 }
 
@@ -90,7 +90,7 @@ struct test_long_transform_reduce
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename T, typename BinaryOperation1,
               typename BinaryOperation2>
     void
-    operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2,
+    operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 /* last2 */,
                T init, BinaryOperation1 opB1, BinaryOperation2 opB2)
     {
         auto expectedB = ::std::inner_product(first1, last1, first2, init, opB1, opB2);
@@ -105,7 +105,7 @@ struct test_short_transform_reduce
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename T, typename BinaryOperation,
               typename UnaryOp>
     void
-    operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2, InputIterator2,
+    operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 /* first2 */, InputIterator2 /* last2 */,
                T init, BinaryOperation opB, UnaryOp opU)
     {
         auto expectedU = transform_reduce_serial(first1, last1, init, opB, opU);

--- a/test/parallel_api/numeric/numeric.ops/transform_reduce.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/transform_reduce.pass.cpp
@@ -79,7 +79,7 @@ CheckResults(const T& expected, const T& in)
 // We need to check correctness only for "int" (for example) except cases
 // if we have "floating-point type"-specialization
 void
-CheckResults(const float32_t& expected, const float32_t& in)
+CheckResults(const float32_t&, const float32_t&)
 {
 }
 
@@ -90,7 +90,7 @@ struct test_long_transform_reduce
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename T, typename BinaryOperation1,
               typename BinaryOperation2>
     void
-    operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2,
+    operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2,
                T init, BinaryOperation1 opB1, BinaryOperation2 opB2)
     {
         auto expectedB = ::std::inner_product(first1, last1, first2, init, opB1, opB2);
@@ -105,7 +105,7 @@ struct test_short_transform_reduce
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename T, typename BinaryOperation,
               typename UnaryOp>
     void
-    operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2,
+    operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2, InputIterator2,
                T init, BinaryOperation opB, UnaryOp opU)
     {
         auto expectedU = transform_reduce_serial(first1, last1, init, opB, opU);
@@ -142,17 +142,17 @@ int
 main()
 {
     test_by_type<int32_t>(42, ::std::plus<int32_t>(), ::std::multiplies<int32_t>(), ::std::negate<int32_t>(),
-                          [](::std::size_t a) -> int32_t { return int32_t(rand() % 1000); });
+                          [](::std::size_t) -> int32_t { return int32_t(rand() % 1000); });
     test_by_type<int64_t>(0, [](const int64_t& a, const int64_t& b) -> int64_t { return a | b; }, XOR(),
                           [](const int64_t& x) -> int64_t { return x * 2; },
-                          [](::std::size_t a) -> int64_t { return int64_t(rand() % 1000); });
+                          [](::std::size_t) -> int64_t { return int64_t(rand() % 1000); });
     test_by_type<float32_t>(1.0f, ::std::multiplies<float32_t>(),
                             [](const float32_t& a, const float32_t& b) -> float32_t { return a + b; },
                             [](const float32_t& x) -> float32_t { return x + 2; },
-                            [](::std::size_t a) -> float32_t { return rand() % 1000; });
+                            [](::std::size_t) -> float32_t { return rand() % 1000; });
     test_by_type<MyClass>(MyClass(), ::std::plus<MyClass>(), ::std::multiplies<MyClass>(),
         [](const MyClass& x) { return MyClass(-x.my_field); },
-        [](::std::size_t a) -> MyClass { return MyClass(rand() % 1000); });
+        [](::std::size_t) -> MyClass { return MyClass(rand() % 1000); });
 
 
     ::std::cout << done() << ::std::endl;

--- a/test/parallel_api/numeric/numeric.ops/transform_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/transform_scan.pass.cpp
@@ -62,9 +62,9 @@ struct test_transform_exclusive_scan
     template <typename Policy, typename InputIterator, typename OutputIterator, typename Size, typename UnaryOp,
               typename T, typename BinaryOp>
     typename ::std::enable_if<TestUtils::isReverse<InputIterator>::value, void>::type
-    operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator out_last, OutputIterator expected_first, OutputIterator expected_last, Size n,
-               UnaryOp unary_op, T init, BinaryOp binary_op, T trash)
+    operator()(Policy&&, InputIterator, InputIterator, OutputIterator,
+               OutputIterator, OutputIterator, OutputIterator, Size,
+               UnaryOp, T, BinaryOp, T)
     {
     }
 };
@@ -105,8 +105,8 @@ struct test_transform_inclusive_scan
               typename T, typename BinaryOp>
     typename ::std::enable_if<!TestUtils::isReverse<InputIterator>::value, void>::type
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator out_last, OutputIterator expected_first, OutputIterator expected_last, Size n,
-               UnaryOp unary_op, T init, BinaryOp binary_op, T trash)
+               OutputIterator out_last, OutputIterator expected_first, OutputIterator, Size n,
+               UnaryOp unary_op, T, BinaryOp binary_op, T trash)
     {
         using namespace std;
 
@@ -123,9 +123,9 @@ struct test_transform_inclusive_scan
     template <typename Policy, typename InputIterator, typename OutputIterator, typename Size, typename UnaryOp,
               typename T, typename BinaryOp>
     typename ::std::enable_if<TestUtils::isReverse<InputIterator>::value, void>::type
-    operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator out_last, OutputIterator expected_first, OutputIterator expected_last, Size n,
-               UnaryOp unary_op, T init, BinaryOp binary_op, T trash)
+    operator()(Policy&&, InputIterator, InputIterator, OutputIterator,
+               OutputIterator, OutputIterator, OutputIterator, Size,
+               UnaryOp, T, BinaryOp, T)
     {
     }
 };

--- a/test/parallel_api/numeric/numeric.ops/transform_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/transform_scan.pass.cpp
@@ -47,7 +47,7 @@ struct test_transform_exclusive_scan
               typename T, typename BinaryOp>
     typename ::std::enable_if<!TestUtils::isReverse<InputIterator>::value, void>::type
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator out_last, OutputIterator expected_first, OutputIterator expected_last, Size n,
+               OutputIterator out_last, OutputIterator expected_first, OutputIterator, Size n,
                UnaryOp unary_op, T init, BinaryOp binary_op, T trash)
     {
         using namespace std;
@@ -76,7 +76,7 @@ struct test_transform_inclusive_scan_init
               typename T, typename BinaryOp>
     typename ::std::enable_if<!TestUtils::isReverse<InputIterator>::value, void>::type
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator out_last, OutputIterator expected_first, OutputIterator expected_last, Size n,
+               OutputIterator out_last, OutputIterator expected_first, OutputIterator, Size n,
                UnaryOp unary_op, T init, BinaryOp binary_op, T trash)
     {
         using namespace std;
@@ -91,9 +91,9 @@ struct test_transform_inclusive_scan_init
     template <typename Policy, typename InputIterator, typename OutputIterator, typename Size, typename UnaryOp,
               typename T, typename BinaryOp>
     typename ::std::enable_if<TestUtils::isReverse<InputIterator>::value, void>::type
-    operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator out_last, OutputIterator expected_first, OutputIterator expected_last, Size n,
-               UnaryOp unary_op, T init, BinaryOp binary_op, T trash)
+    operator()(Policy&&, InputIterator, InputIterator, OutputIterator,
+               OutputIterator, OutputIterator, OutputIterator, Size,
+               UnaryOp, T, BinaryOp, T)
     {
     }
 };

--- a/test/parallel_api/numeric/numeric.ops/transform_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/transform_scan.pass.cpp
@@ -47,7 +47,7 @@ struct test_transform_exclusive_scan
               typename T, typename BinaryOp>
     typename ::std::enable_if<!TestUtils::isReverse<InputIterator>::value, void>::type
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator out_last, OutputIterator expected_first, OutputIterator, Size n,
+               OutputIterator out_last, OutputIterator expected_first, OutputIterator /* expected_last */, Size n,
                UnaryOp unary_op, T init, BinaryOp binary_op, T trash)
     {
         using namespace std;
@@ -62,9 +62,9 @@ struct test_transform_exclusive_scan
     template <typename Policy, typename InputIterator, typename OutputIterator, typename Size, typename UnaryOp,
               typename T, typename BinaryOp>
     typename ::std::enable_if<TestUtils::isReverse<InputIterator>::value, void>::type
-    operator()(Policy&&, InputIterator, InputIterator, OutputIterator,
-               OutputIterator, OutputIterator, OutputIterator, Size,
-               UnaryOp, T, BinaryOp, T)
+    operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, OutputIterator /* out_first */,
+               OutputIterator /* out_last */, OutputIterator /* expected_first */, OutputIterator /* expected_last */, Size /* n */,
+               UnaryOp /* unary_op */, T /* init */, BinaryOp /* binary_op */, T /* trash */)
     {
     }
 };
@@ -76,7 +76,7 @@ struct test_transform_inclusive_scan_init
               typename T, typename BinaryOp>
     typename ::std::enable_if<!TestUtils::isReverse<InputIterator>::value, void>::type
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator out_last, OutputIterator expected_first, OutputIterator, Size n,
+               OutputIterator out_last, OutputIterator expected_first, OutputIterator /* expected_last */, Size n,
                UnaryOp unary_op, T init, BinaryOp binary_op, T trash)
     {
         using namespace std;
@@ -91,9 +91,9 @@ struct test_transform_inclusive_scan_init
     template <typename Policy, typename InputIterator, typename OutputIterator, typename Size, typename UnaryOp,
               typename T, typename BinaryOp>
     typename ::std::enable_if<TestUtils::isReverse<InputIterator>::value, void>::type
-    operator()(Policy&&, InputIterator, InputIterator, OutputIterator,
-               OutputIterator, OutputIterator, OutputIterator, Size,
-               UnaryOp, T, BinaryOp, T)
+    operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, OutputIterator /* out_first */,
+               OutputIterator /* out_last */, OutputIterator /* expected_first */, OutputIterator /* expected_last */, Size /* n */,
+               UnaryOp /* unary_op */, T /* init */, BinaryOp /* binary_op */, T /* trash */)
     {
     }
 };
@@ -105,8 +105,8 @@ struct test_transform_inclusive_scan
               typename T, typename BinaryOp>
     typename ::std::enable_if<!TestUtils::isReverse<InputIterator>::value, void>::type
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator out_last, OutputIterator expected_first, OutputIterator, Size n,
-               UnaryOp unary_op, T, BinaryOp binary_op, T trash)
+               OutputIterator out_last, OutputIterator expected_first, OutputIterator /* expected_last */, Size n,
+               UnaryOp unary_op, T /* init */, BinaryOp binary_op, T trash)
     {
         using namespace std;
 
@@ -123,9 +123,9 @@ struct test_transform_inclusive_scan
     template <typename Policy, typename InputIterator, typename OutputIterator, typename Size, typename UnaryOp,
               typename T, typename BinaryOp>
     typename ::std::enable_if<TestUtils::isReverse<InputIterator>::value, void>::type
-    operator()(Policy&&, InputIterator, InputIterator, OutputIterator,
-               OutputIterator, OutputIterator, OutputIterator, Size,
-               UnaryOp, T, BinaryOp, T)
+    operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, OutputIterator /* out_first */,
+               OutputIterator /* out_last */, OutputIterator /* expected_first */, OutputIterator /* expected_last */, Size /* n */,
+               UnaryOp /* unary_op */, T /* init */, BinaryOp /* binary_op */, T /* trash */)
     {
     }
 };

--- a/test/rng_testsuite/template_tests/discard_block_std_template_test.pass.cpp
+++ b/test/rng_testsuite/template_tests/discard_block_std_template_test.pass.cpp
@@ -107,7 +107,7 @@ int test_portion(oneapi::dpl::internal::element_type_t<typename Engine::result_t
                 Engine engine(seed, offset);
 
                 auto res = engine(part);
-                for(int i = 0; i < n_elems; ++i)
+                for(unsigned int i = 0; i < n_elems; ++i)
                     dpstd_acc.get_pointer()[offset + i] = res[i];
             });
         });

--- a/test/support/iterator_utils.h
+++ b/test/support/iterator_utils.h
@@ -502,7 +502,7 @@ struct iterator_invoker<::std::forward_iterator_tag, /*isReverse=*/::std::true_t
 {
     template <typename... Rest>
     void
-    operator()(Rest&&...)
+    operator()(Rest&&... /* rest */)
     {
     }
 };

--- a/test/support/iterator_utils.h
+++ b/test/support/iterator_utils.h
@@ -257,7 +257,7 @@ struct invoke_if_<::std::false_type, ::std::false_type>
 {
     template <typename Op, typename... Rest>
     void
-    operator()(bool, Op op, Rest&&... rest)
+    operator()(bool /*is_allow*/, Op op, Rest&&... rest)
     {
         op(::std::forward<Rest>(rest)...);
     }
@@ -292,14 +292,14 @@ struct non_const_wrapper_tagged : non_const_wrapper
 
     template <typename Policy, typename Iterator>
     typename ::std::enable_if<IsPositiveCondition != is_same_iterator_category<Iterator, IteratorTag>::value, void>::type
-    operator()(Policy&&, Iterator)
+    operator()(Policy&& /*exec*/, Iterator /*iter*/)
     {
     }
 
     template <typename Policy, typename InputIterator, typename OutputIterator>
     typename ::std::enable_if<IsPositiveCondition != is_same_iterator_category<OutputIterator, IteratorTag>::value,
                             void>::type
-    operator()(Policy&&, InputIterator, OutputIterator)
+    operator()(Policy&& /*exec*/, InputIterator /*input_iter*/, OutputIterator /*out_iter*/)
     {
     }
 };
@@ -352,9 +352,9 @@ struct iterator_invoker
            make_iterator<OutputIterator>()(out_iter));
     }
 
-    template <typename Policy, typename Op, typename Iterator, typename... Rest>
+    template <typename Policy, typename Op, typename Iterator, typename Size, typename... Rest>
     typename ::std::enable_if<is_same_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
-    operator()(Policy&& exec, Op op, Iterator begin, ::std::size_t n, Rest&&... rest)
+    operator()(Policy&& exec, Op op, Iterator begin, Size n, Rest&&... rest)
     {
         invoke_if<Iterator>()(n <= sizeLimit, op, exec, make_iterator<Iterator>()(begin), n,
                               ::std::forward<Rest>(rest)...);
@@ -366,7 +366,7 @@ struct iterator_invoker
                             void>::type
     operator()(Policy&& exec, Op op, Iterator inputBegin, Iterator inputEnd, Rest&&... rest)
     {
-        invoke_if<Iterator>()((::std::size_t)::std::distance(inputBegin, inputEnd) <= sizeLimit, op, exec,
+        invoke_if<Iterator>()(::std::distance(inputBegin, inputEnd) <= sizeLimit, op, exec,
                               make_iterator<Iterator>()(inputBegin), make_iterator<Iterator>()(inputEnd),
                               ::std::forward<Rest>(rest)...);
     }
@@ -377,7 +377,7 @@ struct iterator_invoker
     operator()(Policy&& exec, Op op, InputIterator inputBegin, InputIterator inputEnd, OutputIterator outputBegin,
                Rest&&... rest)
     {
-        invoke_if<InputIterator>()((::std::size_t)::std::distance(inputBegin, inputEnd) <= sizeLimit, op, exec,
+        invoke_if<InputIterator>()(::std::distance(inputBegin, inputEnd) <= sizeLimit, op, exec,
                                    make_iterator<InputIterator>()(inputBegin), make_iterator<InputIterator>()(inputEnd),
                                    make_iterator<OutputIterator>()(outputBegin), ::std::forward<Rest>(rest)...);
     }
@@ -388,7 +388,7 @@ struct iterator_invoker
     operator()(Policy&& exec, Op op, InputIterator inputBegin, InputIterator inputEnd, OutputIterator outputBegin,
                OutputIterator outputEnd, Rest&&... rest)
     {
-        invoke_if<InputIterator>()((::std::size_t)::std::distance(inputBegin, inputEnd) <= sizeLimit, op, exec,
+        invoke_if<InputIterator>()(::std::distance(inputBegin, inputEnd) <= sizeLimit, op, exec,
                                    make_iterator<InputIterator>()(inputBegin), make_iterator<InputIterator>()(inputEnd),
                                    make_iterator<OutputIterator>()(outputBegin),
                                    make_iterator<OutputIterator>()(outputEnd), ::std::forward<Rest>(rest)...);
@@ -402,7 +402,7 @@ struct iterator_invoker
                InputIterator2 inputEnd2, OutputIterator outputBegin, OutputIterator outputEnd, Rest&&... rest)
     {
         invoke_if<InputIterator1>()(
-            (::std::size_t)::std::distance(inputBegin1, inputEnd1) <= sizeLimit, op, exec, make_iterator<InputIterator1>()(inputBegin1),
+            ::std::distance(inputBegin1, inputEnd1) <= sizeLimit, op, exec, make_iterator<InputIterator1>()(inputBegin1),
             make_iterator<InputIterator1>()(inputEnd1), make_iterator<InputIterator2>()(inputBegin2),
             make_iterator<InputIterator2>()(inputEnd2), make_iterator<OutputIterator>()(outputBegin),
             make_iterator<OutputIterator>()(outputEnd), ::std::forward<Rest>(rest)...);
@@ -439,9 +439,9 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
            make_iterator<OutputIterator>()(out_iter));
     }
 
-    template <typename Policy, typename Op, typename Iterator, typename... Rest>
+    template <typename Policy, typename Op, typename Iterator, typename Size, typename... Rest>
     typename ::std::enable_if<is_same_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
-    operator()(Policy&& exec, Op op, Iterator begin, ::std::size_t n, Rest&&... rest)
+    operator()(Policy&& exec, Op op, Iterator begin, Size n, Rest&&... rest)
     {
         if (n <= sizeLimit)
             op(exec, make_iterator<Iterator>()(begin + n), n, ::std::forward<Rest>(rest)...);
@@ -453,7 +453,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
                             void>::type
     operator()(Policy&& exec, Op op, Iterator inputBegin, Iterator inputEnd, Rest&&... rest)
     {
-        if ((::std::size_t)::std::distance(inputBegin, inputEnd) <= sizeLimit)
+        if (::std::distance(inputBegin, inputEnd) <= sizeLimit)
             op(exec, make_iterator<Iterator>()(inputEnd), make_iterator<Iterator>()(inputBegin),
                ::std::forward<Rest>(rest)...);
     }
@@ -464,7 +464,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     operator()(Policy&& exec, Op op, InputIterator inputBegin, InputIterator inputEnd, OutputIterator outputBegin,
                Rest&&... rest)
     {
-        if ((::std::size_t)::std::distance(inputBegin, inputEnd) <= sizeLimit)
+        if (::std::distance(inputBegin, inputEnd) <= sizeLimit)
             op(exec, make_iterator<InputIterator>()(inputEnd), make_iterator<InputIterator>()(inputBegin),
                make_iterator<OutputIterator>()(outputBegin + (inputEnd - inputBegin)), ::std::forward<Rest>(rest)...);
     }
@@ -475,7 +475,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     operator()(Policy&& exec, Op op, InputIterator inputBegin, InputIterator inputEnd, OutputIterator outputBegin,
                OutputIterator outputEnd, Rest&&... rest)
     {
-        if ((::std::size_t)::std::distance(inputBegin, inputEnd) <= sizeLimit)
+        if (::std::distance(inputBegin, inputEnd) <= sizeLimit)
             op(exec, make_iterator<InputIterator>()(inputEnd), make_iterator<InputIterator>()(inputBegin),
                make_iterator<OutputIterator>()(outputEnd), make_iterator<OutputIterator>()(outputBegin),
                ::std::forward<Rest>(rest)...);
@@ -488,7 +488,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     operator()(Policy&& exec, Op op, InputIterator1 inputBegin1, InputIterator1 inputEnd1, InputIterator2 inputBegin2,
                InputIterator2 inputEnd2, OutputIterator outputBegin, OutputIterator outputEnd, Rest&&... rest)
     {
-        if ((::std::size_t)::std::distance(inputBegin1, inputEnd1) <= sizeLimit)
+        if (::std::distance(inputBegin1, inputEnd1) <= sizeLimit)
             op(exec, make_iterator<InputIterator1>()(inputEnd1), make_iterator<InputIterator1>()(inputBegin1),
                make_iterator<InputIterator2>()(inputEnd2), make_iterator<InputIterator2>()(inputBegin2),
                make_iterator<OutputIterator>()(outputEnd), make_iterator<OutputIterator>()(outputBegin),

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -43,7 +43,7 @@ typedef float float32_t;
 
 template <class T, ::std::size_t N>
 constexpr size_t
-const_size(const T (&array)[N]) noexcept
+const_size(const T (&)[N]) noexcept
 {
     return N;
 }
@@ -828,7 +828,7 @@ test_algo_basic_double(F&& f)
 
 template <typename Policy, typename F>
 static void
-invoke_if(Policy&& p, F f)
+invoke_if(Policy&&, F f)
 {
     f();
 }

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -39,7 +39,11 @@ namespace TestUtils
 #define PRINT_DEBUG(message) ::TestUtils::print_debug(message)
 
     inline void
-    print_debug(const char* message)
+    print_debug(const char*
+#       if _ONEDPL_DEBUG_SYCL   
+    message
+#       endif
+    )
     {
 #       if _ONEDPL_DEBUG_SYCL
         ::std::cout << message << ::std::endl;

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -40,14 +40,14 @@ namespace TestUtils
 
     inline void
     print_debug(const char*
-#       if _ONEDPL_DEBUG_SYCL   
+#if _ONEDPL_DEBUG_SYCL   
     message
-#       endif
+#endif
     )
     {
-#       if _ONEDPL_DEBUG_SYCL
+#if _ONEDPL_DEBUG_SYCL
         ::std::cout << message << ::std::endl;
-#       endif
+#endif
     }
 
     // Check values in sequence


### PR DESCRIPTION
To detect warnings keys -Wall -Wformat-security -Werror=format-security -Wno-unused-lambda-capture -Wno-return-std-move were added in test/CMakeLists.
Some cases were fixed to prevent producing these warnings.