### PR TITLE
Add structured binding support for zip_iterator::value_type

### DIFF
--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -91,6 +91,12 @@
 #    define _ONEDPL_CONSTEXPR_VAR constexpr
 #endif
 
+#if (__cplusplus >= 201402L)
+#    define _ONEDPL_CPP14_CONSTEXPR constexpr
+#else
+#    define _ONEDPL_CPP14_CONSTEXPR
+#endif
+
 // Check the user-defined macro for warnings
 #if !defined(_PSTL_USAGE_WARNINGS) && defined(PSTL_USAGE_WARNINGS)
 #    define _PSTL_USAGE_WARNINGS PSTL_USAGE_WARNINGS

--- a/include/oneapi/dpl/pstl/tuple_impl.h
+++ b/include/oneapi/dpl/pstl/tuple_impl.h
@@ -282,12 +282,17 @@ template <typename _Tp>
 struct __copy_assignable_holder<_Tp, false> : oneapi::dpl::__internal::__value_holder<_Tp>
 {
     using oneapi::dpl::__internal::__value_holder<_Tp>::__value_holder;
+    __copy_assignable_holder() = default;
+    __copy_assignable_holder(const __copy_assignable_holder&) = default;
+    __copy_assignable_holder(__copy_assignable_holder&&) = default;
     __copy_assignable_holder&
     operator=(const __copy_assignable_holder& other)
     {
         this->value = other.value;
         return *this;
     }
+    __copy_assignable_holder&
+    operator=(__copy_assignable_holder&& other) = default;
 };
 
 template <typename T1, typename... T>
@@ -330,19 +335,20 @@ struct tuple<T1, T...>
     tuple(const tuple& other) = default;
     tuple(tuple&& other) = default;
     template <typename _U1, typename... _U, typename = typename ::std::enable_if<(sizeof...(_U) == sizeof...(T))>::type>
-    tuple(const tuple<_U1, _U...>& other) : holder(other.holder.value), next(other.next)
+    tuple(const tuple<_U1, _U...>& other) : holder(other.template get<0>()), next(other.next)
     {
     }
 
     template <typename _U1, typename... _U, typename = typename ::std::enable_if<(sizeof...(_U) == sizeof...(T))>::type>
-    tuple(tuple<_U1, _U...>&& other) : holder(std::forward<_U1>(other.holder.value)), next(std::move(other.next))
+    tuple(tuple<_U1, _U...>&& other) : holder(std::move(other).template get<0>()), next(std::move(other.next))
     {
     }
 
     template <typename _U1, typename... _U,
               typename = typename ::std::enable_if<
-                  (sizeof...(_U) == sizeof...(T) && ::std::is_constructible<T1, _U1&&>::value &&
-                   oneapi::dpl::__internal::__conjunction<::std::is_constructible<T, _U&&>...>::value)>::type>
+                  (sizeof...(_U) == sizeof...(T) &&
+                   oneapi::dpl::__internal::__conjunction<::std::is_constructible<T1, _U1&&>,
+                                                          ::std::is_constructible<T, _U&&>...>::value)>::type>
     tuple(_U1&& _value, _U&&... _next) : holder(::std::forward<_U1>(_value)), next(::std::forward<_U>(_next)...)
     {
     }

--- a/include/oneapi/dpl/pstl/tuple_impl.h
+++ b/include/oneapi/dpl/pstl/tuple_impl.h
@@ -299,28 +299,28 @@ struct tuple<T1, T...>
     using tuple_type = ::std::tuple<T1, T...>;
 
     template <::std::size_t I>
-    constexpr auto
+    _ONEDPL_CPP14_CONSTEXPR auto
     get() & -> decltype(get_impl<I>()(*this))
     {
         return get_impl<I>()(*this);
     }
 
     template <::std::size_t I>
-    constexpr auto
+    _ONEDPL_CPP14_CONSTEXPR auto
     get() const& -> decltype(get_impl<I>()(*this))
     {
         return get_impl<I>()(*this);
     }
 
     template <::std::size_t I>
