### PR TITLE
[RNG] Optimize LCG engine + apply clang-format for RNG files

### DIFF
--- a/include/oneapi/dpl/internal/random_impl/discard_block_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/discard_block_engine.h
@@ -112,8 +112,7 @@ class discard_block_engine
 
   private:
     // Static asserts
-    static_assert((0 < _R) && ( _R <= _P),
-        "oneapi::dpl::discard_block_engine. Error: unsupported parameters");
+    static_assert((0 < _R) && (_R <= _P), "oneapi::dpl::discard_block_engine. Error: unsupported parameters");
 
     // Function for state adjustment
     template <int _N>

--- a/include/oneapi/dpl/internal/random_impl/linear_congruential_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/linear_congruential_engine.h
@@ -152,7 +152,8 @@ class linear_congruential_engine
     pow_mult_n(unsigned long long __num_to_skip)
     {
         ::std::uint64_t __a2;
-        ::std::uint64_t __a = multiplier;
+        ::std::uint64_t __mod = static_cast<::std::uint64_t>(modulus);
+        ::std::uint64_t __a = static_cast<::std::uint64_t>(multiplier);
         scalar_type __r;
 
         __r = 1;
@@ -161,13 +162,13 @@ class linear_congruential_engine
         {
             if (__num_to_skip & 1)
             {
-                __a2 = static_cast<::std::uint64_t>(__r) * static_cast<::std::uint64_t>(__a);
-                __r = __a2 % modulus;
+                __a2 = static_cast<::std::uint64_t>(__r) * __a;
+                __r = static_cast<scalar_type>(__a2 % __mod);
             }
 
             __num_to_skip >>= 1;
-            __a2 = static_cast<::std::uint64_t>(__a) * static_cast<::std::uint64_t>(__a);
-            __a = __a2 % modulus;
+            __a2 = __a * __a;
+            __a = __a2 % __mod;
 
         } while (__num_to_skip);
 

--- a/include/oneapi/dpl/internal/random_impl/linear_congruential_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/linear_congruential_engine.h
@@ -41,7 +41,8 @@ class linear_congruential_engine
     static constexpr scalar_type
     min()
     {
-        return (increment == static_cast<scalar_type>(0u)) ? static_cast<scalar_type>(1u) : static_cast<scalar_type>(0u);
+        return (increment == static_cast<scalar_type>(0u)) ? static_cast<scalar_type>(1u)
+                                                           : static_cast<scalar_type>(0u);
     }
     static constexpr scalar_type
     max()
@@ -55,7 +56,7 @@ class linear_congruential_engine
 
     explicit linear_congruential_engine(scalar_type __seed, unsigned long long __offset = 0)
     {
-        init<internal::type_traits_t<result_type>::num_elems, increment>(__seed);
+        init<internal::type_traits_t<result_type>::num_elems>(__seed);
         discard(__offset);
     }
 
@@ -64,7 +65,7 @@ class linear_congruential_engine
     seed(scalar_type __seed = default_seed)
     {
         // Engine initalization
-        init<internal::type_traits_t<result_type>::num_elems, increment>(__seed);
+        init<internal::type_traits_t<result_type>::num_elems>(__seed);
     }
 
     // Discard procedure
@@ -72,7 +73,11 @@ class linear_congruential_engine
     discard(unsigned long long __num_to_skip)
     {
         // Skipping sequence
-        skip_seq<internal::type_traits_t<result_type>::num_elems, increment>(__num_to_skip);
+        if (__num_to_skip == 0)
+            return;
+        constexpr bool flag = (increment == 0) && (modulus < ::std::numeric_limits<::std::uint32_t>::max()) &&
+                              (multiplier < ::std::numeric_limits<::std::uint32_t>::max());
+        skip_seq<internal::type_traits_t<result_type>::num_elems, flag>(__num_to_skip);
     }
 
     // operator () returns bits of engine recurrence
@@ -80,8 +85,9 @@ class linear_congruential_engine
     operator()()
     {
         result_type __state_tmp = state_;
-        unsigned long long __discard_num =
-            (internal::type_traits_t<result_type>::num_elems == 0) ? 1 : internal::type_traits_t<result_type>::num_elems;
+        unsigned long long __discard_num = (internal::type_traits_t<result_type>::num_elems == 0)
+                                               ? 1
+                                               : internal::type_traits_t<result_type>::num_elems;
         discard(__discard_num);
         return __state_tmp;
     }
@@ -95,8 +101,8 @@ class linear_congruential_engine
 
   private:
     // Static asserts
-    static_assert(((_M == 0) || (_A < _M) && ( _C < _M)),
-        "oneapi::dpl::linear_congruential_engine. Error: unsupported parameters");
+    static_assert(((_M == 0) || (_A < _M) && (_C < _M)),
+                  "oneapi::dpl::linear_congruential_engine. Error: unsupported parameters");
 
     // Function for state adjustment
     scalar_type
@@ -107,8 +113,8 @@ class linear_congruential_engine
     }
 
     // Initialization function
