### PR TITLE
Fixed some test failures

### DIFF
--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -19,9 +19,9 @@
 #ifndef DPSTD_EXCLUSIVE_SCAN_BY_KEY
 #define DPSTD_EXCLUSIVE_SCAN_BY_KEY
 
+#include "../pstl/parallel_backend.h"
 #include "function.h"
 #include "by_segment_extension_defs.h"
-#include "../pstl/parallel_backend_tbb.h"
 
 namespace oneapi
 {

--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -21,6 +21,7 @@
 
 #include "function.h"
 #include "by_segment_extension_defs.h"
+#include "../pstl/parallel_backend_tbb.h"
 
 namespace oneapi
 {

--- a/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
@@ -20,6 +20,7 @@
 #define DPCPP_INCLUSIVE_SCAN_BY_KEY_IMPL_H_
 
 #include "../pstl/glue_numeric_impl.h"
+#include "../pstl/parallel_backend.h"
 #include "function.h"
 #include "by_segment_extension_defs.h"
 

--- a/test/extensions_testsuite/dpl_namespace.pass.cpp
+++ b/test/extensions_testsuite/dpl_namespace.pass.cpp
@@ -26,7 +26,6 @@ namespace sycl = cl::sycl;
 
 int main()
 {
-
     const int n = 1000;
     const int k = 1000;
     using T = uint64_t;
@@ -40,13 +39,12 @@ int main()
     auto res_first = dpl::begin(res_buf);
     auto counting_first = dpl::counting_iterator<T>(0);
     auto zip_first = dpl::make_zip_iterator(counting_first, key_first);
- 
+
     // key_buf = {0,0,...0,1,1,...,1}
     std::for_each(dpl::execution::make_device_policy<class ForEach>(dpl::execution::dpcpp_default),
 		zip_first, zip_first + n,
-        [](auto x){
-            using std::get;
-            get<1>(x) = (2 * get<0>(x)) / n;
+        [](std::tuple<T, T> x){
+            std::get<1>(x) = (2 * std::get<0>(x)) / n;
         });
     // val_buf = {0,1,2,...,n-1}
     std::transform(dpl::execution::make_device_policy<class Transform>(dpl::execution::dpcpp_default),

--- a/test/extensions_testsuite/dpl_namespace.pass.cpp
+++ b/test/extensions_testsuite/dpl_namespace.pass.cpp
@@ -19,6 +19,7 @@
 #include <oneapi/dpl/functional>
 
 #include <iostream>
+#include <tuple>
 
 #include <CL/sycl.hpp>
 


### PR DESCRIPTION
Changes:
1. Replace `auto` with actual type for `dpl_namespace.pass` to let it run with C++11.
2. Include a header file for `exclusive_scan_by_segment_impl.h` to prevent failures with `clang++`