### PR TITLE
Added substitution elements for building docs

### DIFF
--- a/documentation/library_guide/before_you_begin.rst
+++ b/documentation/library_guide/before_you_begin.rst
@@ -1,8 +1,8 @@
 Before You Begin
 #################
 
-Visit the `Intel® oneAPI DPC++ Library Release Notes
-<https://software.intel.com/en-us/articles/intel-oneapi-dpcpp-library-release-notes-beta>`_
+Visit the |onedpl_long| `Release Notes
+<https://software.intel.com/content/www/us/en/develop/articles/intel-oneapi-dpcpp-library-release-notes.html>`_
 page for:
 
 - Where to Find the Release
@@ -11,11 +11,11 @@ page for:
 - Known Issues
 
 Install the `Intel® oneAPI Base Toolkit <https://software.intel.com/en-us/oneapi/base-kit>`_
-to use the Intel® oneAPI DPC++ Library (oneDPL).
+to use |onedpl_short|.
 
 To use Parallel STL or the Extension API, include the corresponding header files in your source code.
 All oneDPL header files are in the ``oneapi/dpl`` directory. Use ``#include <oneapi/dpl/…>`` to include them.
-Intel® oneAPI DPC++ Library uses namespace ``oneapi::dpl`` for most its classes and functions.
+|onedpl_short| uses the namespace ``oneapi::dpl`` for most its classes and functions.
 
 To use tested C++ standard APIs, you need to include the corresponding C++ standard header files
 and use the ``std`` namespace.

--- a/documentation/library_guide/extension_api.rst
+++ b/documentation/library_guide/extension_api.rst
@@ -136,7 +136,7 @@ header.  All iterators are implemented in the ``oneapi::dpl`` namespace.
 
 * ``transform_iterator``
 
-  The``transform_iterator`` is an iterator defined over another iterator whose dereferenced value is the result
+  The ``transform_iterator`` is an iterator defined over another iterator whose dereferenced value is the result
   of a function applied to the corresponding element of the original iterator.  Both the type of the original
   iterator and the unary function applied during dereference operations are required template parameters of
   the ``transform_iterator`` class. The constructor of the ``transform_iterator`` receives both the original
@@ -193,7 +193,7 @@ header.  All iterators are implemented in the ``oneapi::dpl`` namespace.
   it returns.
 
   The example provided for ``discard_iterator`` demonstrates ``zip_iterator`` use in defining stencil
-  algorithms. The ``zip_iterator`` is also useful in defining "by key" algorithms where input iterators
+  algorithms. The ``zip_iterator`` is also useful in defining by key algorithms where input iterators
   representing keys and values are processed as key-value pairs. The example below demonstrates a stable sort
   by key where only the keys are compared but both keys and values are swapped::
 
@@ -221,14 +221,14 @@ Range-based API
 
 C++20 indroduces the Ranges library. C++20 standard splits ranges into two categories: factories and adaptors.
 A range factory doesn't have underlying data. An element is generated on success by an index or by dereferencing an iterator.
-A range adaptor, from the DPC++ library perspective, is an utility that transforms base range, or another adapted range into 
+A range adaptor, from the |onedpl_long| perspective, is an utility that transforms base range, or another adapted range into 
 a view with custom behavior.
 
-The DPC++ library supports ``iota_view`` range factory.
+|onedpl_short| supports ``iota_view`` range factory.
 
 ``sycl::buffer`` wrapped with ``all_view`` can be used as the range.
 
-The DPC++ library considers the supported factories and ``all_view`` as base ranges.
+The |onedpl_short| considers the supported factories and ``all_view`` as base ranges.
 The range adaptors may be combined into a pipeline with a ``base`` range at the beginning. For example::
 
     cl::sycl::buffer<int> buf(data, cl::sycl::range<1>(10));
@@ -251,7 +251,7 @@ The signature example of the range-based algorithms looks like::
 
 where ``source`` is used instead of two iterators to represent the input and ``destination`` represents the output.
 
-These algorithms are declared in ``oneapi::dpl::experimental::ranges`` namespace and implemented only for DPC++ policies.
+These algorithms are declared in ``oneapi::dpl::experimental::ranges`` namespace and implemented only for |dpcpp_long| policies.
 In order to make these algorithm available the ``<oneapi/dpl/ranges>`` header should be included.
 Use of the range-based API requires C++17 and the C++ standard libraries coming with GCC 8.1 (or higher) or Clang 7 (or higher).
 
