### PR TITLE
Add check of DPCPP-BE for ranges testing files

### DIFF
--- a/test/support/pstl_test_config.h
+++ b/test/support/pstl_test_config.h
@@ -66,12 +66,13 @@
 #define TEST_DPCPP_BACKEND_PRESENT TEST_SYCL_PRESENT && _ONEDPL_BACKEND_SYCL
 
 // Check for C++ standard and standard library for the use of ranges API
+#define _TEST_RANGES_FOR_CPP_17_DPCPP_BE_ONLY (__cplusplus >= 201703L && _ONEDPL_BACKEND_SYCL)
 #if defined(_GLIBCXX_RELEASE)
-#    define _ENABLE_RANGES_TESTING (__cplusplus >= 201703L && _GLIBCXX_RELEASE >= 8 && __GLIBCXX__ >= 20180502)
+#    define _ENABLE_RANGES_TESTING (_TEST_RANGES_FOR_CPP_17_DPCPP_BE_ONLY && _GLIBCXX_RELEASE >= 8 && __GLIBCXX__ >= 20180502)
 #elif defined(_LIBCPP_VERSION)
-#    define _ENABLE_RANGES_TESTING (__cplusplus >= 201703L && _LIBCPP_VERSION >= 7000)
+#    define _ENABLE_RANGES_TESTING (_TEST_RANGES_FOR_CPP_17_DPCPP_BE_ONLY && _LIBCPP_VERSION >= 7000)
 #else
-#    define _ENABLE_RANGES_TESTING (__cplusplus >= 201703L)
+#    define _ENABLE_RANGES_TESTING (_TEST_RANGES_FOR_CPP_17_DPCPP_BE_ONLY)
 #endif
 
 #endif /* _PSTL_TEST_config_H */


### PR DESCRIPTION
Fix _ENABLE_RANGES_TESTING macro definition: add DPCPP_BE check to run range tests correctly with non-DPCPP-BE.

Signed-off-by: Pavlov, Evgeniy <evgeniy.pavlov@intel.com>