### PR TITLE
Add check for standard library/C++ standard version for the ranges testing, fix the main CMake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,12 +30,6 @@ if (FIND_GXX_EXE)
     execute_process(COMMAND ${FIND_GXX_EXE} -dumpfullversion OUTPUT_VARIABLE _onedpl_gxx_version)
 endif()
 
-option(ONEDPL_USE_PARALLEL_POLICIES "Enable parallel policies" ON)
-if (CMAKE_CXX_STANDARD GREATER_EQUAL 17 AND (NOT _onedpl_gxx_version OR _onedpl_gxx_version VERSION_GREATER_EQUAL 8.1))
-    option(ONEDPL_USE_RANGES_API "Enable the use of ranges API for algorithms" ON)
-else()
-    option(ONEDPL_USE_RANGES_API "Enable the use of ranges API for algorithms" OFF)
-endif()
 option(ONEDPL_USE_UNNAMED_LAMBDA "Pass -fsycl-unnamed-lambda compile option" OFF)
 option(ONEDPL_FPGA_STATIC_REPORT "Enable the static report generation for the FPGA device" OFF)
 option(ONEDPL_USE_AOT_COMPILATION "Enable the ahead of time compilation via OCLOC compiler" OFF)
@@ -72,126 +66,124 @@ else()
     set(CMAKE_CXX_FLAGS_DEBUG "-O0 ${CMAKE_CXX_FLAGS_DEBUG}")
 endif()
 
-if (ONEDPL_USE_PARALLEL_POLICIES)
-    string(TOUPPER ${ONEDPL_BACKEND} ONEDPL_BACKEND)
-    message(STATUS "Using parallel policies with ${ONEDPL_BACKEND} backend")
-    string(TOLOWER ${ONEDPL_BACKEND} ONEDPL_BACKEND)
+string(TOUPPER ${ONEDPL_BACKEND} ONEDPL_BACKEND)
+message(STATUS "Using parallel policies with ${ONEDPL_BACKEND} backend")
+string(TOLOWER ${ONEDPL_BACKEND} ONEDPL_BACKEND)
 
-    if (ONEDPL_BACKEND MATCHES "^(tbb|dpcpp|dpcpp_only)$")
-        string(TOUPPER "${ONEDPL_BACKEND}" ONEDPL_BACKEND_NAME)
-        set(ONEDPL_USE_BACKEND_${ONEDPL_BACKEND_NAME} TRUE)
+if (ONEDPL_BACKEND MATCHES "^(tbb|dpcpp|dpcpp_only)$")
+    string(TOUPPER "${ONEDPL_BACKEND}" ONEDPL_BACKEND_NAME)
+    set(ONEDPL_USE_BACKEND_${ONEDPL_BACKEND_NAME} TRUE)
 
-        if (ONEDPL_BACKEND MATCHES "^(tbb|dpcpp)$")
-            find_package(TBB 2021 REQUIRED tbb OPTIONAL_COMPONENTS tbbmalloc)
-            message(STATUS "oneDPL uses oneTBB ${TBB_VERSION}")
-            target_link_libraries(oneDPL INTERFACE TBB::tbb)
-        endif()
+    if (ONEDPL_BACKEND MATCHES "^(tbb|dpcpp)$")
+        find_package(TBB 2021 REQUIRED tbb OPTIONAL_COMPONENTS tbbmalloc)
+        message(STATUS "oneDPL uses oneTBB ${TBB_VERSION}")
+        target_link_libraries(oneDPL INTERFACE TBB::tbb)
+    endif()
 
-        # It is for Clang and Intel® oneAPI DPC++ Compiler (while the last one is detected as Clang; for Linux only), which are used with libstdc++ standard library
-        if (UNIX)
-            if (CMAKE_CXX_COMPILER_ID STREQUAL Clang)
-                if (FIND_GXX_EXE)
-                    string(REPLACE "\." "0" _onedpl_tbb_use_glibcxx_version ${_onedpl_gxx_version})
-                    target_compile_definitions(oneDPL INTERFACE TBB_USE_GLIBCXX_VERSION=${_onedpl_tbb_use_glibcxx_version})
-                else()
-                    target_compile_definitions(oneDPL INTERFACE TBB_USE_GLIBCXX_VERSION=70300)
-                endif()
-            endif()
-        endif()
-
-        target_compile_definitions(oneDPL INTERFACE
-            $<$<CONFIG:Debug>:TBB_USE_DEBUG=1>
-            $<$<CONFIG:Debug>:PSTL_USE_DEBUG>
-            $<$<BOOL:${ONEDPL_USE_BACKEND_DPCPP_ONLY}>:ONEDPL_USE_TBB_BACKEND=0>
-            $<$<BOOL:${ONEDPL_USE_BACKEND_TBB}>:ONEDPL_USE_DPCPP_BACKEND=0>
-            )
-
-        if (ONEDPL_BACKEND MATCHES "^(dpcpp|dpcpp_only)$")
-            if (NOT _fsycl_option)
-                message(FATAL_ERROR "${CMAKE_CXX_COMPILER} doesn't support -fsycl option.\n"
-                "It is required if ONEDPL_BACKEND=${ONEDPL_BACKEND}")
-            endif()
-
-            # settings for the specific compilation type
-            if (NOT ONEDPL_USE_AOT_COMPILATION)
-                message(STATUS "Use the ahead of time compilation. No additional parameters needed")
+    # It is for Clang and Intel® oneAPI DPC++ Compiler (while the last one is detected as Clang; for Linux only), which are used with libstdc++ standard library
+    if (UNIX)
+        if (CMAKE_CXX_COMPILER_ID STREQUAL Clang)
+            if (FIND_GXX_EXE)
+                string(REPLACE "\." "0" _onedpl_tbb_use_glibcxx_version ${_onedpl_gxx_version})
+                target_compile_definitions(oneDPL INTERFACE TBB_USE_GLIBCXX_VERSION=${_onedpl_tbb_use_glibcxx_version})
             else()
-                if (NOT ONEDPL_AOT_ARCH)
-                    set(ONEDPL_AOT_ARCH "*")
-                    message(STATUS "Ahead of time compilation for all available architectures")
-                else()
-                    string(TOLOWER ${ONEDPL_AOT_ARCH} ONEDPL_AOT_ARCH)
-                    message(STATUS "Ahead of time compilation for ${ONEDPL_AOT_ARCH} architecture")
-                endif()
-                set(ONEDPL_AOT_COMP_OPTION_REL "-Xs \"-device ${ONEDPL_AOT_ARCH}\"")
-                set(ONEDPL_AOT_COMP_OPTION_DEB "-Xs \"-device ${ONEDPL_AOT_ARCH} -internal_options -cl-kernel-debug-enable -options -cl-opt-disable\"")
-                set(ONEDPL_AOT_COMP_OPTION_RELDEB "-Xs \"-device ${ONEDPL_AOT_ARCH} -internal_options -cl-kernel-debug-enable\"")
+                target_compile_definitions(oneDPL INTERFACE TBB_USE_GLIBCXX_VERSION=70300)
             endif()