@@ -287,11 +287,12 @@ Example of Range-based API Usage
 Async API
 --------------------------
 
-Functions defined in the STL ``<algorithm>`` or ``<numeric>`` headers are traditionally blocking. oneDPL extends the functionality of 
-C++17 parallel algorithms by providing asynchronous algorithms with non-blocking behavior.
-This experimental feature enables you to express a concurrent control flow by building dependency chains and interleaving algorithm calls and interoperability with DPC++ and SYCL kernels. 
+The functions defined in the STL ``<algorithm>`` or ``<numeric>`` headers are traditionally blocking. |onedpl_short| extends the
+functionality of C++17 parallel algorithms by providing asynchronous algorithms with non-blocking behavior.
+This experimental feature enables you to express a concurrent control flow by building dependency chains and interleaving algorithm calls
+and interoperability with |dpcpp_short| and SYCL* kernels. 
 
-The current implementation for async algorithms is limited to DPC++ Execution Policies.
+The current implementation for async algorithms is limited to |dpcpp_short| Execution Policies.
 All the functionality described below is available in the ``oneapi::dpl::experimental`` namespace.
 
 The following async algorithms are currently supported:

--- a/documentation/library_guide/intel_variables.txt
+++ b/documentation/library_guide/intel_variables.txt
@@ -3,9 +3,9 @@
 .. |dpcpp_long| replace:: Data Parallel C++ (DPC++)
 .. |dpcpp_short| replace:: DPC++
 .. |hpc_tk| replace:: Intel® oneAPI HPC Toolkit
-.. |onedpl_long| replace:: oneAPI DPC++ Library (oneDPL)
+.. |onedpl_long| replace:: Intel® oneAPI DPC++ Library (oneDPL)
 .. |onedpl_short| replace:: oneDPL
-.. |onetbb_long| replace:: oneAPI Threading Building Blocks (oneTBB)
+.. |onetbb_long| replace:: Intel® oneAPI Threading Building Blocks (oneTBB)
 .. |onetbb_short| replace:: oneTBB
 .. |tbb_long| replace:: Intel® Threading Building Blocks (Intel® TBB)
 .. |tbb_short| replace:: Intel® TBB

--- a/documentation/library_guide/pstl/dpcpp_policies_usage.rst
+++ b/documentation/library_guide/pstl/dpcpp_policies_usage.rst
@@ -1,5 +1,5 @@
 Parallel STL Usage
-###################
+##################
 
 Follow these steps to add Parallel STL to your application:
 
@@ -12,20 +12,20 @@ Follow these steps to add Parallel STL to your application:
    * ``#include <oneapi/dpl/memory>``
 
    For better coexistence with the C++ standard library,
-   include oneDPL header files before the standard C++ header files.
+   include |onedpl_long| header files before the standard C++ header files.
 
-#. Pass a oneDPL execution policy object, defined in the ``oneapi::dpl::execution``
+#. Pass a |onedpl_short| execution policy object, defined in the ``oneapi::dpl::execution``
    namespace, to a parallel algorithm.
 #. Use the C++ Standard Execution Policies:
 
-   * Compile the code with options that enable OpenMP vectorization pragmas.
-   * Link with the oneTBB or TBB dynamic library for parallelism.
-#. Use the DPC++ Execution Policies:
+   * Compile the code with options that enable OpenMP* vectorization pragmas.
+   * Link with the |onetbb_long| or |tbb_long| dynamic library for parallelism.
+#. Use the |dpcpp_long| Execution Policies:
 
    * Compile the code with options that enable support for SYCL* 2020.
 
 Use the C++ Standard Execution Policies
-****************************************
+=======================================
 
 Example:
 
@@ -42,12 +42,12 @@ Example:
       return 0;
   }
 
-Use the DPC++ Execution Policies
-*********************************
+Use the |dpcpp_short| Execution Policies
+========================================
 
-The Data Parallel C++ (DPC++) execution policy specifies where a parallel algorithm runs.
+The |dpcpp_short| execution policy specifies where a parallel algorithm runs.
 It encapsulates a SYCL* device or queue, and