-    template <int _N = 0, scalar_type _INC = 0>
-    typename ::std::enable_if<_N == 0>::type
+    template <int _N = 0>
+    typename ::std::enable_if<(_N == 0)>::type
     init(scalar_type __seed)
     {
         if ((increment % modulus == 0) && (__seed % modulus == 0))
@@ -122,7 +128,7 @@ class linear_congruential_engine
         state_ = mod_scalar(state_);
     }
 
-    template <int _N = 0, scalar_type _INC = 0>
+    template <int _N = 0>
     typename ::std::enable_if<(_N != 0)>::type
     init(scalar_type __seed)
     {
@@ -141,25 +147,54 @@ class linear_congruential_engine
             state_[__i] = mod_scalar(state_[__i - 1u]);
     }
 
+    // Intenal function for calculate degrees of multiplier
+    scalar_type
+    pow_mult_n(unsigned long long __num_to_skip)
+    {
+        ::std::uint64_t __a2;
+        ::std::uint64_t __a = multiplier;
+        scalar_type __r;
+
+        __r = 1;
+
+        do
+        {
+            if (__num_to_skip & 1)
+            {
+                __a2 = static_cast<::std::uint64_t>(__r) * static_cast<::std::uint64_t>(__a);
+                __r = __a2 % modulus;
+            }
+
+            __num_to_skip >>= 1;
+            __a2 = static_cast<::std::uint64_t>(__a) * static_cast<::std::uint64_t>(__a);
+            __a = __a2 % modulus;
+
+        } while (__num_to_skip);
+
+        return __r;
+    }
+
     // Internal function which is used in discard procedure
-    template <int _N = 0, scalar_type _INC = 0>
-    typename ::std::enable_if<_N == 0>::type
+    // _FLAG - is flag that used for optimizations
+    // if _FLAG == true in this case we can used optimized versions of skip_seq
+    template <int _N = 0, bool _FLAG = false>
+    typename ::std::enable_if<(_N == 0) && (_FLAG == false)>::type
     skip_seq(unsigned long long __num_to_skip)
     {
         for (unsigned long long __i = 0; __i < __num_to_skip; ++__i)
             state_ = mod_scalar(state_);
     }
 
-    template <int _N = 0, scalar_type _INC = 0>
-    typename ::std::enable_if<(_N == 1)>::type
+    template <int _N = 0, bool _FLAG = false>
+    typename ::std::enable_if<(_N == 1) && (_FLAG == false)>::type
     skip_seq(unsigned long long __num_to_skip)
     {
         for (unsigned long long __i = 0; __i < __num_to_skip; ++__i)
             state_[0] = mod_scalar(state_[0]);
     }
 
