### PR TITLE
[CI RHEL]Add SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING for RHEL pre-ci

### DIFF
--- a/jenkinsfiles/RHEL_Check.groovy
+++ b/jenkinsfiles/RHEL_Check.groovy
@@ -286,6 +286,7 @@ pipeline {
                                             sh script: """
                                                 rm -rf *
                                                 export PATH=/usr/bin/:$PATH
+                                                export SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING=1
                                                 cmake -DCMAKE_CXX_COMPILER=dpcpp -DCMAKE_CXX_STANDARD=17 -DONEDPL_BACKEND=dpcpp -DONEDPL_DEVICE_TYPE=FPGA_EMU -DCMAKE_BUILD_TYPE=release ..
                                                 make VERBOSE=1 ${TESTS} -k || true
                                                 ctest  -R \"^(`echo ${TESTS} | sed 's/ /|/g'`)\$\" --output-on-failure --timeout ${TEST_TIMEOUT}


### PR DESCRIPTION
[CI RHEL]Add SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING=1 for RHEL pre-ci

Currently compiler has been updated to the latest one, after PR#249 has been merged.
Only RHEL check will fail on 4 cases in “Tests_dpcpp_fpga_emu_cxx_17” as expected. 

[2021-05-19T13:55:27.335Z]        15 - merge.pass (Child aborted)
[2021-05-19T13:55:27.335Z]        59 - set.pass (Child aborted)
[2021-05-19T13:55:27.335Z]        62 - partial_sort_copy.pass (Child aborted)
[2021-05-19T13:55:27.335Z]        63 - sort.pass (Child aborted)
[2021-05-19T13:55:27.335Z] Errors while running CTest

It is suggested to use export SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING=1 to omit these failures.

Signed-off-by: Xiaodong, Li <xiaodong.li@intel.com>