### PR TITLE
Turn off strict aliasing optimization if used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,14 @@ string(TOUPPER ${ONEDPL_BACKEND} ONEDPL_BACKEND)
 message(STATUS "Using parallel policies with ${ONEDPL_BACKEND} backend")
 string(TOLOWER ${ONEDPL_BACKEND} ONEDPL_BACKEND)
 
+# oneDPL test harness may initialize a C++ iterator using iterator with different type
+# that may break code when using icpc with -O3 optimizations on Linux
+if (UNIX)
+    if (CMAKE_CXX_COMPILER STREQUAL "icpc" AND CMAKE_BUILD_TYPE STREQUAL "Release")
+        target_compile_options(oneDPL INTERFACE -fno-strict-aliasing)
+    endif()
+endif()
+
 if (ONEDPL_ENABLE_SIMD)
     # TODO: remove skipping of Intel® oneAPI DPC++ Compiler once it can handle such options.
     if (NOT CMAKE_CXX_COMPILER MATCHES ".*dpcpp(-cl)?(.exe)?$")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,6 @@ add_library(oneDPL INTERFACE)
 
 if (CMAKE_BUILD_TYPE)
     message(STATUS "Build type is ${CMAKE_BUILD_TYPE}")
-    string(TOLOWER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE)
 else()
     message(STATUS "Build type is not set")
 endif()
@@ -70,17 +69,6 @@ endif()
 string(TOUPPER ${ONEDPL_BACKEND} ONEDPL_BACKEND)
 message(STATUS "Using parallel policies with ${ONEDPL_BACKEND} backend")
 string(TOLOWER ${ONEDPL_BACKEND} ONEDPL_BACKEND)
-
-# oneDPL test harness may initialize a C++ iterator using iterator with different type
-# that may break code when using icpc with -O3 optimizations on Linux
-if (UNIX)
-    if (CMAKE_CXX_COMPILER MATCHES ".*icpc")
-        if (CMAKE_BUILD_TYPE STREQUAL "release")
-            message(STATUS "Strict-alising optimization has been explicitly turned off")
-            target_compile_options(oneDPL INTERFACE -fno-strict-aliasing)
-        endif()
-    endif()
-endif()
 
 if (ONEDPL_ENABLE_SIMD)
     # TODO: remove skipping of Intel® oneAPI DPC++ Compiler once it can handle such options.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ add_library(oneDPL INTERFACE)
 
 if (CMAKE_BUILD_TYPE)
     message(STATUS "Build type is ${CMAKE_BUILD_TYPE}")
+    string(TOLOWER ${CMAKE_BUILD_TYPE} CMAKE_BUILD_TYPE)
 else()
     message(STATUS "Build type is not set")
 endif()
@@ -73,8 +74,11 @@ string(TOLOWER ${ONEDPL_BACKEND} ONEDPL_BACKEND)
 # oneDPL test harness may initialize a C++ iterator using iterator with different type
 # that may break code when using icpc with -O3 optimizations on Linux
 if (UNIX)
-    if (CMAKE_CXX_COMPILER STREQUAL "icpc" AND CMAKE_BUILD_TYPE STREQUAL "Release")
-        target_compile_options(oneDPL INTERFACE -fno-strict-aliasing)
+    if (CMAKE_CXX_COMPILER MATCHES ".*icpc")
+        if (CMAKE_BUILD_TYPE STREQUAL "release")
+            message(STATUS "Strict-alising optimization has been explicitly turned off")
+            target_compile_options(oneDPL INTERFACE -fno-strict-aliasing)
+        endif()
     endif()
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -33,10 +33,8 @@ macro(onedpl_add_test test_source_file)
 
     # oneDPL test harness may initialize a C++ iterator using iterator with different type
     # that may break code when using icpc with -O3 flag on Linux
-    if (CMAKE_SYSTEM_NAME MATCHES "Linux")
-        if (CMAKE_CXX_COMPILER_ID STREQUAL Intel)
-            target_compile_options(${_test_name} PRIVATE $<$<CONFIG:Release>:-fno-strict-aliasing>)
-        endif()
+    if (CMAKE_SYSTEM_NAME MATCHES "Linux" AND CMAKE_CXX_COMPILER_ID STREQUAL Intel)
+        target_compile_options(${_test_name} PRIVATE $<$<CONFIG:Release>:-fno-strict-aliasing>)
     endif()
 
     target_include_directories(${_test_name} PRIVATE "${CMAKE_CURRENT_LIST_DIR}")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,6 +30,15 @@ macro(onedpl_add_test test_source_file)
     if (MSVC)
         target_compile_options(${_test_name} PRIVATE /bigobj)
     endif()
+
+    # oneDPL test harness may initialize a C++ iterator using iterator with different type
+    # that may break code when using icpc with -O3 flag on Linux
+    if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+        if (CMAKE_CXX_COMPILER_ID STREQUAL Intel)
+            target_compile_options(${_test_name} PRIVATE $<$<CONFIG:Release>:-fno-strict-aliasing>)
+        endif()
+    endif()
+
     target_include_directories(${_test_name} PRIVATE "${CMAKE_CURRENT_LIST_DIR}")
     target_link_libraries(${_test_name} PRIVATE oneDPL)
     set_target_properties(${_test_name} PROPERTIES CXX_EXTENSIONS NO)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,7 +32,7 @@ macro(onedpl_add_test test_source_file)
     endif()
 
     # oneDPL test harness may initialize a C++ iterator using iterator with different type
-    # that may break code when using icpc with -O3 flag on Linux
+    # that may break code when using Intel(R) C++ Compiler Classic with -O3 flag on Linux
     if (CMAKE_SYSTEM_NAME MATCHES "Linux" AND CMAKE_CXX_COMPILER_ID STREQUAL Intel)
         target_compile_options(${_test_name} PRIVATE $<$<CONFIG:Release>:-fno-strict-aliasing>)
     endif()


### PR DESCRIPTION
oneDPL test harness may initialize a C++ iterator using an iterator with different type. That may break code when using Intel(R) C++ Compiler Classic with -O3 flag on Linux. This optimization is turned off on Windows by default.