### PR TITLE
Allow compilation with DPC++ compiler and non-DPCPP backend

### DIFF
--- a/test/general/interface_check.pass.cpp
+++ b/test/general/interface_check.pass.cpp
@@ -22,6 +22,8 @@
 #include <functional>
 #include <iterator>
 #include <vector>
+#include "../support/pstl_test_config.h"
+
 #if TEST_SYCL_PRESENT
 #include <CL/sycl.hpp>
 #endif

--- a/test/general/interface_check.pass.cpp
+++ b/test/general/interface_check.pass.cpp
@@ -22,11 +22,14 @@
 #include <functional>
 #include <iterator>
 #include <vector>
+#if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION))
 #include <CL/sycl.hpp>
+#endif
 
 template <typename Policy, typename NewName>
 struct rebind_policy { using type = Policy; };
 
+#if ((defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && ONEDPL_USE_DPCPP_BACKEND)
 template <typename KernelName, typename NewName>
 struct rebind_policy<oneapi::dpl::execution::device_policy<KernelName>, NewName>
 { using type = oneapi::dpl::execution::device_policy<NewName>; };
@@ -36,6 +39,7 @@ template <unsigned int factor, typename KernelName, typename NewName>
 struct rebind_policy<oneapi::dpl::execution::fpga_policy<factor, KernelName>, NewName>
 {  using type = oneapi::dpl::execution::fpga_policy<factor, NewName>; };
 #endif
+#endif
 
 
 using oneapi::dpl::counting_iterator;