-    template <int _N = 0, scalar_type _INC = 0>
-    typename ::std::enable_if<(_N > 1)>::type
+    template <int _N = 0, bool _FLAG = false>
+    typename ::std::enable_if<(_N > 1) && (_FLAG == false)>::type
     skip_seq(unsigned long long __num_to_skip)
     {
         for (unsigned long long __i = 0; __i < __num_to_skip; ++__i)
@@ -170,6 +205,34 @@ class linear_congruential_engine
             }
             state_[_N - 1] = mod_scalar(state_[_N - 2]);
         }
+    }
+
+    template <int _N = 0, bool _FLAG = false>
+    typename ::std::enable_if<(_N == 0) && (_FLAG == true)>::type
+    skip_seq(unsigned long long __num_to_skip)
+    {
+        ::std::uint64_t __mod = modulus, __inc = increment;
+        ::std::uint64_t __mult = pow_mult_n(__num_to_skip);
+        state_ = static_cast<scalar_type>((__mult * static_cast<::std::uint64_t>(state_) + __inc) % __mod);
+    }
+
+    template <int _N = 0, bool _FLAG = false>
+    typename ::std::enable_if<(_N == 1) && (_FLAG == true)>::type
+    skip_seq(unsigned long long __num_to_skip)
+    {
+        ::std::uint64_t __mod = modulus;
+        ::std::uint64_t __mult = pow_mult_n(__num_to_skip);
+        state_[0] = static_cast<scalar_type>((__mult * static_cast<::std::uint64_t>(state_[0])) % __mod);
+    }
+
+    template <int _N = 0, bool _FLAG = false>
+    typename ::std::enable_if<(_N > 1) && (_FLAG == true)>::type
+    skip_seq(unsigned long long __num_to_skip)
+    {
+        ::std::uint64_t __mod = modulus, __inc = increment;
+        ::std::uint64_t __mult = pow_mult_n(__num_to_skip);
+        state_ = ((__mult * state_.template convert<::std::uint64_t, cl::sycl::rounding_mode::rte>()) % __mod)
+                     .template convert<scalar_type, cl::sycl::rounding_mode::rte>();
     }
 
     // result_portion implementation

--- a/include/oneapi/dpl/internal/random_impl/linear_congruential_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/linear_congruential_engine.h
@@ -129,7 +129,7 @@ class linear_congruential_engine
     }
 
     template <int _N = 0>
-    typename ::std::enable_if<(_N != 0)>::type
+    typename ::std::enable_if<(_N > 0)>::type
     init(scalar_type __seed)
     {
         if ((increment % modulus == 0) && (__seed % modulus == 0))
@@ -147,7 +147,7 @@ class linear_congruential_engine
             state_[__i] = mod_scalar(state_[__i - 1u]);
     }
 
-    // Intenal function for calculate degrees of multiplier
+    // Internal function for calculate degrees of multiplier
     scalar_type
     pow_mult_n(unsigned long long __num_to_skip)
     {
@@ -231,8 +231,8 @@ class linear_congruential_engine
     {
         ::std::uint64_t __mod = modulus, __inc = increment;
         ::std::uint64_t __mult = pow_mult_n(__num_to_skip);
-        state_ = ((__mult * state_.template convert<::std::uint64_t, cl::sycl::rounding_mode::rte>()) % __mod)
-                     .template convert<scalar_type, cl::sycl::rounding_mode::rte>();
+        state_ = ((__mult * state_.template convert<::std::uint64_t, sycl::rounding_mode::rte>()) % __mod)
+                     .template convert<scalar_type, sycl::rounding_mode::rte>();
     }
 
     // result_portion implementation

--- a/include/oneapi/dpl/internal/random_impl/normal_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/normal_distribution.h
@@ -51,7 +51,9 @@ class normal_distribution
     // Constructors
     normal_distribution() : normal_distribution(static_cast<scalar_type>(0.0)) {}
     explicit normal_distribution(scalar_type __mean, scalar_type __stddev = static_cast<scalar_type>(1.0))
-        : mean_(__mean), stddev_(__stddev) {}
+        : mean_(__mean), stddev_(__stddev)
+    {
+    }
     explicit normal_distribution(const param_type& __params) : mean_(__params.first), stddev_(__params.second) {}
 
     // Reset function
@@ -152,7 +154,7 @@ class normal_distribution
 
     // Static asserts
     static_assert(::std::is_floating_point<scalar_type>::value,
-        "oneapi::dpl::normal_distribution. Error: unsupported data type");
+                  "oneapi::dpl::normal_distribution. Error: unsupported data type");
 
     // Real distribution for the conversion
     uniform_real_distribution<uniform_result_type> uniform_real_distribution_;