-allows you to set an optional kernel name. DPC++ execution policies can be used with all
+allows you to set an optional kernel name. |dpcpp_short| execution policies can be used with all
 standard C++ algorithms that support execution policies.
 
 To use the policy, create a policy object by providing a class type for a unique kernel name
@@ -59,7 +59,7 @@ as a template argument, and one of the following constructor arguments:
 * An existing policy object with a different kernel name
 
 Providing a kernel name for a policy is optional if the used compiler supports implicit
-names for SYCL kernel functions. The Intel® oneAPI DPC++/C++ Compiler supports it by default;
+names for SYCL kernel functions. The |dpcpp_cpp| supports it by default;
 for other compilers it may need to be enabled with compilation options such as
 ``-fsycl-unnamed-lambda``. Refer to your compiler documentation for more information.
 
@@ -73,10 +73,10 @@ kernel names (see above) for compilation.
 The ``make_device_policy`` function templates simplify ``device_policy`` creation.
 
 Usage Examples
-===============
+==============
 
-Code examples below assume ``using namespace oneapi::dpl::execution;``
-and ``using namespace sycl;`` directive when refer to policy classes and functions:
+The code examples below assume you are ``using namespace oneapi::dpl::execution;``
+and ``using namespace sycl;`` directives when refering to policy classes and functions:
 
 .. code::
 
@@ -104,9 +104,9 @@ and ``using namespace sycl;`` directive when refer to policy classes and functio
   std::for_each(policy_e, …);
 
 Use the FPGA Policy
-====================
+===================
 
-The ``fpga_policy`` class is a DPC++ policy tailored to achieve
+The ``fpga_policy`` class is a |dpcpp_short| policy tailored to achieve
 better performance of parallel algorithms on FPGA hardware devices.
 
 Use the policy when you run the application on a FPGA hardware device or FPGA emulation device:
@@ -136,16 +136,16 @@ Use it to create customized policy objects, or pass directly when invoking an al
 :Note: Specifying unroll factor for a policy enables loop unrolling in the implementation of
   algorithms. Default value is 1.
   To find out how to choose a better value, you can refer to the `unroll Pragma
-  <https://software.intel.com/en-us/oneapi-fpga-optimization-guide-unroll-pragma>`_
+  <https://software.intel.com/content/www/us/en/develop/documentation/oneapi-fpga-optimization-guide/top/fpga-optimization-flags-attributes-pragmas-and-extensions/loop-directives/unroll-pragma.html>`_
   and `Loops Analysis
-  <https://software.intel.com/en-us/oneapi-fpga-optimization-guide-loops-analysis>`_ chapters of
+  <https://software.intel.com/content/www/us/en/develop/documentation/oneapi-fpga-optimization-guide/top/analyze-your-design/analyze-the-fpga-early-image/review-the-report-html-file/loops-analysis.html>`_ chapters of
   the `Intel® oneAPI DPC++ FPGA Optimization Guide
-  <https://software.intel.com/en-us/oneapi-fpga-optimization-guide>`_.
+  <https://software.intel.com/content/www/us/en/develop/documentation/oneapi-fpga-optimization-guide/top.html>`_.
 
 The ``make_fpga_policy`` function templates simplify ``fpga_policy`` creation.
 
 FPGA Policy Usage Examples
-===========================
+==========================
 
 The code below assumes ``using namespace oneapi::dpl::execution;`` for policies and
 ``using namespace sycl;`` for queues and device selectors:
@@ -158,16 +158,16 @@ The code below assumes ``using namespace oneapi::dpl::execution;`` for policies 
   auto fpga_policy_c = make_fpga_policy<unroll_factor, class FPGAPolicyC>();
 
 Pass Data to Algorithms
-========================
+=======================
 
-You can use one of the following ways to pass data to an algorithm executed with a DPC++ policy:
+You can use one of the following ways to pass data to an algorithm executed with a |dpcpp_short| policy:
 
 * ``oneapi:dpl::begin`` and ``oneapi::dpl::end`` functions
 * Unified shared memory (USM) pointers and ``std::vector`` with USM allocators
 * Iterators of host-side ``std::vector``
 
 Use oneapi::dpl::begin and oneapi::dpl::end Functions
-------------------------------------------------------
+-----------------------------------------------------
 
 ``oneapi::dpl::begin`` and ``oneapi::dpl::end`` are special helper functions that
 allow you to pass SYCL buffers to parallel algorithms. These functions accept
