### PR TITLE
Code coverage improvement for zip iterator

### DIFF
--- a/test/parallel_api/iterator/iterators.pass.cpp
+++ b/test/parallel_api/iterator/iterators.pass.cpp
@@ -138,12 +138,7 @@ struct test_counting_iterator {
 
         //explicit checks of the counting iterator specific
         // There is a bug in clang when we pass the same arguments in the function
-        if(b[0]!=begin){
-            ::std::cout<<"wrong result with operator[] for an iterator"<<::std::endl;
-            exit(1);
-        }
-        EXPECT_TRUE(*(b + 1) == begin+1, "wrong result with operator+ for an iterator");
-        EXPECT_TRUE(*(b+=1) == begin+1, "wrong result with operator+= for an iterator");
+        test_random_iterator(e);
     }
 };
 
@@ -167,12 +162,14 @@ struct test_zip_iterator {
     void operator()(::std::vector<T1>& in1, ::std::vector<T2>& in2) {
         //runtime call to check default constructor and increase code coverage
         oneapi::dpl::zip_iterator<decltype(in1.begin()), decltype(in2.begin())> b;
+        //runtime call to check constructor with variadic arguments and increase code coverage
+        oneapi::dpl::zip_iterator<decltype(in1.begin()), decltype(in2.begin())> c(in1.begin(), in2.begin());
 
         //runtime call to check copy assignable operator and increase code coverage
         b = oneapi::dpl::make_zip_iterator(in1.begin(), in2.begin());
         auto e = oneapi::dpl::make_zip_iterator(in1.end(), in2.end());
 
-        EXPECT_TRUE( (b+1) != e, "size of input sequence insufficient for test" );
+        EXPECT_TRUE( (c+1) != e, "size of input sequence insufficient for test" );
 
         //simple check for-loop.
         {

--- a/test/parallel_api/iterator/iterators.pass.cpp
+++ b/test/parallel_api/iterator/iterators.pass.cpp
@@ -137,7 +137,6 @@ struct test_counting_iterator {
         EXPECT_TRUE(res, "wrong result with counting_iterator in vector's end portion");
 
         //explicit checks of the counting iterator specific
-        // There is a bug in clang when we pass the same arguments in the function
         EXPECT_TRUE(*(b + 1) == begin+1, "wrong result with operator+ for an iterator");
         EXPECT_TRUE(*(b+=1) == begin+1, "wrong result with operator+= for an iterator");
     }

--- a/test/parallel_api/iterator/iterators.pass.cpp
+++ b/test/parallel_api/iterator/iterators.pass.cpp
@@ -138,7 +138,8 @@ struct test_counting_iterator {
 
         //explicit checks of the counting iterator specific
         // There is a bug in clang when we pass the same arguments in the function
-        test_random_iterator(e);
+        EXPECT_TRUE(*(b + 1) == begin+1, "wrong result with operator+ for an iterator");
+        EXPECT_TRUE(*(b+=1) == begin+1, "wrong result with operator+= for an iterator");
     }
 };
 
@@ -169,13 +170,16 @@ struct test_zip_iterator {
         b = oneapi::dpl::make_zip_iterator(in1.begin(), in2.begin());
         auto e = oneapi::dpl::make_zip_iterator(in1.end(), in2.end());
 
-        EXPECT_TRUE( (c+1) != e, "size of input sequence insufficient for test" );
+        EXPECT_TRUE( (b+1) != e, "size of input sequence insufficient for test" );
 
         //simple check for-loop.
         {
         ::std::for_each(b, e, [](const ::std::tuple<T1&, T2&>& a) { ::std::get<0>(a) = 1, ::std::get<1>(a) = 1;});
         auto res = ::std::all_of(b, e, [](const ::std::tuple<T1&, T2&>& a) {return ::std::get<0>(a) == 1 && ::std::get<1>(a) == 1;});
         EXPECT_TRUE(res, "wrong result sequence assignment to (1,1) with zip_iterator iterator");
+        //all_of check for iterator which is constructed passing variadic arguments
+        res = ::std::all_of(c, e, [](const ::std::tuple<T1&, T2&>& a) {return ::std::get<0>(a) == 1 && ::std::get<1>(a) == 1;});
+        EXPECT_TRUE(res, "wrong result of all_of algorithm with zip_iterator iterator which is constructed passing variadic arguments");
         }
 
         //check swapping de-referenced iterators (required by sort algorithm)


### PR DESCRIPTION
1) Added test for zip iterator's constructor with variadic arguments.
2) Erased duplicate test for counting_iterator's operator[].