### PR TITLE
Range based API for remove and remove_if algorithms

### DIFF
--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_defs.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_defs.h
@@ -107,6 +107,16 @@ template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typenam
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
 transform(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _Range3&& __result, _BinaryOperation __op);
 
+// [alg.remove]
+
+template <typename _ExecutionPolicy, typename _Range, typename _UnaryPredicate>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, oneapi::dpl::__internal::__difference_t<_Range>>
+remove_if(_ExecutionPolicy&& __exec, _Range&& __rng, _UnaryPredicate __pred);
+
+template <typename _ExecutionPolicy, typename _Range, typename _Tp>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, oneapi::dpl::__internal::__difference_t<_Range>>
+remove(_ExecutionPolicy&& __exec, _Range&& __rng, const _Tp& __value);
+
 // [alg.sort]
 
 template <typename _ExecutionPolicy, typename _Range, typename _Compare>

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -185,6 +185,26 @@ transform(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _Range3
         [__op](auto x, auto y, auto& z) { z = __op(x, y); });
 }
 
+// [alg.remove]
+
+template <typename _ExecutionPolicy, typename _Range, typename _UnaryPredicate>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, oneapi::dpl::__internal::__difference_t<_Range>>
+remove_if(_ExecutionPolicy&& __exec, _Range&& __rng, _UnaryPredicate __pred)
+{
+    return oneapi::dpl::__internal::__ranges::__pattern_remove_if(::std::forward<_ExecutionPolicy>(__exec),
+                                                                  views::all(::std::forward<_Range>(__rng)), __pred);
+}
+
+template <typename _ExecutionPolicy, typename _Range, typename _Tp>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, oneapi::dpl::__internal::__difference_t<_Range>>
+remove(_ExecutionPolicy&& __exec, _Range&& __rng, const _Tp& __value)
+{
+    return remove_if(
+        ::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range>(__rng),
+        oneapi::dpl::__internal::__equal_value<oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _Tp>>(
+            __value));
+}
+
 // [alg.sort]
 
 template <typename _ExecutionPolicy, typename _Range, typename _Compare>

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -893,38 +893,6 @@ __pattern_mismatch(_ExecutionPolicy&& __exec, _Iterator1 __first1, _Iterator1 __
 // copy_if
 //------------------------------------------------------------------------
 
-// create mask
-template <typename _Pred, typename _Tp>
-struct __create_mask
-{
-    _Pred __pred;
-
-    template <typename _Idx, typename _Input>
-    _Tp
-    operator()(const _Idx __idx, const _Input& __input) const
-    {
-        using ::std::get;
-        // 1. apply __pred
-        auto __temp = __pred(get<0>(__input[__idx]));
-        // 2. initialize mask
-        get<1>(__input[__idx]) = __temp;
-        return _Tp(__temp);
-    }
-};
-
-// get mask without predicate application
-template <typename _Tp, const int N>
-struct __get_mask
-{
-    template <typename _Idx, typename _Input>
-    _Tp
-    operator()(const _Idx __idx, const _Input& __input) const
-    {
-        using ::std::get;
-        return _Tp(get<N>(__input[__idx]));
-    }
-};
-
 template <typename _ExecutionPolicy, typename _Iterator1, typename _IteratorOrTuple, typename _CreateMaskOp,
           typename _CopyByMaskOp>
 oneapi::dpl::__internal::__enable_if_hetero_execution_policy<
@@ -986,7 +954,7 @@ __pattern_copy_if(_ExecutionPolicy&& __exec, _Iterator1 __first, _Iterator1 __la
     using _It1DifferenceType = typename ::std::iterator_traits<_Iterator1>::difference_type;
     using _ReduceOp = ::std::plus<_It1DifferenceType>;
 
-    __create_mask<_Predicate, _It1DifferenceType> __create_mask_op{__pred};
+    unseq_backend::__create_mask<_Predicate, _It1DifferenceType> __create_mask_op{__pred};
     unseq_backend::__copy_by_mask<_ReduceOp, /*inclusive*/ ::std::true_type, 1> __copy_by_mask_op;
 
     auto __result = __pattern_scan_copy(::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result_first,
@@ -1011,7 +979,7 @@ __pattern_partition_copy(_ExecutionPolicy&& __exec, _Iterator1 __first, _Iterato
     using _It1DifferenceType = typename ::std::iterator_traits<_Iterator1>::difference_type;
     using _ReduceOp = ::std::plus<_It1DifferenceType>;
 
-    __create_mask<_UnaryPredicate, _It1DifferenceType> __create_mask_op{__pred};
+    unseq_backend::__create_mask<_UnaryPredicate, _It1DifferenceType> __create_mask_op{__pred};
     unseq_backend::__partition_by_mask<_ReduceOp, /*inclusive*/ ::std::true_type> __copy_by_mask_op{_ReduceOp{}};
 
     auto __result = __pattern_scan_copy(

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -369,7 +369,7 @@ __pattern_remove_if(_ExecutionPolicy&& __exec, _Range&& __rng, _Predicate __pred
 {
     using _ValueType = typename ::std::iterator_traits<decltype(__rng.begin())>::value_type;
 
-    if (__rng.size() < 2)
+    if (__rng.size() == 0)
         return __rng.size();
 
     oneapi::dpl::__par_backend_hetero::__internal::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec, __rng.size());

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -304,6 +304,9 @@ oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy,
 __pattern_scan_copy(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _CreateMaskOp __create_mask_op,
                     _CopyByMaskOp __copy_by_mask_op)
 {
+    if (__rng1.size() == 0)
+        return __rng1.size();
+
     using _SizeType = decltype(__rng1.size());
     using _ReduceOp = ::std::plus<_SizeType>;
     using _Assigner = unseq_backend::__scan_assigner;
@@ -311,9 +314,6 @@ __pattern_scan_copy(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng
     using _MaskAssigner = unseq_backend::__mask_assigner<1>;
     using _InitType = unseq_backend::__scan_no_init<_SizeType>;
     using _DataAcc = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;
-
-    if (__rng1.size() == 0)
-        return __rng1.size();
 
     _Assigner __assign_op;
     _ReduceOp __reduce_op;
@@ -367,10 +367,10 @@ oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy,
                                                              oneapi::dpl::__internal::__difference_t<_Range>>
 __pattern_remove_if(_ExecutionPolicy&& __exec, _Range&& __rng, _Predicate __pred)
 {
-    using _ValueType = typename ::std::iterator_traits<decltype(__rng.begin())>::value_type;
-
     if (__rng.size() == 0)
         return __rng.size();
+
+    using _ValueType = typename ::std::iterator_traits<decltype(__rng.begin())>::value_type;
 
     oneapi::dpl::__par_backend_hetero::__internal::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec, __rng.size());
     auto __copy_rng = oneapi::dpl::__ranges::views::all(__buf.get_buffer());

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -295,6 +295,98 @@ __pattern_adjacent_find(_ExecutionPolicy&& __exec, _Range&& __rng, _BinaryPredic
 }
 
 //------------------------------------------------------------------------
+// copy_if
+//------------------------------------------------------------------------
+
+template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _CreateMaskOp, typename _CopyByMaskOp>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy,
+                                                             oneapi::dpl::__internal::__difference_t<_Range1>>
+__pattern_scan_copy(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _CreateMaskOp __create_mask_op,
+                    _CopyByMaskOp __copy_by_mask_op)
+{
+    using _SizeType = decltype(__rng1.size());
+    using _ReduceOp = ::std::plus<_SizeType>;
+    using _Assigner = unseq_backend::__scan_assigner;
+    using _NoAssign = unseq_backend::__scan_no_assign;
+    using _MaskAssigner = unseq_backend::__mask_assigner<1>;
+    using _InitType = unseq_backend::__scan_no_init<_SizeType>;
+    using _DataAcc = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;
+
+    if (__rng1.size() == 0)
+        return __rng1.size();
+
+    _Assigner __assign_op;
+    _ReduceOp __reduce_op;
+    _DataAcc __get_data_op;
+    _MaskAssigner __add_mask_op;
+
+    oneapi::dpl::__par_backend_hetero::__internal::__buffer<_ExecutionPolicy, int32_t> __mask_buf(__exec,
+                                                                                                  __rng1.size());
+
+    auto __res = __par_backend_hetero::__parallel_transform_scan(
+        ::std::forward<_ExecutionPolicy>(__exec),
+        oneapi::dpl::__ranges::zip_view(
+            __rng1, oneapi::dpl::__ranges::all_view<int32_t, __par_backend_hetero::access_mode::read_write>(
+                        __mask_buf.get_buffer())),
+        __rng2, __reduce_op, _InitType{},
+        // local scan
+        unseq_backend::__scan</*inclusive*/ ::std::true_type, _ExecutionPolicy, _ReduceOp, _DataAcc, _Assigner,
+                              _MaskAssigner, _CreateMaskOp, _InitType>{__reduce_op, __get_data_op, __assign_op,
+                                                                       __add_mask_op, __create_mask_op},
+        // scan between groups
+        unseq_backend::__scan</*inclusive*/ ::std::true_type, _ExecutionPolicy, _ReduceOp, _DataAcc, _NoAssign,
+                              _Assigner, _DataAcc, _InitType>{__reduce_op, __get_data_op, _NoAssign{}, __assign_op,
+                                                              __get_data_op},
+        // global scan
+        __copy_by_mask_op);
+
+    return __res.second;
+}
+
+template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Predicate>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy,
+                                                             oneapi::dpl::__internal::__difference_t<_Range2>>
+__pattern_copy_if(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _Predicate __pred)
+{
+    using _SizeType = decltype(__rng1.size());
+    using _ReduceOp = ::std::plus<_SizeType>;
+
+    unseq_backend::__create_mask<_Predicate, _SizeType> __create_mask_op{__pred};
+    unseq_backend::__copy_by_mask<_ReduceOp, /*inclusive*/ ::std::true_type, 1> __copy_by_mask_op;
+
+    return __pattern_scan_copy(::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range1>(__rng1),
+                               ::std::forward<_Range2>(__rng2), __create_mask_op, __copy_by_mask_op);
+}
+
+//------------------------------------------------------------------------
+// remove_if
+//------------------------------------------------------------------------
+
+template <typename _ExecutionPolicy, typename _Range, typename _Predicate>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy,
+                                                             oneapi::dpl::__internal::__difference_t<_Range>>
+__pattern_remove_if(_ExecutionPolicy&& __exec, _Range&& __rng, _Predicate __pred)
+{
+    using _ValueType = typename ::std::iterator_traits<decltype(__rng.begin())>::value_type;
+
+    if (__rng.size() < 2)
+        return __rng.size();
+
+    oneapi::dpl::__par_backend_hetero::__internal::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec, __rng.size());
+    auto __copy_rng = oneapi::dpl::__ranges::views::all(__buf.get_buffer());
+
+    auto __copy_last_id = __pattern_copy_if(::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range>(__rng),
+                                            __copy_rng, __not_pred<_Predicate>{__pred});
+    auto __copy_rng_truncated = __copy_rng | oneapi::dpl::experimental::ranges::views::take(__copy_last_id);
+
+    oneapi::dpl::__internal::__ranges::__pattern_walk2(::std::forward<_ExecutionPolicy>(__exec), __copy_rng_truncated,
+                                                       ::std::forward<_Range>(__rng),
+                                                       oneapi::dpl::__internal::__brick_copy<_ExecutionPolicy>{});
+
+    return __copy_last_id;
+}
+
+//------------------------------------------------------------------------
 // merge
 //------------------------------------------------------------------------
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -347,6 +347,25 @@ struct __scan_init_processing
     }
 };
 
+// create mask
+template <typename _Pred, typename _Tp>
+struct __create_mask
+{
+    _Pred __pred;
+
+    template <typename _Idx, typename _Input>
+    _Tp
+    operator()(const _Idx __idx, const _Input& __input) const
+    {
+        using ::std::get;
+        // 1. apply __pred
+        auto __temp = __pred(get<0>(__input[__idx]));
+        // 2. initialize mask
+        get<1>(__input[__idx]) = __temp;
+        return _Tp(__temp);
+    }
+};
+
 // functors for scan
 template <typename _BinaryOp, typename _Inclusive, ::std::size_t N>
 struct __copy_by_mask

--- a/test/parallel_api/ranges/remove_if_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/remove_if_ranges_sycl.pass.cpp
@@ -36,13 +36,12 @@ main()
     auto lambda1 = [](T val) -> bool { return val % 2 == 0; };
     auto lambda2 = [](T val) -> bool { return val % 3 == 0; };
     ::std::vector<T> data = {2, 5, 2, 4, 2, 0, 6, -7, 7, 3};
-    const int max_n = data.size();
 
     ::std::vector<T> in(data);
     ::std::vector<T>::difference_type in_end_n;
     using namespace oneapi::dpl::experimental::ranges;
     {
-        sycl::buffer<T> A(in.data(), sycl::range<1>(max_n));
+        sycl::buffer<T> A(in.data(), sycl::range<1>(in.size()));
 
         auto exec = TestUtils::default_dpcpp_policy;
         using Policy = decltype(exec);

--- a/test/parallel_api/ranges/remove_if_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/remove_if_ranges_sycl.pass.cpp
@@ -33,8 +33,8 @@ main()
 #if _ENABLE_RANGES_TESTING
     using T = int;
 
-    T val1 = 2;
-    T val2 = 3;
+    auto lambda1 = [](T val) -> bool { return val % 2 == 0; };
+    auto lambda2 = [](T val) -> bool { return val % 3 == 0; };
     ::std::vector<T> data = {2, 5, 2, 4, 2, 0, 6, -7, 7, 3};
     const int max_n = data.size();
 
@@ -49,14 +49,14 @@ main()
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);
 
-        in_end_n = remove(exec1, A, val1); //check passing a buffer
-        in_end_n = remove(exec2, views::all(A) | views::take(in_end_n), val2); //check passing a view
+        in_end_n = remove_if(exec1, A, lambda1); //check passing a buffer
+        in_end_n = remove_if(exec2, views::all(A) | views::take(in_end_n), lambda2); //check passing a view
     }
 
     //check result
     ::std::vector<T> exp(data);
-    auto exp_end = ::std::remove(exp.begin(), exp.end(), val1);
-    exp_end = ::std::remove(exp.begin(), exp_end, val2);
+    auto exp_end = ::std::remove_if(exp.begin(), exp.end(), lambda1);
+    exp_end = ::std::remove_if(exp.begin(), exp_end, lambda2);
 
     EXPECT_TRUE(::std::distance(exp.begin(), exp_end) == in_end_n, "wrong effect from remove with sycl ranges");
     EXPECT_EQ_N(exp.begin(), in.begin(), in_end_n, "wrong effect from remove with sycl ranges");

--- a/test/parallel_api/ranges/remove_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/remove_ranges_sycl.pass.cpp
@@ -1,0 +1,82 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#include <oneapi/dpl/execution>
+
+#include "support/pstl_test_config.h"
+
+#if _ENABLE_RANGES_TESTING
+#include <oneapi/dpl/ranges>
+#endif
+
+#include "support/utils.h"
+
+#include <vector>
+#include <iostream>
+#include <iterator>
+
+template<typename T>
+class print_t;
+
+int32_t
+main()
+{
+#if _ENABLE_RANGES_TESTING
+    using T = int;
+    ::std::vector<T> data = {2, 5, 2, 4, 4, 0, 6, -7, 7, 3};
+    const int max_n = data.size();
+
+    auto lambda = [](T val){ return val % 2 == 0; };
+    T val = 2;
+
+    ::std::vector<T> in1(data);
+    ::std::vector<T> in2(data);
+
+    using namespace TestUtils;
+    using namespace oneapi::dpl::experimental::ranges;
+
+    ::std::vector<T>::difference_type in1_end_n;
+    ::std::vector<T>::difference_type in2_end_n;
+    {
+        sycl::buffer<T> A(in1.data(), sycl::range<1>(max_n));
+        sycl::buffer<T> B(in2.data(), sycl::range<1>(max_n));
+
+        using Policy = decltype(TestUtils::default_dpcpp_policy);
+        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec1 = make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
+        auto exec2 = make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);
+
+        in1_end_n = remove(exec1, all_view<T, sycl::access::mode::read_write>(A), val);
+        in2_end_n = remove_if(exec2, all_view<T, sycl::access::mode::read_write>(B), lambda);
+    }
+
+    //check result
+    ::std::vector<T> exp2(data);
+    ::std::vector<T> exp1(data);
+
+    auto exp1_end = ::std::remove(exp1.begin(), exp1.end(), val);
+    auto exp2_end = ::std::remove_if(exp2.begin(), exp2.end(), lambda);
+
+    EXPECT_TRUE(::std::distance(exp1.begin(), exp1_end) == in1_end_n, "wrong effect from remove with sycl ranges");
+    EXPECT_TRUE(::std::distance(exp2.begin(), exp2_end) == in2_end_n, "wrong effect from remove_if with sycl ranges");
+
+    EXPECT_EQ_N(exp1.begin(), in1.begin(), in1_end_n, "wrong effect from remove with sycl ranges");
+    EXPECT_EQ_N(exp2.begin(), in2.begin(), in2_end_n, "wrong effect from remove_if with sycl ranges");
+#endif //_ENABLE_RANGES_TESTING
+
+    ::std::cout << TestUtils::done() << ::std::endl;
+    return 0;
+}
+

--- a/test/parallel_api/ranges/remove_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/remove_ranges_sycl.pass.cpp
@@ -36,13 +36,12 @@ main()
     T val1 = 2;
     T val2 = 3;
     ::std::vector<T> data = {2, 5, 2, 4, 2, 0, 6, -7, 7, 3};
-    const int max_n = data.size();
 
     ::std::vector<T> in(data);
     ::std::vector<T>::difference_type in_end_n;
     using namespace oneapi::dpl::experimental::ranges;
     {
-        sycl::buffer<T> A(in.data(), sycl::range<1>(max_n));
+        sycl::buffer<T> A(in.data(), sycl::range<1>(in.size()));
 
         auto exec = TestUtils::default_dpcpp_policy;
         using Policy = decltype(exec);

--- a/test/parallel_api/ranges/remove_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/remove_ranges_sycl.pass.cpp
@@ -27,9 +27,6 @@
 #include <iostream>
 #include <iterator>
 
-template<typename T>
-class print_t;
-
 int32_t
 main()
 {


### PR DESCRIPTION
- Added range based API for remove and remove_if algorithms. 
- Added simple test for both algorithms. 
- Removed unused `__get_mask` function. 
- Moved `__create_mask` to `unseq_backend_sycl.h` for reusing it with ranges.