### PR TITLE
Remove include 'support' folder relative path for some test codes

### DIFF
--- a/test/general/interface_check.pass.cpp
+++ b/test/general/interface_check.pass.cpp
@@ -22,6 +22,7 @@
 #include <functional>
 #include <iterator>
 #include <vector>
+#include "support/pstl_test_config.h"
 
 #if TEST_SYCL_PRESENT
 #include <CL/sycl.hpp>

--- a/test/general/interface_check.pass.cpp
+++ b/test/general/interface_check.pass.cpp
@@ -22,7 +22,6 @@
 #include <functional>
 #include <iterator>
 #include <vector>
-#include "../support/pstl_test_config.h"
 
 #if TEST_SYCL_PRESENT
 #include <CL/sycl.hpp>

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
@@ -19,8 +19,6 @@
 
 #include <iostream>
 
-#include "../../../../../support/pstl_test_config.h"
-
 #if TEST_DPCPP_BACKEND_PRESENT
 
 #include <CL/sycl.hpp>

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
@@ -19,6 +19,8 @@
 
 #include <iostream>
 
+#include "support/pstl_test_config.h"
+
 #if TEST_DPCPP_BACKEND_PRESENT
 
 #include <CL/sycl.hpp>

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
@@ -19,6 +19,8 @@
 
 #include <iostream>
 
+#include "support/pstl_test_config.h"
+
 #if TEST_SYCL_PRESENT
 #include <CL/sycl.hpp>
 #endif

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
@@ -19,8 +19,6 @@
 
 #include <iostream>
 
-#include "../../../../../support/pstl_test_config.h"
-
 #if TEST_SYCL_PRESENT
 #include <CL/sycl.hpp>
 #endif

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
@@ -19,6 +19,8 @@
 
 #include <iostream>
 
+#include "support/pstl_test_config.h"
+
 #if TEST_SYCL_PRESENT
 #include <CL/sycl.hpp>
 #endif

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
@@ -19,8 +19,6 @@
 
 #include <iostream>
 
-#include "../../../../../support/pstl_test_config.h"
-
 #if TEST_SYCL_PRESENT
 #include <CL/sycl.hpp>
 #endif

--- a/test/parallel_api/iterator/discard_iterator.pass.cpp
+++ b/test/parallel_api/iterator/discard_iterator.pass.cpp
@@ -23,8 +23,6 @@
 #include <cmath>
 #include <vector>
 
-#include "../../support/pstl_test_config.h"
-
 #if TEST_SYCL_PRESENT
 #include <CL/sycl.hpp>
 #endif

--- a/test/parallel_api/iterator/discard_iterator.pass.cpp
+++ b/test/parallel_api/iterator/discard_iterator.pass.cpp
@@ -23,6 +23,8 @@
 #include <cmath>
 #include <vector>
 
+#include "support/pstl_test_config.h"
+
 #if TEST_SYCL_PRESENT
 #include <CL/sycl.hpp>
 #endif

--- a/test/parallel_api/iterator/permutation_iterator.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator.pass.cpp
@@ -23,8 +23,6 @@
 #include <cmath>
 #include <vector>
 
-#include "../../support/pstl_test_config.h"
-
 #if TEST_SYCL_PRESENT
 #include <CL/sycl.hpp>
 #endif

--- a/test/parallel_api/iterator/permutation_iterator.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator.pass.cpp
@@ -23,6 +23,8 @@
 #include <cmath>
 #include <vector>
 
+#include "support/pstl_test_config.h"
+
 #if TEST_SYCL_PRESENT
 #include <CL/sycl.hpp>
 #endif

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
@@ -17,6 +17,8 @@
 #include "oneapi/dpl/algorithm"
 #include "oneapi/dpl/iterator"
 
+#include "support/pstl_test_config.h"
+
 #include <iostream>
 #include <iomanip>
 

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
@@ -17,8 +17,6 @@
 #include "oneapi/dpl/algorithm"
 #include "oneapi/dpl/iterator"
 
-#include "../../../support/pstl_test_config.h"
-
 #include <iostream>
 #include <iomanip>
 

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -17,6 +17,8 @@
 #include "oneapi/dpl/algorithm"
 #include "oneapi/dpl/iterator"
 
+#include "support/pstl_test_config.h"
+
 #include <iostream>
 #include <iomanip>
 

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -17,8 +17,6 @@
 #include "oneapi/dpl/algorithm"
 #include "oneapi/dpl/iterator"
 
-#include "../../../support/pstl_test_config.h"
-
 #include <iostream>
 #include <iomanip>
 

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -18,6 +18,8 @@
 #include "oneapi/dpl/numeric"
 #include "oneapi/dpl/iterator"
 
+#include "support/pstl_test_config.h"
+
 #include <iostream>
 #include <iomanip>
 

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -18,8 +18,6 @@
 #include "oneapi/dpl/numeric"
 #include "oneapi/dpl/iterator"
 
-#include "../../../support/pstl_test_config.h"
-
 #include <iostream>
 #include <iomanip>
 


### PR DESCRIPTION
For our nightly test, it will add 'oneDPL/test/support' file path to 'CPATH'. So I request to remove this including path for some test codes.