### PR TITLE
Fix radix sort: guarantee that block size is a power of 2

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -668,11 +668,11 @@ __parallel_radix_sort(_ExecutionPolicy&& __exec, _Range&& __in_rng)
         if (__radix_iter % 2 == 0)
             __iteration_event = __parallel_radix_sort_iteration<__radix_bits, __is_comp_asc>(
                 ::std::forward<_ExecutionPolicy>(__exec), __segments, __radix_iter,
-                ::std::forward<_ExecutionPolicy>(__in_rng), __out_rng, __tmp_buf, __iteration_event);
+                ::std::forward<_Range>(__in_rng), __out_rng, __tmp_buf, __iteration_event);
         else //swap __in_rng and __out_rng
             __iteration_event = __parallel_radix_sort_iteration<__radix_bits, __is_comp_asc>(
                 make_wrapped_policy<__odd_iteration>(::std::forward<_ExecutionPolicy>(__exec)), __segments,
-                __radix_iter, __out_rng, ::std::forward<_ExecutionPolicy>(__in_rng), __tmp_buf, __iteration_event);
+                __radix_iter, __out_rng, ::std::forward<_Range>(__in_rng), __tmp_buf, __iteration_event);
 
         // TODO: since reassign to __iteration_event does not work, we have to make explicit wait on the event
         explicit_wait_if<::std::is_pointer<decltype(__in_rng.begin())>::value>{}(__iteration_event);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -195,7 +195,7 @@ inline _T
 __get_rounded_down_power2(_T __x)
 {
     _T __val = 1;
-    while(__x >= 2 * __val)
+    while (__x >= 2 * __val)
         __val <<= 1;
     return __val;
 }
@@ -582,8 +582,8 @@ __parallel_radix_sort_iteration(_ExecutionPolicy&& __exec, ::std::size_t __segme
 
     ::std::size_t __max_sg_size = oneapi::dpl::__internal::__max_sub_group_size(__exec);
     ::std::size_t __scan_wg_size = oneapi::dpl::__internal::__max_work_group_size(__exec);
-    ::std::size_t __reorder_sg_size = __max_sg_size;
     ::std::size_t __block_size = __max_sg_size;
+    ::std::size_t __reorder_sg_size = __max_sg_size;
 #if _ONEDPL_COMPILE_KERNEL
     auto __count_kernel = _RadixCountKernel::__compile_kernel(::std::forward<_ExecutionPolicy>(__exec));
     auto __reorder_kernel = _RadixReorderKernel::__compile_kernel(::std::forward<_ExecutionPolicy>(__exec));

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -18,7 +18,6 @@
 
 #include <CL/sycl.hpp>
 #include <climits>
-#include <cmath>
 
 #include "parallel_backend_sycl_utils.h"
 #include "execution_sycl_defs.h"
@@ -189,6 +188,16 @@ inline auto
 __get_roundedup_div(_T1 __number, _T2 __divisor) -> decltype((__number - 1) / __divisor + 1)
 {
     return (__number - 1) / __divisor + 1;
+}
+
+template <typename _T>
+inline _T
+__get_rounded_down_power2(_T __x)
+{
+    _T __val = 1;
+    while(__x >= 2 * __val)
+        __val <<= 1;
+    return __val;
 }
 
 //------------------------------------------------------------------------
@@ -592,7 +601,7 @@ __parallel_radix_sort_iteration(_ExecutionPolicy&& __exec, ::std::size_t __segme
     __block_size = __get_roundedup_div(__max_allocation_size, __radix_states);
 
     // TODO: block size must be power of 2 and more than number of states. Check how to get rid of that restriction.
-    __block_size = ::std::pow(2, static_cast<::std::size_t>(::std::log2(__block_size)));
+    __block_size = __get_rounded_down_power2(__block_size);
     if (__block_size < __radix_states)
         __block_size = __radix_states;
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -611,7 +611,6 @@ __parallel_radix_sort_iteration(_ExecutionPolicy&& __exec, ::std::size_t __segme
         ::std::forward<_ExecutionPolicy>(__exec), __scan_wg_size, __segments, ::std::forward<_TmpBuf>(__tmp_buf),
         __count_event);
 
-    std::cout << "__reorder_sg_size: " << __reorder_sg_size << std::endl;
     // 3. Reorder Phase
     sycl::event __reorder_event = __radix_sort_reorder_submit<_RadixReorderKernel, __radix_bits, __is_comp_asc>(
         ::std::forward<_ExecutionPolicy>(__exec), __segments, __block_size, __reorder_sg_size, __radix_iter,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -667,8 +667,8 @@ __parallel_radix_sort(_ExecutionPolicy&& __exec, _Range&& __in_rng)
         // TODO: convert to ordered type once at the first iteration and convert back at the last one
         if (__radix_iter % 2 == 0)
             __iteration_event = __parallel_radix_sort_iteration<__radix_bits, __is_comp_asc>(
-                ::std::forward<_ExecutionPolicy>(__exec), __segments, __radix_iter,
-                ::std::forward<_Range>(__in_rng), __out_rng, __tmp_buf, __iteration_event);
+                ::std::forward<_ExecutionPolicy>(__exec), __segments, __radix_iter, ::std::forward<_Range>(__in_rng),
+                __out_rng, __tmp_buf, __iteration_event);
         else //swap __in_rng and __out_rng
             __iteration_event = __parallel_radix_sort_iteration<__radix_bits, __is_comp_asc>(
                 make_wrapped_policy<__odd_iteration>(::std::forward<_ExecutionPolicy>(__exec)), __segments,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -667,12 +667,12 @@ __parallel_radix_sort(_ExecutionPolicy&& __exec, _Range&& __in_rng)
         // TODO: convert to ordered type once at the first iteration and convert back at the last one
         if (__radix_iter % 2 == 0)
             __iteration_event = __parallel_radix_sort_iteration<__radix_bits, __is_comp_asc>(
-                ::std::forward<_ExecutionPolicy>(__exec), __segments, __radix_iter, __in_rng, __out_rng, __tmp_buf,
-                __iteration_event);
+                ::std::forward<_ExecutionPolicy>(__exec), __segments, __radix_iter,
+                ::std::forward<_ExecutionPolicy>(__in_rng), __out_rng, __tmp_buf, __iteration_event);
         else //swap __in_rng and __out_rng
             __iteration_event = __parallel_radix_sort_iteration<__radix_bits, __is_comp_asc>(
                 make_wrapped_policy<__odd_iteration>(::std::forward<_ExecutionPolicy>(__exec)), __segments,
-                __radix_iter, __out_rng, __in_rng, __tmp_buf, __iteration_event);
+                __radix_iter, __out_rng, ::std::forward<_ExecutionPolicy>(__in_rng), __tmp_buf, __iteration_event);
 
         // TODO: since reassign to __iteration_event does not work, we have to make explicit wait on the event
         explicit_wait_if<::std::is_pointer<decltype(__in_rng.begin())>::value>{}(__iteration_event);


### PR DESCRIPTION
Count phase requires block size which is a power of 2. We may get some other size, e.g. 85 when compiling for CPU that will result in wrong data after reduction at step 2.2 of the count phase.

Additionally added missing `forward` instructions and removed extra compilation of a kernel for scan phase.