-    constexpr auto
+    _ONEDPL_CPP14_CONSTEXPR auto
     get() && -> decltype(get_impl<I>()(::std::move(*this)))
     {
         return get_impl<I>()(::std::move(*this));
     }
 
     template <::std::size_t I>
-    constexpr auto
+    _ONEDPL_CPP14_CONSTEXPR auto
     get() const&& -> decltype(get_impl<I>()(::std::move(*this)))
     {
         return get_impl<I>()(::std::move(*this));
@@ -329,8 +329,13 @@ struct tuple<T1, T...>
     tuple() = default;
     tuple(const tuple& other) = default;
     tuple(tuple&& other) = default;
-    template <typename U1, typename... U>
-    tuple(const tuple<U1, U...>& other) : holder(other.holder.value), next(other.next)
+    template <typename _U1, typename... _U, typename = typename ::std::enable_if<(sizeof...(_U) == sizeof...(T))>::type>
+    tuple(const tuple<_U1, _U...>& other) : holder(other.holder.value), next(other.next)
+    {
+    }
+
+    template <typename _U1, typename... _U, typename = typename ::std::enable_if<(sizeof...(_U) == sizeof...(T))>::type>
+    tuple(tuple<_U1, _U...>&& other) : holder(std::forward<_U1>(other.holder.value)), next(std::move(other.next))
     {
     }
 

--- a/include/oneapi/dpl/pstl/tuple_impl.h
+++ b/include/oneapi/dpl/pstl/tuple_impl.h
@@ -29,12 +29,39 @@ namespace dpl
 {
 namespace __internal
 {
-
-//custom tuple utilities
-
 template <typename... T>
 struct tuple;
+} // namespace __internal
+} // namespace dpl
+} // namespace oneapi
 
