### PR TITLE
[Pre-CI] Will add retry/try catch protection for UB18 test

### DIFF
--- a/jenkinsfiles/UB18_Check.groovy
+++ b/jenkinsfiles/UB18_Check.groovy
@@ -197,20 +197,25 @@ pipeline {
 
                 stage('Setting_Env') {
                     steps {
-                        script {
-                            try {
-                                sh script: """
-                                    bash /export/users/oneDPL_CI/generate_env_file.sh ${env.OneAPI_Package_Date}
-                                    if [ ! -f ./envs_tobe_loaded.txt ]; then
-                                        echo "Environment file not generated."
-                                        exit -1
-                                    fi
-                                """, label: "Generate environment vars"
-                            }
-                            catch (e) {
-                                build_ok = false
-                                fail_stage = fail_stage + "    " + "Setting_Env"
-                                sh script: "exit -1", label: "Set failure"
+                        timeout(time: 20) {
+                            script {
+                                try {
+                                    retry(2) {
+                                        sh script: """
+                                            bash /export/users/oneDPL_CI/generate_env_file.sh ${env.OneAPI_Package_Date}
+                                            if [ ! -f ./envs_tobe_loaded.txt ]; then
+                                                echo "Environment file not generated."
+                                                exit -1
+                                            fi
+                                        """, label: "Generate environment vars"
+                                    }
+
+                                }
+                                catch (e) {
+                                    build_ok = false
+                                    fail_stage = fail_stage + "    " + "Setting_Env"
+                                    sh script: "exit -1", label: "Set failure"
+                                }
                             }
                         }
                     }
@@ -239,7 +244,7 @@ pipeline {
                                         sh script: """
                                             exit -1
                                         """
-                                       
+
                                     }
                                 }
                             }
@@ -270,7 +275,7 @@ pipeline {
                                         sh script: """
                                             exit -1
                                         """
-                                       
+
                                     }
                                 }
                             }


### PR DESCRIPTION
It is observed that "setting env" step may fail for UB18 test due to mount folder issue from infrastructure side. 
This PR can improve stability of UB18 CI check by adding retry/try catch method.
The PR has been verified with link below:
http://icl-jenkins2.sc.intel.com:8080/blue/organizations/jenkins/OneDPL_CI%2FUB1804_Check/detail/UB1804_Check/355/pipeline

Signed-off-by: Xiaodong, Li <xiaodong.li@intel.com>
