### PR TITLE
Improve testing coverage of sorting algorithms

### DIFF
--- a/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
@@ -61,26 +61,29 @@ struct test_brick_partial_sort
     typename ::std::enable_if<is_same_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value,
                             void>::type
     operator()(Policy&& exec, InputIterator first, InputIterator last, InputIterator exp_first, InputIterator exp_last,
-               Compare compare)
+               InputIterator tmp_first, InputIterator tmp_last, Compare compare)
     {
         const ::std::size_t n = last - first;
+        ::std::copy_n(first, n, exp_first);
+        ::std::copy_n(first, n, tmp_first);
+
         for (::std::size_t p = 0; p < n; p = p <= 16 ? p + 1 : ::std::size_t(31.415 * p))
         {
-            auto m1 = first + p;
+            auto m1 = tmp_first + p;
             auto m2 = exp_first + p;
 
             ::std::partial_sort(exp_first, m2, exp_last, compare);
 #if !TEST_DPCPP_BACKEND_PRESENT
             count_comp = 0;
 #endif
-            ::std::partial_sort(exec, first, m1, last, compare);
-            EXPECT_EQ_N(exp_first, first, p, "wrong effect from partial_sort with predicate");
+            ::std::partial_sort(exec, tmp_first, m1, tmp_last, compare);
+            EXPECT_EQ_N(exp_first, tmp_first, p, "wrong effect from partial_sort with predicate");
 
 #if !TEST_DPCPP_BACKEND_PRESENT
             //checking upper bound number of comparisons; O(p*(last-first)log(middle-first)); where p - number of threads;
-            if (m1 - first > 1)
+            if (m1 - tmp_first > 1)
             {
-                auto complex = ::std::ceil(n * ::std::log(float32_t(m1 - first)));
+                auto complex = ::std::ceil(n * ::std::log(float32_t(m1 - tmp_first)));
 #if TEST_TBB_BACKEND_PRESENT
                 auto p = tbb::this_task_arena::max_concurrency();
 #else
@@ -101,32 +104,37 @@ struct test_brick_partial_sort
     template <typename Policy, typename InputIterator, typename Compare>
     typename ::std::enable_if<!is_same_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value,
                             void>::type
-    operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, InputIterator /* exp_first */, InputIterator /* exp_last */,
-               Compare /* compare */)
+    operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, InputIterator /* exp_first */,
+               InputIterator /* exp_last */, InputIterator /* tmp_first */, InputIterator /* tmp_last */, Compare /* compare */)
     {
     }
 
     template <typename Policy, typename InputIterator>
     typename ::std::enable_if<is_same_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value &&
                               can_use_default_less_operator<Type>::value, void>::type
-    operator()(Policy&& exec, InputIterator first, InputIterator last, InputIterator exp_first, InputIterator exp_last)
+    operator()(Policy&& exec, InputIterator first, InputIterator last, InputIterator exp_first, InputIterator exp_last,
+               InputIterator tmp_first, InputIterator tmp_last)
     {
         const ::std::size_t n = last - first;
+        ::std::copy_n(first, n, exp_first);
+        ::std::copy_n(first, n, tmp_first);
+
         for (::std::size_t p = 0; p < n; p = p <= 16 ? p + 1 : ::std::size_t(31.415 * p))
         {
-            auto m1 = first + p;
+            auto m1 = tmp_first + p;
             auto m2 = exp_first + p;
 
             ::std::partial_sort(exp_first, m2, exp_last);
-            ::std::partial_sort(exec, first, m1, last);
-            EXPECT_EQ_N(exp_first, first, p, "wrong effect from partial_sort without predicate");
+            ::std::partial_sort(exec, tmp_first, m1, tmp_last);
+            EXPECT_EQ_N(exp_first, tmp_first, p, "wrong effect from partial_sort without predicate");
         }
     }
 
     template <typename Policy, typename InputIterator>
     typename ::std::enable_if<!is_same_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value ||
                               !can_use_default_less_operator<Type>::value, void>::type
-    operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, InputIterator /* exp_first */, InputIterator /* exp_last */)
+    operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, InputIterator /* exp_first */,
+               InputIterator /* exp_last */, InputIterator /* tmp_first */, InputIterator /* tmp_last */)
     {
     }
 };
