### PR TITLE
Adding memory deallocation calls to algorithm extension USM tests.

### DIFF
--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
@@ -37,14 +37,14 @@ void ASSERT_EQUAL(_T1&& X, _T2&& Y) {
 void test_with_buffers()
 {
     // create a buffer, being responsible for moving data around and counting dependencies
-    cl::sycl::buffer<uint64_t, 1> _key_buf{ cl::sycl::range<1>(10) };
-    cl::sycl::buffer<uint64_t, 1> _val_buf{ cl::sycl::range<1>(10) };
-    cl::sycl::buffer<uint64_t, 1> _res_buf{ cl::sycl::range<1>(10) };
+    sycl::buffer<uint64_t, 1> _key_buf{ sycl::range<1>(10) };
+    sycl::buffer<uint64_t, 1> _val_buf{ sycl::range<1>(10) };
+    sycl::buffer<uint64_t, 1> _res_buf{ sycl::range<1>(10) };
 
     {
-        auto key_buf = _key_buf.template get_access<cl::sycl::access::mode::read_write>();
-        auto val_buf = _val_buf.template get_access<cl::sycl::access::mode::read_write>();
-        auto res_buf = _res_buf.template get_access<cl::sycl::access::mode::read_write>();
+        auto key_buf = _key_buf.template get_access<sycl::access::mode::read_write>();
+        auto val_buf = _val_buf.template get_access<sycl::access::mode::read_write>();
+        auto res_buf = _res_buf.template get_access<sycl::access::mode::read_write>();
 
         // Initialize data
         key_buf[0] = 0; key_buf[1] = 0; key_buf[2] = 0; key_buf[3] = 1; key_buf[4] = 1;
@@ -70,9 +70,9 @@ void test_with_buffers()
         (uint64_t)0, std::equal_to<uint64_t>(), std::plus<uint64_t>());
 
     // check values
-    auto key_acc = _key_buf.get_access<cl::sycl::access::mode::read>();
-    auto val_acc = _val_buf.get_access<cl::sycl::access::mode::read>();
-    auto res_acc = _res_buf.get_access<cl::sycl::access::mode::read>();
+    auto key_acc = _key_buf.get_access<sycl::access::mode::read>();
+    auto val_acc = _val_buf.get_access<sycl::access::mode::read>();
+    auto res_acc = _res_buf.get_access<sycl::access::mode::read>();
     uint64_t check_value;
     for (int i = 0; i != 10; ++i) {
             if (i == 0 || key_acc[i] != key_acc[i-1])
@@ -85,13 +85,13 @@ void test_with_buffers()
 
 void test_with_usm()
 {
-    cl::sycl::queue q;
+    sycl::queue q;
     const int n = 10;
 
     // Allocate space for data using USM.
-    uint64_t* key_head = static_cast<uint64_t*>(cl::sycl::malloc_shared(n * sizeof(uint64_t), q.get_device(), q.get_context()));
-    uint64_t* val_head = static_cast<uint64_t*>(cl::sycl::malloc_shared(n * sizeof(uint64_t), q.get_device(), q.get_context()));
-    uint64_t* res_head = static_cast<uint64_t*>(cl::sycl::malloc_shared(n * sizeof(uint64_t), q.get_device(), q.get_context()));
+    uint64_t* key_head = static_cast<uint64_t*>(sycl::malloc_shared(n * sizeof(uint64_t), q.get_device(), q.get_context()));
+    uint64_t* val_head = static_cast<uint64_t*>(sycl::malloc_shared(n * sizeof(uint64_t), q.get_device(), q.get_context()));
+    uint64_t* res_head = static_cast<uint64_t*>(sycl::malloc_shared(n * sizeof(uint64_t), q.get_device(), q.get_context()));
 
     // Initialize data
     key_head[0] = 0; key_head[1] = 0; key_head[2] = 0; key_head[3] = 1; key_head[4] = 1;
@@ -127,6 +127,11 @@ void test_with_usm()
 
     // check values
     ASSERT_EQUAL(0, res_head[0]);
+
+    // Deallocate memory
+    sycl::free(key_head, q);
+    sycl::free(val_head, q);
+    sycl::free(res_head, q);
 }
 #endif
 

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -37,14 +37,14 @@ void ASSERT_EQUAL(_T1&& X, _T2&& Y) {
 void test_with_buffers()
 {
     // create a buffer, being responsible for moving data around and counting dependencies
-    cl::sycl::buffer<uint64_t, 1> _key_buf{ cl::sycl::range<1>(10) };
-    cl::sycl::buffer<uint64_t, 1> _val_buf{ cl::sycl::range<1>(10) };
-    cl::sycl::buffer<uint64_t, 1> _res_buf{ cl::sycl::range<1>(10) };
+    sycl::buffer<uint64_t, 1> _key_buf{ sycl::range<1>(10) };
+    sycl::buffer<uint64_t, 1> _val_buf{ sycl::range<1>(10) };
+    sycl::buffer<uint64_t, 1> _res_buf{ sycl::range<1>(10) };
 
     {
-    auto key_buf = _key_buf.template get_access<cl::sycl::access::mode::read_write>();
-    auto val_buf = _val_buf.template get_access<cl::sycl::access::mode::read_write>();
-    auto res_buf = _res_buf.template get_access<cl::sycl::access::mode::read_write>();
+    auto key_buf = _key_buf.template get_access<sycl::access::mode::read_write>();
+    auto val_buf = _val_buf.template get_access<sycl::access::mode::read_write>();
+    auto res_buf = _res_buf.template get_access<sycl::access::mode::read_write>();
 
     // Initialize data
     key_buf[0] = 0; key_buf[1] = 0; key_buf[2] = 0; key_buf[3] = 1; key_buf[4] = 1;
@@ -69,9 +69,9 @@ void test_with_buffers()
         std::equal_to<uint64_t>(), std::plus<uint64_t>());
 
     // check values
-    auto key_acc = _key_buf.get_access<cl::sycl::access::mode::read>();
-    auto val_acc = _val_buf.get_access<cl::sycl::access::mode::read>();
-    auto res_acc = _res_buf.get_access<cl::sycl::access::mode::read>();
+    auto key_acc = _key_buf.get_access<sycl::access::mode::read>();
+    auto val_acc = _val_buf.get_access<sycl::access::mode::read>();
+    auto res_acc = _res_buf.get_access<sycl::access::mode::read>();
     uint64_t check_value;
     for (int i = 0; i != 10; ++i) {
         if (i == 0 || key_acc[i] != key_acc[i-1])
@@ -84,13 +84,13 @@ void test_with_buffers()
 
 void test_with_usm()
 {
-    cl::sycl::queue q;
+    sycl::queue q;
     const int n = 10;
 
     // Allocate space for data using USM.
-    uint64_t* key_head = static_cast<uint64_t*>(cl::sycl::malloc_shared(n * sizeof(uint64_t), q.get_device(), q.get_context()));
-    uint64_t* val_head = static_cast<uint64_t*>(cl::sycl::malloc_shared(n * sizeof(uint64_t), q.get_device(), q.get_context()));
-    uint64_t* res_head = static_cast<uint64_t*>(cl::sycl::malloc_shared(n * sizeof(uint64_t), q.get_device(), q.get_context()));
+    uint64_t* key_head = static_cast<uint64_t*>(sycl::malloc_shared(n * sizeof(uint64_t), q.get_device(), q.get_context()));
+    uint64_t* val_head = static_cast<uint64_t*>(sycl::malloc_shared(n * sizeof(uint64_t), q.get_device(), q.get_context()));
+    uint64_t* res_head = static_cast<uint64_t*>(sycl::malloc_shared(n * sizeof(uint64_t), q.get_device(), q.get_context()));
 
     // Initialize data
     key_head[0] = 0; key_head[1] = 0; key_head[2] = 0; key_head[3] = 1; key_head[4] = 1;
@@ -124,6 +124,11 @@ void test_with_usm()
 
     // check values
     ASSERT_EQUAL(1, res_head[0]);
+
+    // Deallocate memory
+    sycl::free(key_head, q);
+    sycl::free(val_head, q);
+    sycl::free(res_head, q);
 }
 #endif
 

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -38,16 +38,16 @@ void ASSERT_EQUAL(_T1&& X, _T2&& Y) {
 void test_with_buffers()
 {
     // create buffers
-    cl::sycl::buffer<uint64_t, 1> key_buf{ cl::sycl::range<1>(13) };
-    cl::sycl::buffer<uint64_t, 1> val_buf{ cl::sycl::range<1>(13) };
-    cl::sycl::buffer<uint64_t, 1> key_res_buf{ cl::sycl::range<1>(13) };
-    cl::sycl::buffer<uint64_t, 1> val_res_buf{ cl::sycl::range<1>(13) };
+    sycl::buffer<uint64_t, 1> key_buf{ sycl::range<1>(13) };
+    sycl::buffer<uint64_t, 1> val_buf{ sycl::range<1>(13) };
+    sycl::buffer<uint64_t, 1> key_res_buf{ sycl::range<1>(13) };
+    sycl::buffer<uint64_t, 1> val_res_buf{ sycl::range<1>(13) };
 
     {
-        auto keys    = key_buf.template get_access<cl::sycl::access::mode::read_write>();
-        auto vals    = val_buf.template get_access<cl::sycl::access::mode::read_write>();
-        auto keys_res    = key_res_buf.template get_access<cl::sycl::access::mode::read_write>();
-        auto vals_res    = val_res_buf.template get_access<cl::sycl::access::mode::read_write>();
+        auto keys    = key_buf.template get_access<sycl::access::mode::read_write>();
+        auto vals    = val_buf.template get_access<sycl::access::mode::read_write>();
+        auto keys_res    = key_res_buf.template get_access<sycl::access::mode::read_write>();
+        auto vals_res    = val_res_buf.template get_access<sycl::access::mode::read_write>();
 
         //T keys[n1] = { 1, 2, 3, 4, 1, 1, 3, 3, 1, 1, 3, 3, 0 };
         //T vals[n1] = { 1, 2, 3, 4, 1, 1, 3, 3, 1, 1, 3, 3, 0 };
@@ -89,8 +89,8 @@ void test_with_buffers()
 
     {
         // check values
-        auto keys_res    = key_res_buf.template get_access<cl::sycl::access::mode::read_write>();
-        auto vals_res    = val_res_buf.template get_access<cl::sycl::access::mode::read_write>();
+        auto keys_res    = key_res_buf.template get_access<sycl::access::mode::read_write>();
+        auto vals_res    = val_res_buf.template get_access<sycl::access::mode::read_write>();
         int n = std::distance(key_res_beg, res1.first);
         for (auto i = 0; i != n; ++i) {
             if (i < 4) {
@@ -120,14 +120,14 @@ void test_with_buffers()
 
 void test_with_usm()
 {
-    cl::sycl::queue q;
+    sycl::queue q;
     int n = 13;
 
     // Allocate space for data using USM.
-    uint64_t* key_head = static_cast<uint64_t*>(cl::sycl::malloc_shared(n * sizeof(uint64_t), q.get_device(), q.get_context()));
-    uint64_t* val_head = static_cast<uint64_t*>(cl::sycl::malloc_shared(n * sizeof(uint64_t), q.get_device(), q.get_context()));
-    uint64_t* key_res_head = static_cast<uint64_t*>(cl::sycl::malloc_shared(n * sizeof(uint64_t), q.get_device(), q.get_context()));
-    uint64_t* val_res_head = static_cast<uint64_t*>(cl::sycl::malloc_shared(n * sizeof(uint64_t), q.get_device(), q.get_context()));
+    uint64_t* key_head = static_cast<uint64_t*>(sycl::malloc_shared(n * sizeof(uint64_t), q.get_device(), q.get_context()));
+    uint64_t* val_head = static_cast<uint64_t*>(sycl::malloc_shared(n * sizeof(uint64_t), q.get_device(), q.get_context()));
+    uint64_t* key_res_head = static_cast<uint64_t*>(sycl::malloc_shared(n * sizeof(uint64_t), q.get_device(), q.get_context()));
+    uint64_t* val_res_head = static_cast<uint64_t*>(sycl::malloc_shared(n * sizeof(uint64_t), q.get_device(), q.get_context()));
 
     //T keys[n1] = { 1, 2, 3, 4, 1, 1, 3, 3, 1, 1, 3, 3, 0 };
     //T vals[n1] = { 1, 2, 3, 4, 1, 1, 3, 3, 1, 1, 3, 3, 0 };
@@ -188,6 +188,12 @@ void test_with_usm()
     ASSERT_EQUAL(n, 1);
     ASSERT_EQUAL(key_res_head[0], 1);
     ASSERT_EQUAL(val_res_head[0], 1);
+
+    // Deallocate memory
+    sycl::free(key_head, q);
+    sycl::free(val_head, q);
+    sycl::free(key_res_head, q);
+    sycl::free(val_res_head, q);
 }
 #endif
 


### PR DESCRIPTION
The `test_with_usm` function of the algorithm extension tests were not deallocating memory allocated in the function.  Correcting this and removing changing `cl::sycl` to `sycl` in the tests to match SYCL 2020 support.