+namespace std
+{
+template <::std::size_t N, typename T, typename... Rest>
+struct tuple_element<N, oneapi::dpl::__internal::tuple<T, Rest...>>
+    : tuple_element<N - 1, oneapi::dpl::__internal::tuple<Rest...>>
+{
+};
+
+template <typename T, typename... Rest>
+struct tuple_element<0, oneapi::dpl::__internal::tuple<T, Rest...>>
+{
+    using type = T;
+};
+
+template <typename... Args>
+struct tuple_size<oneapi::dpl::__internal::tuple<Args...>> : ::std::integral_constant<::std::size_t, sizeof...(Args)>
+{
+};
+} // namespace std
+
+//custom tuple utilities
+namespace oneapi
+{
+namespace dpl
+{
+namespace __internal
+{
 template <typename... Size>
 struct get_value_by_idx;
 
@@ -101,22 +128,6 @@ make_tuplewrapper(T&&... t)
     return {::std::forward<T>(t)...};
 }
 
-// __internal::tuple_element
-template <::std::size_t N, typename T>
-struct tuple_element;
-
-template <::std::size_t N, typename T, typename... Rest>
-struct tuple_element<N, oneapi::dpl::__internal::tuple<T, Rest...>>
-    : tuple_element<N - 1, oneapi::dpl::__internal::tuple<Rest...>>
-{
-};
-
-template <typename T, typename... Rest>
-struct tuple_element<0, oneapi::dpl::__internal::tuple<T, Rest...>>
-{
-    using type = T;
-};
-
 template <size_t N>
 struct get_impl
 {
@@ -133,13 +144,27 @@ struct get_impl
     {
         return get_impl<N - 1>()(t.next);
     }
+
+    template <typename... T>
+    constexpr auto
+    operator()(oneapi::dpl::__internal::tuple<T...>&& t) const -> decltype(get_impl<N - 1>()(::std::move(t.next)))
+    {
+        return get_impl<N - 1>()(::std::move(t.next));
+    }
+
+    template <typename... T>
+    constexpr auto
+    operator()(const oneapi::dpl::__internal::tuple<T...>&& t) const -> decltype(get_impl<N - 1>()(::std::move(t.next)))
+    {
+        return get_impl<N - 1>()(::std::move(t.next));
+    }
 };
 
 template <>
 struct get_impl<0>
 {
     template <typename... T>
-    using ret_type = typename oneapi::dpl::__internal::tuple_element<0, oneapi::dpl::__internal::tuple<T...>>::type;
+    using ret_type = typename ::std::tuple_element<0, oneapi::dpl::__internal::tuple<T...>>::type;
 
     template <typename... T>
     constexpr ret_type<T...>&
@@ -149,10 +174,24 @@ struct get_impl<0>
     }
 
     template <typename... T>
-    constexpr ret_type<T...> const&
+    constexpr const ret_type<T...>&
     operator()(const oneapi::dpl::__internal::tuple<T...>& t) const
     {
         return t.holder.value;
+    }
+
+    template <typename... T>
+    constexpr ret_type<T...>&&
+    operator()(oneapi::dpl::__internal::tuple<T...>&& t) const
+    {
+        return ::std::forward<ret_type<T...>&&>(t.holder.value);
+    }
+
+    template <typename... T>
+    constexpr const ret_type<T...>&&
+    operator()(const oneapi::dpl::__internal::tuple<T...>&& t) const
+    {
+        return ::std::forward<const ret_type<T...>&&>(t.holder.value);
     }
 };
 
@@ -223,7 +262,10 @@ template <typename _Tp>
 struct __value_holder
 {
     __value_holder() = default;
-    __value_holder(const _Tp& t) : value(t) {}
+    template <typename _Up>
+    __value_holder(_Up&& t) : value(::std::forward<_Up>(t))
+    {
+    }
     _Tp value;
 };
 
@@ -256,14 +298,49 @@ struct tuple<T1, T...>
 
     using tuple_type = ::std::tuple<T1, T...>;
 
+    template <::std::size_t I>
+    constexpr auto
+    get() & -> decltype(get_impl<I>()(*this))
+    {
+        return get_impl<I>()(*this);
+    }
+
+    template <::std::size_t I>
+    constexpr auto
+    get() const& -> decltype(get_impl<I>()(*this))
+    {
+        return get_impl<I>()(*this);
+    }
+
+    template <::std::size_t I>
+    constexpr auto
+    get() && -> decltype(get_impl<I>()(::std::move(*this)))
+    {
+        return get_impl<I>()(::std::move(*this));
+    }
+
+    template <::std::size_t I>
+    constexpr auto
+    get() const&& -> decltype(get_impl<I>()(::std::move(*this)))
+    {
+        return get_impl<I>()(::std::move(*this));
+    }
+
     tuple() = default;
     tuple(const tuple& other) = default;
+    tuple(tuple&& other) = default;
     template <typename U1, typename... U>
     tuple(const tuple<U1, U...>& other) : holder(other.holder.value), next(other.next)
     {
     }
 
-    tuple(const T1& _value, const T&... _next) : holder(_value), next(_next...) {}
+    template <typename _U1, typename... _U,
+              typename = typename ::std::enable_if<
+                  (sizeof...(_U) == sizeof...(T) && ::std::is_constructible<T1, _U1&&>::value &&
+                   oneapi::dpl::__internal::__conjunction<::std::is_constructible<T, _U&&>...>::value)>::type>
+    tuple(_U1&& _value, _U&&... _next) : holder(::std::forward<_U1>(_value)), next(::std::forward<_U>(_next)...)
+    {
+    }
 
     // required to convert ::std::tuple to inner tuple in user-provided functor
     tuple(const ::std::tuple<T1, T...>& other)
@@ -282,7 +359,7 @@ struct tuple<T1, T...>
     template <typename U1, typename... U>
     operator ::std::tuple<U1, U...>() const
     {
-        static constexpr ::std::size_t __tuple_size = sizeof...(T) + 1;
+        constexpr ::std::size_t __tuple_size = sizeof...(T) + 1;
         return to_std_tuple(static_cast<tuple<U1, U...>>(*this),
                             oneapi::dpl::__internal::__make_index_sequence<__tuple_size>());
     }
@@ -542,19 +619,31 @@ operator-(Size idx, const oneapi::dpl::__internal::tuple<T1...>& tuple1)
 namespace std
 {
 template <size_t _Idx, typename... _Tp>
-constexpr typename oneapi::dpl::__internal::tuple_element<_Idx, oneapi::dpl::__internal::tuple<_Tp...>>::type&
+constexpr typename ::std::tuple_element<_Idx, oneapi::dpl::__internal::tuple<_Tp...>>::type&
 get(oneapi::dpl::__internal::tuple<_Tp...>& __a)
 {
-    return oneapi::dpl::__internal::get_impl<_Idx>()(__a);
+    return __a.template get<_Idx>();
 }
 
 template <size_t _Idx, typename... _Tp>
-constexpr typename oneapi::dpl::__internal::tuple_element<_Idx, oneapi::dpl::__internal::tuple<_Tp...>>::type const&
+constexpr typename ::std::tuple_element<_Idx, oneapi::dpl::__internal::tuple<_Tp...>>::type const&
 get(const oneapi::dpl::__internal::tuple<_Tp...>& __a)
 {
-    return oneapi::dpl::__internal::get_impl<_Idx>()(__a);
+    return __a.template get<_Idx>();
+}
+template <size_t _Idx, typename... _Tp>
+constexpr typename ::std::tuple_element<_Idx, oneapi::dpl::__internal::tuple<_Tp...>>::type&&
+get(oneapi::dpl::__internal::tuple<_Tp...>&& __a)
+{
+    return ::std::move(__a).template get<_Idx>();
 }
 
+template <size_t _Idx, typename... _Tp>
+constexpr typename ::std::tuple_element<_Idx, oneapi::dpl::__internal::tuple<_Tp...>>::type const&&
+get(const oneapi::dpl::__internal::tuple<_Tp...>&& __a)
+{
+    return ::std::move(__a).template get<_Idx>();
+}
 } // namespace std
 
 #endif /* _ONEDPL_tuple_impl_H */

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -608,6 +608,21 @@ struct __next_to_last
 template <typename _T, class _Enable = void>
 class __future;
 
+template <typename... _Bs>
+struct __conjunction : ::std::true_type
+{
+};
+
+template <typename _B1>
+struct __conjunction<_B1> : _B1
+{
+};
+
+template <typename _B1, typename... _Bs>
+struct __conjunction<_B1, _Bs...> : ::std::conditional<!bool(_B1::value), _B1, __conjunction<_Bs...>>::type
+{
+};
+
 } // namespace __internal
 } // namespace dpl
 } // namespace oneapi