@@ -204,17 +206,17 @@ class normal_distribution
 
         if (!flag_)
         {
-            result_type __u1 =
-                uniform_real_distribution_(__engine, ::std::pair<scalar_type, scalar_type>(static_cast<scalar_type>(0.0),
-                                                                                       static_cast<scalar_type>(1.0)));
-            result_type __u2 =
-                uniform_real_distribution_(__engine, ::std::pair<scalar_type, scalar_type>(static_cast<scalar_type>(0.0),
-                                                                                       static_cast<scalar_type>(1.0)));
+            result_type __u1 = uniform_real_distribution_(
+                __engine,
+                ::std::pair<scalar_type, scalar_type>(static_cast<scalar_type>(0.0), static_cast<scalar_type>(1.0)));
+            result_type __u2 = uniform_real_distribution_(
+                __engine,
+                ::std::pair<scalar_type, scalar_type>(static_cast<scalar_type>(0.0), static_cast<scalar_type>(1.0)));
 
             __ln = (__u1 == static_cast<scalar_type>(0.0)) ? callback<scalar_type>() : sycl::log(__u1);
 
             __res = __params.first + __params.second * (sycl::sqrt(-static_cast<scalar_type>(2.0) * __ln) *
-                                                  sycl::sin(pi2<scalar_type>() * __u2));
+                                                        sycl::sin(pi2<scalar_type>() * __u2));
 
             saved_ln_ = __ln;
             saved_u2_ = __u2;
@@ -222,7 +224,7 @@ class normal_distribution
         else
         {
             __res = __params.first + __params.second * (sycl::sqrt(-static_cast<scalar_type>(2.0) * saved_ln_) *
-                                                  sycl::cos(pi2<scalar_type>() * saved_u2_));
+                                                        sycl::cos(pi2<scalar_type>() * saved_u2_));
         }
 
         flag_ = !flag_;
@@ -253,9 +255,9 @@ class normal_distribution
                 __u2 = __u[__i + 1];
                 __ln = (__u1 == static_cast<scalar_type>(0.0)) ? callback<scalar_type>() : sycl::log(__u1);
                 __res[__i] = __mean + __stddev * (sycl::sqrt(-static_cast<scalar_type>(2.0) * __ln) *
-                                          sycl::sin(pi2<scalar_type>() * __u2));
+                                                  sycl::sin(pi2<scalar_type>() * __u2));
                 __res[__i + 1] = __mean + __stddev * (sycl::sqrt(-static_cast<scalar_type>(2.0) * __ln) *
-                                              sycl::cos(pi2<scalar_type>() * __u2));
+                                                      sycl::cos(pi2<scalar_type>() * __u2));
             }
             if (__tail)
             {
@@ -263,7 +265,7 @@ class normal_distribution
                 __u2 = __u[__N];
                 __ln = (__u1 == static_cast<scalar_type>(0.0)) ? callback<scalar_type>() : sycl::log(__u1);
                 __res[__N - 1] = __mean + __stddev * (sycl::sqrt(-static_cast<scalar_type>(2.0) * __ln) *
-                                              sycl::sin(pi2<scalar_type>() * __u2));
+                                                      sycl::sin(pi2<scalar_type>() * __u2));
 
                 saved_ln_ = __ln;
                 saved_u2_ = __u2;
