### PR TITLE
Fixed issues with scan algorithms using GCC10 (host policies) and dpcpp policies

### DIFF
--- a/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
@@ -285,10 +285,12 @@ test_matrix(Out init, BinaryOp binary_op, Out trash)
 #endif
 
 #ifdef _PSTL_TEST_EXCLUSIVE_SCAN
+#if !TEST_GCC10_EXCLUSIVE_SCAN_BROKEN
         invoke_on_all_policies<8>()(test_exclusive_scan_with_binary_op<In>(), in.begin(), in.end(), out.begin(),
                                     out.end(), expected.begin(), expected.end(), in.size(), init, binary_op, trash);
         invoke_on_all_policies<9>()(test_exclusive_scan_with_binary_op<In>(), in.cbegin(), in.cend(), out.begin(),
                                     out.end(), expected.begin(), expected.end(), in.size(), init, binary_op, trash);
+#endif
 #endif
     }
 }

--- a/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
@@ -296,12 +296,10 @@ test_matrix(Out init, BinaryOp binary_op, Out trash)
 int
 main()
 {
-#if !_PSTL_ICC_19_TEST_SIMD_UDS_WINDOWS_RELEASE_BROKEN
-#if !TEST_DPCPP_BACKEND_PRESENT
+#if !_PSTL_ICC_19_TEST_SIMD_UDS_WINDOWS_RELEASE_BROKEN && !TEST_DPCPP_BACKEND_PRESENT && !_PSTL_GCC_TEST_UNSEQ_SCAN_DEBUG_BROKEN
     // Test with highly restricted type and associative but not commutative operation
     test_matrix<Matrix2x2<int32_t>, Matrix2x2<int32_t>>(Matrix2x2<int32_t>(), multiply_matrix<int32_t>,
                                                             Matrix2x2<int32_t>(-666, 666));
-#endif
 #endif
 
     // Since the implicit "+" forms of the scan delegate to the generic forms,

--- a/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
@@ -296,9 +296,9 @@ test_matrix(Out init, BinaryOp binary_op, Out trash)
 int
 main()
 {
-#if !_PSTL_ICC_19_TEST_SIMD_UDS_WINDOWS_RELEASE_BROKEN && !TEST_DPCPP_BACKEND_PRESENT && !_PSTL_GCC_TEST_UNSEQ_SCAN_DEBUG_BROKEN
+#if !_PSTL_ICC_19_TEST_SIMD_UDS_WINDOWS_RELEASE_BROKEN
     // Test with highly restricted type and associative but not commutative operation
-    test_matrix<Matrix2x2<int32_t>, Matrix2x2<int32_t>>(Matrix2x2<int32_t>(), multiply_matrix<int32_t>,
+    test_matrix<Matrix2x2<int32_t>, Matrix2x2<int32_t>>(Matrix2x2<int32_t>(), multiply_matrix<int32_t>(),
                                                             Matrix2x2<int32_t>(-666, 666));
 #endif
 

--- a/test/parallel_api/numeric/numeric.ops/transform_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/transform_scan.pass.cpp
@@ -232,14 +232,16 @@ test_matrix(UnaryOp unary_op, Out init, BinaryOp binary_op, Out trash)
         invoke_on_all_policies<7>()(test_transform_inclusive_scan_init<In>(), in.begin(), in.end(), out.begin(),
                                     out.end(), expected.begin(), expected.end(), in.size(), unary_op, init, binary_op,
                                     trash);
-        invoke_on_all_policies<8>()(test_transform_inclusive_scan<In>(), in.begin(), in.end(), out.begin(), out.end(),
-                                     expected.begin(), expected.end(), in.size(), unary_op, init, binary_op, trash);
-        invoke_on_all_policies<9>()(test_transform_inclusive_scan_init<In>(), in.cbegin(), in.cend(), out.begin(),
+        invoke_on_all_policies<8>()(test_transform_inclusive_scan_init<In>(), in.cbegin(), in.cend(), out.begin(),
                                     out.end(), expected.begin(), expected.end(), in.size(), unary_op, init, binary_op,
                                     trash);
+#if !TEST_GCC10_TRANSFORM_INCLUSIVE_SCAN_BROKEN
+        invoke_on_all_policies<9>()(test_transform_inclusive_scan<In>(), in.begin(), in.end(), out.begin(), out.end(),
+                                     expected.begin(), expected.end(), in.size(), unary_op, init, binary_op, trash);
         invoke_on_all_policies<10>()(test_transform_inclusive_scan<In>(), in.cbegin(), in.cend(), out.begin(),
                                      out.end(), expected.begin(), expected.end(), in.size(), unary_op, init, binary_op,
                                      trash);
+#endif
 #endif
 #ifdef _PSTL_TEST_TRANSFORM_EXCLUSIVE_SCAN
         invoke_on_all_policies<11>()(test_transform_exclusive_scan<In>(), in.begin(), in.end(), out.begin(), out.end(),

--- a/test/parallel_api/numeric/numeric.ops/transform_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/transform_scan.pass.cpp
@@ -235,20 +235,20 @@ test_matrix(UnaryOp unary_op, Out init, BinaryOp binary_op, Out trash)
         invoke_on_all_policies<8>()(test_transform_inclusive_scan_init<In>(), in.cbegin(), in.cend(), out.begin(),
                                     out.end(), expected.begin(), expected.end(), in.size(), unary_op, init, binary_op,
                                     trash);
-#if !TEST_GCC10_TRANSFORM_INCLUSIVE_SCAN_BROKEN
         invoke_on_all_policies<9>()(test_transform_inclusive_scan<In>(), in.begin(), in.end(), out.begin(), out.end(),
                                      expected.begin(), expected.end(), in.size(), unary_op, init, binary_op, trash);
         invoke_on_all_policies<10>()(test_transform_inclusive_scan<In>(), in.cbegin(), in.cend(), out.begin(),
                                      out.end(), expected.begin(), expected.end(), in.size(), unary_op, init, binary_op,
                                      trash);
 #endif
-#endif
 #ifdef _PSTL_TEST_TRANSFORM_EXCLUSIVE_SCAN
+#if !TEST_GCC10_EXCLUSIVE_SCAN_BROKEN
         invoke_on_all_policies<11>()(test_transform_exclusive_scan<In>(), in.begin(), in.end(), out.begin(), out.end(),
                                     expected.begin(), expected.end(), in.size(), unary_op, init, binary_op, trash);
         invoke_on_all_policies<12>()(test_transform_exclusive_scan<In>(), in.cbegin(), in.cend(), out.begin(),
                                     out.end(), expected.begin(), expected.end(), in.size(), unary_op, init, binary_op,
                                     trash);
+#endif
 #endif
     }
 }

--- a/test/parallel_api/numeric/numeric.ops/transform_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/transform_scan.pass.cpp
@@ -255,11 +255,9 @@ int
 main()
 {
 #if !_PSTL_ICC_19_TEST_SIMD_UDS_WINDOWS_RELEASE_BROKEN
-#if !TEST_DPCPP_BACKEND_PRESENT
     test_matrix<Matrix2x2<int32_t>, Matrix2x2<int32_t>>([](const Matrix2x2<int32_t> x) { return x; },
-                                                        Matrix2x2<int32_t>(), multiply_matrix<int32_t>,
+                                                        Matrix2x2<int32_t>(), multiply_matrix<int32_t>(),
                                                         Matrix2x2<int32_t>(-666, 666));
-#endif
 #endif
     test<int32_t, uint32_t>([](int32_t x) { return x++; }, -123, [](int32_t x, int32_t y) { return x + y; }, 666);
 

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -39,9 +39,6 @@
 // ICC 19 has encountered an unexpected problem: Segmentation violation signal raised
 #define _PSTL_ICC_19_TEST_IS_PARTITIONED_RELEASE_BROKEN                                                               \
     (!PSTL_USE_DEBUG && (__linux__ || __APPLE__) && __INTEL_COMPILER == 1900)
-// ICC 19 has encountered an unexpected problem: Segmentation violation signal raised
-#define _PSTL_ICL_19_VC14_VC141_TEST_SCAN_RELEASE_BROKEN                                                              \
-    (__INTEL_COMPILER == 1900 && _MSC_VER >= 1900 && _MSC_VER <= 1910)
 // ICC 19 generates wrong result with UDS on Windows
 #define _PSTL_ICC_19_TEST_SIMD_UDS_WINDOWS_RELEASE_BROKEN (__INTEL_COMPILER == 1900 && _MSC_VER && !_DEBUG)
 // ICC 18,19 generate wrong result

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -52,9 +52,6 @@
     (__i386__ && (__INTEL_COMPILER == 1800 || __INTEL_COMPILER == 1900))
 // VC14 uninitialized_fill with no policy has broken implementation
 #define _PSTL_STD_UNINITIALIZED_FILL_BROKEN (_MSC_VER == 1900)
-// GCC10 (Debug mode) produce wrong result using vectorization
-#define _PSTL_GCC_TEST_UNSEQ_SCAN_DEBUG_BROKEN                                                                      \
-    (_GLIBCXX_RELEASE == 10 && PSTL_USE_DEBUG && __cplusplus >= 201703L)
 
 #define _PSTL_SYCL_TEST_USM 1
 

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -52,6 +52,8 @@
     (__i386__ && (__INTEL_COMPILER == 1800 || __INTEL_COMPILER == 1900))
 // VC14 uninitialized_fill with no policy has broken implementation
 #define _PSTL_STD_UNINITIALIZED_FILL_BROKEN (_MSC_VER == 1900)
+// GCC10 produces wrong answer calling tranform_inclusive_scan using vectorized polices
+#define TEST_GCC10_TRANSFORM_INCLUSIVE_SCAN_BROKEN (_GLIBCXX_RELEASE == 10)
 
 #define _PSTL_SYCL_TEST_USM 1
 

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -49,8 +49,8 @@
     (__i386__ && (__INTEL_COMPILER == 1800 || __INTEL_COMPILER == 1900))
 // VC14 uninitialized_fill with no policy has broken implementation
 #define _PSTL_STD_UNINITIALIZED_FILL_BROKEN (_MSC_VER == 1900)
-// GCC10 produces wrong answer calling tranform_inclusive_scan using vectorized polices
-#define TEST_GCC10_TRANSFORM_INCLUSIVE_SCAN_BROKEN (_GLIBCXX_RELEASE == 10)
+// GCC10 produces wrong answer calling exclusive_scan using vectorized polices
+#define TEST_GCC10_EXCLUSIVE_SCAN_BROKEN (_GLIBCXX_RELEASE == 10)
 
 #define _PSTL_SYCL_TEST_USM 1
 

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -52,6 +52,9 @@
     (__i386__ && (__INTEL_COMPILER == 1800 || __INTEL_COMPILER == 1900))
 // VC14 uninitialized_fill with no policy has broken implementation
 #define _PSTL_STD_UNINITIALIZED_FILL_BROKEN (_MSC_VER == 1900)
+// GCC10 (Debug mode) produce wrong result using vectorization
+#define _PSTL_GCC_TEST_UNSEQ_SCAN_DEBUG_BROKEN                                                                      \
+    (_GLIBCXX_RELEASE == 10 && PSTL_USE_DEBUG && __cplusplus >= 201703L)
 
 #define _PSTL_SYCL_TEST_USM 1
 

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -574,43 +574,32 @@ class AssocOp
 template <typename T>
 struct Matrix2x2
 {
-    T a[2][2];
-    Matrix2x2() : a{{1, 0}, {0, 1}} {}
-    Matrix2x2(T x, T y) : a{{0, x}, {x, y}} {}
-    //Explicit definition of a copy constructor and assignment operator to avoid an error for some compilers
-#if !_PSTL_ICL_19_VC14_VC141_TEST_SCAN_RELEASE_BROKEN
-    Matrix2x2(const Matrix2x2& m) : a{{m.a[0][0], m.a[0][1]}, {m.a[1][0], m.a[1][1]}} {}
-    Matrix2x2&
-    operator=(const Matrix2x2& m)
-    {
-        a[0][0] = m.a[0][0], a[0][1] = m.a[0][1], a[1][0] = m.a[1][0], a[1][1] = m.a[1][1];
-        return *this;
-    }
-#endif
+    T a00, a01, a10, a11;
+    Matrix2x2() = default;
+    Matrix2x2(T x, T y) : a00(0), a01(x), a10(x), a11(y) {}
 };
 
 template <typename T>
 bool
 operator==(const Matrix2x2<T>& left, const Matrix2x2<T>& right)
 {
-    return left.a[0][0] == right.a[0][0] && left.a[0][1] == right.a[0][1] && left.a[1][0] == right.a[1][0] &&
-           left.a[1][1] == right.a[1][1];
+    return left.a00 == right.a00 && left.a01 == right.a01 && left.a10 == right.a10 && left.a11 == right.a11;
 }
 
 template <typename T>
-Matrix2x2<T>
-multiply_matrix(const Matrix2x2<T>& left, const Matrix2x2<T>& right)
+struct multiply_matrix
 {
-    Matrix2x2<T> result;
-    for (int32_t i = 0; i < 2; ++i)
+    Matrix2x2<T> operator()(const Matrix2x2<T>& left, const Matrix2x2<T>& right) const
     {
-        for (int32_t j = 0; j < 2; ++j)
-        {
-            result.a[i][j] = left.a[i][0] * right.a[0][j] + left.a[i][1] * right.a[1][j];
-        }
+        Matrix2x2<T> result;
+        result.a00 = left.a00 * right.a00 + left.a01 * right.a10;
+        result.a01 = left.a00 * right.a01 + left.a01 * right.a11;
+        result.a10 = left.a10 * right.a00 + left.a11 * right.a10;
+        result.a11 = left.a10 * right.a01 + left.a11 * right.a11;
+
+        return result;
     }
-    return result;
-}
+};
 
 // Check that Intel(R) Threading Building Blocks header files are not used when parallel policies are off
 #if !_ONEDPL_USE_PAR_POLICIES

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -575,7 +575,7 @@ template <typename T>
 struct Matrix2x2
 {
     T a00, a01, a10, a11;
-    Matrix2x2() = default;
+    Matrix2x2() : a00(1), a01(0), a10(0), a11(1) {}
     Matrix2x2(T x, T y) : a00(0), a01(x), a10(x), a11(y) {}
 };
 


### PR DESCRIPTION
1. Fixed issues where scan algorithms with host policies worked incorrectly using gcc10
2. Enable testing matrices for dpcpp policies. `Matrix` is default constructible now