--- a/test/parallel_api/iterator/zip_iterator.pass.cpp
+++ b/test/parallel_api/iterator/zip_iterator.pass.cpp
@@ -144,12 +144,13 @@ struct test_for_each_structured_binding
                         [f](auto value) {
                             auto [x, y] = value;
                             f(x);
+                            f(y);
                         });
 #if _PSTL_SYCL_TEST_USM
         exec.queue().wait_and_throw();
 #endif
         host_first1 = get_host_pointer(first1);
-        EXPECT_TRUE(check_values(host_first1, host_first1 + n, value + 1), "wrong effect from for_each(tuple)");
+        EXPECT_TRUE(check_values(host_first1, host_first1 + n, value + 2), "wrong effect from for_each(tuple)");
     }
 };
 #endif // __cplusplus >= 201703L

--- a/test/parallel_api/iterator/zip_iterator.pass.cpp
+++ b/test/parallel_api/iterator/zip_iterator.pass.cpp
@@ -41,7 +41,6 @@
     !defined(_PSTL_TEST_LEXICOGRAPHICAL_COMPIARE) && \
     !defined(_PSTL_TEST_COUNTING_ZIP_TRANSFORM)
 #define _PSTL_TEST_FOR_EACH
-#define _PSTL_TEST_FOR_EACH_STRUCTURED_BINDING
 #define _PSTL_TEST_TRANSFORM_REDUCE_UNARY
 #define _PSTL_TEST_TRANSFORM_REDUCE_BINARY
 #define _PSTL_TEST_COUNT_IF