@@ -140,17 +148,15 @@ test_partial_sort(Compare compare)
     ::std::srand(42);
     // The rand()%(2*k+1) encourages generation of some duplicates.
     Sequence<T> in(n_max, [](::std::size_t k){ return T(rand() % (2 * k + 1)); });
+    Sequence<T> exp(n_max);
+    Sequence<T> tmp(n_max);
 
     for (::std::size_t n = 0; n < n_max; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
-        Sequence<T> in_tmp(n);
-        ::std::copy(in.begin(), in.begin() + n, in_tmp.begin());
-        Sequence<T> exp(in_tmp);
-
-        invoke_on_all_policies<0>()(test_brick_partial_sort<T>(), in_tmp.begin(), in_tmp.begin() + n, exp.begin(),
-                                    exp.begin() + n, compare);
-        invoke_on_all_policies<1>()(test_brick_partial_sort<T>(), in_tmp.begin(), in_tmp.begin() + n, exp.begin(),
-                                    exp.begin() + n);
+        invoke_on_all_policies<0>()(test_brick_partial_sort<T>(), in.begin(), in.begin() + n,
+                                    exp.begin(), exp.begin() + n, tmp.begin(), tmp.begin() + n, compare);
+        invoke_on_all_policies<1>()(test_brick_partial_sort<T>(), in.begin(), in.begin() + n,
+                                    exp.begin(), exp.begin() + n, tmp.begin(), tmp.begin() + n);
     }
 }
 

--- a/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
@@ -55,7 +55,66 @@ struct Num
 #endif
 
 template <typename Type>
