### PR TITLE
Reduce number of elements to scan due to taking too much time when testing

### DIFF
--- a/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
@@ -159,7 +159,14 @@ test_with_plus(T init, T trash, Convert convert)
     }
 
 #if _ONEDPL_BACKEND_SYCL && !_ONEDPL_FPGA_DEVICE
-    unsigned long n = 70000000;
+    // testing of large number of items may take too much time in debug mode
+    unsigned long n =
+#if PSTL_USE_DEBUG
+        70000000;
+#else
+        100000000;
+#endif
+
     Sequence<T> in(n, convert);
     Sequence<T> expected(in);
     Sequence<T> out(n, [&](int32_t) { return trash; });

--- a/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
@@ -159,7 +159,7 @@ test_with_plus(T init, T trash, Convert convert)
     }
 
 #if _ONEDPL_BACKEND_SYCL && !_ONEDPL_FPGA_DEVICE
-    unsigned long n = 100000000;
+    unsigned long n = 70000000;
     Sequence<T> in(n, convert);
     Sequence<T> expected(in);
     Sequence<T> out(n, [&](int32_t) { return trash; });


### PR DESCRIPTION
Testing of `scan.pass` takes too much time on CPU devices when there are a few number of cores (e.g. due to limits in docker containers). This reduces testing time by ~30% when the test is built in debug mode. 

Reduction is not necessary with release mode, so let's keep it as is. 
Testing in debug mode with large number of elements may detect some specific issues, so let's test such scenario, but reduce the number to have reasonable execution time.