@@ -53,6 +52,10 @@
 #define _PSTL_TEST_STABLE_SORT
 #define _PSTL_TEST_LEXICOGRAPHICAL_COMPIARE
 #define _PSTL_TEST_COUNTING_ZIP_TRANSFORM
+#if (__cplusplus >= 201703L)
+#   define _PSTL_TEST_FOR_EACH_STRUCTURED_BINDING
+#   define _PSTL_TEST_EQUAL_STRUCTURED_BINDING
+#endif
 #endif
 
 using namespace TestUtils;
@@ -124,7 +127,7 @@ struct test_for_each
     }
 };
 
-#if __cplusplus >= 201703L
+#if defined(_PSTL_TEST_FOR_EACH_STRUCTURED_BINDING)
 struct test_for_each_structured_binding
 {
     template <typename Policy, typename Iterator1, typename Size>
@@ -153,7 +156,7 @@ struct test_for_each_structured_binding
         EXPECT_TRUE(check_values(host_first1, host_first1 + n, value + 2), "wrong effect from for_each(tuple)");
     }
 };
-#endif // __cplusplus >= 201703L
+#endif // _PSTL_TEST_FOR_EACH_STRUCTURED_BINDING
 
 struct test_transform_reduce_unary
 {
@@ -301,6 +304,53 @@ struct test_equal
         EXPECT_TRUE(!is_equal, "wrong effect from equal(tuple) 2");
     }
 };
+
+#if defined(_PSTL_TEST_EQUAL_STRUCTURED_BINDING)
+struct test_equal_structured_binding
+{
+    template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
+    void
+    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator2 /* last2 */, Size n)
+    {
+        using T = typename ::std::iterator_traits<Iterator1>::value_type;
+        auto value = T(42);
+        auto host_first1 = get_host_pointer(first1);
+        auto host_first2 = get_host_pointer(first2);
+        ::std::iota(host_first1, host_first1 + n, value);
+        ::std::iota(host_first2, host_first2 + n, value);
+
+        auto tuple_first1 = oneapi::dpl::make_zip_iterator(first1, first1);
+        auto tuple_last1 = oneapi::dpl::make_zip_iterator(last1, last1);
+        auto tuple_first2 = oneapi::dpl::make_zip_iterator(first2, first2);
+
+        auto compare = [](auto tuple_first1, auto tuple_first2)
+        {
+            const auto& [a, b] = tuple_first1;
+            const auto& [c, d] = tuple_first2;
+
+            static_assert(::std::is_reference<decltype(a)>::value, "tuple element type is not a reference");
+            static_assert(::std::is_reference<decltype(b)>::value, "tuple element type is not a reference");
+            static_assert(::std::is_reference<decltype(c)>::value, "tuple element type is not a reference");
+            static_assert(::std::is_reference<decltype(d)>::value, "tuple element type is not a reference");
+
+            return (a == c) && (c == d);
+        };
+
+        bool is_equal = ::std::equal(make_new_policy<new_kernel_name<Policy, 0>>(exec), tuple_first1, tuple_last1, tuple_first2,
+                                     compare);
+#if _PSTL_SYCL_TEST_USM
+        exec.queue().wait_and_throw();
+#endif
+        EXPECT_TRUE(is_equal, "wrong effect from equal(tuple with use of structured binding) 1");
+
+        host_first2 = get_host_pointer(first2);
+        *(host_first2 + n - 1) = T{0};
+        is_equal = ::std::equal(make_new_policy<new_kernel_name<Policy, 1>>(exec), tuple_first1, tuple_last1, tuple_first2,
+                                compare);
+        EXPECT_TRUE(!is_equal, "wrong effect from equal(tuple with use of structured binding) 2");
+    }
+};
+#endif // _PSTL_TEST_EQUAL_STRUCTURED_BINDING
 
 struct test_find_if
 {
@@ -626,7 +676,7 @@ main()
     PRINT_DEBUG("test_for_each");
     test1buffer<int32_t, test_for_each>();
 #endif
-#if (__cplusplus >= 201703L) && defined(_PSTL_TEST_FOR_EACH_STRUCTURED_BINDING)
+#if defined(_PSTL_TEST_FOR_EACH_STRUCTURED_BINDING)
     PRINT_DEBUG("test_for_each_structured_binding");
     test1buffer<int32_t, test_for_each_structured_binding>();
 #endif
@@ -645,6 +695,10 @@ main()
 #if defined(_PSTL_TEST_EQUAL)
     PRINT_DEBUG("test_equal");
     test2buffers<int32_t, test_equal>();
+#endif
+#if defined(_PSTL_TEST_EQUAL_STRUCTURED_BINDING)
+    PRINT_DEBUG("test_equal_structured_binding");
+    test2buffers<int32_t, test_equal_structured_binding>();
 #endif
 #if defined(_PSTL_TEST_INCLUSIVE_SCAN)
     PRINT_DEBUG("test_inclusive_scan");

--- a/test/parallel_api/iterator/zip_iterator.pass.cpp
+++ b/test/parallel_api/iterator/zip_iterator.pass.cpp
@@ -124,6 +124,7 @@ struct test_for_each
     }
 };
 