-
-            # check device type
-            if (NOT ONEDPL_DEVICE_TYPE)
-                set(ONEDPL_DEVICE_TYPE "GPU")
-                message(STATUS "Use GPU as default device")
-            endif()
-
-            string(TOUPPER ${ONEDPL_DEVICE_TYPE} ONEDPL_DEVICE_TYPE)
-            if (ONEDPL_DEVICE_TYPE MATCHES "^(CPU|GPU|FPGA_EMU|FPGA_HW?)$")
-                message(STATUS "Compilation for ${ONEDPL_DEVICE_TYPE}")
-                set(ONEDPL_USE_DEVICE_${ONEDPL_DEVICE_TYPE} TRUE)
-            else()
-                message(FATAL_ERROR "Unsupported device type: ${ONEDPL_DEVICE_TYPE}.\n"
-                    "Select one of the following devices: CPU, GPU, FPGA_EMU or FPGA_HW")
-            endif()
-
-            # Check correctness of STATIC_REPORT
-            if (ONEDPL_FPGA_STATIC_REPORT)
-                if (NOT ONEDPL_USE_DEVICE_FPGA_HW)
-                    message(FATAL_ERROR "Static report can only be generated for FPGA hardware")
-                else()
-                    message(STATUS "Static report will be generated")
-                endif()
-            endif()
-
-            # DPC++ specific compiler options
-            target_compile_options(oneDPL INTERFACE
-                $<$<BOOL:${ONEDPL_USE_UNNAMED_LAMBDA}>:-fsycl-unnamed-lambda>
-                $<$<OR:$<BOOL:${ONEDPL_USE_DEVICE_FPGA_HW}>,$<BOOL:${ONEDPL_USE_DEVICE_FPGA_EMU}>>:-fintelfpga>
-                )
-
-            # DPC++ specific macro
-            target_compile_definitions(oneDPL INTERFACE
-                $<$<BOOL:${ONEDPL_USE_RANGES_API}>:_ONEDPL_USE_RANGES=1>
-                $<$<OR:$<BOOL:${ONEDPL_USE_DEVICE_FPGA_HW}>,$<BOOL:${ONEDPL_USE_DEVICE_FPGA_EMU}>>:ONEDPL_FPGA_DEVICE>
-                $<$<BOOL:${ONEDPL_USE_DEVICE_FPGA_EMU}>:ONEDPL_FPGA_EMULATOR>
-                )
-
-            # DPC++ specific link options
-            target_link_libraries(oneDPL INTERFACE
-                $<$<OR:$<BOOL:${ONEDPL_USE_DEVICE_FPGA_HW}>,$<BOOL:${ONEDPL_USE_DEVICE_FPGA_EMU}>>:-fintelfpga>
-                $<$<BOOL:${ONEDPL_USE_DEVICE_FPGA_HW}>:-Xshardware>
-                $<$<AND:$<BOOL:${ONEDPL_USE_DEVICE_FPGA_HW}>,$<BOOL:${ONEDPL_FPGA_STATIC_REPORT}>>:-fsycl-link>
-                $<$<BOOL:${ONEDPL_USE_AOT_COMPILATION}>:-fsycl-targets=spir64_gen-unknown-unknown-sycldevice>
-                $<$<AND:$<CONFIG:Release>,$<BOOL:${ONEDPL_USE_AOT_COMPILATION}>>:${ONEDPL_AOT_COMP_OPTION_REL}>
-                $<$<AND:$<CONFIG:Debug>,$<BOOL:${ONEDPL_USE_AOT_COMPILATION}>>:${ONEDPL_AOT_COMP_OPTION_DEB}>
-                $<$<AND:$<CONFIG:RelWithDebInfo>,$<BOOL:${ONEDPL_USE_AOT_COMPILATION}>>:${ONEDPL_AOT_COMP_OPTION_RELDEB}>
-                )
-        endif()
-
-    else()
-        message(STATUS "Using Parallel Policies, but not oneTBB/DPC++")
-        if (TARGET ${ONEDPL_BACKEND})
-            target_link_libraries(oneDPL INTERFACE ${ONEDPL_BACKEND})
-        else()
-            find_package(${ONEDPL_BACKEND} REQUIRED)
-            target_link_libraries(oneDPL INTERFACE ${${ONEDPL_BACKEND}_IMPORTED_TARGETS})
         endif()
     endif()
-else()
+
     target_compile_definitions(oneDPL INTERFACE
-        PSTL_USE_PARALLEL_POLICIES=0
+        $<$<CONFIG:Debug>:TBB_USE_DEBUG=1>
+        $<$<CONFIG:Debug>:PSTL_USE_DEBUG>
+        $<$<BOOL:${ONEDPL_USE_BACKEND_DPCPP_ONLY}>:ONEDPL_USE_TBB_BACKEND=0>
+        $<$<BOOL:${ONEDPL_USE_BACKEND_TBB}>:ONEDPL_USE_DPCPP_BACKEND=0>
+        )
+
+    if (ONEDPL_BACKEND MATCHES "^(dpcpp|dpcpp_only)$")
+        if (NOT _fsycl_option)
+            message(FATAL_ERROR "${CMAKE_CXX_COMPILER} doesn't support -fsycl option.\n"
+            "It is required if ONEDPL_BACKEND=${ONEDPL_BACKEND}")
+        endif()
+
+        # settings for the specific compilation type
+        if (NOT ONEDPL_USE_AOT_COMPILATION)
+            message(STATUS "Use the ahead of time compilation. No additional parameters needed")
+        else()
+            if (NOT ONEDPL_AOT_ARCH)
+                set(ONEDPL_AOT_ARCH "*")
+                message(STATUS "Ahead of time compilation for all available architectures")
+            else()
+                string(TOLOWER ${ONEDPL_AOT_ARCH} ONEDPL_AOT_ARCH)
+                message(STATUS "Ahead of time compilation for ${ONEDPL_AOT_ARCH} architecture")
+            endif()
+            set(ONEDPL_AOT_COMP_OPTION_REL "-Xs \"-device ${ONEDPL_AOT_ARCH}\"")
+            set(ONEDPL_AOT_COMP_OPTION_DEB "-Xs \"-device ${ONEDPL_AOT_ARCH} -internal_options -cl-kernel-debug-enable -options -cl-opt-disable\"")
+            set(ONEDPL_AOT_COMP_OPTION_RELDEB "-Xs \"-device ${ONEDPL_AOT_ARCH} -internal_options -cl-kernel-debug-enable\"")
+        endif()
+
+        # check device type
+        if (NOT ONEDPL_DEVICE_TYPE)
+            set(ONEDPL_DEVICE_TYPE "GPU")
+            message(STATUS "Use GPU as default device")
+        endif()
+
+        string(TOUPPER ${ONEDPL_DEVICE_TYPE} ONEDPL_DEVICE_TYPE)
+        if (ONEDPL_DEVICE_TYPE MATCHES "^(CPU|GPU|FPGA_EMU|FPGA_HW?)$")
+            message(STATUS "Compilation for ${ONEDPL_DEVICE_TYPE}")
+            set(ONEDPL_USE_DEVICE_${ONEDPL_DEVICE_TYPE} TRUE)
+        else()
+            message(FATAL_ERROR "Unsupported device type: ${ONEDPL_DEVICE_TYPE}.\n"
+                "Select one of the following devices: CPU, GPU, FPGA_EMU or FPGA_HW")
+        endif()
+
+        # Check correctness of STATIC_REPORT
+        if (ONEDPL_FPGA_STATIC_REPORT)
+            if (NOT ONEDPL_USE_DEVICE_FPGA_HW)
+                message(FATAL_ERROR "Static report can only be generated for FPGA hardware")
+            else()
+                message(STATUS "Static report will be generated")
+            endif()
+        endif()
+
+        # DPC++ specific compiler options
+        target_compile_options(oneDPL INTERFACE
+            $<$<BOOL:${ONEDPL_USE_UNNAMED_LAMBDA}>:-fsycl-unnamed-lambda>
+            $<$<OR:$<BOOL:${ONEDPL_USE_DEVICE_FPGA_HW}>,$<BOOL:${ONEDPL_USE_DEVICE_FPGA_EMU}>>:-fintelfpga>
+            )
+
+        # DPC++ specific macro
+        target_compile_definitions(oneDPL INTERFACE
+            $<$<OR:$<BOOL:${ONEDPL_USE_DEVICE_FPGA_HW}>,$<BOOL:${ONEDPL_USE_DEVICE_FPGA_EMU}>>:ONEDPL_FPGA_DEVICE>
+            $<$<BOOL:${ONEDPL_USE_DEVICE_FPGA_EMU}>:ONEDPL_FPGA_EMULATOR>
+            )
+
+        # DPC++ specific link options
+        target_link_libraries(oneDPL INTERFACE
+            $<$<OR:$<BOOL:${ONEDPL_USE_DEVICE_FPGA_HW}>,$<BOOL:${ONEDPL_USE_DEVICE_FPGA_EMU}>>:-fintelfpga>
+            $<$<BOOL:${ONEDPL_USE_DEVICE_FPGA_HW}>:-Xshardware>
+            $<$<AND:$<BOOL:${ONEDPL_USE_DEVICE_FPGA_HW}>,$<BOOL:${ONEDPL_FPGA_STATIC_REPORT}>>:-fsycl-link>
+            $<$<BOOL:${ONEDPL_USE_AOT_COMPILATION}>:-fsycl-targets=spir64_gen-unknown-unknown-sycldevice>
+            $<$<AND:$<CONFIG:Release>,$<BOOL:${ONEDPL_USE_AOT_COMPILATION}>>:${ONEDPL_AOT_COMP_OPTION_REL}>
+            $<$<AND:$<CONFIG:Debug>,$<BOOL:${ONEDPL_USE_AOT_COMPILATION}>>:${ONEDPL_AOT_COMP_OPTION_DEB}>
+            $<$<AND:$<CONFIG:RelWithDebInfo>,$<BOOL:${ONEDPL_USE_AOT_COMPILATION}>>:${ONEDPL_AOT_COMP_OPTION_RELDEB}>
+            )
+    endif()
+
+elseif(ONEDPL_BACKEND MATCHES "^(serial)$")
+    target_compile_definitions(oneDPL INTERFACE
         ONEDPL_USE_TBB_BACKEND=0
         ONEDPL_USE_DPCPP_BACKEND=0
         )
