### PR TITLE
CMake: skip xpu_api test for non-dpcpp backends

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -74,7 +74,13 @@ macro(onedpl_add_test test_source_file)
     add_dependencies(build-all ${_test_name})
 endmacro()
 
+set(_skip_regex_for_not_dpcpp "(xpu_api)")
 file(GLOB_RECURSE UNIT_TESTS "*.pass.cpp")
 foreach (_file IN LISTS UNIT_TESTS)
+    if (_file MATCHES "${_skip_regex_for_not_dpcpp}" AND NOT ONEDPL_BACKEND MATCHES "^(dpcpp|dpcpp_only)$")
+        message(STATUS "Skip test ${_file} as it requires DPC++ backend")
+        continue()
+    endif()
+
     onedpl_add_test(${_file})
 endforeach()


### PR DESCRIPTION
Tests from xpu_api folder are not supported for non-dpcpp backends. This patch provides a short-term solution to skip these tests. Later more scalable/universal solution may be proposed if needed.