+#if __cplusplus >= 201703L
 struct test_for_each_structured_binding
 {
     template <typename Policy, typename Iterator1, typename Size>
@@ -151,6 +152,7 @@ struct test_for_each_structured_binding
         EXPECT_TRUE(check_values(host_first1, host_first1 + n, value + 1), "wrong effect from for_each(tuple)");
     }
 };
+#endif // __cplusplus >= 201703L
 
 struct test_transform_reduce_unary
 {
@@ -623,7 +625,7 @@ main()
     PRINT_DEBUG("test_for_each");
     test1buffer<int32_t, test_for_each>();
 #endif
-#if defined(_PSTL_TEST_FOR_EACH_STRUCTURED_BINDING)
+#if (__cplusplus >= 201703L) && defined(_PSTL_TEST_FOR_EACH_STRUCTURED_BINDING)
     PRINT_DEBUG("test_for_each_structured_binding");
     test1buffer<int32_t, test_for_each_structured_binding>();
 #endif

--- a/test/parallel_api/iterator/zip_iterator.pass.cpp
+++ b/test/parallel_api/iterator/zip_iterator.pass.cpp
@@ -333,7 +333,7 @@ struct test_equal_structured_binding
             static_assert(::std::is_reference<decltype(c)>::value, "tuple element type is not a reference");
             static_assert(::std::is_reference<decltype(d)>::value, "tuple element type is not a reference");
 
-            return (a == c) && (c == d);
+            return (a == c) && (b == d);
         };
 
         bool is_equal = ::std::equal(make_new_policy<new_kernel_name<Policy, 0>>(exec), tuple_first1, tuple_last1, tuple_first2,


### PR DESCRIPTION
To make structured binding work properly tuple-like type require:
- ``std::tuple_size<T>`` to be well-formed, where ``T`` is the tuple-like type
- ``std::tuple_element<i, T>`` to be well-formed, where ``T`` is the tuple-like type and ``i`` is a non-type template parameter representing the index
- Either ``t.get<i>`` or ``get<i>(t)`` to be well-formed, where ``t`` is tuple-like object  and ``i`` is a non-type template parameter representing the index
