### PR TITLE
Use kernel_device_specific queries instead of the deprecated ones

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -349,7 +349,7 @@ __max_compute_units(_ExecutionPolicy&& __policy)
 // Kernel run-time information helpers
 //-----------------------------------------------------------------------------
 
-// 20201214 value corresponds to oneAPI C++ Compiler Classic 2021.1.2 Patch release
+// 20201214 value corresponds to Intel(R) oneAPI C++ Compiler Classic 2021.1.2 Patch release
 #define _USE_KERNEL_DEVICE_SPECIFIC_API (__SYCL_COMPILER_VERSION > 20201214)
 
 template <typename _ExecutionPolicy>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -349,6 +349,13 @@ __max_compute_units(_ExecutionPolicy&& __policy)
 // Kernel run-time information helpers
 //-----------------------------------------------------------------------------
 
+// 20201214 value corresponds to oneAPI C++ Compiler Classic 2021.1.2 Patch release
+#if __SYCL_COMPILER_VERSION > 20201214
+#    define _USE_KERNEL_DEVICE_SPECIFIC_API 1
+#else
+#    define _USE_KERNEL_DEVICE_SPECIFIC_API 0
+#endif
+
 template <typename _ExecutionPolicy>
 ::std::size_t
 __kernel_work_group_size(_ExecutionPolicy&& __policy, const sycl::kernel& __kernel)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -356,7 +356,11 @@ __kernel_work_group_size(_ExecutionPolicy&& __policy, const sycl::kernel& __kern
     const auto& __device = __policy.queue().get_device();
     // TODO: investigate can we use kernel_work_group::preferred_work_group_size_multiple here.
     auto __max_wg_size =
+#if _USE_KERNEL_DEVICE_SPECIFIC_API
+        __kernel.template get_info<sycl::info::kernel_device_specific::work_group_size>(__device);
+#else
         __kernel.template get_work_group_info<sycl::info::kernel_work_group::work_group_size>(__device);
+#endif
     // The variable below is needed to achieve better performance on CPU devices.
     // Experimentally it was found that the most common divisor is 4 with all patterns.
     // TODO: choose the divisor according to specific pattern.
@@ -372,8 +376,13 @@ __kernel_sub_group_size(_ExecutionPolicy&& __policy, const sycl::kernel& __kerne
     auto __device = __policy.queue().get_device();
     auto __wg_size = __kernel_work_group_size(::std::forward<_ExecutionPolicy>(__policy), __kernel);
     const ::std::size_t __sg_size =
+#if _USE_KERNEL_DEVICE_SPECIFIC_API
+        __kernel.template get_info<sycl::info::kernel_device_specific::max_sub_group_size>(
+            __device, sycl::range<3>{__wg_size, 1, 1});
+#else
         __kernel.template get_sub_group_info<sycl::info::kernel_sub_group::max_sub_group_size>(
             __device, sycl::range<3>{__wg_size, 1, 1});
+#endif
     return __sg_size;
 }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -350,11 +350,7 @@ __max_compute_units(_ExecutionPolicy&& __policy)
 //-----------------------------------------------------------------------------
 
 // 20201214 value corresponds to oneAPI C++ Compiler Classic 2021.1.2 Patch release
-#if __SYCL_COMPILER_VERSION > 20201214
-#    define _USE_KERNEL_DEVICE_SPECIFIC_API 1
-#else
-#    define _USE_KERNEL_DEVICE_SPECIFIC_API 0
-#endif
+#define _USE_KERNEL_DEVICE_SPECIFIC_API (__SYCL_COMPILER_VERSION > 20201214)
 
 template <typename _ExecutionPolicy>
 ::std::size_t
@@ -385,11 +381,10 @@ __kernel_sub_group_size(_ExecutionPolicy&& __policy, const sycl::kernel& __kerne
     const ::std::size_t __sg_size =
 #if _USE_KERNEL_DEVICE_SPECIFIC_API
         __kernel.template get_info<sycl::info::kernel_device_specific::max_sub_group_size>(
-            __device, sycl::range<3>{__wg_size, 1, 1});
 #else
         __kernel.template get_sub_group_info<sycl::info::kernel_sub_group::max_sub_group_size>(
-            __device, sycl::range<3>{__wg_size, 1, 1});
 #endif
+            __device, sycl::range<3>{__wg_size, 1, 1});
     return __sg_size;
 }
 

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -302,20 +302,20 @@ static_assert(__cplusplus >= 201703L, "The Range support requires C++17 as minim
 #    if !defined(_ONEDPL_COMPILE_KERNEL)
 #        define _ONEDPL_COMPILE_KERNEL 1
 #    endif
+
+// Get access to __SYCL_COMPILER_VERSION macro
+#    include <CL/sycl/version.hpp>
+
+// 20201214 value corresponds to oneAPI C++ Compiler Classic 2021.1.2 Patch release
+#    if __SYCL_COMPILER_VERSION <= 20201214
+#        define _USE_KERNEL_DEVICE_SPECIFIC_API 0
+#    else
+#        define _USE_KERNEL_DEVICE_SPECIFIC_API 1
+#    endif
 #endif
 
 #if !defined(ONEDPL_ALLOW_DEFERRED_WAITING)
 #    define ONEDPL_ALLOW_DEFERRED_WAITING 0
-#endif
-
-// Get access to __SYCL_COMPILER_VERSION macro
-#include <CL/sycl.hpp>
-
-// 20201214 value corresponds to oneAPI C++ Compiler Classic 2021.1.2 Patch release
-#if __SYCL_COMPILER_VERSION <= 20201214
-#    define _USE_KERNEL_DEVICE_SPECIFIC_API 0
-#else
-#    define _USE_KERNEL_DEVICE_SPECIFIC_API 1
 #endif
 
 #endif /* _ONEDPL_CONFIG_H */

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -302,16 +302,6 @@ static_assert(__cplusplus >= 201703L, "The Range support requires C++17 as minim
 #    if !defined(_ONEDPL_COMPILE_KERNEL)
 #        define _ONEDPL_COMPILE_KERNEL 1
 #    endif
-
-// Get access to __SYCL_COMPILER_VERSION macro
-#    include <CL/sycl/version.hpp>
-
-// 20201214 value corresponds to oneAPI C++ Compiler Classic 2021.1.2 Patch release
-#    if __SYCL_COMPILER_VERSION <= 20201214
-#        define _USE_KERNEL_DEVICE_SPECIFIC_API 0
-#    else
-#        define _USE_KERNEL_DEVICE_SPECIFIC_API 1
-#    endif
 #endif
 
 #if !defined(ONEDPL_ALLOW_DEFERRED_WAITING)

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -308,4 +308,14 @@ static_assert(__cplusplus >= 201703L, "The Range support requires C++17 as minim
 #    define ONEDPL_ALLOW_DEFERRED_WAITING 0
 #endif
 
+// Get access to __SYCL_COMPILER_VERSION macro
+#include <CL/sycl.hpp>
+
+// 20201214 value corresponds to oneAPI C++ Compiler Classic 2021.1.2 Patch release
+#if __SYCL_COMPILER_VERSION <= 20201214
+#    define _USE_KERNEL_DEVICE_SPECIFIC_API 0
+#else
+#    define _USE_KERNEL_DEVICE_SPECIFIC_API 1
+#endif
+
 #endif /* _ONEDPL_CONFIG_H */


### PR DESCRIPTION
`get_workgroup_info` and `get_sub_group_info` queries have been deprecated in favor of  “device-specific kernel” `get_info`
queries (`info::kernel_device_specific`).