-struct test_brick_partial_sort
+struct test_without_compare
+{
+    template <typename Policy, typename InputIterator>
+    typename ::std::enable_if<is_same_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value &&
+                              can_use_default_less_operator<Type>::value, void>::type
+    operator()(Policy&& exec, InputIterator first, InputIterator last, InputIterator exp_first, InputIterator exp_last)
+    {
+        // The rand()%(2*n+1) encourages generation of some duplicates.
+        ::std::srand(42);
+        const ::std::size_t n = last - first;
+        for (::std::size_t k = 0; k < n; ++k)
+        {
+            first[k] = Type(rand() % (2 * n + 1));
+        }
+        ::std::copy(first, last, exp_first);
+
+        for (::std::size_t p = 0; p < n; p = p <= 16 ? p + 1 : ::std::size_t(31.415 * p))
+        {
+            auto m1 = first + p;
+            auto m2 = exp_first + p;
+
+            ::std::partial_sort(exp_first, m2, exp_last);
+#if !_ONEDPL_BACKEND_SYCL
+            count_comp = 0;
+#endif
+            ::std::partial_sort(exec, first, m1, last);
+            EXPECT_EQ_N(exp_first, first, p, "wrong effect from partial_sort without predicate");
+
+#if !_ONEDPL_BACKEND_SYCL
+            //checking upper bound number of comparisons; O(p*(last-first)log(middle-first)); where p - number of threads;
+            if (m1 - first > 1)
+            {
+                auto complex = ::std::ceil(n * ::std::log(float32_t(m1 - first)));
+#if defined(_ONEDPL_PAR_BACKEND_TBB)
+                auto p = tbb::this_task_arena::max_concurrency();
+#else
+                auto p = 1;
+#endif
+
+#ifdef PSTL_USE_DEBUG
+                if (count_comp > complex * p)
+                {
+                    ::std::cout << "complexity exceeded" << ::std::endl;
+                }
+#endif
+            }
+#endif // !_ONEDPL_BACKEND_SYCL
+        }
+    }
+
+    template <typename Policy, typename InputIterator>
+    typename ::std::enable_if<!is_same_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value ||
+                              !can_use_default_less_operator<Type>::value, void>::type
+    operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, InputIterator /* exp_first */, InputIterator /* exp_last */)
+    {
+    }
+};
+
+template <typename Type>
+struct test_with_compare
 {
     template <typename Policy, typename InputIterator, typename Compare>
     typename ::std::enable_if<is_same_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value,
@@ -63,15 +122,12 @@ struct test_brick_partial_sort
     operator()(Policy&& exec, InputIterator first, InputIterator last, InputIterator exp_first, InputIterator exp_last,
                Compare compare)
     {
-
-        typedef typename ::std::iterator_traits<InputIterator>::value_type T;
-
         // The rand()%(2*n+1) encourages generation of some duplicates.
         ::std::srand(42);
         const ::std::size_t n = last - first;
         for (::std::size_t k = 0; k < n; ++k)
         {
-            first[k] = T(rand() % (2 * n + 1));
+            first[k] = Type(rand() % (2 * n + 1));
         }
         ::std::copy(first, last, exp_first);
 
@@ -85,7 +141,7 @@ struct test_brick_partial_sort
             count_comp = 0;
 #endif
             ::std::partial_sort(exec, first, m1, last, compare);
-            EXPECT_EQ_N(exp_first, first, p, "wrong effect from partial_sort");
+            EXPECT_EQ_N(exp_first, first, p, "wrong effect from partial_sort with predicate");
 
 #if !TEST_DPCPP_BACKEND_PRESENT
             //checking upper bound number of comparisons; O(p*(last-first)log(middle-first)); where p - number of threads;
@@ -98,7 +154,7 @@ struct test_brick_partial_sort
                 auto p = 1;
 #endif
 
-#ifdef _DEBUG
+#ifdef PSTL_USE_DEBUG
                 if (count_comp > complex * p)
                 {
                     ::std::cout << "complexity exceeded" << ::std::endl;
@@ -128,7 +184,7 @@ test_partial_sort(Compare compare)
     Sequence<T> exp(n_max);
     for (::std::size_t n = 0; n < n_max; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
-        invoke_on_all_policies<0>()(test_brick_partial_sort<T>(), in.begin(), in.begin() + n, exp.begin(),
+        invoke_on_all_policies<0>()(test_with_compare<T>(), in.begin(), in.begin() + n, exp.begin(),
                                     exp.begin() + n, compare);
     }
 }

--- a/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
@@ -55,66 +55,7 @@ struct Num
 #endif
 
 template <typename Type>
-struct test_without_compare
-{
-    template <typename Policy, typename InputIterator>
-    typename ::std::enable_if<is_same_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value &&
-                              can_use_default_less_operator<Type>::value, void>::type
-    operator()(Policy&& exec, InputIterator first, InputIterator last, InputIterator exp_first, InputIterator exp_last)
-    {
-        // The rand()%(2*n+1) encourages generation of some duplicates.
-        ::std::srand(42);
-        const ::std::size_t n = last - first;
-        for (::std::size_t k = 0; k < n; ++k)
-        {
-            first[k] = Type(rand() % (2 * n + 1));
-        }
-        ::std::copy(first, last, exp_first);
-
-        for (::std::size_t p = 0; p < n; p = p <= 16 ? p + 1 : ::std::size_t(31.415 * p))
-        {
-            auto m1 = first + p;
-            auto m2 = exp_first + p;
-
-            ::std::partial_sort(exp_first, m2, exp_last);
-#if !TEST_DPCPP_BACKEND_PRESENT
-            count_comp = 0;
-#endif
-            ::std::partial_sort(exec, first, m1, last);
-            EXPECT_EQ_N(exp_first, first, p, "wrong effect from partial_sort without predicate");
-
-#if !TEST_DPCPP_BACKEND_PRESENT
-            //checking upper bound number of comparisons; O(p*(last-first)log(middle-first)); where p - number of threads;
-            if (m1 - first > 1)
-            {
-                auto complex = ::std::ceil(n * ::std::log(float32_t(m1 - first)));
-#if TEST_TBB_BACKEND_PRESENT
-                auto p = tbb::this_task_arena::max_concurrency();
-#else
-                auto p = 1;
-#endif
-
-#ifdef PSTL_USE_DEBUG
-                if (count_comp > complex * p)
-                {
-                    ::std::cout << "complexity exceeded" << ::std::endl;
-                }
-#endif
-            }
-#endif // !TEST_DPCPP_BACKEND_PRESENT
-        }
-    }
-
-    template <typename Policy, typename InputIterator>
-    typename ::std::enable_if<!is_same_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value ||
-                              !can_use_default_less_operator<Type>::value, void>::type
-    operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, InputIterator /* exp_first */, InputIterator /* exp_last */)
-    {
-    }
-};
-
-template <typename Type>
-struct test_with_compare
+struct test_brick_partial_sort
 {
     template <typename Policy, typename InputIterator, typename Compare>
     typename ::std::enable_if<is_same_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value,
@@ -122,15 +63,7 @@ struct test_with_compare
     operator()(Policy&& exec, InputIterator first, InputIterator last, InputIterator exp_first, InputIterator exp_last,
                Compare compare)
     {
-        // The rand()%(2*n+1) encourages generation of some duplicates.
-        ::std::srand(42);
         const ::std::size_t n = last - first;
-        for (::std::size_t k = 0; k < n; ++k)
-        {
-            first[k] = Type(rand() % (2 * n + 1));
-        }
-        ::std::copy(first, last, exp_first);
-
         for (::std::size_t p = 0; p < n; p = p <= 16 ? p + 1 : ::std::size_t(31.415 * p))
         {
             auto m1 = first + p;
@@ -154,7 +87,7 @@ struct test_with_compare
                 auto p = 1;
 #endif
 
-#ifdef PSTL_USE_DEBUG
+#if PSTL_USE_DEBUG
                 if (count_comp > complex * p)
                 {
                     ::std::cout << "complexity exceeded" << ::std::endl;
@@ -172,6 +105,30 @@ struct test_with_compare
                Compare /* compare */)
     {
     }
+
+    template <typename Policy, typename InputIterator>
+    typename ::std::enable_if<is_same_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value &&
+                              can_use_default_less_operator<Type>::value, void>::type
+    operator()(Policy&& exec, InputIterator first, InputIterator last, InputIterator exp_first, InputIterator exp_last)
+    {
+        const ::std::size_t n = last - first;
+        for (::std::size_t p = 0; p < n; p = p <= 16 ? p + 1 : ::std::size_t(31.415 * p))
+        {
+            auto m1 = first + p;
+            auto m2 = exp_first + p;
+
+            ::std::partial_sort(exp_first, m2, exp_last);
+            ::std::partial_sort(exec, first, m1, last);
+            EXPECT_EQ_N(exp_first, first, p, "wrong effect from partial_sort without predicate");
+        }
+    }
+
+    template <typename Policy, typename InputIterator>
+    typename ::std::enable_if<!is_same_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value ||
+                              !can_use_default_less_operator<Type>::value, void>::type
+    operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, InputIterator /* exp_first */, InputIterator /* exp_last */)
+    {
+    }
 };
 
 template <typename T, typename Compare>
@@ -179,13 +136,20 @@ void
 test_partial_sort(Compare compare)
 {
     const ::std::size_t n_max = 100000;
-    Sequence<T> in(n_max);
-    Sequence<T> exp(n_max);
+
+    ::std::srand(42);
+    // The rand()%(2*k+1) encourages generation of some duplicates.
+    Sequence<T> in(n_max, [](::std::size_t k){ return T(rand() % (2 * k + 1)); });
+
     for (::std::size_t n = 0; n < n_max; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
-        invoke_on_all_policies<0>()(test_with_compare<T>(), in.begin(), in.begin() + n, exp.begin(),
+        Sequence<T> in_tmp(n);
+        ::std::copy(in.begin(), in.begin() + n, in_tmp.begin());
+        Sequence<T> exp(in_tmp);
+
+        invoke_on_all_policies<0>()(test_brick_partial_sort<T>(), in_tmp.begin(), in_tmp.begin() + n, exp.begin(),
                                     exp.begin() + n, compare);
-        invoke_on_all_policies<1>()(test_without_compare<T>(), in.begin(), in.begin() + n, exp.begin(),
+        invoke_on_all_policies<1>()(test_brick_partial_sort<T>(), in_tmp.begin(), in_tmp.begin() + n, exp.begin(),
                                     exp.begin() + n);
     }
 }

--- a/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
@@ -77,18 +77,18 @@ struct test_without_compare
             auto m2 = exp_first + p;
 
             ::std::partial_sort(exp_first, m2, exp_last);
-#if !_ONEDPL_BACKEND_SYCL
+#if !TEST_DPCPP_BACKEND_PRESENT
             count_comp = 0;
 #endif
             ::std::partial_sort(exec, first, m1, last);
             EXPECT_EQ_N(exp_first, first, p, "wrong effect from partial_sort without predicate");
 
-#if !_ONEDPL_BACKEND_SYCL
+#if !TEST_DPCPP_BACKEND_PRESENT
             //checking upper bound number of comparisons; O(p*(last-first)log(middle-first)); where p - number of threads;
             if (m1 - first > 1)
             {
                 auto complex = ::std::ceil(n * ::std::log(float32_t(m1 - first)));
-#if defined(_ONEDPL_PAR_BACKEND_TBB)
+#if TEST_TBB_BACKEND_PRESENT
                 auto p = tbb::this_task_arena::max_concurrency();
 #else
                 auto p = 1;
@@ -101,7 +101,7 @@ struct test_without_compare
                 }
 #endif
             }
-#endif // !_ONEDPL_BACKEND_SYCL
+#endif // !TEST_DPCPP_BACKEND_PRESENT
         }
     }
 
@@ -148,7 +148,7 @@ struct test_with_compare
             if (m1 - first > 1)
             {
                 auto complex = ::std::ceil(n * ::std::log(float32_t(m1 - first)));
-#if defined(_ONEDPL_PAR_BACKEND_TBB)
+#if TEST_TBB_BACKEND_PRESENT
                 auto p = tbb::this_task_arena::max_concurrency();
 #else
                 auto p = 1;
@@ -178,7 +178,6 @@ template <typename T, typename Compare>
 void
 test_partial_sort(Compare compare)
 {
-
     const ::std::size_t n_max = 100000;
     Sequence<T> in(n_max);
     Sequence<T> exp(n_max);
@@ -186,6 +185,8 @@ test_partial_sort(Compare compare)
     {
         invoke_on_all_policies<0>()(test_with_compare<T>(), in.begin(), in.begin() + n, exp.begin(),
                                     exp.begin() + n, compare);
+        invoke_on_all_policies<1>()(test_without_compare<T>(), in.begin(), in.begin() + n, exp.begin(),
+                                    exp.begin() + n);
     }
 }
 

--- a/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
@@ -25,18 +25,6 @@
 #define _PSTL_TEST_STABLE_SORT
 #endif
 
-#if !defined(_PSTL_TEST_RADIX_SORT) && !defined(_PSTL_TEST_MERGE_SORT)
-#define _PSTL_TEST_MERGE_SORT
-
-#if _USE_RADIX_SORT
-#define _PSTL_TEST_RADIX_SORT
-#endif
-#endif // !defined(_PSTL_TEST_RADIX_SORT) && !defined(_PSTL_TEST_MERGE_SORT)
-
-#if defined(_PSTL_TEST_RADIX_SORT) && !_USE_RADIX_SORT
-#pragma message("WARNING: Radix sort is not supported. Merge sort with no predicate is going to be tested instead.")
-#endif
-
 using namespace TestUtils;
 #define _CRT_SECURE_NO_WARNINGS
 
@@ -206,7 +194,7 @@ struct test_sort_with_compare
         for (size_t i = 0; i < n; ++i, ++expected_first, ++tmp_first)
         {
             // Check that expected[i] is equal to tmp[i]
-            EXPECT_TRUE(Equal(*expected_first, *tmp_first), "bad sort");
+            EXPECT_TRUE(Equal(*expected_first, *tmp_first), "bad sort without predicate");
         }
         int32_t count1 = KeyCount;
         EXPECT_EQ(count0, count1, "key cleanup error");
@@ -246,7 +234,7 @@ struct test_sort_without_compare
         for (size_t i = 0; i < n; ++i, ++expected_first, ++tmp_first)
         {
             // Check that expected[i] is equal to tmp[i]
-            EXPECT_TRUE(Equal(*expected_first, *tmp_first), "bad sort");
+            EXPECT_TRUE(Equal(*expected_first, *tmp_first), "bad sort with predicate");
         }
         int32_t count1 = KeyCount;
         EXPECT_EQ(count0, count1, "key cleanup error");
@@ -272,14 +260,10 @@ test_sort(Compare compare, Convert convert)
         Sequence<T> in(n + 2, [=](size_t k) { return convert(k, rand() % (2 * n + 1)); });
         Sequence<T> expected(in);
         Sequence<T> tmp(in);
-#if defined(_PSTL_TEST_RADIX_SORT)
         invoke_on_all_policies<0>()(test_sort_without_compare<T>(), tmp.begin(), tmp.end(), expected.begin(),
                                     expected.end(), in.begin(), in.end(), in.size());
-#endif
-#if defined(_PSTL_TEST_MERGE_SORT)
         invoke_on_all_policies<1>()(test_sort_with_compare<T>(), tmp.begin(), tmp.end(), expected.begin(),
                                     expected.end(), in.begin(), in.end(), in.size(), compare);
-#endif
     }
 }
 

--- a/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
@@ -25,6 +25,12 @@
 #define _PSTL_TEST_STABLE_SORT
 #endif
 
+// Testing with and without predicate may be usefull due to different implementations, e.g. merge-sort and radix-sort
+#if !defined(_PSTL_TEST_WITH_PREDICATE) && !defined(_PSTL_TEST_WITHOUT_PREDICATE)
+#define _PSTL_TEST_WITH_PREDICATE
+#define _PSTL_TEST_WITHOUT_PREDICATE
+#endif
+
 using namespace TestUtils;
 #define _CRT_SECURE_NO_WARNINGS
 
@@ -194,7 +200,7 @@ struct test_sort_with_compare
         for (size_t i = 0; i < n; ++i, ++expected_first, ++tmp_first)
         {
             // Check that expected[i] is equal to tmp[i]
-            EXPECT_TRUE(Equal(*expected_first, *tmp_first), "bad sort without predicate");
+            EXPECT_TRUE(Equal(*expected_first, *tmp_first), "wrong result from sort without predicate");
         }
         int32_t count1 = KeyCount;
         EXPECT_EQ(count0, count1, "key cleanup error");
@@ -234,7 +240,7 @@ struct test_sort_without_compare
         for (size_t i = 0; i < n; ++i, ++expected_first, ++tmp_first)
         {
             // Check that expected[i] is equal to tmp[i]
-            EXPECT_TRUE(Equal(*expected_first, *tmp_first), "bad sort with predicate");
+            EXPECT_TRUE(Equal(*expected_first, *tmp_first), "wrong result from sort with predicate");
         }
         int32_t count1 = KeyCount;
         EXPECT_EQ(count0, count1, "key cleanup error");
@@ -260,10 +266,14 @@ test_sort(Compare compare, Convert convert)
         Sequence<T> in(n + 2, [=](size_t k) { return convert(k, rand() % (2 * n + 1)); });
         Sequence<T> expected(in);
         Sequence<T> tmp(in);
+#ifdef _PSTL_TEST_WITHOUT_PREDICATE
         invoke_on_all_policies<0>()(test_sort_without_compare<T>(), tmp.begin(), tmp.end(), expected.begin(),
                                     expected.end(), in.begin(), in.end(), in.size());
+#endif
+#ifdef _PSTL_TEST_WITH_PREDICATE
         invoke_on_all_policies<1>()(test_sort_with_compare<T>(), tmp.begin(), tmp.end(), expected.begin(),
                                     expected.end(), in.begin(), in.end(), in.size(), compare);
+#endif
     }
 }
 

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -62,6 +62,9 @@
 #define TEST_DPCPP_BACKEND_PRESENT 0
 #endif
 
+// Enable test when the TBB backend is available
+#define TEST_TBB_BACKEND_PRESENT (!defined(ONEDPL_USE_TBB_BACKEND) || ONEDPL_USE_TBB_BACKEND != 0)
+
 // Check for C++ standard and standard library for the use of ranges API
 #define _TEST_RANGES_FOR_CPP_17_DPCPP_BE_ONLY (__cplusplus >= 201703L && TEST_DPCPP_BACKEND_PRESENT)
 #if defined(_GLIBCXX_RELEASE)


### PR DESCRIPTION
partial_sort: 

- Added a case with no predicate

sort/stable_sort: 

- Enabled the case with no predicate on the host side

- Removed `_PSTL_TEST_RADIX_SORT` and `_PSTL_TEST_MERGE_SORT` and added alternative macros. Improved diagnostics.