### PR TITLE
Update CHANGES file with 2021.2 release changes (#173)

### DIFF
--- a/documentation/CHANGES.rst
+++ b/documentation/CHANGES.rst
@@ -6,6 +6,53 @@ Overview
 
 The list of the most significant changes made over time in oneDPL.
 
+New in 2021.2
+=============
+
+New Features
+------------
+-  Added support of parallel, vector and DPC++ execution policies for the following algorithms: ``shift_left``, ``shift_right``.
+-  Added the Range-based versions of the following algorithms: ``sort``, ``stable_sort``, ``merge``.
+-  Added non-blocking versions of the following algorithms: ``copy``, ``fill``, ``for_each``, ``reduce``, ``sort``, ``transform``, ``transform_reduce``. These algorithms are declared in ``oneapi::dpl::experimental`` namespace with suffix _async and implemented only for DPC++ policies. In order to make these algorithms available the ``<oneapi/dpl/async>`` header should be included. Use of the non-blocking API requires C++11.
+-  Utility function ``wait_for_all`` enables waiting for completion of an arbitrary number of events.
+-  Added the ``ONEDPL_USE_PREDEFINED_POLICIES`` macro, which enables predefined policy objects and ``make_device_policy``, ``make_fpga_policy`` functions without arguments. It is turned on by default.
+
+Changes to Existing Features
+-----------------------------
+- Improved performance of the following algorithms: ``count``, ``count_if``, ``is_partitioned``, ``lexicographical_compare``, ``max_element``, ``min_element``, ``minmax_element``, ``reduce``, ``transform_reduce``, and ``sort``, ``stable_sort`` when using Radix sort [#fnote1]_.
+- Improved performance of the linear_congruential_engine RNG engine (including ``minstd_rand``, ``minstd_rand0``, ``minstd_rand_vec``, ``minstd_rand0_vec`` predefined engines).
+
+Fixed Issues
+------------
+- Fixed runtime errors occurring with ``find_end``, ``search``, ``search_n`` algorithms when a program is built with -O0 option and executed on CPU devices.
+- Fixed the majority of unused parameter warnings.
+
+Known Issues and Limitations
+-----------------------------
+- ``exclusive_scan`` and ``transform_exclusive_scan`` algorithms may provide wrong results with vector execution policies
+  when building a program with GCC 10 and using -O0 option.
+- Some algorithms may hang when a program is built with -O0 option, executed on GPU devices and large number of elements is to be processed.
+- The use of oneDPL together with the GNU C++ standard library (libstdc++) version 9 or 10 may lead to
+  compilation errors (caused by oneTBB API changes).
+  To overcome these issues, include oneDPL header files before the standard C++ header files,
+  or disable parallel algorithms support in the standard library. For more information, please see `Intel® oneAPI Threading Building Blocks (oneTBB) Release Notes`_.
+- The ``using namespace oneapi;`` directive in a oneDPL program code may result in compilation errors
+  with some compilers including GCC 7 and earlier. Instead of this directive, explicitly use
+  ``oneapi::dpl`` namespace, or create a namespace alias.
+- The implementation does not yet provide ``namespace oneapi::std`` as defined in `the oneDPL Specification`_.
+- The use of the range-based API requires C++17 and the C++ standard libraries coming with GCC 8.1 (or higher)
+  or Clang 7 (or higher).
+- ``std::tuple``, ``std::pair`` cannot be used with SYCL buffers to transfer data between host and device.
+- When used within DPC++ kernels or transferred to/from a device, ``std::array`` can only hold objects
+  whose type meets DPC++ requirements for use in kernels and for data transfer, respectively.
+- ``std::array::at`` member function cannot be used in kernels because it may throw an exception;
+  use ``std::array::operator[]`` instead.
+- ``std::array`` cannot be swapped in DPC++ kernels with ``std::swap`` function or ``swap`` member function
+  in the Microsoft* Visual C++ standard library.
+- Due to specifics of Microsoft* Visual C++, some standard floating-point math functions
+  (including ``std::ldexp``, ``std::frexp``, ``std::sqrt(std::complex<float>)``) require device support
+  for double precision.
+
 New in 2021.1 Gold
 ====================
 
@@ -20,7 +67,7 @@ Changes to Existing Features
 Fixed Issues
 -------------
 - Fixed compilation errors of oneDPL parallel algorithms when using "-sycl-std=2020" compiler switch.
-- Fixed the segmentation fault issue on oneAPI CPU devices in the ``exclusive_scan`` and ``transform_exclusive_scan`` algorithms.
+- Fixed the segmentation fault issue on CPU devices in the ``exclusive_scan`` and ``transform_exclusive_scan`` algorithms.
 - Fixed the failures of the ``partial_sort_copy``, ``sort`` and ``stable_sort`` algorithms when using Radix sort with 32-bit ``float`` data type.
 - Fixed compilation issues that occurred using libstdc++9 or newer.
 - Got rid of unused variables. 
@@ -35,7 +82,7 @@ Known Issues and Limitations
   with some compilers including GCC 7 and earlier. Instead of this directive, use fully qualified
   names or namespace aliases.
 - The ``partial_sort_copy``, ``sort`` and ``stable_sort`` algorithms are prone to ``CL_BUILD_PROGRAM_FAILURE``
-  when using Radix sort in debug mode on oneAPI CPU devices.
+  when a program uses Radix sort [#fnote1]_, is built with -O0 option and executed on CPU devices.
 - Some algorithms with a DPC++ policy may fail on CPU or on FPGA emulator.
 - ``std::tuple``, ``std::pair`` cannot be used with SYCL buffers to transfer data between host and device.
 - When used within DPC++ kernels or transferred to/from a device, ``std::array`` can only hold objects whose type meets DPC++ requirements for use in kernels
@@ -65,8 +112,7 @@ Changes to Existing Features
 
 Fixed Issues
 -------------
-- Fixed the failures of the ``sort``, ``stable_sort`` algorithms when using Radix sort on oneAPI
-  CPU devices.
+- Fixed the failures of the ``sort``, ``stable_sort`` algorithms when using Radix sort on CPU devices.
 
 Known Issues and Limitations
 ----------------------------
@@ -77,7 +123,7 @@ Known Issues and Limitations
   with some compilers including GCC 7 and earlier. Instead of this directive, use fully qualified
   names or namespace aliases.
 - The ``partial_sort_copy``, ``sort`` and ``stable_sort`` algorithms are prone to ``CL_BUILD_PROGRAM_FAILURE``
-  when using Radix sort in debug mode on oneAPI CPU devices.
+  when a program uses Radix sort [#fnote1]_, is built with -O0 option and executed on CPU devices.
 - The ``partial_sort_copy``, ``sort`` and ``stable_sort`` algorithms may produce incorrect result
   when using Radix sort with 32-bit ``float`` data type.
 - Some algorithms with a DPC++ policy may fail on CPU or on FPGA emulator.
@@ -130,7 +176,7 @@ Known Issues and Limitations
 - The ``sort``, ``stable_sort``, ``partial_sort``, ``partial_sort_copy`` algorithms
   may work incorrectly on CPU device.
 - The ``partial_sort_copy``, ``sort`` and ``stable_sort`` algorithms are prone to ``CL_BUILD_PROGRAM_FAILURE``
-  when using Radix sort in debug mode on oneAPI CPU devices.
+  when a program uses Radix sort [#fnote1]_, is built with -O0 option and executed on CPU devices.
 - The ``partial_sort_copy``, ``sort`` and ``stable_sort`` algorithms may produce incorrect result
   when using Radix sort with 32-bit ``float`` data type.
 - Some algorithms with a DPC++ policy may fail on CPU or on FPGA emulator.
@@ -381,4 +427,7 @@ Known Issues and Limitations
 
 `*` Other names and brands may be claimed as the property of others.
 
+.. [#fnote1] The sorting algorithms in oneDPL use Radix sort for arithmetic data types compared with
+   ``std::less`` or ``std::greater``, otherwise Merge sort.
+.. _`the oneDPL Specification`: https://spec.oneapi.com/versions/latest/elements/oneDPL/source/index.html
 .. _`Intel® oneAPI Threading Building Blocks (oneTBB) Release Notes`: https://software.intel.com/content/www/us/en/develop/articles/intel-oneapi-threading-building-blocks-release-notes.html


### PR DESCRIPTION
* Added 2021.2.0 release changes

* Fixed typo

* Added footnote for Radix sort

* Fixed link to oneDPL specification

* Added missed changes noticed by Dmitriy

* Added missed space

(cherry picked from commit 1dd8af11c56ae0c26e2532481d1413356a060cbf)