@@ -273,7 +275,7 @@ class normal_distribution
         else
         {
             __res[0] = __mean + __stddev * (sycl::sqrt(-static_cast<scalar_type>(2.0) * saved_ln_) *
-                                      sycl::cos(pi2<scalar_type>() * saved_u2_));
+                                            sycl::cos(pi2<scalar_type>() * saved_u2_));
 
             flag_ = false;
 
@@ -288,9 +290,9 @@ class normal_distribution
                 __u2 = __u[__i];
                 __ln = (__u1 == static_cast<scalar_type>(0.0)) ? callback<scalar_type>() : sycl::log(__u1);
                 __res[__i] = __mean + __stddev * (sycl::sqrt(-static_cast<scalar_type>(2.0) * __ln) *
-                                          sycl::sin(pi2<scalar_type>() * __u2));
+                                                  sycl::sin(pi2<scalar_type>() * __u2));
                 __res[__i + 1] = __mean + __stddev * (sycl::sqrt(-static_cast<scalar_type>(2.0) * __ln) *
-                                              sycl::cos(pi2<scalar_type>() * __u2));
+                                                      sycl::cos(pi2<scalar_type>() * __u2));
             }
             if (__tail)
             {
@@ -298,7 +300,7 @@ class normal_distribution
                 __u2 = __u[__N];
                 __ln = (__u1 == static_cast<scalar_type>(0.0)) ? callback<scalar_type>() : sycl::log(__u1);
                 __res[__N - 1] = __mean + __stddev * (sycl::sqrt(-static_cast<scalar_type>(2.0) * __ln) *
-                                              sycl::sin(pi2<scalar_type>() * __u2));
+                                                      sycl::sin(pi2<scalar_type>() * __u2));
 
                 saved_ln_ = __ln;
                 saved_u2_ = __u2;

--- a/include/oneapi/dpl/internal/random_impl/subtract_with_carry_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/subtract_with_carry_engine.h
@@ -100,11 +100,10 @@ class subtract_with_carry_engine
 
   private:
     // Static asserts
-    static_assert((0 < _S) && (_S < _R),
-        "oneapi::dpl::subtract_with_carry_engine. Error: unsupported parameters");
+    static_assert((0 < _S) && (_S < _R), "oneapi::dpl::subtract_with_carry_engine. Error: unsupported parameters");
 
     static_assert((0 < _W) && (_W <= std::numeric_limits<scalar_type>::digits),
-        "oneapi::dpl::subtract_with_carry_engine. Error: unsupported parameters");
+                  "oneapi::dpl::subtract_with_carry_engine. Error: unsupported parameters");
     // Initialization function
     void
     init(scalar_type __seed)
@@ -159,7 +158,6 @@ class subtract_with_carry_engine
     {
         return generate_internal_scalar();
     }
-
 
     template <int _N>
     typename ::std::enable_if<(_N > 0), result_type>::type

--- a/include/oneapi/dpl/internal/random_impl/uniform_int_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/uniform_int_distribution.h
@@ -150,7 +150,7 @@ class uniform_int_distribution
             __engine, ::std::pair<double, double>(static_cast<double>(__params.first),
                                                   static_cast<double>(__params.second) + 1.0));
 
-        return __res.template convert<scalar_type, cl::sycl::rounding_mode::rte>();
+        return __res.template convert<scalar_type, sycl::rounding_mode::rte>();
     }
 
     template <int _Ndistr, class _Engine>
@@ -175,7 +175,7 @@ class uniform_int_distribution
                                                                    static_cast<double>(__params.second) + 1.0),
                                        __N);
 
-        return __res.template convert<scalar_type, cl::sycl::rounding_mode::rte>();
+        return __res.template convert<scalar_type, sycl::rounding_mode::rte>();
     }
 };
 