@@ -199,7 +199,8 @@ Example:
   }
 
 Use Unified Shared Memory
---------------------------------
+-------------------------
+
 The following examples demonstrate two ways to use the parallel algorithms with USM:
 
 * USM pointers
@@ -244,8 +245,9 @@ Alternatively, use ``std::vector`` with a USM allocator:
   }
 
 Use Host-Side ``std::vector``
-------------------------------
-oneDPL parallel algorithms can be called with ordinary (host-side) iterators, as seen in the
+-----------------------------
+
+|onedpl_short| parallel algorithms can be called with ordinary (host-side) iterators, as seen in the
 example below.
 In this case, a temporary SYCL buffer is created and the data is copied to this buffer.
 After processing of the temporary buffer on a device is complete, the data is copied back
@@ -265,56 +267,56 @@ Example:
     return 0;
   }
 
-Error Handling with DPC++ Execution Policies
-=============================================
+Error Handling with |dpcpp_short| Execution Policies
+====================================================
 
-The DPC++ error handling model supports two types of errors. In cases of synchronous errors
-DPC++ host runtime libraries throw exceptions, while asynchronous errors may only
-be processed in a user-supplied error handler associated with a DPC++ queue.
+The |dpcpp_short| error handling model supports two types of errors. In cases of synchronous errors
+|dpcpp_short| host runtime libraries throw exceptions, while asynchronous errors may only
+be processed in a user-supplied error handler associated with a |dpcpp_short| queue.
 
-For algorithms executed with DPC++ policies, handling all errors, synchronous or asynchronous, is a
+For algorithms executed with |dpcpp_short| policies, handling all errors, synchronous or asynchronous, is a
 responsibility of the caller. Specifically:
 
 * No exceptions are thrown explicitly by algorithms.
-* Exceptions thrown by runtime libraries at the host CPU, including DPC++ synchronous exceptions,
+* Exceptions thrown by runtime libraries at the host CPU, including |dpcpp_short| synchronous exceptions,
   are passed through to the caller.
-* DPC++ asynchronous errors are not handled.
+* |dpcpp_short| asynchronous errors are not handled.
 
-In order to process DPC++ asynchronous errors, the queue associated with a DPC++ policy must be
+In order to process |dpcpp_short| asynchronous errors, the queue associated with a |dpcpp_short| policy must be
 created with an error handler object. The predefined policy objects (``dpcpp_default`` etc.) have
 no error handlers; do not use those if you need to process asynchronous errors.
 
 Restrictions
-=============
+============
 
-When used with DPC++ execution policies, oneDPL algorithms apply the same restrictions as DPC++
-does (see the DPC++ specification and the SYCL specification for details), such as:
+When used with |dpcpp_short| execution policies, |onedpl_short| algorithms apply the same restrictions as |dpcpp_short|
+does (see the |dpcpp_short| specification and the SYCL specification for details), such as:
 
 * Adding buffers to a lambda capture list is not allowed for lambdas passed to an algorithm.
 * Passing data types, which are not trivially constructible, is only allowed in USM,
   but not in buffers or host-allocated containers.
 
 Known Limitations
-==================
+=================
 
 For ``transform_exclusive_scan``, ``transform_inclusive_scan`` algorithms result of
 unary operation should be convertible to the type of the initial value if one is provided,
 otherwise to the type of values in the processed data sequence
 (``std::iterator_traits<IteratorType>::value_type``).
 
-Build Your Code with oneDPL
-============================
+Build Your Code with |onedpl_short|
+===================================
 
-Use these steps to build your code with oneDPL:
+Use these steps to build your code with |onedpl_short|:
 
-#. To build with the Intel® oneAPI DPC++/C++ Complier, see the `Get Started with the Intel® oneAPI DPC++/C++ Compiler
+#. To build with the |dpcpp_cpp|, see the `Get Started with the Intel® oneAPI DPC++/C++ Compiler
    <https://software.intel.com/content/www/us/en/develop/documentation/get-started-with-dpcpp-compiler/top.html>`_
    for details.
-#. Set the environment for oneDPL and oneTBB.
+#. Set the environment for |onedpl_short| and |onetbb_short|.
 #. To avoid naming device policy objects explicitly, add the ``–fsycl-unnamed-lambda`` option.
 
 Below is an example of a command line used to compile code that contains
