### PR TITLE
 C++14 by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@
 ##===----------------------------------------------------------------------===##
 
 cmake_minimum_required(VERSION 3.4.3)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 file(READ ${CMAKE_CURRENT_SOURCE_DIR}/include/oneapi/dpl/pstl/onedpl_config.h


### PR DESCRIPTION
OneDPL need C++11 or 14 by default. Indeed GCC works with C++11 by default but is not guarantee with clang (Apple). A simple CMake command can fix it (since CMake 3.1). Up to you to accept it ;-)