### PR TITLE
Implement tag dispatching prototype

### DIFF
--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -134,6 +134,15 @@ __brick_walk1(_DifferenceType __n, _Function __f, ::std::true_type) noexcept
     oneapi::dpl::__internal::__brick_walk1(__n, __f, ::std::false_type{});
 }
 
+template <class _ExecutionPolicy, class _ForwardIterator, class _Function>
+void
+__pattern_walk1(__serial_tag<_ExecutionPolicy, _ForwardIterator> __tag, _ExecutionPolicy&&, _ForwardIterator __first,
+                _ForwardIterator __last, _Function __f) noexcept
+{
+    using __tag_type = decltype(__tag);
+    __internal::__brick_walk1(__first, __last, __f, typename __tag_type::__is_vector{});
+}
+
 template <class _ExecutionPolicy, class _ForwardIterator, class _Function, class _IsVector>
 oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
 __pattern_walk1(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, _Function __f,
@@ -141,6 +150,44 @@ __pattern_walk1(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator _
                 /*parallel=*/::std::false_type) noexcept
 {
     __internal::__brick_walk1(__first, __last, __f, __is_vector);
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Function>
+void
+__pattern_walk1(__parallel_forward_tag<_ExecutionPolicy, _ForwardIterator>, _ExecutionPolicy&& __exec,
+                _ForwardIterator __first, _ForwardIterator __last, _Function __f)
+{
+    typedef typename ::std::iterator_traits<_ForwardIterator>::reference _ReferenceType;
+    auto __func = [&__f](_ReferenceType arg) { __f(arg); };
+    __internal::__except_handler([&]() {
+        __par_backend::__parallel_for_each(::std::forward<_ExecutionPolicy>(__exec), __first, __last, __func);
+    });
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Function>
+void
+__pattern_walk1(__parallel_tag<_ExecutionPolicy, _ForwardIterator> __tag, _ExecutionPolicy&& __exec,
+                _ForwardIterator __first, _ForwardIterator __last, _Function __f)
+{
+    using __tag_type = decltype(__tag);
+    __internal::__except_handler([&]() {
+        __par_backend::__parallel_for(::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                                      [__f](_ForwardIterator __i, _ForwardIterator __j) {
+                                          __internal::__brick_walk1(__i, __j, __f, typename __tag_type::__is_vector{});
+                                      });
+    });
+}
+
+template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate, class _Tp>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+__pattern_replace_if(_Tag __tag, _ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last,
+                     _UnaryPredicate __pred, const _Tp& __new_value)
+{
+    oneapi::dpl::__internal::__pattern_walk1(
+        __tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+        oneapi::dpl::__internal::__replace_functor<
+            oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _Tp>,
+            oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, _UnaryPredicate>>(__new_value, __pred));
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Function, class _IsVector>
@@ -680,25 +727,24 @@ __brick_find_if(_RandomAccessIterator __first, _RandomAccessIterator __last, _Pr
         [&__pred](_RandomAccessIterator __it, _SizeType __i) { return __pred(__it[__i]); });
 }
 
-template <class _ExecutionPolicy, class _ForwardIterator, class _Predicate, class _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, _ForwardIterator>
-__pattern_find_if(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred,
-                  _IsVector __is_vector,
-                  /*is_parallel=*/::std::false_type) noexcept
+template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
+_ForwardIterator
+__pattern_find_if(_Tag __tag, _ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last,
+                  _Predicate __pred) noexcept
 {
-    return __internal::__brick_find_if(__first, __last, __pred, __is_vector);
+    return __internal::__brick_find_if(__first, __last, __pred, typename _Tag::__is_vector{});
 }
 
-template <class _ExecutionPolicy, class _ForwardIterator, class _Predicate, class _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, _ForwardIterator>
-__pattern_find_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred,
-                  _IsVector __is_vector,
-                  /*is_parallel=*/::std::true_type)
+template <class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
+_ForwardIterator
+__pattern_find_if(__parallel_tag<_ExecutionPolicy, _ForwardIterator> __tag, _ExecutionPolicy&& __exec,
+                  _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred)
 {
+    using __tag_type = decltype(__tag);
     return __except_handler([&]() {
         return __parallel_find(::std::forward<_ExecutionPolicy>(__exec), __first, __last,
-                               [__pred, __is_vector](_ForwardIterator __i, _ForwardIterator __j) {
-                                   return __brick_find_if(__i, __j, __pred, __is_vector);
+                               [__pred](_ForwardIterator __i, _ForwardIterator __j) {
+                                   return __brick_find_if(__i, __j, __pred, typename __tag_type::__is_vector{});
                                },
                                ::std::true_type{});
     });

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -134,13 +134,12 @@ __brick_walk1(_DifferenceType __n, _Function __f, ::std::true_type) noexcept
     oneapi::dpl::__internal::__brick_walk1(__n, __f, ::std::false_type{});
 }
 
-template <class _ExecutionPolicy, class _ForwardIterator, class _Function>
+template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _Function>
 void
-__pattern_walk1(__serial_tag<_ExecutionPolicy, _ForwardIterator> __tag, _ExecutionPolicy&&, _ForwardIterator __first,
+__pattern_walk1(_Tag, _ExecutionPolicy&&, _ForwardIterator __first,
                 _ForwardIterator __last, _Function __f) noexcept
 {
-    using __tag_type = decltype(__tag);
-    __internal::__brick_walk1(__first, __last, __f, typename __tag_type::__is_vector{});
+    __internal::__brick_walk1(__first, __last, __f, typename _Tag::__is_vector{});
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Function, class _IsVector>
@@ -154,26 +153,27 @@ __pattern_walk1(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator _
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Function>
 void
-__pattern_walk1(__parallel_forward_tag<_ExecutionPolicy, _ForwardIterator>, _ExecutionPolicy&& __exec,
+__pattern_walk1(__parallel_forward_tag, _ExecutionPolicy&& __exec,
                 _ForwardIterator __first, _ForwardIterator __last, _Function __f)
 {
+
     typedef typename ::std::iterator_traits<_ForwardIterator>::reference _ReferenceType;
     auto __func = [&__f](_ReferenceType arg) { __f(arg); };
     __internal::__except_handler([&]() {
-        __par_backend::__parallel_for_each(::std::forward<_ExecutionPolicy>(__exec), __first, __last, __func);
+        __par_backend::__parallel_for_each(__parallel_forward_tag::__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __func);
     });
 }
 
-template <class _ExecutionPolicy, class _ForwardIterator, class _Function>
+template <class _IsVector, class _ExecutionPolicy, class _ForwardIterator, class _Function>
 void
-__pattern_walk1(__parallel_tag<_ExecutionPolicy, _ForwardIterator> __tag, _ExecutionPolicy&& __exec,
+__pattern_walk1(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec,
                 _ForwardIterator __first, _ForwardIterator __last, _Function __f)
 {
-    using __tag_type = decltype(__tag);
+    using __backend_tag = typename decltype(__tag)::__backend_tag;
     __internal::__except_handler([&]() {
-        __par_backend::__parallel_for(::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+        __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
                                       [__f](_ForwardIterator __i, _ForwardIterator __j) {
-                                          __internal::__brick_walk1(__i, __j, __f, typename __tag_type::__is_vector{});
+                                          __internal::__brick_walk1(__i, __j, __f, _IsVector{});
                                       });
     });
 }
@@ -735,16 +735,17 @@ __pattern_find_if(_Tag __tag, _ExecutionPolicy&&, _ForwardIterator __first, _For
     return __internal::__brick_find_if(__first, __last, __pred, typename _Tag::__is_vector{});
 }
 
-template <class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
+
+template <class _IsVector, class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
 _ForwardIterator
-__pattern_find_if(__parallel_tag<_ExecutionPolicy, _ForwardIterator> __tag, _ExecutionPolicy&& __exec,
+__pattern_find_if(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& __exec,
                   _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred)
 {
-    using __tag_type = decltype(__tag);
+    using __backend_tag = typename decltype(__tag)::__backend_tag;
     return __except_handler([&]() {
-        return __parallel_find(::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+        return __parallel_find(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
                                [__pred](_ForwardIterator __i, _ForwardIterator __j) {
-                                   return __brick_find_if(__i, __j, __pred, typename __tag_type::__is_vector{});
+                                   return __brick_find_if(__i, __j, __pred, _IsVector{});
                                },
                                ::std::true_type{});
     });

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -142,15 +142,6 @@ __pattern_walk1(_Tag, _ExecutionPolicy&&, _ForwardIterator __first,
     __internal::__brick_walk1(__first, __last, __f, typename _Tag::__is_vector{});
 }
 
-template <class _ExecutionPolicy, class _ForwardIterator, class _Function, class _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
-__pattern_walk1(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, _Function __f,
-                _IsVector __is_vector,
-                /*parallel=*/::std::false_type) noexcept
-{
-    __internal::__brick_walk1(__first, __last, __f, __is_vector);
-}
-
 template <class _ExecutionPolicy, class _ForwardIterator, class _Function>
 void
 __pattern_walk1(__parallel_forward_tag, _ExecutionPolicy&& __exec,
@@ -188,34 +179,6 @@ __pattern_replace_if(_Tag __tag, _ExecutionPolicy&& __exec, _ForwardIterator __f
         oneapi::dpl::__internal::__replace_functor<
             oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _Tp>,
             oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, _UnaryPredicate>>(__new_value, __pred));
-}
-
-template <class _ExecutionPolicy, class _ForwardIterator, class _Function, class _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy_conditional<
-    _ExecutionPolicy, __is_random_access_iterator<_ForwardIterator>::value, void>
-__pattern_walk1(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Function __f,
-                _IsVector __is_vector,
-                /*parallel=*/::std::true_type)
-{
-    __internal::__except_handler([&]() {
-        __par_backend::__parallel_for(::std::forward<_ExecutionPolicy>(__exec), __first, __last,
-                                      [__f, __is_vector](_ForwardIterator __i, _ForwardIterator __j) {
-                                          __internal::__brick_walk1(__i, __j, __f, __is_vector);
-                                      });
-    });
-}
-
-template <class _ExecutionPolicy, class _ForwardIterator, class _Function, class _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy_conditional<
-    _ExecutionPolicy, !__is_random_access_iterator<_ForwardIterator>::value, void>
-__pattern_walk1(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Function __f, _IsVector,
-                /*parallel=*/::std::true_type)
-{
-    typedef typename ::std::iterator_traits<_ForwardIterator>::reference _ReferenceType;
-    auto __func = [&__f](_ReferenceType arg) { __f(arg); };
-    __internal::__except_handler([&]() {
-        __par_backend::__parallel_for_each(::std::forward<_ExecutionPolicy>(__exec), __first, __last, __func);
-    });
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Brick>

--- a/include/oneapi/dpl/pstl/execution_defs.h
+++ b/include/oneapi/dpl/pstl/execution_defs.h
@@ -31,88 +31,20 @@ inline namespace v1
 // 2.4, Sequential execution policy
 class sequenced_policy
 {
-  public:
-    // For internal use only
-    static constexpr ::std::false_type
-    __allow_unsequenced()
-    {
-        return ::std::false_type{};
-    }
-    static constexpr ::std::false_type
-    __allow_vector()
-    {
-        return ::std::false_type{};
-    }
-    static constexpr ::std::false_type
-    __allow_parallel()
-    {
-        return ::std::false_type{};
-    }
 };
 
 // 2.5, Parallel execution policy
 class parallel_policy
 {
-  public:
-    // For internal use only
-    static constexpr ::std::false_type
-    __allow_unsequenced()
-    {
-        return ::std::false_type{};
-    }
-    static constexpr ::std::false_type
-    __allow_vector()
-    {
-        return ::std::false_type{};
-    }
-    static constexpr ::std::true_type
-    __allow_parallel()
-    {
-        return ::std::true_type{};
-    }
 };
 
 // 2.6, Parallel+Vector execution policy
 class parallel_unsequenced_policy
 {
-  public:
-    // For internal use only
-    static constexpr ::std::true_type
-    __allow_unsequenced()
-    {
-        return ::std::true_type{};
-    }
-    static constexpr ::std::true_type
-    __allow_vector()
-    {
-        return ::std::true_type{};
-    }
-    static constexpr ::std::true_type
-    __allow_parallel()
-    {
-        return ::std::true_type{};
-    }
 };
 
 class unsequenced_policy
 {
-  public:
-    // For internal use only
-    static constexpr ::std::true_type
-    __allow_unsequenced()
-    {
-        return ::std::true_type{};
-    }
-    static constexpr ::std::true_type
-    __allow_vector()
-    {
-        return ::std::true_type{};
-    }
-    static constexpr ::std::false_type
-    __allow_parallel()
-    {
-        return ::std::false_type{};
-    }
 };
 
 // 2.8, Execution policy objects
@@ -181,15 +113,6 @@ struct __is_host_execution_policy<oneapi::dpl::execution::unsequenced_policy> : 
 template <class _ExecPolicy, class _T>
 using __enable_if_execution_policy = typename ::std::enable_if<
     oneapi::dpl::execution::is_execution_policy<typename ::std::decay<_ExecPolicy>::type>::value, _T>::type;
-
-template <class _ExecPolicy, class _T>
-using __enable_if_host_execution_policy = typename ::std::enable_if<
-    oneapi::dpl::__internal::__is_host_execution_policy<typename ::std::decay<_ExecPolicy>::type>::value, _T>::type;
-
-template <class _ExecPolicy, const bool __condition, class _T>
-using __enable_if_host_execution_policy_conditional = typename ::std::enable_if<
-    oneapi::dpl::__internal::__is_host_execution_policy<typename ::std::decay<_ExecPolicy>::type>::value && __condition,
-    _T>::type;
 
 template <typename _ExecPolicy, typename _T>
 struct __ref_or_copy_impl

--- a/include/oneapi/dpl/pstl/execution_impl.h
+++ b/include/oneapi/dpl/pstl/execution_impl.h
@@ -131,21 +131,55 @@ __is_parallelization_preferred(_ExecutionPolicy& __exec)
                                   typename __internal::__is_random_access_iterator<_IteratorTypes...>::type());
 }
 
-template <typename policy, typename... _IteratorTypes>
-struct __prefer_unsequenced_tag
+//------------------------------------------------------------------------
+// backend selector with tags
+//------------------------------------------------------------------------
+
+template <class _Policy, class... _IteratorTypes>
+struct __vectorable_tag
 {
-    static constexpr bool value = __internal::__allow_unsequenced<policy>::value &&
-                                  __internal::__is_random_access_iterator<_IteratorTypes...>::value;
-    typedef ::std::integral_constant<bool, value> type;
+    using __is_vector = __conjunction<__allow_unsequenced<_Policy>,
+                                      typename __internal::__is_random_access_iterator<_IteratorTypes...>>;
 };
 
-template <typename policy, typename... _IteratorTypes>
-struct __prefer_parallel_tag
+template <class _Policy, class... _IteratorTypes>
+struct __serial_tag : __vectorable_tag<_Policy, _IteratorTypes...>
 {
-    static constexpr bool value = __internal::__allow_parallel<policy>::value &&
-                                  __internal::__is_random_access_iterator<_IteratorTypes...>::value;
-    typedef ::std::integral_constant<bool, value> type;
 };
+
+template <class _Policy, class... _IteratorTypes>
+struct __parallel_tag : __vectorable_tag<_Policy, _IteratorTypes...>
+{
+};
+
+template <class _Policy, class... _IteratorTypes>
+struct __parallel_forward_tag : __vectorable_tag<_Policy, _IteratorTypes...>
+{
+};
+
+template <typename _Policy, typename... _IteratorTypes>
+using __tag_type =
+    typename ::std::conditional<__internal::__is_random_access_iterator<_IteratorTypes...>::value,
+                                __parallel_tag<_Policy, _IteratorTypes...>,
+                                typename ::std::conditional<__is_forward_iterator<_IteratorTypes...>::value,
+                                                            __parallel_forward_tag<_Policy, _IteratorTypes...>,
+                                                            __serial_tag<_Policy, _IteratorTypes...>>::type>::type;
+
+template <typename _Policy, class... _IteratorTypes>
+typename ::std::enable_if<!__allow_parallel<_Policy>::value,
+                          __serial_tag<_Policy, typename ::std::decay<_IteratorTypes>::type...>>::type
+__select_backend(_Policy&&, _IteratorTypes&&...)
+{
+    return {};
+}
+
+template <typename _Policy, class... _IteratorTypes>
+typename ::std::enable_if<__allow_parallel<_Policy>::value,
+                          __tag_type<_Policy, typename ::std::decay<_IteratorTypes>::type...>>::type
+__select_backend(_Policy&&, _IteratorTypes&&...)
+{
+    return {};
+}
 
 } // namespace __internal
 } // namespace dpl

--- a/include/oneapi/dpl/pstl/execution_impl.h
+++ b/include/oneapi/dpl/pstl/execution_impl.h
@@ -135,48 +135,65 @@ __is_parallelization_preferred(_ExecutionPolicy& __exec)
 // backend selector with tags
 //------------------------------------------------------------------------
 
-template <class _Policy, class... _IteratorTypes>
-struct __vectorable_tag
+struct __tbb_backend {};
+
+template <class _IsVector>
+struct __serial_tag
 {
-    using __is_vector = __conjunction<__allow_unsequenced<_Policy>,
-                                      typename __internal::__is_random_access_iterator<_IteratorTypes...>>;
+    using __is_vector = _IsVector;
 };
 
-template <class _Policy, class... _IteratorTypes>
-struct __serial_tag : __vectorable_tag<_Policy, _IteratorTypes...>
+template <class _IsVector>
+struct __parallel_tag
 {
+    using __is_vector = _IsVector;
+    // backend tag can be change depending on
+    // TBB availability in the environment
+    using __backend_tag = __tbb_backend;
 };
 
-template <class _Policy, class... _IteratorTypes>
-struct __parallel_tag : __vectorable_tag<_Policy, _IteratorTypes...>
+struct __parallel_forward_tag
 {
+    using __is_vector = ::std::false_type;
+    // backend tag can be change depending on
+    // TBB availability in the environment
+    using __backend_tag = __tbb_backend;
 };
 
-template <class _Policy, class... _IteratorTypes>
-struct __parallel_forward_tag : __vectorable_tag<_Policy, _IteratorTypes...>
-{
-};
-
-template <typename _Policy, typename... _IteratorTypes>
+template <class _IsVector, class... _IteratorTypes>
 using __tag_type =
     typename ::std::conditional<__internal::__is_random_access_iterator<_IteratorTypes...>::value,
-                                __parallel_tag<_Policy, _IteratorTypes...>,
+                                __parallel_tag<_IsVector>,
                                 typename ::std::conditional<__is_forward_iterator<_IteratorTypes...>::value,
-                                                            __parallel_forward_tag<_Policy, _IteratorTypes...>,
-                                                            __serial_tag<_Policy, _IteratorTypes...>>::type>::type;
+                                                            __parallel_forward_tag,
+                                                            __serial_tag<_IsVector>
+                                                            >::type
+                                >::type;
 
-template <typename _Policy, class... _IteratorTypes>
-typename ::std::enable_if<!__allow_parallel<_Policy>::value,
-                          __serial_tag<_Policy, typename ::std::decay<_IteratorTypes>::type...>>::type
-__select_backend(_Policy&&, _IteratorTypes&&...)
+template <class... _IteratorTypes>
+__serial_tag<std::false_type>
+__select_backend(oneapi::dpl::execution::sequenced_policy, _IteratorTypes&&...)
 {
     return {};
 }
 
-template <typename _Policy, class... _IteratorTypes>
-typename ::std::enable_if<__allow_parallel<_Policy>::value,
-                          __tag_type<_Policy, typename ::std::decay<_IteratorTypes>::type...>>::type
-__select_backend(_Policy&&, _IteratorTypes&&...)
+template <class... _IteratorTypes>
+__serial_tag<__internal::__is_random_access_iterator<_IteratorTypes...>>
+__select_backend(oneapi::dpl::execution::unsequenced_policy, _IteratorTypes&&...)
+{
+    return {};
+}
+
+template <class... _IteratorTypes>
+__tag_type<std::false_type, _IteratorTypes...>
+__select_backend(oneapi::dpl::execution::parallel_policy, _IteratorTypes&&...)
+{
+    return {};
+}
+
+template <class... _IteratorTypes>
+__tag_type<__internal::__is_random_access_iterator<_IteratorTypes...>, _IteratorTypes...>
+__select_backend(oneapi::dpl::execution::parallel_unsequenced_policy, _IteratorTypes&&...)
 {
     return {};
 }

--- a/include/oneapi/dpl/pstl/execution_impl.h
+++ b/include/oneapi/dpl/pstl/execution_impl.h
@@ -29,34 +29,6 @@ namespace dpl
 namespace __internal
 {
 
-/* predicate */
-
-template <typename _Tp>
-::std::false_type __lazy_and(_Tp, ::std::false_type)
-{
-    return ::std::false_type{};
-}
-
-template <typename _Tp>
-inline _Tp
-__lazy_and(_Tp __a, ::std::true_type)
-{
-    return __a;
-}
-
-template <typename _Tp>
-::std::true_type __lazy_or(_Tp, ::std::true_type)
-{
-    return ::std::true_type{};
-}
-
-template <typename _Tp>
-inline _Tp
-__lazy_or(_Tp __a, ::std::false_type)
-{
-    return __a;
-}
-
 /* policy */
 template <typename Policy>
 struct __policy_traits
@@ -96,10 +68,6 @@ struct __policy_traits<oneapi::dpl::execution::parallel_unsequenced_policy>
 };
 
 template <typename _ExecutionPolicy>
-using __collector_t =
-    typename __internal::__policy_traits<typename ::std::decay<_ExecutionPolicy>::type>::__collector_type;
-
-template <typename _ExecutionPolicy>
 using __allow_vector =
     typename __internal::__policy_traits<typename ::std::decay<_ExecutionPolicy>::type>::__allow_vector;
 
@@ -110,26 +78,6 @@ using __allow_unsequenced =
 template <typename _ExecutionPolicy>
 using __allow_parallel =
     typename __internal::__policy_traits<typename ::std::decay<_ExecutionPolicy>::type>::__allow_parallel;
-
-template <typename _ExecutionPolicy, typename... _IteratorTypes>
-auto
-__is_vectorization_preferred(_ExecutionPolicy& __exec)
-    -> decltype(__internal::__lazy_and(__exec.__allow_vector(),
-                                       typename __internal::__is_random_access_iterator<_IteratorTypes...>::type()))
-{
-    return __internal::__lazy_and(__exec.__allow_vector(),
-                                  typename __internal::__is_random_access_iterator<_IteratorTypes...>::type());
-}
-
-template <typename _ExecutionPolicy, typename... _IteratorTypes>
-auto
-__is_parallelization_preferred(_ExecutionPolicy& __exec)
-    -> decltype(__internal::__lazy_and(__exec.__allow_parallel(),
-                                       typename __internal::__is_random_access_iterator<_IteratorTypes...>::type()))
-{
-    return __internal::__lazy_and(__exec.__allow_parallel(),
-                                  typename __internal::__is_random_access_iterator<_IteratorTypes...>::type());
-}
 
 //------------------------------------------------------------------------
 // backend selector with tags

--- a/include/oneapi/dpl/pstl/glue_algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_impl.h
@@ -97,7 +97,7 @@ template <class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 find_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred)
 {
-    auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(std::forward<_ExecutionPolicy>(__exec), __first);
+    auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
     return oneapi::dpl::__internal::__pattern_find_if(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first,
                                                       __last, __pred);
@@ -363,7 +363,7 @@ oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
 replace_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred,
            const _Tp& __new_value)
 {
-    auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(::std::forward<_ExecutionPolicy>(__exec), __first);
+    auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
     __pattern_replace_if(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __pred,
                          __new_value);
 }

--- a/include/oneapi/dpl/pstl/glue_algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_impl.h
@@ -97,10 +97,10 @@ template <class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 find_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred)
 {
-    return oneapi::dpl::__internal::__pattern_find_if(
-        ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __pred,
-        oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
-        oneapi::dpl::__internal::__is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
+    auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(std::forward<_ExecutionPolicy>(__exec), __first);
+
+    return oneapi::dpl::__internal::__pattern_find_if(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first,
+                                                      __last, __pred);
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
@@ -363,13 +363,9 @@ oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
 replace_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred,
            const _Tp& __new_value)
 {
-    oneapi::dpl::__internal::__pattern_walk1(
-        ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
-        oneapi::dpl::__internal::__replace_functor<
-            oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _Tp>,
-            oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, _UnaryPredicate>>(__new_value, __pred),
-        oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
-        oneapi::dpl::__internal::__is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
+    auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(::std::forward<_ExecutionPolicy>(__exec), __first);
+    __pattern_replace_if(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __pred,
+                         __new_value);
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -54,6 +54,24 @@ __pattern_walk1(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIte
         .wait();
 }
 
+template <typename _ExecutionPolicy, typename _ForwardIterator, typename _Function>
+void
+__pattern_walk1(__offload_tag, _ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last,
+                _Function __f)
+{
+    auto __n = __last - __first;
+    if (__n <= 0)
+        return;
+
+    auto __keep =
+        oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read_write, _ForwardIterator>();
+    auto __buf = __keep(__first, __last);
+
+    oneapi::dpl::__par_backend_hetero::__parallel_for(__exec, unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f},
+                                                      __n, __buf.all_view())
+        .wait();
+}
+
 //------------------------------------------------------------------------
 // walk1_n
 //------------------------------------------------------------------------
@@ -707,9 +725,8 @@ __pattern_equal(_ExecutionPolicy&& __exec, _Iterator1 __first1, _Iterator1 __las
 //------------------------------------------------------------------------
 
 template <typename _ExecutionPolicy, typename _Iterator, typename _Pred>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, _Iterator>
-__pattern_find_if(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, _Pred __pred,
-                  /*vector=*/::std::true_type, /*parallel=*/::std::true_type)
+_Iterator
+__pattern_find_if(__offload_tag, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, _Pred __pred)
 {
     if (__first == __last)
         return __last;

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -36,24 +36,6 @@ namespace __internal
 // walk1
 //------------------------------------------------------------------------
 
-template <typename _ExecutionPolicy, typename _ForwardIterator, typename _Function>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, void>
-__pattern_walk1(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Function __f,
-                /*vector=*/::std::true_type, /*parallel=*/::std::true_type)
-{
-    auto __n = __last - __first;
-    if (__n <= 0)
-        return;
-
-    auto __keep =
-        oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read_write, _ForwardIterator>();
-    auto __buf = __keep(__first, __last);
-
-    oneapi::dpl::__par_backend_hetero::__parallel_for(__exec, unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f},
-                                                      __n, __buf.all_view())
-        .wait();
-}
-
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator, typename _Function>
 void
 __pattern_walk1(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last,

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -54,9 +54,9 @@ __pattern_walk1(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIte
         .wait();
 }
 
-template <typename _ExecutionPolicy, typename _ForwardIterator, typename _Function>
+template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator, typename _Function>
 void
-__pattern_walk1(__offload_tag, _ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last,
+__pattern_walk1(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last,
                 _Function __f)
 {
     auto __n = __last - __first;
@@ -67,7 +67,7 @@ __pattern_walk1(__offload_tag, _ExecutionPolicy&& __exec, _ForwardIterator __fir
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read_write, _ForwardIterator>();
     auto __buf = __keep(__first, __last);
 
-    oneapi::dpl::__par_backend_hetero::__parallel_for(__exec, unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f},
+    oneapi::dpl::__par_backend_hetero::__parallel_for(_BackendTag{}, __exec, unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f},
                                                       __n, __buf.all_view())
         .wait();
 }
@@ -724,16 +724,16 @@ __pattern_equal(_ExecutionPolicy&& __exec, _Iterator1 __first1, _Iterator1 __las
 // find_if
 //------------------------------------------------------------------------
 
-template <typename _ExecutionPolicy, typename _Iterator, typename _Pred>
+template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _Pred>
 _Iterator
-__pattern_find_if(__offload_tag, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, _Pred __pred)
+__pattern_find_if(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, _Pred __pred)
 {
     if (__first == __last)
         return __last;
 
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<_ExecutionPolicy, _Pred>;
 
-    return __par_backend_hetero::__parallel_find(
+    return __par_backend_hetero::__parallel_find(_BackendTag{},
         ::std::forward<_ExecutionPolicy>(__exec),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__last), _Predicate{__pred},

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -62,24 +62,6 @@ class device_policy
         return q;
     }
 
-    // For internal use only
-    static constexpr ::std::true_type
-    __allow_unsequenced()
-    {
-        return ::std::true_type{};
-    }
-    // __allow_vector is needed for __is_vectorization_preferred
-    static constexpr ::std::true_type
-    __allow_vector()
-    {
-        return ::std::true_type{};
-    }
-    static constexpr ::std::true_type
-    __allow_parallel()
-    {
-        return ::std::true_type{};
-    }
-
   private:
     sycl::queue q;
 };
@@ -231,43 +213,7 @@ struct is_execution_policy<__dpl::fpga_policy<unroll_factor, PolicyParams...>> :
 namespace __internal
 {
 
-// Extension: hetero execution policy type trait
-template <typename _T>
-struct __is_hetero_execution_policy : ::std::false_type
-{
-};
-
-template <typename... PolicyParams>
-struct __is_hetero_execution_policy<execution::device_policy<PolicyParams...>> : ::std::true_type
-{
-};
-
-template <typename _T>
-struct __is_device_execution_policy : ::std::false_type
-{
-};
-
-template <typename... PolicyParams>
-struct __is_device_execution_policy<execution::device_policy<PolicyParams...>> : ::std::true_type
-{
-};
-
-template <typename _T>
-struct __is_fpga_execution_policy : ::std::false_type
-{
-};
-
 #if _ONEDPL_FPGA_DEVICE
-template <unsigned int unroll_factor, typename... PolicyParams>
-struct __is_hetero_execution_policy<execution::fpga_policy<unroll_factor, PolicyParams...>> : ::std::true_type
-{
-};
-
-template <unsigned int unroll_factor, typename... PolicyParams>
-struct __is_fpga_execution_policy<execution::fpga_policy<unroll_factor, PolicyParams...>> : ::std::true_type
-{
-};
-
 template <typename _T, unsigned int unroll_factor, typename... PolicyParams>
 struct __ref_or_copy_impl<execution::fpga_policy<unroll_factor, PolicyParams...>, _T>
 {
@@ -298,24 +244,11 @@ template <typename _T, typename... _Events>
 using __enable_if_convertible_to_events =
     typename ::std::enable_if<oneapi::dpl::__internal::__is_convertible_to_event<_Events...>::value, _T>::type;
 
-// Extension: execution policies type traits
-template <typename _ExecPolicy, typename _T, typename... _Events>
-using __enable_if_device_execution_policy = typename ::std::enable_if<
-    oneapi::dpl::__internal::__is_device_execution_policy<typename ::std::decay<_ExecPolicy>::type>::value &&
-        oneapi::dpl::__internal::__is_convertible_to_event<_Events...>::value,
-    _T>::type;
-
-template <typename _ExecPolicy, typename _T>
-using __enable_if_hetero_execution_policy = typename ::std::enable_if<
-    oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<_ExecPolicy>::type>::value, _T>::type;
-
-template <typename _ExecPolicy, typename _T>
-using __enable_if_fpga_execution_policy = typename ::std::enable_if<
-    oneapi::dpl::__internal::__is_fpga_execution_policy<typename ::std::decay<_ExecPolicy>::type>::value, _T>::type;
 
 template <typename _BackendTag>
 struct __hetero_tag
 {
+    // __backend_tag to do not duplicate the algorithm_impl level
     using __backend_tag = _BackendTag;
 };
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -19,6 +19,7 @@
 #include <CL/sycl.hpp>
 #include "../../onedpl_config.h"
 #include "../../execution_defs.h"
+#include "../../iterator_defs.h"
 #if _ONEDPL_FPGA_DEVICE
 #    include <CL/sycl/INTEL/fpga_extensions.hpp>
 #endif
@@ -311,6 +312,17 @@ using __enable_if_hetero_execution_policy = typename ::std::enable_if<
 template <typename _ExecPolicy, typename _T>
 using __enable_if_fpga_execution_policy = typename ::std::enable_if<
     oneapi::dpl::__internal::__is_fpga_execution_policy<typename ::std::decay<_ExecPolicy>::type>::value, _T>::type;
+
+struct __offload_tag
+{
+};
+
+template <class... _IteratorTypes, typename... _PolicyParams>
+typename ::std::enable_if<__is_random_access_iterator<_IteratorTypes...>::value, __offload_tag>::type
+__select_backend(const execution::device_policy<_PolicyParams...>&, _IteratorTypes&&...)
+{
+    return {};
+}
 
 //-----------------------------------------------------------------------------
 // Device run-time information helpers

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -262,6 +262,31 @@ __parallel_for(_ExecutionPolicy&& __exec, _Fp __brick, _Index __count, _Ranges&&
     return __future<void>(__event);
 }
 
+template <typename _ExecutionPolicy, typename _Fp, typename _Index, typename... _Ranges>
+__future<void>
+__parallel_for(oneapi::dpl::__internal::__device_backend, _ExecutionPolicy&& __exec, _Fp __brick, _Index __count, _Ranges&&... __rngs)
+{
+    assert(__get_first_range_size(__rngs...) > 0);
+
+    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _CustomName = typename _Policy::kernel_name;
+    using _ForKernel = oneapi::dpl::__par_backend_hetero::__internal::_KernelName_t<__parallel_for_kernel, _CustomName,
+                                                                                    _Fp, _Ranges...>;
+
+    _PRINT_INFO_IN_DEBUG_MODE(__exec);
+    auto __event = __exec.queue().submit([&__rngs..., &__brick, __count](sycl::handler& __cgh) {
+        //get an access to data under SYCL buffer:
+        oneapi::dpl::__ranges::__require_access(__cgh, __rngs...);
+
+        __cgh.parallel_for<_ForKernel>(sycl::range</*dim=*/1>(__count), [=](sycl::item</*dim=*/1> __item_id) {
+            auto __idx = __item_id.get_linear_id();
+            __brick(__idx, __rngs...);
+        });
+    });
+
+    return __future<void>(__event);
+}
+
 //------------------------------------------------------------------------
 // parallel_transform_reduce - sync pattern
 //------------------------------------------------------------------------
@@ -780,6 +805,22 @@ __parallel_find(_ExecutionPolicy&& __exec, _Iterator1 __first, _Iterator1 __last
 template <typename _ExecutionPolicy, typename _Iterator, typename _Brick, typename _IsFirst>
 oneapi::dpl::__internal::__enable_if_device_execution_policy<_ExecutionPolicy, _Iterator>
 __parallel_find(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, _Brick __f, _IsFirst)
+{
+    auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
+    auto __buf = __keep(__first, __last);
+
+    using _TagType =
+        typename ::std::conditional<_IsFirst::value, __parallel_find_forward_tag<decltype(__buf.all_view())>,
+                                    __parallel_find_backward_tag<decltype(__buf.all_view())>>::type;
+    return __first + oneapi::dpl::__par_backend_hetero::__parallel_find_or(
+                         __par_backend_hetero::make_wrapped_policy<__find_policy_wrapper>(
+                             ::std::forward<_ExecutionPolicy>(__exec)),
+                         __f, _TagType{}, __buf.all_view());
+}
+
+template <typename _ExecutionPolicy, typename _Iterator, typename _Brick, typename _IsFirst>
+_Iterator
+__parallel_find(oneapi::dpl::__internal::__device_backend, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, _Brick __f, _IsFirst)
 {
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
     auto __buf = __keep(__first, __last);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -239,30 +239,6 @@ class __parallel_sort_copy_back_kernel : public __kernel_name_base<__parallel_so
 //General version of parallel_for, one additional parameter - __count of iterations of loop __cgh.parallel_for,
 //for some algorithms happens that size of processing range is n, but amount of iterations is n/2.
 template <typename _ExecutionPolicy, typename _Fp, typename _Index, typename... _Ranges>
-oneapi::dpl::__internal::__enable_if_device_execution_policy<_ExecutionPolicy, __future<void>>
-__parallel_for(_ExecutionPolicy&& __exec, _Fp __brick, _Index __count, _Ranges&&... __rngs)
-{
-    assert(__get_first_range_size(__rngs...) > 0);
-
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
-    using _CustomName = typename _Policy::kernel_name;
-    using _ForKernel = oneapi::dpl::__par_backend_hetero::__internal::_KernelName_t<__parallel_for_kernel, _CustomName,
-                                                                                    _Fp, _Ranges...>;
-
-    _PRINT_INFO_IN_DEBUG_MODE(__exec);
-    auto __event = __exec.queue().submit([&__rngs..., &__brick, __count](sycl::handler& __cgh) {
-        //get an access to data under SYCL buffer:
-        oneapi::dpl::__ranges::__require_access(__cgh, __rngs...);
-
-        __cgh.parallel_for<_ForKernel>(sycl::range</*dim=*/1>(__count), [=](sycl::item</*dim=*/1> __item_id) {
-            auto __idx = __item_id.get_linear_id();
-            __brick(__idx, __rngs...);
-        });
-    });
-    return __future<void>(__event);
-}
-
-template <typename _ExecutionPolicy, typename _Fp, typename _Index, typename... _Ranges>
 __future<void>
 __parallel_for(oneapi::dpl::__internal::__device_backend, _ExecutionPolicy&& __exec, _Fp __brick, _Index __count, _Ranges&&... __rngs)
 {
@@ -802,22 +778,6 @@ __parallel_find(_ExecutionPolicy&& __exec, _Iterator1 __first, _Iterator1 __last
 // Special overload for single sequence cases.
 // TODO: check if similar pattern may apply to other algorithms. If so, these overloads should be moved out of
 // backend code.
-template <typename _ExecutionPolicy, typename _Iterator, typename _Brick, typename _IsFirst>
-oneapi::dpl::__internal::__enable_if_device_execution_policy<_ExecutionPolicy, _Iterator>
-__parallel_find(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, _Brick __f, _IsFirst)
-{
-    auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
-    auto __buf = __keep(__first, __last);
-
-    using _TagType =
-        typename ::std::conditional<_IsFirst::value, __parallel_find_forward_tag<decltype(__buf.all_view())>,
-                                    __parallel_find_backward_tag<decltype(__buf.all_view())>>::type;
-    return __first + oneapi::dpl::__par_backend_hetero::__parallel_find_or(
-                         __par_backend_hetero::make_wrapped_policy<__find_policy_wrapper>(
-                             ::std::forward<_ExecutionPolicy>(__exec)),
-                         __f, _TagType{}, __buf.all_view());
-}
-
 template <typename _ExecutionPolicy, typename _Iterator, typename _Brick, typename _IsFirst>
 _Iterator
 __parallel_find(oneapi::dpl::__internal::__device_backend, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, _Brick __f, _IsFirst)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
@@ -75,6 +75,38 @@ __parallel_for(_ExecutionPolicy&& __exec, _Fp __brick, _Index __count, _Ranges&&
     return __future<void>(__event);
 }
 
+template <typename _ExecutionPolicy, typename _Fp, typename _Index, typename... _Ranges>
+__future<void>
+__parallel_for(oneapi::dpl::__internal::__fpga_backend, _ExecutionPolicy&& __exec, _Fp __brick, _Index __count, _Ranges&&... __rngs)
+{
+    auto __n = __get_first_range_size(__rngs...);
+    assert(__n > 0);
+
+    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using __kernel_name = typename _Policy::kernel_name;
+#if __SYCL_UNNAMED_LAMBDA__
+    using __kernel_name_t = __parallel_for_kernel<_Fp, __kernel_name, _Ranges...>;
+#else
+    using __kernel_name_t = __parallel_for_kernel<__kernel_name>;
+#endif
+
+    _PRINT_INFO_IN_DEBUG_MODE(__exec);
+    auto __event = __exec.queue().submit([&__rngs..., &__brick, __count](sycl::handler& __cgh) {
+        //get an access to data under SYCL buffer:
+        oneapi::dpl::__ranges::__require_access(__cgh, __rngs...);
+
+        __cgh.single_task<__kernel_name_t>([=]() {
+#pragma unroll(::std::decay <_ExecutionPolicy>::type::unroll_factor)
+            for (auto __idx = 0; __idx < __count; ++__idx)
+            {
+                __brick(__idx, __rngs...);
+            }
+        });
+    });
+
+    return __future<void>(__event);
+}
+
 //------------------------------------------------------------------------
 // parallel_transform_reduce
 //------------------------------------------------------------------------
@@ -165,6 +197,7 @@ oneapi::dpl::__internal::__enable_if_fpga_execution_policy<_ExecutionPolicy, _It
 __parallel_find(_ExecutionPolicy&& __exec, _Iterator1 __first, _Iterator1 __last, _Iterator2 __s_first,
                 _Iterator2 __s_last, _Brick __f, _IsFirst __is_first)
 {
+
     // workaround until we implement more performant version for patterns
     using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
     using __kernel_name = typename _Policy::kernel_name;
@@ -182,6 +215,17 @@ __parallel_find(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, 
     using __kernel_name = typename _Policy::kernel_name;
     auto __device_policy = oneapi::dpl::execution::make_device_policy<__kernel_name>(__exec.queue());
     return oneapi::dpl::__par_backend_hetero::__parallel_find(__device_policy, __first, __last, __f, __is_first);
+}
+
+template <typename _ExecutionPolicy, typename _Iterator, typename _Brick, typename _IsFirst>
+_Iterator
+__parallel_find(oneapi::dpl::__internal::__fpga_backend __tag, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, _Brick __f, _IsFirst __is_first)
+{
+    // workaround until we implement more performant version for patterns
+    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using __kernel_name = typename _Policy::kernel_name;
+    auto __device_policy = oneapi::dpl::execution::make_device_policy<__kernel_name>(__exec.queue());
+    return oneapi::dpl::__par_backend_hetero::__parallel_find(oneapi::dpl::__internal::__device_backend{}, __device_policy, __first, __last, __f, __is_first);
 }
 
 template <typename _ExecutionPolicy>

--- a/include/oneapi/dpl/pstl/iterator_defs.h
+++ b/include/oneapi/dpl/pstl/iterator_defs.h
@@ -54,7 +54,7 @@ struct __iterator_traits<_Tp*, void> : ::std::iterator_traits<_Tp*>
 //SFINAE with a non-iterator type by providing a default value.
 template <typename _IteratorTag, typename... _IteratorTypes>
 auto
-__is_needed_iter(int)
+__is_iterator_of(int)
     -> decltype(__conjunction<::std::is_base_of<_IteratorTag, typename __iterator_traits<typename ::std::decay<
                                                                   _IteratorTypes>::type>::iterator_category>...>{});
 
@@ -63,12 +63,12 @@ auto
 __is_needed_iter(...) -> ::std::false_type;
 
 template <typename... _IteratorTypes>
-struct __is_random_access_iterator : decltype(__is_needed_iter<::std::random_access_iterator_tag, _IteratorTypes...>(0))
+struct __is_random_access_iterator : decltype(__is_iterator_of<::std::random_access_iterator_tag, _IteratorTypes...>(0))
 {
 };
 
 template <typename... _IteratorTypes>
-struct __is_forward_iterator : decltype(__is_needed_iter<::std::forward_iterator_tag, _IteratorTypes...>(0))
+struct __is_forward_iterator : decltype(__is_iterator_of<::std::forward_iterator_tag, _IteratorTypes...>(0))
 {
 };
 

--- a/include/oneapi/dpl/pstl/iterator_defs.h
+++ b/include/oneapi/dpl/pstl/iterator_defs.h
@@ -50,30 +50,25 @@ struct __iterator_traits<_Tp*, void> : ::std::iterator_traits<_Tp*>
 {
 };
 
-// Make is_random_access_iterator not to fail with a 'hard' error when it's used in SFINAE with
-// a non-iterator type by providing a default value.
-template <typename _IteratorType, typename = void>
-struct __is_random_access_iterator_impl : ::std::false_type
+// Make is_random_access_iterator and is_forward_iterator not to fail with a 'hard' error when it's used in
+//SFINAE with a non-iterator type by providing a default value.
+template <typename _IteratorTag, typename... _IteratorTypes>
+auto
+__is_needed_iter(int)
+    -> decltype(__conjunction<::std::is_base_of<_IteratorTag, typename __iterator_traits<typename ::std::decay<
+                                                                  _IteratorTypes>::type>::iterator_category>...>{});
+
+template <typename... _IteratorTypes>
+auto
+__is_needed_iter(...) -> ::std::false_type;
+
+template <typename... _IteratorTypes>
+struct __is_random_access_iterator : decltype(__is_needed_iter<::std::random_access_iterator_tag, _IteratorTypes...>(0))
 {
 };
 
-template <typename _IteratorType>
-struct __is_random_access_iterator_impl<_IteratorType,
-                                        __void_type<typename __iterator_traits<_IteratorType>::iterator_category>>
-    : ::std::is_same<typename __iterator_traits<_IteratorType>::iterator_category, ::std::random_access_iterator_tag>
-{
-};
-
-/* iterator */
-template <typename _IteratorType, typename... _OtherIteratorTypes>
-struct __is_random_access_iterator
-    : ::std::conditional<__is_random_access_iterator_impl<_IteratorType>::value,
-                         __is_random_access_iterator<_OtherIteratorTypes...>, ::std::false_type>::type
-{
-};
-
-template <typename _IteratorType>
-struct __is_random_access_iterator<_IteratorType> : __is_random_access_iterator_impl<_IteratorType>
+template <typename... _IteratorTypes>
+struct __is_forward_iterator : decltype(__is_needed_iter<::std::forward_iterator_tag, _IteratorTypes...>(0))
 {
 };
 

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -121,6 +121,17 @@ __parallel_for(_ExecutionPolicy&&, _Index __first, _Index __last, _Fp __f)
 }
 
 //! Evaluation of brick f[i,j) for each subrange [i,j) of [first,last)
+// wrapper over tbb::parallel_for
+template <class _ExecutionPolicy, class _Index, class _Fp>
+void
+__parallel_for(oneapi::dpl::__internal::__tbb_backend, _ExecutionPolicy&&, _Index __first, _Index __last, _Fp __f)
+{
+    tbb::this_task_arena::isolate([=]() {
+        tbb::parallel_for(tbb::blocked_range<_Index>(__first, __last), __parallel_for_body<_Index, _Fp>(__f));
+    });
+}
+
+//! Evaluation of brick f[i,j) for each subrange [i,j) of [first,last)
 // wrapper over tbb::parallel_reduce
 template <class _ExecutionPolicy, class _Value, class _Index, typename _RealBody, typename _Reduction>
 _Value
@@ -1309,6 +1320,13 @@ __parallel_invoke(_ExecutionPolicy&&, _F1&& __f1, _F2&& __f2)
 template <class _ExecutionPolicy, class _ForwardIterator, class _Fp>
 void
 __parallel_for_each(_ExecutionPolicy&&, _ForwardIterator __begin, _ForwardIterator __end, _Fp __f)
+{
+    tbb::this_task_arena::isolate([&]() { tbb::parallel_for_each(__begin, __end, __f); });
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Fp>
+void
+__parallel_for_each(oneapi::dpl::__internal::__tbb_backend, _ExecutionPolicy&&, _ForwardIterator __begin, _ForwardIterator __end, _Fp __f)
 {
     tbb::this_task_arena::isolate([&]() { tbb::parallel_for_each(__begin, __end, __f); });
 }

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -113,17 +113,6 @@ class __parallel_for_body
 // wrapper over tbb::parallel_for
 template <class _ExecutionPolicy, class _Index, class _Fp>
 void
-__parallel_for(_ExecutionPolicy&&, _Index __first, _Index __last, _Fp __f)
-{
-    tbb::this_task_arena::isolate([=]() {
-        tbb::parallel_for(tbb::blocked_range<_Index>(__first, __last), __parallel_for_body<_Index, _Fp>(__f));
-    });
-}
-
-//! Evaluation of brick f[i,j) for each subrange [i,j) of [first,last)
-// wrapper over tbb::parallel_for
-template <class _ExecutionPolicy, class _Index, class _Fp>
-void
 __parallel_for(oneapi::dpl::__internal::__tbb_backend, _ExecutionPolicy&&, _Index __first, _Index __last, _Fp __f)
 {
     tbb::this_task_arena::isolate([=]() {
@@ -1312,16 +1301,6 @@ __parallel_invoke(_ExecutionPolicy&&, _F1&& __f1, _F2&& __f2)
     //TODO: a version of tbb::this_task_arena::isolate with variadic arguments pack should be added in the future
     tbb::this_task_arena::isolate(
         [&]() { tbb::parallel_invoke(::std::forward<_F1>(__f1), ::std::forward<_F2>(__f2)); });
-}
-
-//------------------------------------------------------------------------
-// parallel_for_each
-//------------------------------------------------------------------------
-template <class _ExecutionPolicy, class _ForwardIterator, class _Fp>
-void
-__parallel_for_each(_ExecutionPolicy&&, _ForwardIterator __begin, _ForwardIterator __end, _Fp __f)
-{
-    tbb::this_task_arena::isolate([&]() { tbb::parallel_for_each(__begin, __end, __f); });
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Fp>

--- a/include/oneapi/dpl/pstl/parallel_impl.h
+++ b/include/oneapi/dpl/pstl/parallel_impl.h
@@ -34,7 +34,7 @@ namespace __internal
 Each f[i,j) must return a value in [i,j). */
 template <class _ExecutionPolicy, class _Index, class _Brick, class _IsFirst>
 _Index
-__parallel_find(_ExecutionPolicy&& __exec, _Index __first, _Index __last, _Brick __f, _IsFirst)
+__parallel_find(__tbb_backend __tag, _ExecutionPolicy&& __exec, _Index __first, _Index __last, _Brick __f, _IsFirst)
 {
     typedef typename ::std::iterator_traits<_Index>::difference_type _DifferenceType;
     const _DifferenceType __n = __last - __first;
@@ -44,7 +44,7 @@ __parallel_find(_ExecutionPolicy&& __exec, _Index __first, _Index __last, _Brick
 
     ::std::atomic<_DifferenceType> __extremum(__initial_dist);
     // TODO: find out what is better here: parallel_for or parallel_reduce
-    __par_backend::__parallel_for(::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+    __par_backend::__parallel_for(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
                                   [__comp, __f, __first, &__extremum](_Index __i, _Index __j) {
                                       // See "Reducing Contention Through Priority Updates", PPoPP '13, for discussion of
                                       // why using a shared variable scales fairly well in this situation.

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -605,6 +605,21 @@ struct __next_to_last
     }
 };
 
+template <typename... _Args>
+struct __conjunction : ::std::true_type
+{
+};
+
+template <typename _B1>
+struct __conjunction<_B1> : _B1
+{
+};
+
+template <typename _B1, typename... _Bs>
+struct __conjunction<_B1, _Bs...> : ::std::conditional<!(bool(_B1::value)), _B1, __conjunction<_Bs...>>::type
+{
+};
+
 } // namespace __internal
 } // namespace dpl
 } // namespace oneapi


### PR DESCRIPTION
Tag dispatching mechanism:
- Allows to select parallel pattern to go (with ``select_backend`` function)
  - Decision is made once basing on the execution policy and Iterator category
  - Provides nested tags for the next level dispatching (parallel backend, vectorization, etc.) For example: `tbb_backend`, `is_vector`
- Patterns are selected based on the tag
  - overload with generic tag (customization point)
  - overloads for concrete tag types with optimized implementation
- Parallel backend as well as vectorized vs non-vectorized bricks are selected basing on the nested tags.