-oneDPL parallel algorithms on Linux* (depending on the code, parameters within [] could be unnecessary):
+|onedpl_short| parallel algorithms on Linux* (depending on the code, parameters within [] could be unnecessary):
 
 .. code::
 

--- a/documentation/library_guide/pstl/macros.rst
+++ b/documentation/library_guide/pstl/macros.rst
@@ -1,9 +1,9 @@
 Macros
-#######
+######
 
 Version Macros
-===============
-Use these macros to get the current version of the oneAPI DPC++ Library (oneDPL).
+==============
+Use these macros to get the current version of |onedpl_long|.
 
 ================================= ==============================
 Macro                             Description
@@ -14,7 +14,7 @@ Macro                             Description
 --------------------------------- ------------------------------
 ``ONEDPL_VERSION_PATCH``          A decimal number for the patch.
 --------------------------------- ------------------------------
-``_PSTL_VERSION``                 The version of LLVM PSTL code used in oneDPL.
+``_PSTL_VERSION``                 The version of LLVM PSTL code used in |onedpl_short|.
 
                                   The value is a decimal numeral of the form ``xxyyz``
                                   where ``xx`` is the major version number, ``yy`` is the
@@ -29,8 +29,8 @@ Macro                             Description
 
 Additional Macros
 ==================
-Use these macros to control aspects of oneDPL usage. You can set them in your program code
-before including oneDPL headers.
+Use these macros to control aspects of |onedpl_short| usage. You can set them in your program code
+before including |onedpl_short| headers.
 
 ================================== ==============================
 Macro                              Description
@@ -39,7 +39,8 @@ Macro                              Description
                                    for write-only data when algorithms such as ``std::copy``, ``std::fill``, etc.,
                                    are executed with unsequenced policies.
                                    For further details about the pragma,
-                                   see the `Developer Guide and Reference <https://software.intel.com/
+                                   see the `vector page in the Intel® oneAPI DPC++/C++ Compiler Developer Guide and Reference
+                                   <https://software.intel.com/
                                    content/www/us/en/develop/documentation/
                                    oneapi-dpcpp-cpp-compiler-dev-guide-and-reference/top/
                                    compiler-reference/pragmas/
@@ -61,32 +62,32 @@ Macro                              Description
                                    Using this macro may have the same effect on the implementation of parallel
                                    algorithms in the C++ standard libraries of GCC and LLVM.
 ---------------------------------- ------------------------------
-``ONEDPL_USE_TBB_BACKEND``         This macro controls the use of oneAPI Threading Building Blocks (oneTBB) or
-                                   Threading Building Blocks (TBB) for parallel policies.
+``ONEDPL_USE_TBB_BACKEND``         This macro controls the use of |onetbb_long| or
+                                   |tbb_long| for parallel policies.
                                    When the macro is set to 0, algorithms with the ``par`` and ``par_unseq`` policies are only
                                    executed by the calling thread. This is recommended for code that should not depend on the
-                                   presence of the oneTBB or TBB library. When the macro is not defined (by default)
+                                   presence of the |onetbb_short| or |tbb_short| library. When the macro is not defined (by default)
                                    or evaluates to a non-zero value,
-                                   parallel policies are executed using the oneTBB or TBB library.
+                                   parallel policies are executed using the |onetbb_short| or |tbb_short| library.
 ---------------------------------- ------------------------------
-``ONEDPL_USE_DPCPP_BACKEND``       This macro enables the use of the DPC++ policies.
+``ONEDPL_USE_DPCPP_BACKEND``       This macro enables the use of the |dpcpp_short| policies.
                                    When the macro is not defined (by default)
-                                   or evaluates to non-zero, DPC++ policies are enabled.
+                                   or evaluates to non-zero, |dpcpp_short| policies are enabled.
                                    When the macro is set to 0 there is no dependency on
-                                   the oneAPI DPC++/C++ Compiler and runtime libraries.
-                                   Trying to use DPC++ policies will lead to compilation errors.
+                                   the |dpcpp_cpp| and runtime libraries.
+                                   Trying to use |dpcpp_short| policies will lead to compilation errors.
 ---------------------------------- ------------------------------
 ``ONEDPL_USE_PREDEFINED_POLICIES`` This macro enables the use of predefined policies objects,
