### PR TITLE
Make kernel names unique in some tests

### DIFF
--- a/test/parallel_api/ranges/copy_ranges_factory_sycl.pass.cpp
+++ b/test/parallel_api/ranges/copy_ranges_factory_sycl.pass.cpp
@@ -42,11 +42,15 @@ main()
         sycl::buffer<int> C(max_n);
 
         auto view = iota_view(0, max_n) | views::transform(lambda1);
-
-        copy(TestUtils::default_dpcpp_policy, view, C); //check passing a buffer for writting
-
         auto range_res = all_view<int, sycl::access::mode::write>(B);
-        copy(TestUtils::default_dpcpp_policy, C, range_res); //check passing a buffer for reading
+
+        auto exec = TestUtils::default_dpcpp_policy;
+        using Policy = decltype(exec);
+        auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
+        auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);
+
+        copy(exec1, view, C); //check passing a buffer for writting
+        copy(exec2, C, range_res); //check passing a buffer for reading
     }
 
     //check result

--- a/test/parallel_api/ranges/copy_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/copy_ranges_sycl.pass.cpp
@@ -43,12 +43,16 @@ main()
         sycl::buffer<int> C(max_n);
 
         auto sv = all_view(A);
-
         auto view = views::reverse(sv) | views::transform(lambda1);
-
         auto range_res = all_view<int, sycl::access::mode::write>(B);
-        copy(TestUtils::default_dpcpp_policy, view, C); //check passing a buffer for writting
-        copy(TestUtils::default_dpcpp_policy, C, range_res); //check passing a buffer for reading
+
+        auto exec = TestUtils::default_dpcpp_policy;
+        using Policy = decltype(exec);
+        auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
+        auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);
+
+        copy(exec1, view, C); //check passing a buffer for writting
+        copy(exec2, C, range_res); //check passing a buffer for reading
     }
 
     //check result

--- a/test/parallel_api/ranges/find_end_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/find_end_ranges_sycl.pass.cpp
@@ -45,8 +45,14 @@ main()
 
         auto view_a = all_view(A);
         auto view_b = all_view(B);
-        res = find_end(TestUtils::default_dpcpp_policy, view_a, view_b);
-        res = find_end(TestUtils::default_dpcpp_policy, A, B); //check passing sycl buffer directly
+
+        auto exec = TestUtils::default_dpcpp_policy;
+        using Policy = decltype(exec);
+        auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
+        auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);
+
+        res = find_end(exec1, view_a, view_b);
+        res = find_end(exec2, A, B); //check passing sycl buffer directly
     }
 
     //check result

--- a/test/parallel_api/ranges/find_first_of_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/find_first_of_ranges_sycl.pass.cpp
@@ -45,8 +45,14 @@ main()
 
         auto view_a = all_view(A);
         auto view_b = all_view(B);
-        res = find_first_of(TestUtils::default_dpcpp_policy, view_a, view_b);
-        res = find_first_of(TestUtils::default_dpcpp_policy, A, B); //check passing sycl buffer directly
+
+        auto exec = TestUtils::default_dpcpp_policy;
+        using Policy = decltype(exec);
+        auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
+        auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);
+
+        res = find_first_of(exec1, view_a, view_b);
+        res = find_first_of(exec2, A, B); //check passing sycl buffer directly
     }
 
     //check result

--- a/test/parallel_api/ranges/for_each_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/for_each_ranges_sycl.pass.cpp
@@ -39,8 +39,14 @@ main()
 
     {
         sycl::buffer<int> A(data, sycl::range<1>(max_n));
-        for_each(TestUtils::default_dpcpp_policy, all_view<int, sycl::access::mode::read_write>(A), lambda1);
-        for_each(TestUtils::default_dpcpp_policy, A, lambda1); //check with passing sycl::buffer directly
+
+        auto exec = TestUtils::default_dpcpp_policy;
+        using Policy = decltype(exec);
+        auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
+        auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);
+
+        for_each(exec1, all_view<int, sycl::access::mode::read_write>(A), lambda1);
+        for_each(exec2, A, lambda1); //check with passing sycl::buffer directly
     }
 
     //check result

--- a/test/parallel_api/ranges/search_n_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/search_n_ranges_sycl.pass.cpp
@@ -42,8 +42,14 @@ main()
         sycl::buffer<int> A(data, sycl::range<1>(count));
 
         auto view_a = all_view(A);