--- a/include/oneapi/dpl/internal/random_impl/uniform_int_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/uniform_int_distribution.h
@@ -36,13 +36,17 @@ class uniform_int_distribution
 
     // Constructors
     uniform_int_distribution() : uniform_int_distribution(static_cast<scalar_type>(0)) {}
-    explicit uniform_int_distribution(scalar_type __a, scalar_type __b = ::std::numeric_limits<scalar_type>::max()) :
-        a_(__a), b_(__b) {}
+    explicit uniform_int_distribution(scalar_type __a, scalar_type __b = ::std::numeric_limits<scalar_type>::max())
+        : a_(__a), b_(__b)
+    {
+    }
     explicit uniform_int_distribution(const param_type& __params) : a_(__params.first), b_(__params.second) {}
 
     // Reset function
     void
-    reset() {}
+    reset()
+    {
+    }
 
     // Property functions
     scalar_type
@@ -81,7 +85,6 @@ class uniform_int_distribution
     {
         return b();
     }
-
 
     // Generate functions
     template <class _Engine>
@@ -129,7 +132,7 @@ class uniform_int_distribution
 
     // Static asserts
     static_assert(::std::is_integral<scalar_type>::value,
-        "oneapi::dpl::uniform_int_distribution. Error: unsupported data type");
+                  "oneapi::dpl::uniform_int_distribution. Error: unsupported data type");
 
     // Distribution parameters
     scalar_type a_;
@@ -143,9 +146,9 @@ class uniform_int_distribution
     typename ::std::enable_if<(_Ndistr != 0), result_type>::type
     generate(_Engine& __engine, const param_type& __params)
     {
-        RealType __res =
-            uniform_real_distribution_(__engine, ::std::pair<double, double>(static_cast<double>(__params.first),
-                                                                         static_cast<double>(__params.second) + 1.0));
+        RealType __res = uniform_real_distribution_(
+            __engine, ::std::pair<double, double>(static_cast<double>(__params.first),
+                                                  static_cast<double>(__params.second) + 1.0));
 
         return __res.template convert<scalar_type, cl::sycl::rounding_mode::rte>();
     }
@@ -154,9 +157,9 @@ class uniform_int_distribution
     typename ::std::enable_if<(_Ndistr == 0), result_type>::type
     generate(_Engine& __engine, const param_type& __params)
     {
-        RealType __res =
-            uniform_real_distribution_(__engine, ::std::pair<double, double>(static_cast<double>(__params.first),
-                                                                         static_cast<double>(__params.second) + 1.0));
+        RealType __res = uniform_real_distribution_(
+            __engine, ::std::pair<double, double>(static_cast<double>(__params.first),
+                                                  static_cast<double>(__params.second) + 1.0));
 
         return static_cast<scalar_type>(__res);
     }
@@ -166,9 +169,11 @@ class uniform_int_distribution
     typename ::std::enable_if<(_Ndistr != 0), result_type>::type
     result_portion_internal(_Engine& __engine, const param_type& __params, unsigned int __N)
     {
-        RealType __res = uniform_real_distribution_(__engine,
-            ::std::pair<double, double>(static_cast<double>(__params.first),
-            static_cast<double>(__params.second) + 1.0), __N);
+        RealType __res =
+            uniform_real_distribution_(__engine,
+                                       ::std::pair<double, double>(static_cast<double>(__params.first),
+                                                                   static_cast<double>(__params.second) + 1.0),
+                                       __N);
 
         return __res.template convert<scalar_type, cl::sycl::rounding_mode::rte>();
     }

--- a/include/oneapi/dpl/internal/random_impl/uniform_real_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/uniform_real_distribution.h
@@ -36,13 +36,17 @@ class uniform_real_distribution
 
     // Constructors
     uniform_real_distribution() : uniform_real_distribution(static_cast<scalar_type>(0.0)) {}