-                                   e.g. ``dpcpp_default``, ``dpcpp_fpga``. When the macro is not defined (by default)
+                                   (for example ``dpcpp_default`` or ``dpcpp_fpga``). When the macro is not defined (by default)
                                    or evaluates to non-zero, predefined policies objects can be used.
                                    When the macro is set to 0, predefined policies objects and make functions
-                                   without arguments, e.g. ``make_device_policy()``,
+                                   without arguments, when ``make_device_policy()``,
                                    ``make_fpga_policy()``, are not available.
 ---------------------------------- ------------------------------
 ``ONEDPL_ALLOW_DEFERRED_WAITING``  This macro allows waiting for completion of certain algorithms executed with 
-                                   DPC++ policies to be deferred. (Disabled by default.)
+                                   |dpcpp_short| policies to be deferred. (Disabled by default.)
 ---------------------------------- ------------------------------
-``ONEDPL_FPGA_DEVICE``             Use this macro to build your code containing oneDPL parallel
+``ONEDPL_FPGA_DEVICE``             Use this macro to build your code containing |onedpl_short| parallel
                                    algorithms for FPGA devices. (Disabled by default.)
 ---------------------------------- ------------------------------
 ``ONEDPL_FPGA_EMULATOR``           Use this macro to build your code containing Parallel STL

--- a/documentation/library_guide/pstl_main.rst
+++ b/documentation/library_guide/pstl_main.rst
@@ -7,16 +7,17 @@ Introduction to Parallel STL
 Parallel STL is an implementation of the C++ standard library algorithms with support for execution
 policies, as specified in ISO/IEC 14882:2017 standard, commonly called C++17. The implementation also
 supports the unsequenced execution policy and the algorithms shift_left and shift_right, which are specified
-in the the final draft for the C++ 20 standard (N4860). For more details see `the standard execution
-policies <https://en.cppreference.com/w/cpp/algorithm/execution_policy_tag_t>`_.
+in the the final draft for the C++ 20 standard (N4860). For more details see the `C++ Reference Standard Execution
+Policies <https://en.cppreference.com/w/cpp/algorithm/execution_policy_tag_t>`_.
 
 Parallel STL offers efficient support for both parallel and vectorized execution of
 algorithms for Intel® processors. For sequential execution, it relies on an available
 implementation of the C++ standard library. 
 
-The implementation supports the DPC++ execution policies used to run the massive parallel
+The implementation supports the |dpcpp_long| execution policies used to run the massive parallel
 computational model for heterogeneous systems. The policies are specified in
-`the oneDPL Spec <https://spec.oneapi.com/versions/latest/elements/oneDPL/source/index.html#dpc-execution-policy>`_.
+the |onedpl_long| section of the `oneAPI Specification
+<https://spec.oneapi.com/versions/latest/elements/oneDPL/source/index.html#dpc-execution-policy>`_.
 
 For any of the implemented algorithms, pass one of the execution policies values as the first
 argument in a call to the algorithm to specify the desired execution policy. The policies have
@@ -34,25 +35,25 @@ Execution policy value            Description
 --------------------------------- ------------------------------
 ``par_unseq``                     Combined effect of ``unseq`` and ``par``.
 --------------------------------- ------------------------------
-``dpcpp_default``                 Massive parallel execution on devices using DPC++.
+``dpcpp_default``                 Massive parallel execution on devices using |dpcpp_short|.
 --------------------------------- ------------------------------
 ``dpcpp_fpga``                    Massive parallel execution on FPGA devices.
 ================================= ==============================
 
-Implementation is based on Parallel STL from
-`LLVM <https://github.com/llvm/llvm-project/tree/master/pstl>`_.
+The implementation is based on Parallel STL from the
+`LLVM Project <https://github.com/llvm/llvm-project/tree/main/pstl>`_.
 
 Prerequisites
 ==============
 
-C++11 is the minimal version of the C++ standard, which oneDPL requires. That means, any use of oneDPL
+C++11 is the minimal version of the C++ standard, which |onedpl_short| requires. That means, any use of |onedpl_short|
 requires at least a C++11 compiler. Some uses of the library may require a higher version of C++.
 To use Parallel STL with the C++ standard policies, you must have the following software installed:
 
 * C++ compiler with support for OpenMP* 4.0 (or higher) SIMD constructs