-        res1 = search_n(TestUtils::default_dpcpp_policy, view_a, n_val, val, [](auto a, auto b) { return a == b; });
-        res2 = search_n(TestUtils::default_dpcpp_policy, A, n_val, val, [](auto a, auto b) { return a == b; });
+
+        auto exec = TestUtils::default_dpcpp_policy;
+        using Policy = decltype(exec);
+        auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
+        auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);
+
+        res1 = search_n(exec1, view_a, n_val, val, [](auto a, auto b) { return a == b; });
+        res2 = search_n(exec2, A, n_val, val, [](auto a, auto b) { return a == b; });
     }
 
     //check result

--- a/test/parallel_api/ranges/transform2_ranges_factory_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform2_ranges_factory_sycl.pass.cpp
@@ -44,10 +44,15 @@ main()
         sycl::buffer<int> C(data3, sycl::range<1>(max_n));
 
         auto view = iota_view(0, max_n) | views::transform(lambda1);
-
         auto range_res = all_view<int, sycl::access::mode::write>(B);
-        transform(TestUtils::default_dpcpp_policy, view, view, range_res, lambda2);
-        transform(TestUtils::default_dpcpp_policy, view, view, C, lambda2); //check passing sycl buffer 
+
+        auto exec = TestUtils::default_dpcpp_policy;
+        using Policy = decltype(exec);
+        auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
+        auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);
+
+        transform(exec1, view, view, range_res, lambda2);
+        transform(exec2, view, view, C, lambda2); //check passing sycl buffer
     }
 
     //check result

--- a/test/parallel_api/ranges/transform_exclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_exclusive_scan_ranges_sycl.pass.cpp
@@ -47,8 +47,13 @@ main()
         auto view = ranges::all_view<int, sycl::access::mode::read>(A);
         auto view_res = ranges::all_view<int, sycl::access::mode::write>(B);
 
-        ranges::transform_exclusive_scan(TestUtils::default_dpcpp_policy, view, view_res, 100, ::std::plus<int>(), lambda);
-        ranges::transform_exclusive_scan(TestUtils::default_dpcpp_policy, A, C, 100, ::std::plus<int>(), lambda);
+        auto exec = TestUtils::default_dpcpp_policy;
+        using Policy = decltype(exec);
+        auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
+        auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);
+
+        ranges::transform_exclusive_scan(exec1, view, view_res, 100, ::std::plus<int>(), lambda);
+        ranges::transform_exclusive_scan(exec2, A, C, 100, ::std::plus<int>(), lambda);
     }
 
     //check result

--- a/test/parallel_api/ranges/transform_ranges_factory_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_ranges_factory_sycl.pass.cpp
@@ -44,10 +44,15 @@ main()
         sycl::buffer<int> C(data3, sycl::range<1>(max_n));
 
         auto view = iota_view(0, max_n) | views::transform(lambda1);
-
         auto range_res = all_view<int, sycl::access::mode::write>(B);
-        transform(TestUtils::default_dpcpp_policy, view, range_res, lambda2);
-        transform(TestUtils::default_dpcpp_policy, view, C, lambda2); //check passing sycl buffer
+
+        auto exec = TestUtils::default_dpcpp_policy;
+        using Policy = decltype(exec);
+        auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
+        auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);
+
+        transform(exec1, view, range_res, lambda2);
+        transform(exec2, view, C, lambda2); //check passing sycl buffer
     }
 
     //check result


### PR DESCRIPTION
This fixes the following issue (arises during build stage):
```c++
onedpl/test/parallel_api/ranges/search_n_ranges_sycl.pass.cpp:16:
onedpl/include/oneapi/dpl/execution:65:
onedpl/include/oneapi/dpl/pstl/glue_execution_defs.h:57:
onedpl/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h:21:
onedpl/include/oneapi/dpl/pstl/parallel_backend.h:22:
onedpl/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:666:17: error: definition with same mangled name '_ZTSN6oneapi3dpl20__par_backend_hetero25__parallel_find_or_kernelIJNS0_10__internal8__ranges13equal_wrapperINS0_9execution5__dpl17DefaultKernelNameEEEEEE' as another definition
                [=](sycl::nd_item</*dim=*/1> __item_id) {
                ^
onedpl/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:666:17: note: previous definition is here
onedpl/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:666:17: error: definition with same mangled name '_ZTSN6oneapi3dpl20__par_backend_hetero25__parallel_find_or_kernelIJNS1_21__find_policy_wrapperINS0_9execution5__dpl17DefaultKernelNameEEEEEE' as another definition
                [=](sycl::nd_item</*dim=*/1> __item_id) {
                ^
onedpl/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:666:17: note: previous definition is here
2 errors generated.
```