### PR TITLE
Support  "-fopenmp-simd" in the "make" files for dpcpp, clang, icpx

### DIFF
--- a/make/Makefile.common
+++ b/make/Makefile.common
@@ -91,7 +91,7 @@ ifneq (, $(filter $(compiler), clang clang++))
     include $(proj_root)/make/clang.inc
 endif
 
-ifneq (, $(filter $(compiler), icc icpc))
+ifneq (, $(filter $(compiler), icc icpc icpx))
     include $(proj_root)/make/icc.inc
 endif
 

--- a/make/Makefile.common
+++ b/make/Makefile.common
@@ -91,7 +91,7 @@ ifneq (, $(filter $(compiler), clang clang++))
     include $(proj_root)/make/clang.inc
 endif
 
-ifneq (, $(filter $(compiler), icc icpc icpx))
+ifneq (, $(filter $(compiler), icc icpc))
     include $(proj_root)/make/icc.inc
 endif
 
@@ -99,7 +99,7 @@ ifneq (, $(filter $(compiler), icl))
     include $(proj_root)/make/icl.inc
 endif
 
-ifneq (, $(filter $(compiler), dpcpp dpc++))
+ifneq (, $(filter $(compiler), dpcpp dpc++ icpx))
     include $(proj_root)/make/dpcpp.inc
 endif
 

--- a/make/clang.inc
+++ b/make/clang.inc
@@ -29,6 +29,10 @@ ifneq (,$(shell clang --version | egrep  "clang version [6-9]\.[0-9]\.[0-9]"))
 CPLUS_FLAGS += -fopenmp-simd #supported at least since 6.0 version
 endif
 
+ifneq (,$(shell clang --version | egrep  "DPC++"))
+CPLUS_FLAGS += -fopenmp-simd
+endif
+
 # In case of TBB backend and using Clang with libstdc++ the version of the library should be specify explicitly via TBB_USE_GLIBCXX_VERSION
 ifeq ($(backend), tbb)
 export gcc_version:=$(shell gcc -dumpfullversion -dumpversion)

--- a/make/clang.inc
+++ b/make/clang.inc
@@ -29,7 +29,7 @@ ifneq (,$(shell clang --version | egrep  "clang version [6-9]\.[0-9]\.[0-9]"))
 CPLUS_FLAGS += -fopenmp-simd #supported at least since 6.0 version
 endif
 
-ifneq (,$(shell clang --version | egrep  "DPC++"))
+ifneq (,$(shell clang --version | egrep  "DPC"))
 CPLUS_FLAGS += -fopenmp-simd
 endif
 

--- a/make/dpcpp.inc
+++ b/make/dpcpp.inc
@@ -19,6 +19,7 @@ ifeq ($(os_name), linux)
     ifneq (, $(shell which dpcpp))
         override compiler:=dpcpp
     endif
+    CPLUS_FLAGS += -fopenmp-simd
     ifeq ($(compiler), clang++)
         CPLUS_FLAGS += -fsycl
         DYN_LDFLAGS += -fsycl
@@ -37,6 +38,7 @@ endif
 ifeq ($(os_name), windows)
     DPCPP_OPTIMIZATION_DISABLED_FLAGS=$(KEY)O1 $(KEY)Zi $(KEY)Fd"$*.pdb" $(KEY)DEBUG
     override compiler:=dpcpp
+    CPLUS_FLAGS += -qopenmp-simd
     ifneq ($(stdver),)
         CPLUS_FLAGS += $(QKEY)std:$(stdver)
     endif


### PR DESCRIPTION
Support  "-fopenmp-simd" in the "make" files for dpcpp, clang, icpx