-* oneAPI Threading Building Blocks (oneTBB) or Threading Building Blocks (TBB) 2019 and later
+* |onetbb_long| or |tbb_long| 2019 and later
 
-To use Parallel STL with the DPC++ execution policies, you must have the following software installed:
+To use Parallel STL with the |dpcpp_short| execution policies, you must have the following software installed:
 
 * C++ compiler with support for SYCL* 2020
 

--- a/documentation/library_guide/random.rst
+++ b/documentation/library_guide/random.rst
@@ -1,19 +1,17 @@
 Random Number Generators
 ########################
 
-An introduction to random number generation usage in the oneAPI DPC++ Library (oneDPL).
-
-oneDPL offers support of random number generation, including:
+|onedpl_long| offers support of random number generation, including:
 
 - Random number engines, which generate unsigned integer sequences of random numbers.
-- Random number distributions (example: ``uniform_real_distribution``), which convert the output of
+- Random number distributions (example: ``uniform_real_distribution``), which converts the output of
   random number engines into various statistical distributions.
 
 Random Number Engines
 ---------------------
 
 Random number engines use seed data as an entropy source to generate pseudo-random numbers. 
-oneDPL provides several class templates for customized engines, they are defined in the header
+|onedpl_short| provides several class templates for customized engines, they are defined in the header
 ``<oneapi/dpl/random>``.
 
 ============================== =========================================================================================================
@@ -25,7 +23,7 @@ Engine                         Description
 ============================== =========================================================================================================
 
 Predefined Random Number Engines
------------------------------------
+--------------------------------
 
 Predefined random number engines are instantiations of random number engines class templates. 
 The types below are are defined in the header ``<oneapi/dpl/random>`` under the ``oneapi::dpl::`` namespace.
@@ -76,10 +74,10 @@ Distribution                   Description
 ``normal_distribution``        Produces real values according to the Normal (Gaussian) distribution
 ============================== =========================================================================================================
 
-Usage Model of oneDPL Random Number Generation Functionality
-------------------------------------------------------------
+Usage Model of |onedpl_short| Random Number Generation Functionality
+--------------------------------------------------------------------
 
-Random number generation is available for DPC++ device-side and host-side code. Example:
+Random number generation is available for |dpcpp_long| device-side and host-side code. Example:
 
 .. code:: cpp
 

--- a/documentation/library_guide/tested_standard_cpp_api.rst
+++ b/documentation/library_guide/tested_standard_cpp_api.rst
@@ -1,16 +1,14 @@
 Tested Standard C++ APIs
 ########################
 
-Contains the Tested Standard C++ APIs for oneAPI DPC++ Library (oneDPL).
-
-The basic functionality for a number of C++ standard APIs has been tested for use in DPC++ kernels.
+The basic functionality for a number of C++ standard APIs has been tested for use in |dpcpp_long| kernels.
 These APIs can be employed in device kernels similarly to how they are employed in code for a typical CPU-based platform.
-The Tested Standard C++ APIs are added to namespace ``oneapi::dpl``, corresponding headers have been added in the oneDPL package.
+The Tested Standard C++ APIs are added to namespace ``oneapi::dpl``, corresponding headers have been added in the |onedpl_long| package.
 In order to use these APIs via the namespace ``oneapi::dpl``, the headers in ``<oneapi/dpl/...>`` must be included.
 Currently, Tested Standard C++ APIs can be used in two ways:
 
 #. Via the namespace ``std::`` and standard headers (for example: ``<utility>...``)
-#. Via the namespace ``oneapi::dpl`` and oneDPL headers (for example: ``<oneapi/dpl/utility>...``)
+#. Via the namespace ``oneapi::dpl`` and |onedpl_short| headers (for example: ``<oneapi/dpl/utility>...``)
 
 Below is an example code that shows how to use ``oneapi::dpl::swap`` in SYCL* device code:
 


### PR DESCRIPTION
        modified:   before_you_begin.rst
        modified:   extension_api.rst
        new file:   intel_variables.txt
        modified:   pstl/dpcpp_policies_usage.rst
        modified:   pstl/macros.rst
        modified:   pstl_main.rst
        modified:   random.rst
        modified:   tested_standard_cpp_api.rst
        modified:   variables.txt