+    message(STATUS "Compilation for CPU device due to serial backend")
+
+else()
+    message(STATUS "Using Parallel Policies, but not oneTBB/DPC++")
+    if (TARGET ${ONEDPL_BACKEND})
+        target_link_libraries(oneDPL INTERFACE ${ONEDPL_BACKEND})
+    else()
+        find_package(${ONEDPL_BACKEND} REQUIRED)
+        target_link_libraries(oneDPL INTERFACE ${${ONEDPL_BACKEND}_IMPORTED_TARGETS})
+    endif()
 endif()
 
 target_include_directories(oneDPL

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -8,11 +8,9 @@ The following variables are provided for oneDPL configuration:
 
 | Variable                     | Type   | Description                                                                                   | Default value |
 |------------------------------|--------|-----------------------------------------------------------------------------------------------|---------------|
-| ONEDPL_USE_PARALLEL_POLICIES | BOOL   | Enable parallel policies                                                                      | ON            |
-| ONEDPL_BACKEND               | STRING | Threading backend; supported values: tbb, dpcpp, dpcpp_only, ...; the default value is defined by compiler: dpcpp for DPC++ and tbb for others | tbb/dpcpp |
+| ONEDPL_BACKEND               | STRING | Threading backend; supported values: tbb, dpcpp, dpcpp_only, serial, ...; the default value is defined by compiler: dpcpp for DPC++ and tbb for others | tbb/dpcpp |
 | ONEDPL_DEVICE_TYPE           | STRING | Device type, applicable only for sycl backends; supported values: GPU, CPU, FPGA_HW, FPGA_EMU | GPU           |
 | ONEDPL_USE_UNNAMED_LAMBDA    | BOOL   | Pass `-fsycl-unnamed-lambda` compile option                                                   | OFF           |
-| ONEDPL_USE_RANGES_API        | BOOL   | Enable the use of ranges API for algorithms                                                   | OFF           |
 | ONEDPL_FPGA_STATIC_REPORT    | BOOL   | Enable the static report generation for the FPGA_HW device type                               | OFF           |
 | ONEDPL_USE_AOT_COMPILATION   | BOOL   | Enable the ahead of time compilation via OpenCL™ Offline Compiler (OCLOC)                     | OFF           |
 | ONEDPL_AOT_ARCH              | STRING | Architecture options for the ahead of time compilation, supported values can be found [here](https://software.intel.com/content/www/us/en/develop/documentation/oneapi-dpcpp-cpp-compiler-dev-guide-and-reference/top/compilation/ahead-of-time-compilation.html); the default value `*` means compilation for all available options | *             |

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -83,9 +83,7 @@
 #    define _ONEDPL_PAR_BACKEND_SERIAL 1
 #endif
 
-#if _ONEDPL_USE_RANGES
-static_assert(__cplusplus >= 201703L, "The Range support requires C++17 as minimal version");
-
+#if (__cplusplus >= 201703L)
 #    define _ONEDPL_CONSTEXPR_FUN constexpr
 #    define _ONEDPL_CONSTEXPR_VAR inline constexpr
 #else

--- a/include/oneapi/dpl/ranges
+++ b/include/oneapi/dpl/ranges
@@ -28,9 +28,7 @@
 #    endif // __has_include(<tbb/version.h>)
 #endif     // __cplusplus >= 201703L
 
-#define _ONEDPL_USE_RANGES 1
 #include "oneapi/dpl/pstl/onedpl_config.h"
-
 #include "oneapi/dpl/pstl/ranges_defs.h"
 
 #if !_ONEDPL_ALGORITHM_RANGES_FORWARD_DECLARED

--- a/include/oneapi/dpl/ranges
+++ b/include/oneapi/dpl/ranges
@@ -16,17 +16,27 @@
 #ifndef _ONEDPL_RANGES
 #define _ONEDPL_RANGES
 
+#if defined(_GLIBCXX_RELEASE)
+#    define _ONEDPL_CXX_STANDARD_LIBRARY_CHECK (_GLIBCXX_RELEASE >= 8 && __GLIBCXX__ >= 20180502)
+#elif defined(_LIBCPP_VERSION)
+#    define _ONEDPL_CXX_STANDARD_LIBRARY_CHECK (_LIBCPP_VERSION >= 7000)
+#else
+#    define _ONEDPL_CXX_STANDARD_LIBRARY_CHECK 1
+#endif
+
+static_assert(__cplusplus >= 201703L && _ONEDPL_CXX_STANDARD_LIBRARY_CHECK,
+              "The use of the range-based API requires C++17 and the C++ standard libraries coming with GCC 8.1 (or "
+              "higher) or Clang 7 (or higher)");
+
 // Workarounds for libstdc++9, libstdc++10 when new TBB version is found in the environment
-#if __cplusplus >= 201703L
-#    if __has_include(<tbb/version.h>)
-#        ifndef PSTL_USE_PARALLEL_POLICIES
-#            define PSTL_USE_PARALLEL_POLICIES (_GLIBCXX_RELEASE != 9)
-#        endif
-#        ifndef _GLIBCXX_USE_TBB_PAR_BACKEND
-#            define _GLIBCXX_USE_TBB_PAR_BACKEND (_GLIBCXX_RELEASE > 10)
-#        endif
-#    endif // __has_include(<tbb/version.h>)
-#endif     // __cplusplus >= 201703L
+#if __has_include(<tbb/version.h>)
+#    ifndef PSTL_USE_PARALLEL_POLICIES
+#        define PSTL_USE_PARALLEL_POLICIES (_GLIBCXX_RELEASE != 9)
+#    endif
+#    ifndef _GLIBCXX_USE_TBB_PAR_BACKEND
+#        define _GLIBCXX_USE_TBB_PAR_BACKEND (_GLIBCXX_RELEASE > 10)
+#    endif
+#endif // __has_include(<tbb/version.h>)
 
 #include "oneapi/dpl/pstl/onedpl_config.h"
 #include "oneapi/dpl/pstl/ranges_defs.h"

--- a/include/oneapi/dpl/ranges
+++ b/include/oneapi/dpl/ranges
@@ -16,6 +16,8 @@
 #ifndef _ONEDPL_RANGES
 #define _ONEDPL_RANGES
 
+// TODO: Figure out the order of headers and add standard header version/ciso646 for library version macros.
+// Also, remove dependecy on <execution> header.
 #if defined(_GLIBCXX_RELEASE)
 #    define _ONEDPL_CXX_STANDARD_LIBRARY_CHECK (_GLIBCXX_RELEASE >= 8 && __GLIBCXX__ >= 20180502)
 #elif defined(_LIBCPP_VERSION)

--- a/test/parallel_api/ranges/copy_ranges_factory_sycl.pass.cpp
+++ b/test/parallel_api/ranges/copy_ranges_factory_sycl.pass.cpp
@@ -13,11 +13,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <oneapi/dpl/execution>
+
 #include "support/pstl_test_config.h"
 
-#include _PSTL_TEST_HEADER(execution)
 #if _ENABLE_RANGES_TESTING
-#include _PSTL_TEST_HEADER(ranges)
+#include <oneapi/dpl/ranges>
 #endif
 
 #include "support/utils.h"

--- a/test/parallel_api/ranges/copy_ranges_factory_sycl.pass.cpp
+++ b/test/parallel_api/ranges/copy_ranges_factory_sycl.pass.cpp
@@ -16,7 +16,7 @@
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
 #include _PSTL_TEST_HEADER(ranges)
 #endif
 
@@ -27,7 +27,7 @@
 int32_t
 main()
 {
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
     constexpr int max_n = 10;
     int data[max_n] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     int data2[max_n];
@@ -50,7 +50,7 @@ main()
     ::std::transform(data, data + max_n, expected, lambda1);
 
     EXPECT_EQ_N(expected, data2, max_n, "wrong effect from copy with factory and sycl ranges");
-#endif //_ONEDPL_USE_RANGES
+#endif //_ENABLE_RANGES_TESTING
     ::std::cout << TestUtils::done() << ::std::endl;
     return 0;
 }

--- a/test/parallel_api/ranges/copy_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/copy_ranges_sycl.pass.cpp
@@ -13,11 +13,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <oneapi/dpl/execution>
+
 #include "support/pstl_test_config.h"
 
-#include _PSTL_TEST_HEADER(execution)
 #if _ENABLE_RANGES_TESTING
-#include _PSTL_TEST_HEADER(ranges)
+#include <oneapi/dpl/ranges>
 #endif
 
 #include "support/utils.h"

--- a/test/parallel_api/ranges/copy_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/copy_ranges_sycl.pass.cpp
@@ -16,7 +16,7 @@
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
 #include _PSTL_TEST_HEADER(ranges)
 #endif
 
@@ -27,7 +27,7 @@
 int32_t
 main()
 {
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
     constexpr int max_n = 10;
     int data[max_n] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     int data2[max_n];
@@ -54,7 +54,7 @@ main()
     ::std::transform(data, data + max_n, expected, lambda1);
 
     EXPECT_EQ_N(expected, data2, max_n, "wrong effect from copy with sycl ranges");
-#endif //_ONEDPL_USE_RANGES
+#endif //_ENABLE_RANGES_TESTING
     ::std::cout << TestUtils::done() << ::std::endl;
     return 0;
 }

--- a/test/parallel_api/ranges/exclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/exclusive_scan_ranges_sycl.pass.cpp
@@ -17,7 +17,7 @@
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(numeric)
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
 #include _PSTL_TEST_HEADER(ranges)
 #endif
 
@@ -28,7 +28,7 @@
 int32_t
 main()
 {
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
     constexpr int max_n = 10;
     int data[max_n] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     int data1[max_n], data2[max_n];
@@ -60,7 +60,7 @@ main()
     EXPECT_EQ_N(expected1, data1, max_n, "wrong effect from exclusive_scan with init, sycl ranges");
     EXPECT_EQ_N(expected2, data2, max_n, "wrong effect from exclusive_scan with init andbinary operation, sycl ranges");
 
-#endif //_ONEDPL_USE_RANGES
+#endif //_ENABLE_RANGES_TESTING
     ::std::cout << TestUtils::done() << ::std::endl;
     return 0;
 }

--- a/test/parallel_api/ranges/exclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/exclusive_scan_ranges_sycl.pass.cpp
@@ -13,12 +13,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <oneapi/dpl/execution>
+
 #include "support/pstl_test_config.h"
 
-#include _PSTL_TEST_HEADER(execution)
-#include _PSTL_TEST_HEADER(numeric)
+#include <oneapi/dpl/numeric>
+
 #if _ENABLE_RANGES_TESTING
-#include _PSTL_TEST_HEADER(ranges)
+#include <oneapi/dpl/ranges>
 #endif
 
 #include "support/utils.h"

--- a/test/parallel_api/ranges/find_end_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/find_end_ranges_sycl.pass.cpp
@@ -17,7 +17,7 @@
 
 #include _PSTL_TEST_HEADER(execution)
 
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
 #include _PSTL_TEST_HEADER(ranges)
 #endif
 
@@ -28,7 +28,7 @@
 int32_t
 main()
 {
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
     const int count1 = 10;
     int data1[count1] = {5, 6, 7, 3, 4, 5, 6, 7, 8, 9};
 
@@ -51,7 +51,7 @@ main()
     //check result
     EXPECT_TRUE(res == idx, "wrong effect from 'find_end' with sycl ranges");
 
-#endif //_ONEDPL_USE_RANGES
+#endif //_ENABLE_RANGES_TESTING
 
     ::std::cout << TestUtils::done() << ::std::endl;
     return 0;

--- a/test/parallel_api/ranges/find_end_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/find_end_ranges_sycl.pass.cpp
@@ -13,12 +13,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <oneapi/dpl/execution>
+
 #include "support/pstl_test_config.h"
 
-#include _PSTL_TEST_HEADER(execution)
-
 #if _ENABLE_RANGES_TESTING
-#include _PSTL_TEST_HEADER(ranges)
+#include <oneapi/dpl/ranges>
 #endif
 
 #include "support/utils.h"

--- a/test/parallel_api/ranges/find_first_of_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/find_first_of_ranges_sycl.pass.cpp
@@ -13,12 +13,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <oneapi/dpl/execution>
+
 #include "support/pstl_test_config.h"
 
-#include _PSTL_TEST_HEADER(execution)
-
 #if _ENABLE_RANGES_TESTING
-#include _PSTL_TEST_HEADER(ranges)
+#include <oneapi/dpl/ranges>
 #endif
 
 #include "support/utils.h"

--- a/test/parallel_api/ranges/find_first_of_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/find_first_of_ranges_sycl.pass.cpp
@@ -17,7 +17,7 @@
 
 #include _PSTL_TEST_HEADER(execution)
 
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
 #include _PSTL_TEST_HEADER(ranges)
 #endif
 
@@ -28,7 +28,7 @@
 int32_t
 main()
 {
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
     const int count1 = 10;
     int data1[count1] = {5, 6, 7, 3, 4, 5, 6, 7, 8, 9};
 
@@ -51,7 +51,7 @@ main()
     //check result
     EXPECT_TRUE(res == idx, "wrong effect from 'find_first_of' with sycl ranges");
 
-#endif //_ONEDPL_USE_RANGES
+#endif //_ENABLE_RANGES_TESTING
 
     ::std::cout << TestUtils::done() << ::std::endl;
     return 0;

--- a/test/parallel_api/ranges/find_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/find_ranges_sycl.pass.cpp
@@ -17,7 +17,7 @@
 
 #include _PSTL_TEST_HEADER(execution)
 
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
 #include _PSTL_TEST_HEADER(ranges)
 #endif
 
@@ -29,7 +29,7 @@ int32_t
 main()
 {
 
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
     const int max_n = 10;
     int data[max_n] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
@@ -58,7 +58,7 @@ main()
     EXPECT_TRUE(res2 == idx_val, "wrong effect from 'find_if' with sycl ranges");
     EXPECT_TRUE(res3 == idx_val, "wrong effect from 'find_if_not' with sycl ranges");
 
-#endif //_ONEDPL_USE_RANGES
+#endif //_ENABLE_RANGES_TESTING
 
     ::std::cout << TestUtils::done() << ::std::endl;
     return 0;

--- a/test/parallel_api/ranges/find_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/find_ranges_sycl.pass.cpp
@@ -13,12 +13,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <oneapi/dpl/execution>
+
 #include "support/pstl_test_config.h"
 
-#include _PSTL_TEST_HEADER(execution)
-
 #if _ENABLE_RANGES_TESTING
-#include _PSTL_TEST_HEADER(ranges)
+#include <oneapi/dpl/ranges>
 #endif
 
 #include "support/utils.h"

--- a/test/parallel_api/ranges/for_each_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/for_each_ranges_sycl.pass.cpp
@@ -13,11 +13,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <oneapi/dpl/execution>
+
 #include "support/pstl_test_config.h"
 
-#include _PSTL_TEST_HEADER(execution)
 #if _ENABLE_RANGES_TESTING
-#include _PSTL_TEST_HEADER(ranges)
+#include <oneapi/dpl/ranges>
 #endif
 
 #include "support/utils.h"

--- a/test/parallel_api/ranges/for_each_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/for_each_ranges_sycl.pass.cpp
@@ -16,7 +16,7 @@
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
 #include _PSTL_TEST_HEADER(ranges)
 #endif
 
@@ -27,7 +27,7 @@
 int32_t
 main()
 {
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
     constexpr int max_n = 10;
     int data[max_n] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
@@ -47,7 +47,7 @@ main()
     ::std::transform(data, data + max_n, expected, lambda1);
 
     EXPECT_EQ_N(expected, data, max_n, "wrong effect from for_each with sycl ranges");
-#endif //_ONEDPL_USE_RANGES
+#endif //_ENABLE_RANGES_TESTING
     ::std::cout << TestUtils::done() << ::std::endl;
     return 0;
 }

--- a/test/parallel_api/ranges/inclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/inclusive_scan_ranges_sycl.pass.cpp
@@ -17,7 +17,7 @@
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(numeric)
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
 #include _PSTL_TEST_HEADER(ranges)
 #endif
 
@@ -28,7 +28,7 @@
 int32_t
 main()
 {
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
     constexpr int max_n = 10;
     int data[max_n] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     int data1[max_n], data2[max_n], data3[max_n];
@@ -65,7 +65,7 @@ main()
     EXPECT_EQ_N(expected2, data2, max_n, "wrong effect from inclusive_scan with binary operation, sycl ranges");
     EXPECT_EQ_N(expected3, data3, max_n, "wrong effect from inclusive_scan with binary operation and init, sycl ranges");
 
-#endif //_ONEDPL_USE_RANGES
+#endif //_ENABLE_RANGES_TESTING
     ::std::cout << TestUtils::done() << ::std::endl;
     return 0;
 }

--- a/test/parallel_api/ranges/inclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/inclusive_scan_ranges_sycl.pass.cpp
@@ -13,12 +13,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <oneapi/dpl/execution>
+
 #include "support/pstl_test_config.h"
 
-#include _PSTL_TEST_HEADER(execution)
-#include _PSTL_TEST_HEADER(numeric)
+#include <oneapi/dpl/numeric>
+
 #if _ENABLE_RANGES_TESTING
-#include _PSTL_TEST_HEADER(ranges)
+#include <oneapi/dpl/ranges>
 #endif
 
 #include "support/utils.h"

--- a/test/parallel_api/ranges/is_sorted_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/is_sorted_ranges_sycl.pass.cpp
@@ -17,7 +17,7 @@
 
 #include _PSTL_TEST_HEADER(execution)
 
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
 #include _PSTL_TEST_HEADER(ranges)
 #endif
 
@@ -28,7 +28,7 @@
 int32_t
 main()
 {
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
     const int max_n = 10;
     int data1[max_n] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     int data2[max_n] = {0, 1, 2, -1, 4, 5, 6, 7, 8, 9};
@@ -51,7 +51,7 @@ main()
     //check result
     EXPECT_TRUE(res1, "wrong effect from 'is_sorted' with sycl ranges (sorted)");
     EXPECT_TRUE(!res2, "wrong effect from 'is_sorted' with sycl ranges (unsorted)");
-#endif //_ONEDPL_USE_RANGES
+#endif //_ENABLE_RANGES_TESTING
 
     ::std::cout << TestUtils::done() << ::std::endl;
     return 0;

--- a/test/parallel_api/ranges/is_sorted_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/is_sorted_ranges_sycl.pass.cpp
@@ -13,12 +13,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <oneapi/dpl/execution>
+
 #include "support/pstl_test_config.h"
 
-#include _PSTL_TEST_HEADER(execution)
-
 #if _ENABLE_RANGES_TESTING
-#include _PSTL_TEST_HEADER(ranges)
+#include <oneapi/dpl/ranges>
 #endif
 
 #include "support/utils.h"

--- a/test/parallel_api/ranges/is_sorted_until_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/is_sorted_until_ranges_sycl.pass.cpp
@@ -17,7 +17,7 @@
 
 #include _PSTL_TEST_HEADER(execution)
 
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
 #include _PSTL_TEST_HEADER(ranges)
 #endif
 
@@ -28,7 +28,7 @@
 int32_t
 main()
 {
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
     const int max_n = 10;
     int data[max_n] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
@@ -54,7 +54,7 @@ main()
     EXPECT_TRUE(res1 == idx, "wrong effect from 'is_sorted_until' with sycl ranges");
     EXPECT_TRUE(res2 == idx, "wrong effect from 'is_sorted_until' with comparator, sycl ranges");
 
-#endif //_ONEDPL_USE_RANGES
+#endif //_ENABLE_RANGES_TESTING
 
     ::std::cout << TestUtils::done() << ::std::endl;
     return 0;

--- a/test/parallel_api/ranges/is_sorted_until_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/is_sorted_until_ranges_sycl.pass.cpp
@@ -13,12 +13,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <oneapi/dpl/execution>
+
 #include "support/pstl_test_config.h"
 
-#include _PSTL_TEST_HEADER(execution)
-
 #if _ENABLE_RANGES_TESTING
-#include _PSTL_TEST_HEADER(ranges)
+#include <oneapi/dpl/ranges>
 #endif
 
 #include "support/utils.h"

--- a/test/parallel_api/ranges/merge_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/merge_ranges_sycl.pass.cpp
@@ -17,7 +17,7 @@
 
 #include _PSTL_TEST_HEADER(execution)
 
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
 #include _PSTL_TEST_HEADER(ranges)
 #endif
 
@@ -28,7 +28,7 @@
 int32_t
 main()
 {
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
     using T = int;
 
     const int in_n = 10;
@@ -63,7 +63,7 @@ main()
     res2 &= ::std::includes(out2, out2 + out_n, in1, in1 + in_n, ::std::less<T>());
     res2 &= ::std::includes(out2, out2 + out_n, in2, in2 + in_n, ::std::less<T>());
     EXPECT_TRUE(res2, "wrong effect from 'merge' with sycl ranges with predicate");
-#endif //_ONEDPL_USE_RANGES
+#endif //_ENABLE_RANGES_TESTING
 
     ::std::cout << TestUtils::done() << ::std::endl;
     return 0;

--- a/test/parallel_api/ranges/merge_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/merge_ranges_sycl.pass.cpp
@@ -13,12 +13,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <oneapi/dpl/execution>
+
 #include "support/pstl_test_config.h"
 
-#include _PSTL_TEST_HEADER(execution)
-
 #if _ENABLE_RANGES_TESTING
-#include _PSTL_TEST_HEADER(ranges)
+#include <oneapi/dpl/ranges>
 #endif
 
 #include "support/utils.h"

--- a/test/parallel_api/ranges/minmax_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/minmax_ranges_sycl.pass.cpp
@@ -17,7 +17,7 @@
 
 #include _PSTL_TEST_HEADER(execution)
 
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
 #include _PSTL_TEST_HEADER(ranges)
 #endif
 
@@ -28,7 +28,7 @@
 int32_t
 main()
 {
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
     const int max_n = 10;
     int data[max_n] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
@@ -74,7 +74,7 @@ main()
     EXPECT_TRUE(res_minmax1.first == idx_val && res_minmax1.second == idx_max, "wrong effect from 'minmax_element', sycl ranges");
     EXPECT_TRUE(res_minmax2.first == idx_val && res_minmax2.second == idx_max, "wrong effect from 'minmax_element' with predicate, sycl ranges");
 
-#endif //_ONEDPL_USE_RANGES
+#endif //_ENABLE_RANGES_TESTING
 
     ::std::cout << TestUtils::done() << ::std::endl;
     return 0;

--- a/test/parallel_api/ranges/minmax_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/minmax_ranges_sycl.pass.cpp
@@ -13,12 +13,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <oneapi/dpl/execution>
+
 #include "support/pstl_test_config.h"
 
-#include _PSTL_TEST_HEADER(execution)
-
 #if _ENABLE_RANGES_TESTING
-#include _PSTL_TEST_HEADER(ranges)
+#include <oneapi/dpl/ranges>
 #endif
 
 #include "support/utils.h"

--- a/test/parallel_api/ranges/reduce_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/reduce_ranges_sycl.pass.cpp
@@ -16,7 +16,7 @@
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
 #include _PSTL_TEST_HEADER(ranges)
 #endif
 
@@ -27,7 +27,7 @@
 int32_t
 main()
 {
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
     constexpr int max_n = 10;
     int data[max_n] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
@@ -55,7 +55,7 @@ main()
     EXPECT_TRUE(res1 == expected1, "wrong effect from reduce with sycl ranges");
     EXPECT_TRUE(res2 == expected2, "wrong effect from reduce with init, sycl ranges");
     EXPECT_TRUE(res3 == expected3, "wrong effect from reduce with init and binary operation, sycl ranges");
-#endif //_ONEDPL_USE_RANGES
+#endif //_ENABLE_RANGES_TESTING
     ::std::cout << TestUtils::done() << ::std::endl;
     return 0;
 }

--- a/test/parallel_api/ranges/reduce_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/reduce_ranges_sycl.pass.cpp
@@ -13,11 +13,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <oneapi/dpl/execution>
+
 #include "support/pstl_test_config.h"
 
-#include _PSTL_TEST_HEADER(execution)
 #if _ENABLE_RANGES_TESTING
-#include _PSTL_TEST_HEADER(ranges)
+#include <oneapi/dpl/ranges>
 #endif
 
 #include "support/utils.h"

--- a/test/parallel_api/ranges/search_n_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/search_n_ranges_sycl.pass.cpp
@@ -13,11 +13,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <oneapi/dpl/execution>
+
 #include "support/pstl_test_config.h"
 
-#include _PSTL_TEST_HEADER(execution)
 #if _ENABLE_RANGES_TESTING
-#include _PSTL_TEST_HEADER(ranges)
+#include <oneapi/dpl/ranges>
 #endif
 
 #include "support/utils.h"

--- a/test/parallel_api/ranges/search_n_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/search_n_ranges_sycl.pass.cpp
@@ -16,7 +16,7 @@
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
 #include _PSTL_TEST_HEADER(ranges)
 #endif
 
@@ -27,7 +27,7 @@
 int32_t
 main()
 {
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
     const int count = 10;
     int data[count] = {0, 1, 2, 3, 4, 4, 4, 7, 8, 9};
 
@@ -47,7 +47,7 @@ main()
     //check result
     EXPECT_TRUE(res == idx, "wrong effect from 'search_n' with sycl ranges");
 
-#endif //_ONEDPL_USE_RANGES
+#endif //_ENABLE_RANGES_TESTING
 
     ::std::cout << TestUtils::done() << ::std::endl;
     return 0;

--- a/test/parallel_api/ranges/search_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/search_ranges_sycl.pass.cpp
@@ -17,7 +17,7 @@
 
 #include _PSTL_TEST_HEADER(execution)
 
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
 #include _PSTL_TEST_HEADER(ranges)
 #endif
 
@@ -28,7 +28,7 @@
 int32_t
 main()
 {
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
     const int count1 = 10;
     int data1[count1] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
@@ -58,7 +58,7 @@ main()
     EXPECT_TRUE(res1 == idx, "wrong effect from 'search' with sycl ranges");
     EXPECT_TRUE(res2 == idx, "wrong effect from 'search' with predicate, sycl ranges");
 
-#endif //_ONEDPL_USE_RANGES
+#endif //_ENABLE_RANGES_TESTING
 
     ::std::cout << TestUtils::done() << ::std::endl;
     return 0;

--- a/test/parallel_api/ranges/search_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/search_ranges_sycl.pass.cpp
@@ -13,12 +13,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <oneapi/dpl/execution>
+
 #include "support/pstl_test_config.h"
 
-#include _PSTL_TEST_HEADER(execution)
-
 #if _ENABLE_RANGES_TESTING
-#include _PSTL_TEST_HEADER(ranges)
+#include <oneapi/dpl/ranges>
 #endif
 
 #include "support/utils.h"

--- a/test/parallel_api/ranges/sort_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/sort_ranges_sycl.pass.cpp
@@ -13,12 +13,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <oneapi/dpl/execution>
+
 #include "support/pstl_test_config.h"
 
-#include _PSTL_TEST_HEADER(execution)
-
 #if _ENABLE_RANGES_TESTING
-#include _PSTL_TEST_HEADER(ranges)
+#include <oneapi/dpl/ranges>
 #endif
 
 #include "support/utils.h"

--- a/test/parallel_api/ranges/sort_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/sort_ranges_sycl.pass.cpp
@@ -17,7 +17,7 @@
 
 #include _PSTL_TEST_HEADER(execution)
 
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
 #include _PSTL_TEST_HEADER(ranges)
 #endif
 
@@ -28,7 +28,7 @@
 int32_t
 main()
 {
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
     const int max_n = 10;
     int data1[max_n] = {0, 1, 2, -1, 4, 5, 6, 7, 8, 9};
     int data2[max_n] = {0, 1, 2, -1, 4, 5, 6, 7, 8, 9};
@@ -53,7 +53,7 @@ main()
 
     bool res2 = ::std::is_sorted(data2, data2 + max_n, ::std::greater<int>());
     EXPECT_TRUE(res2, "wrong effect from 'sort with comparator' with sycl ranges");
-#endif //_ONEDPL_USE_RANGES
+#endif //_ENABLE_RANGES_TESTING
 
     ::std::cout << TestUtils::done() << ::std::endl;
     return 0;

--- a/test/parallel_api/ranges/stable_sort_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/stable_sort_ranges_sycl.pass.cpp
@@ -13,12 +13,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <oneapi/dpl/execution>
+
 #include "support/pstl_test_config.h"
 
-#include _PSTL_TEST_HEADER(execution)
-
 #if _ENABLE_RANGES_TESTING
-#include _PSTL_TEST_HEADER(ranges)
+#include <oneapi/dpl/ranges>
 #endif
 
 #include "support/utils.h"

--- a/test/parallel_api/ranges/stable_sort_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/stable_sort_ranges_sycl.pass.cpp
@@ -17,7 +17,7 @@
 
 #include _PSTL_TEST_HEADER(execution)
 
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
 #include _PSTL_TEST_HEADER(ranges)
 #endif
 
@@ -28,7 +28,7 @@
 int32_t
 main()
 {
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
     const int max_n = 10;
     int data1[max_n] = {0, 1, 2, -1, 4, 5, 6, 7, 8, 9};
     int data2[max_n] = {0, 1, 2, -1, 4, 5, -6, 7, 8, 9};
@@ -53,7 +53,7 @@ main()
 
     bool res2 = ::std::is_sorted(data2, data2 + max_n, ::std::greater<int>());
     EXPECT_TRUE(res2, "wrong effect from 'stable_sort with comparator' with sycl ranges");
-#endif //_ONEDPL_USE_RANGES
+#endif //_ENABLE_RANGES_TESTING
 
     ::std::cout << TestUtils::done() << ::std::endl;
     return 0;

--- a/test/parallel_api/ranges/transform2_ranges_factory_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform2_ranges_factory_sycl.pass.cpp
@@ -13,11 +13,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <oneapi/dpl/execution>
+
 #include "support/pstl_test_config.h"
 
-#include _PSTL_TEST_HEADER(execution)
 #if _ENABLE_RANGES_TESTING
-#include _PSTL_TEST_HEADER(ranges)
+#include <oneapi/dpl/ranges>
 #endif
 
 #include "support/utils.h"

--- a/test/parallel_api/ranges/transform2_ranges_factory_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform2_ranges_factory_sycl.pass.cpp
@@ -16,7 +16,7 @@
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
 #include _PSTL_TEST_HEADER(ranges)
 #endif
 
@@ -27,7 +27,7 @@
 int32_t
 main()
 {
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
     constexpr int max_n = 10;
     int data[max_n] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     int data2[max_n];
@@ -52,7 +52,7 @@ main()
     ::std::transform(expected, expected + max_n, expected, expected, lambda2);
 
     EXPECT_EQ_N(expected, data2, max_n, "wrong effect from trasnform2 with sycl ranges");
-#endif //_ONEDPL_USE_RANGES
+#endif //_ENABLE_RANGES_TESTING
     ::std::cout << TestUtils::done() << ::std::endl;
     return 0;
 }

--- a/test/parallel_api/ranges/transform2_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform2_ranges_sycl.pass.cpp
@@ -13,11 +13,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <oneapi/dpl/execution>
+
 #include "support/pstl_test_config.h"
 
-#include _PSTL_TEST_HEADER(execution)
 #if _ENABLE_RANGES_TESTING
-#include _PSTL_TEST_HEADER(ranges)
+#include <oneapi/dpl/ranges>
 #endif
 
 #include "support/utils.h"

--- a/test/parallel_api/ranges/transform2_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform2_ranges_sycl.pass.cpp
@@ -16,7 +16,7 @@
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
 #include _PSTL_TEST_HEADER(ranges)
 #endif
 
@@ -27,7 +27,7 @@
 int32_t
 main()
 {
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
     constexpr int max_n = 10;
     int data[max_n] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     int data2[max_n];
@@ -55,7 +55,7 @@ main()
     ::std::transform(expected, expected + max_n, expected, expected, lambda2);
 
     EXPECT_EQ_N(expected, data2, max_n, "wrong effect from trasnform2 with sycl ranges");
-#endif //_ONEDPL_USE_RANGES
+#endif //_ENABLE_RANGES_TESTING
     ::std::cout << TestUtils::done() << ::std::endl;
     return 0;
 }

--- a/test/parallel_api/ranges/transform_exclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_exclusive_scan_ranges_sycl.pass.cpp
@@ -17,7 +17,7 @@
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(numeric)
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
 #include _PSTL_TEST_HEADER(ranges)
 #endif
 
@@ -28,7 +28,7 @@
 int32_t
 main()
 {
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
     constexpr int max_n = 10;
     int data[max_n] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     int data1[max_n];
@@ -52,7 +52,7 @@ main()
 
     EXPECT_EQ_N(expected, data1, max_n, "wrong effect from transform_exclusive_scan with init, sycl ranges");
 
-#endif //_ONEDPL_USE_RANGES
+#endif //_ENABLE_RANGES_TESTING
     ::std::cout << TestUtils::done() << ::std::endl;
     return 0;
 }

--- a/test/parallel_api/ranges/transform_exclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_exclusive_scan_ranges_sycl.pass.cpp
@@ -13,12 +13,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <oneapi/dpl/execution>
+
 #include "support/pstl_test_config.h"
 
-#include _PSTL_TEST_HEADER(execution)
-#include _PSTL_TEST_HEADER(numeric)
+#include <oneapi/dpl/numeric>
+
 #if _ENABLE_RANGES_TESTING
-#include _PSTL_TEST_HEADER(ranges)
+#include <oneapi/dpl/ranges>
 #endif
 
 #include "support/utils.h"

--- a/test/parallel_api/ranges/transform_inclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_inclusive_scan_ranges_sycl.pass.cpp
@@ -13,12 +13,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <oneapi/dpl/execution>
+
 #include "support/pstl_test_config.h"
 
-#include _PSTL_TEST_HEADER(execution)
-#include _PSTL_TEST_HEADER(numeric)
+#include <oneapi/dpl/numeric>
+
 #if _ENABLE_RANGES_TESTING
-#include _PSTL_TEST_HEADER(ranges)
+#include <oneapi/dpl/ranges>
 #endif
 
 #include "support/utils.h"

--- a/test/parallel_api/ranges/transform_inclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_inclusive_scan_ranges_sycl.pass.cpp
@@ -17,7 +17,7 @@
 
 #include _PSTL_TEST_HEADER(execution)
 #include _PSTL_TEST_HEADER(numeric)
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
 #include _PSTL_TEST_HEADER(ranges)
 #endif
 
@@ -28,7 +28,7 @@
 int32_t
 main()
 {
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
     constexpr int max_n = 10;
     int data[max_n] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     int data1[max_n], data2[max_n];
@@ -62,7 +62,7 @@ main()
     EXPECT_EQ_N(expected1, data1, max_n, "wrong effect from transform_inclusive_scan, sycl ranges");
     EXPECT_EQ_N(expected2, data2, max_n, "wrong effect from transform_inclusive_scan with init, sycl ranges");
 
-#endif //_ONEDPL_USE_RANGES
+#endif //_ENABLE_RANGES_TESTING
     ::std::cout << TestUtils::done() << ::std::endl;
     return 0;
 }

--- a/test/parallel_api/ranges/transform_ranges_factory_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_ranges_factory_sycl.pass.cpp
@@ -16,7 +16,7 @@
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
 #include _PSTL_TEST_HEADER(ranges)
 #endif
 
@@ -27,7 +27,7 @@
 int32_t
 main()
 {
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
     constexpr int max_n = 10;
     int data[max_n] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     int data2[max_n];
@@ -52,7 +52,7 @@ main()
     ::std::transform(expected, expected + max_n, expected, lambda2);
 
     EXPECT_EQ_N(expected, data2, max_n, "wrong effect from trasnform with sycl ranges");
-#endif //_ONEDPL_USE_RANGES
+#endif //_ENABLE_RANGES_TESTING
     ::std::cout << TestUtils::done() << ::std::endl;
     return 0;
 }

--- a/test/parallel_api/ranges/transform_ranges_factory_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_ranges_factory_sycl.pass.cpp
@@ -13,11 +13,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <oneapi/dpl/execution>
+
 #include "support/pstl_test_config.h"
 
-#include _PSTL_TEST_HEADER(execution)
 #if _ENABLE_RANGES_TESTING
-#include _PSTL_TEST_HEADER(ranges)
+#include <oneapi/dpl/ranges>
 #endif
 
 #include "support/utils.h"

--- a/test/parallel_api/ranges/transform_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_ranges_sycl.pass.cpp
@@ -16,7 +16,7 @@
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
 #include _PSTL_TEST_HEADER(ranges)
 #endif
 
@@ -27,7 +27,7 @@
 int32_t
 main()
 {
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
     constexpr int max_n = 10;
     int data[max_n] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
     int data2[max_n];
@@ -55,7 +55,7 @@ main()
     ::std::transform(expected, expected + max_n, expected, lambda2);
 
     EXPECT_EQ_N(expected, data2, max_n, "wrong effect from trasnform with sycl ranges");
-#endif //_ONEDPL_USE_RANGES
+#endif //_ENABLE_RANGES_TESTING
     ::std::cout << TestUtils::done() << ::std::endl;
     return 0;
 }

--- a/test/parallel_api/ranges/transform_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_ranges_sycl.pass.cpp
@@ -13,11 +13,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <oneapi/dpl/execution>
+
 #include "support/pstl_test_config.h"
 
-#include _PSTL_TEST_HEADER(execution)
 #if _ENABLE_RANGES_TESTING
-#include _PSTL_TEST_HEADER(ranges)
+#include <oneapi/dpl/ranges>
 #endif
 
 #include "support/utils.h"

--- a/test/parallel_api/ranges/transform_reduce_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_reduce_ranges_sycl.pass.cpp
@@ -13,11 +13,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <oneapi/dpl/execution>
+
 #include "support/pstl_test_config.h"
 
-#include _PSTL_TEST_HEADER(execution)
 #if _ENABLE_RANGES_TESTING
-#include _PSTL_TEST_HEADER(ranges)
+#include <oneapi/dpl/ranges>
 #endif
 
 #include "support/utils.h"

--- a/test/parallel_api/ranges/transform_reduce_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_reduce_ranges_sycl.pass.cpp
@@ -16,7 +16,7 @@
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
 #include _PSTL_TEST_HEADER(ranges)
 #endif
 
@@ -27,7 +27,7 @@
 int32_t
 main()
 {
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
     constexpr int max_n = 10;
     int data[max_n] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
 
@@ -59,7 +59,7 @@ main()
     EXPECT_TRUE(res1 == expected1, "wrong effect from transform_reduce1 with sycl ranges");
     EXPECT_TRUE(res2 == expected2, "wrong effect from transform_reduce2 with sycl ranges");
     EXPECT_TRUE(res3 == expected3, "wrong effect from transform_reduce3 with sycl ranges");
-#endif //_ONEDPL_USE_RANGES
+#endif //_ENABLE_RANGES_TESTING
     ::std::cout << TestUtils::done() << ::std::endl;
     return 0;
 }

--- a/test/parallel_api/ranges/zip_view.pass.cpp
+++ b/test/parallel_api/ranges/zip_view.pass.cpp
@@ -13,11 +13,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <oneapi/dpl/execution>
+
 #include "support/pstl_test_config.h"
 
-#include _PSTL_TEST_HEADER(execution)
 #if _ENABLE_RANGES_TESTING
-#include _PSTL_TEST_HEADER(ranges)
+#include <oneapi/dpl/ranges>
 #endif
 
 #include "support/utils.h"

--- a/test/parallel_api/ranges/zip_view.pass.cpp
+++ b/test/parallel_api/ranges/zip_view.pass.cpp
@@ -16,7 +16,7 @@
 #include "support/pstl_test_config.h"
 
 #include _PSTL_TEST_HEADER(execution)
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
 #include _PSTL_TEST_HEADER(ranges)
 #endif
 
@@ -27,7 +27,7 @@
 int32_t
 main()
 {
-#if _ONEDPL_USE_RANGES
+#if _ENABLE_RANGES_TESTING
     constexpr int max_n = 10;
     char data[max_n] = {'b', 'e', 'g', 'f', 'c', 'd', 'a', 'j', 'i', 'h'};
     int key[max_n] = {1, 4, 6, 5, 2, 3, 0, 9, 8, 7};
@@ -39,7 +39,7 @@ main()
 
     //check access
     EXPECT_TRUE(::std::get<0>(z[2]) == 'g', "wrong effect with zip_view");
-#endif //_ONEDPL_USE_RANGES
+#endif //_ENABLE_RANGES_TESTING
     ::std::cout << TestUtils::done() << ::std::endl;
     return 0;
 }

--- a/test/support/pstl_test_config.h
+++ b/test/support/pstl_test_config.h
@@ -56,7 +56,12 @@
 #define _PSTL_SYCL_TEST_USM 1
 
 // Check for C++ standard and standard library for the use of ranges API
-#define _ONEDPL_USE_RANGES                                                                                            \
-    (__cplusplus >= 201703L && ((_GLIBCXX_RELEASE >= 8 && __GLIBCXX__ >= 20180502) || _LIBCPP_VERSION >= 7000))
+#if defined(_GLIBCXX_RELEASE)
+#    define _ENABLE_RANGES_TESTING (__cplusplus >= 201703L && _GLIBCXX_RELEASE >= 8 && __GLIBCXX__ >= 20180502)
+#elif defined(_LIBCPP_VERSION)
+#    define _ENABLE_RANGES_TESTING (__cplusplus >= 201703L && _LIBCPP_VERSION >= 7000)
+#else
+#    define _ENABLE_RANGES_TESTING (__cplusplus >= 201703L)
+#endif
 
 #endif /* _PSTL_TEST_config_H */

--- a/test/support/pstl_test_config.h
+++ b/test/support/pstl_test_config.h
@@ -46,7 +46,7 @@
 #define _PSTL_ICC_19_TEST_SIMD_UDS_WINDOWS_RELEASE_BROKEN (__INTEL_COMPILER == 1900 && _MSC_VER && !_DEBUG)
 // ICC 18,19 generate wrong result
 #define _PSTL_ICC_18_19_TEST_SIMD_MONOTONIC_WINDOWS_RELEASE_BROKEN													  \
-	((__INTEL_COMPILER == 1800 || __INTEL_COMPILER == 1900) && _MSC_VER && !_DEBUG)
+    ((__INTEL_COMPILER == 1800 || __INTEL_COMPILER == 1900) && _MSC_VER && !_DEBUG)
 // ICC 18,19 generate wrong result with for_loop_strided and reverse iterators
 #define _PSTL_ICC_18_19_TEST_REVERSE_ITERATOR_WITH_STRIDE_BROKEN                                                      \
     (__i386__ && (__INTEL_COMPILER == 1800 || __INTEL_COMPILER == 1900))
@@ -54,5 +54,9 @@
 #define _PSTL_STD_UNINITIALIZED_FILL_BROKEN (_MSC_VER == 1900)
 
 #define _PSTL_SYCL_TEST_USM 1
+
+// Check for C++ standard and standard library for the use of ranges API
+#define _ONEDPL_USE_RANGES                                                                                            \
+    (__cplusplus >= 201703L && ((_GLIBCXX_RELEASE >= 8 && __GLIBCXX__ >= 20180502) || _LIBCPP_VERSION >= 7000))
 
 #endif /* _PSTL_TEST_config_H */


### PR DESCRIPTION
[CMake]: 
* Remove unnecessary variables and macro from the main CMakeLists.txt: ONEDPL_USE_PARALLEL_POLICIES, ONEDPL_USE_RANGES_API
* Add check for the serial back-end

[Testing]
* Add check for C++ standard and standard library versions for the testing of ranges