-    explicit uniform_real_distribution(scalar_type __a, scalar_type __b = static_cast<scalar_type>(1.0)) :
-        a_(__a), b_(__b) {}
+    explicit uniform_real_distribution(scalar_type __a, scalar_type __b = static_cast<scalar_type>(1.0))
+        : a_(__a), b_(__b)
+    {
+    }
     explicit uniform_real_distribution(const param_type& __params) : a_(__params.first), b_(__params.second) {}
 
     // Reset function
     void
-    reset() {}
+    reset()
+    {
+    }
 
     // Property functions
     scalar_type
@@ -95,8 +99,8 @@ class uniform_real_distribution
     operator()(_Engine& __engine, const param_type& __params)
     {
         result_type __res =
-            generate<size_of_type_, internal::type_traits_t<typename _Engine::result_type>::num_elems, _Engine>(__engine,
-                                                                                                              __params);
+            generate<size_of_type_, internal::type_traits_t<typename _Engine::result_type>::num_elems, _Engine>(
+                __engine, __params);
         return __res;
     }
 
@@ -129,7 +133,7 @@ class uniform_real_distribution
 
     // Static asserts
     static_assert(::std::is_floating_point<scalar_type>::value,
-        "oneapi::dpl::uniform_real_distribution. Error: unsupported data type");
+                  "oneapi::dpl::uniform_real_distribution. Error: unsupported data type");
 
     // Distribution parameters
     scalar_type a_;
