### PR TITLE
Fix for kernel names check

### DIFF
--- a/test/general/lambda_naming.pass.cpp
+++ b/test/general/lambda_naming.pass.cpp
@@ -32,8 +32,8 @@ using namespace TestUtils;
 int main() {
 #if _ONEDPL_BACKEND_SYCL
     const int n = 1000;
-    sycl::buffer<int, 1> buf{ sycl::range<1>(n) };
-    sycl::buffer<int, 1> out_buf{ sycl::range<1>(n) };
+    sycl::buffer<int> buf{ sycl::range<1>(n) };
+    sycl::buffer<int> out_buf{ sycl::range<1>(n) };
     auto buf_begin = oneapi::dpl::begin(buf);
     auto buf_end = buf_begin + n;
 
@@ -52,6 +52,10 @@ int main() {
     ::std::for_each(policy, buf_begin, buf_end, [](int& x) { x += 41; });
 
 #if !_ONEDPL_FPGA_DEVICE
+    sycl::buffer<float> out_buf_2{ sycl::range<1>(n) };
+    auto buf_out_begin_2 = oneapi::dpl::begin(out_buf_2);
+    ::std::copy(policy, buf_begin, buf_end, buf_out_begin_2);
+    ::std::copy(policy, buf_out_begin_2, buf_out_begin_2 + n, buf_begin);
     ::std::inplace_merge(policy, buf_begin, buf_begin + n / 2, buf_end);
     auto red_val = ::std::reduce(policy, buf_begin, buf_end, 1);
     EXPECT_TRUE(red_val == 42001, "wrong return value from reduce");


### PR DESCRIPTION
This is the fix for the #113 PR.

Regression test:
```
int main() {
  sycl::queue q;
  sycl::usm_allocator<int, sycl::usm::alloc::shared> alloc(q);
  int* storage = alloc.allocate(4);
  std::vector<int> hv = {1, 2, 3, 4}; // host vector

  auto policy = oneapi::dpl::execution::make_device_policy(q);
  std::copy(policy, hv.begin(), hv.end(), storage);
  std::copy(policy, storage, storage + 4, hv.begin());

  return 0;
}
```