### PR TITLE
Fix segmentation fault in the global scan functor

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -452,7 +452,7 @@ struct __global_scan_functor
         constexpr auto __shift = _Inclusive{} ? 0 : 1;
         auto __item_idx = __item.get_linear_id();
         // skip the first group scanned locally
-        if (__item_idx >= __size_per_wg && __item_idx < __n)
+        if (__item_idx >= __size_per_wg && __item_idx < __n - __shift)
         {
             auto __wg_sums_idx = __item_idx / __size_per_wg - 1;
             // an initial value preceeds the first group for the exclusive scan

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -452,7 +452,7 @@ struct __global_scan_functor
         constexpr auto __shift = _Inclusive{} ? 0 : 1;
         auto __item_idx = __item.get_linear_id();
         // skip the first group scanned locally
-        if (__item_idx >= __size_per_wg && __item_idx < __n - __shift)
+        if (__item_idx >= __size_per_wg && __item_idx + __shift < __n)
         {
             auto __wg_sums_idx = __item_idx / __size_per_wg - 1;
             // an initial value preceeds the first group for the exclusive scan


### PR DESCRIPTION
Fix an issue with segmentation fault in the global scan functor, which causes memory corruption and double memory free operation (CPU, Debug)

Signed-off-by: Pavlov, Evgeniy <evgeniy.pavlov@intel.com>