@@ -143,8 +147,8 @@ class uniform_real_distribution
         auto __engine_output = __engine();
         auto __res = __engine_output.template convert<scalar_type, sycl::rounding_mode::rte>();
         __res = ((__res - __engine.min()) / (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
-                  (__params.second - __params.first) +
-              __params.first;
+                    (__params.second - __params.first) +
+                __params.first;
         return __res;
     }
 
@@ -155,9 +159,9 @@ class uniform_real_distribution
         auto __engine_output = __engine();
         auto __res = static_cast<scalar_type>(__engine_output);
         __res = ((__res - static_cast<scalar_type>(__engine.min())) /
-               (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
-                  (__params.second - __params.first) +
-              __params.first;
+                 (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
+                    (__params.second - __params.first) +
+                __params.first;
         return __res;
     }
 
@@ -170,9 +174,10 @@ class uniform_real_distribution
         for (int __i = 0; __i < _Ndistr; ++__i)
         {
             __res[__i] = static_cast<scalar_type>(__engine_output[__i]);
-            __res[__i] = ((__res[__i] - __engine.min()) / (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
-                         (__params.second - __params.first) +
-                     __params.first;
+            __res[__i] =
+                ((__res[__i] - __engine.min()) / (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
+                    (__params.second - __params.first) +
+                __params.first;
         }
 
         return __res;
@@ -184,8 +189,8 @@ class uniform_real_distribution
     {
         scalar_type __res = static_cast<scalar_type>(__engine(1)[0]);
         __res = ((__res - __engine.min()) / (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
-                  (__params.second - __params.first) +
-              __params.first;
+                    (__params.second - __params.first) +
+                __params.first;
         return __res;
     }
 
@@ -200,9 +205,10 @@ class uniform_real_distribution
         {
             auto __engine_output = __engine();
             auto __res_tmp = __engine_output.template convert<scalar_type, sycl::rounding_mode::rte>();
-            __res_tmp = ((__res_tmp - __engine.min()) / (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
-                          (__params.second - __params.first) +
-                      __params.first;
+            __res_tmp =
+                ((__res_tmp - __engine.min()) / (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
+                    (__params.second - __params.first) +
+                __params.first;
 
             for (int __j = 0; __j < _Negnine; ++__j)
                 __res[__i + __j] = __res_tmp[__j];
@@ -213,9 +219,10 @@ class uniform_real_distribution
             __i = _Ndistr - __tail_size;
             auto __engine_output = __engine(__tail_size);
             auto __res_tmp = __engine_output.template convert<scalar_type, sycl::rounding_mode::rte>();
-            __res_tmp = ((__res_tmp - __engine.min()) / (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
-                          (__params.second - __params.first) +
-                      __params.first;
+            __res_tmp =
+                ((__res_tmp - __engine.min()) / (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
+                    (__params.second - __params.first) +
+                __params.first;
             for (int __j = 0; __j < _Negnine; __j++)
                 __res[__i + __j] = __res_tmp[__j];
         }
@@ -230,9 +237,10 @@ class uniform_real_distribution
         for (int __i = 0; __i < _Ndistr; ++__i)
         {
             __res[__i] = static_cast<scalar_type>(__engine());
-            __res[__i] = ((__res[__i] - __engine.min()) / (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
-                         (__params.second - __params.first) +
-                     __params.first;
+            __res[__i] =
+                ((__res[__i] - __engine.min()) / (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
+                    (__params.second - __params.first) +
+                __params.first;
         }
         return __res;
     }
@@ -247,9 +255,10 @@ class uniform_real_distribution
         for (unsigned int __i = 0; __i < __N; ++__i)
         {
             __res[__i] = static_cast<scalar_type>(__engine_output[__i]);
-            __res[__i] = ((__res[__i] - __engine.min()) / (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
-                         (__params.second - __params.first) +
-                     __params.first;
+            __res[__i] =
+                ((__res[__i] - __engine.min()) / (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
+                    (__params.second - __params.first) +
+                __params.first;
         }
 
         return __res;
@@ -268,9 +277,10 @@ class uniform_real_distribution
             for (unsigned int __i = 0; __i < __N; ++__i)
             {
                 __res[__i] = static_cast<scalar_type>(__engine_output[__i]);
-                __res[__i] = ((__res[__i] - __engine.min()) / (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
-                             (__params.second - __params.first) +
-                         __params.first;
+                __res[__i] =
+                    ((__res[__i] - __engine.min()) / (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
+                        (__params.second - __params.first) +
+                    __params.first;
             }
         }
         else
@@ -280,8 +290,10 @@ class uniform_real_distribution
             {
                 auto __engine_output = __engine();
                 auto __res_tmp = __engine_output.template convert<scalar_type, sycl::rounding_mode::rte>();
-                __res_tmp = ((__res_tmp - __engine.min()) / (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
-                              (__params.second - __params.first) + __params.first;
+                __res_tmp =
+                    ((__res_tmp - __engine.min()) / (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
+                        (__params.second - __params.first) +
+                    __params.first;
                 for (int __j = 0; __j < _Negnine; ++__j)
                 {
                     __res[__i + __j] = __res_tmp[__j];
@@ -292,8 +304,10 @@ class uniform_real_distribution
                 __i = _Ndistr - __tail_size;
                 auto __engine_output = __engine(__tail_size);
                 auto __res_tmp = __engine_output.template convert<scalar_type, sycl::rounding_mode::rte>();
-                __res_tmp = ((__res_tmp - __engine.min()) / (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
-                              (__params.second - __params.first) + __params.first;
+                __res_tmp =
+                    ((__res_tmp - __engine.min()) / (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
+                        (__params.second - __params.first) +
+                    __params.first;
 
                 for (unsigned int __j = 0; __j < __tail_size; ++__j)
                 {
@@ -313,9 +327,10 @@ class uniform_real_distribution
         for (unsigned int __i = 0; __i < __N; ++__i)
         {
             __res[__i] = static_cast<scalar_type>(__engine());
-            __res[__i] = ((__res[__i] - __engine.min()) / (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
-                         (__params.second - __params.first) +
-                     __params.first;
+            __res[__i] =
+                ((__res[__i] - __engine.min()) / (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
+                    (__params.second - __params.first) +
+                __params.first;
         }
 
         return __res;


### PR DESCRIPTION
Optimize skip-ahead procedure of LCG instantiations
Apply clang-format for RNG files