### PR TITLE
Add macro guards for variables, which used/not used depending on BE-type

### DIFF
--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.copy/copy_if.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.copy/copy_if.pass.cpp
@@ -54,7 +54,11 @@ struct run_copy_if
               typename Predicate, typename T>
     void
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator /* out_last */, OutputIterator2 expected_first, OutputIterator2 /* expected_last */, Size n,
+               OutputIterator
+#if !_ONEDPL_BACKEND_SYCL
+               out_last
+#endif
+               , OutputIterator2 expected_first, OutputIterator2 /* expected_last */, Size n,
                Predicate pred, T trash)
     {
         // Cleaning
@@ -106,7 +110,11 @@ template <typename InputIterator, typename OutputIterator, typename OutputIterat
               typename Predicate, typename T>
     void
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator /* out_last */, OutputIterator2 expected_first, OutputIterator2 /* expected_last */, Size n,
+               OutputIterator
+#if !_ONEDPL_BACKEND_SYCL
+               out_last
+#endif
+               , OutputIterator2 expected_first, OutputIterator2 /* expected_last */, Size n,
                Predicate pred, T trash)
     {
         // Cleaning

--- a/test/parallel_api/algorithm/alg.modifying.operations/remove_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/remove_copy.pass.cpp
@@ -28,7 +28,11 @@ struct run_remove_copy
     template <typename Policy, typename InputIterator, typename OutputIterator, typename OutputIterator2, typename Size>
     void
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator, OutputIterator2 expected_first, OutputIterator2 /* expected_last */, Size n,
+               OutputIterator
+#if !_ONEDPL_BACKEND_SYCL
+               out_last
+#endif
+               , OutputIterator2 expected_first, OutputIterator2 /* expected_last */, Size n,
                const T& value, T trash)
     {
         // Cleaning

--- a/test/parallel_api/algorithm/alg.modifying.operations/unique_copy_equal.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/unique_copy_equal.pass.cpp
@@ -48,7 +48,11 @@ struct run_unique_copy
     template <typename Policy, typename InputIterator, typename OutputIterator, typename OutputIterator2, typename Size>
     void
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator /* out_last */, OutputIterator2 expected_first, OutputIterator2 /* expected_last */,
+               OutputIterator
+#if !_ONEDPL_BACKEND_SYCL
+               out_last
+#endif
+               , OutputIterator2 expected_first, OutputIterator2 /* expected_last */,
                Size n, T trash)
     {
         // Cleaning
@@ -103,7 +107,11 @@ struct run_unique_copy_predicate
               typename Predicate>
     void
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator /* out_last */, OutputIterator2 expected_first, OutputIterator2 /* expected_last */, Size n,
+               OutputIterator
+#if !_ONEDPL_BACKEND_SYCL
+               out_last
+#endif
+               , OutputIterator2 expected_first, OutputIterator2 /* expected_last */, Size n,
                Predicate pred, T trash)
     {
         // Cleaning


### PR DESCRIPTION
Fix some issues after the fixing of warnings: add macro guards for variables, which used/not used depending on BE-type to avoid wanings during compilation.

Signed-off-by: Pavlov, Evgeniy <evgeniy.pavlov@intel.com>