### PR TITLE
Add <vector> inclusion to discard/permutation iterator tests

### DIFF
--- a/test/parallel_api/iterator/discard_iterator.pass.cpp
+++ b/test/parallel_api/iterator/discard_iterator.pass.cpp
@@ -21,6 +21,7 @@
 #include <iostream>
 #include <chrono>
 #include <cmath>
+#include <vector>
 
 #include "../../support/pstl_test_config.h"
 

--- a/test/parallel_api/iterator/permutation_iterator.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator.pass.cpp
@@ -21,6 +21,7 @@
 #include <iostream>
 #include <chrono>
 #include <cmath>
+#include <vector>
 
 #include "../../support/pstl_test_config.h"
 


### PR DESCRIPTION
Add <vector> inclusion to discard/permutation iterator tests to avoid build errors at some platforms.

Signed-off-by: Pavlov, Evgeniy <evgeniy.pavlov@intel.com>