@@ -44,10 +48,12 @@ using oneapi::dpl::make_zip_iterator;
 
 int main()
 {
+#if ((defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && ONEDPL_USE_DPCPP_BACKEND)
     cl::sycl::buffer<int, 1> buf{ cl::sycl::range<1>(10) };
 
     auto b = oneapi::dpl::begin(buf);
     auto e = oneapi::dpl::end(buf);
+#endif
     auto z = make_zip_iterator(counting_iterator<int>(), discard_iterator());
     std::get<1>(z[0]) = oneapi::dpl::identity()(*counting_iterator<int>());
     return 0;

--- a/test/general/interface_check.pass.cpp
+++ b/test/general/interface_check.pass.cpp
@@ -22,14 +22,14 @@
 #include <functional>
 #include <iterator>
 #include <vector>
-#if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION))
+#if TEST_SYCL_PRESENT
 #include <CL/sycl.hpp>
 #endif
 
 template <typename Policy, typename NewName>
 struct rebind_policy { using type = Policy; };
 
-#if ((defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && ONEDPL_USE_DPCPP_BACKEND)
+#if TEST_DPCPP_BACKEND_PRESENT
 template <typename KernelName, typename NewName>
 struct rebind_policy<oneapi::dpl::execution::device_policy<KernelName>, NewName>
 { using type = oneapi::dpl::execution::device_policy<NewName>; };
@@ -48,7 +48,7 @@ using oneapi::dpl::make_zip_iterator;
 
 int main()
 {
-#if ((defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && ONEDPL_USE_DPCPP_BACKEND)
+#if TEST_DPCPP_BACKEND_PRESENT
     cl::sycl::buffer<int, 1> buf{ cl::sycl::range<1>(10) };
 
     auto b = oneapi::dpl::begin(buf);

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
@@ -19,7 +19,8 @@
 
 #include <iostream>
 
-#if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION))
+#if ((defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && ONEDPL_USE_DPCPP_BACKEND)
+
 #include <CL/sycl.hpp>
 
 void test_on_device()
@@ -110,7 +111,7 @@ bool test_on_host()
 
 int main()
 {
-#if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION))
+#if ((defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && ONEDPL_USE_DPCPP_BACKEND)
     test_on_device();
 #endif
     test_on_host();

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
@@ -19,6 +19,8 @@
 
 #include <iostream>
 
+#include "../../../../../support/pstl_test_config.h"
+
 #if TEST_DPCPP_BACKEND_PRESENT
 
 #include <CL/sycl.hpp>

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
@@ -19,7 +19,7 @@
 
 #include <iostream>
 
-#if ((defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && ONEDPL_USE_DPCPP_BACKEND)
+#if TEST_DPCPP_BACKEND_PRESENT
 
 #include <CL/sycl.hpp>
 
@@ -111,7 +111,7 @@ bool test_on_host()
 
 int main()
 {
-#if ((defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && ONEDPL_USE_DPCPP_BACKEND)
+#if TEST_DPCPP_BACKEND_PRESENT
     test_on_device();
 #endif
     test_on_host();

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
@@ -19,7 +19,7 @@
 
 #include <iostream>
 
-#if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION))
+#if TEST_SYCL_PRESENT
 #include <CL/sycl.hpp>
 #endif
 
@@ -37,7 +37,7 @@ void test_on_host()
          std::cout << "lower_bound on host FAIL." << std::endl;
 }
 
-#if ((defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && ONEDPL_USE_DPCPP_BACKEND)
+#if TEST_DPCPP_BACKEND_PRESENT
 void test_on_device()
 {
     bool correctness_flag =true;
@@ -108,7 +108,7 @@ void test_on_device()
 
 int main()
 {
-#if ((defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && ONEDPL_USE_DPCPP_BACKEND)
+#if TEST_DPCPP_BACKEND_PRESENT
     test_on_device();
 #endif
     test_on_host();    

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
@@ -19,6 +19,8 @@
 
 #include <iostream>
 
+#include "../../../../../support/pstl_test_config.h"
+
 #if TEST_SYCL_PRESENT
 #include <CL/sycl.hpp>
 #endif

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
@@ -37,7 +37,7 @@ void test_on_host()
          std::cout << "lower_bound on host FAIL." << std::endl;
 }
 
-#if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION))
+#if ((defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && ONEDPL_USE_DPCPP_BACKEND)
 void test_on_device()
 {
     bool correctness_flag =true;
@@ -108,7 +108,7 @@ void test_on_device()
 
 int main()
 {
-#if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION))
+#if ((defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && ONEDPL_USE_DPCPP_BACKEND)
     test_on_device();
 #endif
     test_on_host();    

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
@@ -19,7 +19,7 @@
 
 #include <iostream>
 
-#if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION))
+#if TEST_SYCL_PRESENT
 #include <CL/sycl.hpp>
 #endif
 
@@ -37,7 +37,7 @@ void test_on_host()
          std::cout << "upper_bound on host FAIL." << std::endl;
 }
 
-#if ((defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && ONEDPL_USE_DPCPP_BACKEND)
+#if TEST_DPCPP_BACKEND_PRESENT
 void test_on_device()
 {
      bool correctness_flag = true;
@@ -105,7 +105,7 @@ void test_on_device()
 
 int main()
 {
-#if ((defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && ONEDPL_USE_DPCPP_BACKEND)
+#if TEST_DPCPP_BACKEND_PRESENT
     test_on_device();
 #endif
     test_on_host();

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
@@ -37,7 +37,7 @@ void test_on_host()
          std::cout << "upper_bound on host FAIL." << std::endl;
 }
 
-#if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION))
+#if ((defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && ONEDPL_USE_DPCPP_BACKEND)
 void test_on_device()
 {
      bool correctness_flag = true;
@@ -105,7 +105,7 @@ void test_on_device()
 
 int main()
 {
-#if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION))
+#if ((defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && ONEDPL_USE_DPCPP_BACKEND)
     test_on_device();
 #endif
     test_on_host();

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
@@ -19,6 +19,8 @@
 
 #include <iostream>
 
+#include "../../../../../support/pstl_test_config.h"
+
 #if TEST_SYCL_PRESENT
 #include <CL/sycl.hpp>
 #endif

--- a/test/parallel_api/iterator/discard_iterator.pass.cpp
+++ b/test/parallel_api/iterator/discard_iterator.pass.cpp
@@ -22,6 +22,8 @@
 #include <chrono>
 #include <cmath>
 
+#include "../../support/pstl_test_config.h"
+
 #if TEST_SYCL_PRESENT
 #include <CL/sycl.hpp>
 #endif

--- a/test/parallel_api/iterator/discard_iterator.pass.cpp
+++ b/test/parallel_api/iterator/discard_iterator.pass.cpp
@@ -22,7 +22,7 @@
 #include <chrono>
 #include <cmath>
 
-#if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION))
+#if TEST_SYCL_PRESENT
 #include <CL/sycl.hpp>
 #endif
 
@@ -172,7 +172,7 @@ int main(int argc, char** argv) {
 
     evaluate(oneapi::dpl::execution::par, ref.begin(), ref.end(), p, std::string("CPU discard"));
 
-#if ((defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && ONEDPL_USE_DPCPP_BACKEND)
+#if TEST_DPCPP_BACKEND_PRESENT
     // Case 2 -- Compare traversal on accelerator
     {
         using policy_type = decltype(oneapi::dpl::execution::dpcpp_default);

--- a/test/parallel_api/iterator/discard_iterator.pass.cpp
+++ b/test/parallel_api/iterator/discard_iterator.pass.cpp
@@ -172,7 +172,7 @@ int main(int argc, char** argv) {
 
     evaluate(oneapi::dpl::execution::par, ref.begin(), ref.end(), p, std::string("CPU discard"));
 
-#if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION))
+#if ((defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && ONEDPL_USE_DPCPP_BACKEND)
     // Case 2 -- Compare traversal on accelerator
     {
         using policy_type = decltype(oneapi::dpl::execution::dpcpp_default);

--- a/test/parallel_api/iterator/permutation_iterator.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator.pass.cpp
@@ -22,7 +22,7 @@
 #include <chrono>
 #include <cmath>
 
-#if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION))
+#if TEST_SYCL_PRESENT
 #include <CL/sycl.hpp>
 #endif
 
@@ -167,7 +167,7 @@ int main(int argc, char** argv) {
 
     evaluate(oneapi::dpl::execution::par, oneapi::dpl::execution::par, ref.begin(), ref.end(), p, std::string("CPU Reverse"));
 
-#if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION))
+#if TEST_DPCPP_BACKEND_PRESENT
     // Case 4 -- Linear traversal on accelerator
     {
         using policy_type = decltype(oneapi::dpl::execution::dpcpp_default);

--- a/test/parallel_api/iterator/permutation_iterator.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator.pass.cpp
@@ -22,6 +22,8 @@
 #include <chrono>
 #include <cmath>
 
+#include "../../support/pstl_test_config.h"
+
 #if TEST_SYCL_PRESENT
 #include <CL/sycl.hpp>
 #endif

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
@@ -20,7 +20,7 @@
 #include <iostream>
 #include <iomanip>
 
-#if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION))
+#if TEST_SYCL_PRESENT
 #include <CL/sycl.hpp>
 #endif
 
@@ -30,7 +30,7 @@ void ASSERT_EQUAL(_T1&& X, _T2&& Y) {
         std::cout << "CHECK CORRECTNESS (EXCLUSIVE_SCAN_BY_SEGMENT): fail (" << X << "," << Y << ")" << std::endl;
 }
 
-#if ((defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && ONEDPL_USE_DPCPP_BACKEND)
+#if TEST_DPCPP_BACKEND_PRESENT
 void test_with_buffers()
 {
     // create a buffer, being responsible for moving data around and counting dependencies
@@ -149,7 +149,7 @@ void test_on_host() {
 }
 
 int main() {
-#if ((defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && ONEDPL_USE_DPCPP_BACKEND)
+#if TEST_DPCPP_BACKEND_PRESENT
     test_with_buffers();
     test_with_usm();
 #endif

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
@@ -30,7 +30,7 @@ void ASSERT_EQUAL(_T1&& X, _T2&& Y) {
         std::cout << "CHECK CORRECTNESS (EXCLUSIVE_SCAN_BY_SEGMENT): fail (" << X << "," << Y << ")" << std::endl;
 }
 
-#if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION))
+#if ((defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && ONEDPL_USE_DPCPP_BACKEND)
 void test_with_buffers()
 {
     // create a buffer, being responsible for moving data around and counting dependencies
@@ -149,7 +149,7 @@ void test_on_host() {
 }
 
 int main() {
-#if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION))
+#if ((defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && ONEDPL_USE_DPCPP_BACKEND)
     test_with_buffers();
     test_with_usm();
 #endif

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
@@ -17,6 +17,8 @@
 #include "oneapi/dpl/algorithm"
 #include "oneapi/dpl/iterator"
 
+#include "../../../support/pstl_test_config.h"
+
 #include <iostream>
 #include <iomanip>
 

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -30,7 +30,7 @@ void ASSERT_EQUAL(_T1&& X, _T2&& Y) {
         std::cout << "CHECK CORRECTNESS (INCLUSIVE_SCAN_BY_SEGMENT): fail (" << X << "," << Y << ")" << std::endl;
 }
 
-#if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION))
+#if ((defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && ONEDPL_USE_DPCPP_BACKEND)
 void test_with_buffers()
 {
     // create a buffer, being responsible for moving data around and counting dependencies
@@ -146,7 +146,7 @@ void test_on_host()
 }
 
 int main() {
-#if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION))
+#if ((defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && ONEDPL_USE_DPCPP_BACKEND)
     test_with_buffers();
     test_with_usm();
 #endif

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -20,7 +20,7 @@
 #include <iostream>
 #include <iomanip>
 
-#if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION))
+#if TEST_SYCL_PRESENT
 #include <CL/sycl.hpp>
 #endif
 
@@ -30,7 +30,7 @@ void ASSERT_EQUAL(_T1&& X, _T2&& Y) {
         std::cout << "CHECK CORRECTNESS (INCLUSIVE_SCAN_BY_SEGMENT): fail (" << X << "," << Y << ")" << std::endl;
 }
 
-#if ((defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && ONEDPL_USE_DPCPP_BACKEND)
+#if TEST_DPCPP_BACKEND_PRESENT
 void test_with_buffers()
 {
     // create a buffer, being responsible for moving data around and counting dependencies
@@ -146,7 +146,7 @@ void test_on_host()
 }
 
 int main() {
-#if ((defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && ONEDPL_USE_DPCPP_BACKEND)
+#if TEST_DPCPP_BACKEND_PRESENT
     test_with_buffers();
     test_with_usm();
 #endif

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -17,6 +17,8 @@
 #include "oneapi/dpl/algorithm"
 #include "oneapi/dpl/iterator"
 
+#include "../../../support/pstl_test_config.h"
+
 #include <iostream>
 #include <iomanip>
 

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -21,7 +21,7 @@
 #include <iostream>
 #include <iomanip>
 
-#if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION))
+#if TEST_SYCL_PRESENT
 #include <CL/sycl.hpp>
 #endif
 
@@ -31,7 +31,7 @@ void ASSERT_EQUAL(_T1&& X, _T2&& Y) {
         std::cout << "CHECK CORRECTNESS (REDUCE_BY_SEGMENT): fail (" << X << "," << Y << ")" << std::endl;
 }
 
-#if ((defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && ONEDPL_USE_DPCPP_BACKEND)
+#if TEST_DPCPP_BACKEND_PRESENT
 void test_with_buffers()
 {
     // create buffers
@@ -213,7 +213,7 @@ void test_on_host() {
 }
 
 int main() {
-#if ((defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && ONEDPL_USE_DPCPP_BACKEND)
+#if TEST_DPCPP_BACKEND_PRESENT
     test_with_buffers();
     test_with_usm();
 #endif

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -18,6 +18,8 @@
 #include "oneapi/dpl/numeric"
 #include "oneapi/dpl/iterator"
 
+#include "../../../support/pstl_test_config.h"
+
 #include <iostream>
 #include <iomanip>
 

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -31,7 +31,7 @@ void ASSERT_EQUAL(_T1&& X, _T2&& Y) {
         std::cout << "CHECK CORRECTNESS (REDUCE_BY_SEGMENT): fail (" << X << "," << Y << ")" << std::endl;
 }
 
-#if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION))
+#if ((defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && ONEDPL_USE_DPCPP_BACKEND)
 void test_with_buffers()
 {
     // create buffers
@@ -213,7 +213,7 @@ void test_on_host() {
 }
 
 int main() {
-#if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION))
+#if ((defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && ONEDPL_USE_DPCPP_BACKEND)
     test_with_buffers();
     test_with_usm();
 #endif

--- a/test/support/pstl_test_config.h
+++ b/test/support/pstl_test_config.h
@@ -55,4 +55,10 @@
 
 #define _PSTL_SYCL_TEST_USM 1
 
+// Enable when compiler supports SYCL
+#define TEST_SYCL_PRESENT defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)
+
+// Enable test when the DPC++ backend is available
+#define TEST_DPCPP_BACKEND_PRESENT TEST_SYCL_PRESENT && ONEDPL_USE_DPCPP_BACKEND
+
 #endif /* _PSTL_TEST_config_H */

--- a/test/support/pstl_test_config.h
+++ b/test/support/pstl_test_config.h
@@ -56,9 +56,13 @@
 #define _PSTL_SYCL_TEST_USM 1
 
 // Enable when compiler supports SYCL
-#define TEST_SYCL_PRESENT defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)
+#if defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)
+#define TEST_SYCL_PRESENT 1
+#else
+#define TEST_SYCL_PRESENT 0
+#endif
 
 // Enable test when the DPC++ backend is available
-#define TEST_DPCPP_BACKEND_PRESENT TEST_SYCL_PRESENT && ONEDPL_USE_DPCPP_BACKEND
+#define TEST_DPCPP_BACKEND_PRESENT TEST_SYCL_PRESENT && _ONEDPL_BACKEND_SYCL
 
 #endif /* _PSTL_TEST_config_H */


### PR DESCRIPTION
The tests modified here fail to compile when dpcpp is used with `-DONEDPL_USE_DPCPP_BACKEND=0`

Signed-off-by: Timmie Smith <timmie.smith@intel.com>