### PR TITLE
Fix for reduction stage of scan pattern

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -484,21 +484,21 @@ struct __scan
                     _InitType __init = __scan_no_init<typename _InitType::__value_type>{}) const
     {
         using _Tp = typename _InitType::__value_type;
-        auto __group_id = __item.get_group(0);
-        auto __global_id = __item.get_global_id(0);
-        auto __local_id = __item.get_local_id(0);
-        auto __use_init = __scan_init_processing<_Tp>{};
+        ::std::size_t __group_id = __item.get_group(0);
+        ::std::size_t __global_id = __item.get_global_id(0);
+        ::std::size_t __local_id = __item.get_local_id(0);
+        __scan_init_processing<_Tp> __use_init{};
 
-        auto __shift = 0;
+        ::std::size_t __shift = 0;
         __internal::__invoke_if_not(_Inclusive{}, [&]() {
             __shift = 1;
             if (__global_id == 0)
                 __use_init(__init, __out_acc[__global_id]);
         });
 
-        auto __adjusted_global_id = __local_id + __size_per_wg * __group_id;
+        ::std::size_t __adjusted_global_id = __local_id + __size_per_wg * __group_id;
         auto __adder = __local_acc[0];
-        for (auto __iter = 0; __iter < __iters_per_wg; ++__iter, __adjusted_global_id += __wgroup_size)
+        for (_ItersPerWG __iter = 0; __iter < __iters_per_wg; ++__iter, __adjusted_global_id += __wgroup_size)
         {
             if (__adjusted_global_id < __n)
             {
@@ -513,7 +513,7 @@ struct __scan
                 __use_init(__init, __local_acc[__global_id], __bin_op);
 
             // 1. reduce
-            auto __k = 1;
+            ::std::size_t __k = 1;
             // TODO: use adjacent work items for better SIMD utilization
             // Consider the example with the mask of work items performing reduction:
             // iter    now         proposed

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -517,9 +517,9 @@ struct __scan
             // TODO: use adjacent work items for better SIMD utilization
             // Consider the example with the mask of work items performing reduction:
             // iter    now         proposed
-            // 1:      10101010    11110000
-            // 2:      10001000    11000000
-            // 3:      10000000    10000000
+            // 1:      01010101    11110000
+            // 2:      00010001    11000000
+            // 3:      00000001    10000000
             do
             {
                 __item.barrier(sycl::access::fence_space::local_space);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -523,7 +523,7 @@ struct __scan
             do
             {
                 __item.barrier(sycl::access::fence_space::local_space);
-                if (__adjusted_global_id < __n && __local_id % (2 * __k) == (2 * __k) - 1)
+                if (__adjusted_global_id < __n && __local_id % (2 * __k) == 2 * __k - 1)
                 {
                     __local_acc[__local_id] = __bin_op(__local_acc[__local_id - __k], __local_acc[__local_id]);
                 }


### PR DESCRIPTION
It continues fixing that started at https://github.com/oneapi-src/oneDPL/pull/107.
Th thing is code worked incorrect if work group size = 10, n = 9, for example. Now I've changed the logic based on the thing that we work with current local id, not with others id.