### PR TITLE
[dpc++][ranges] + usage of make_device_policy<__new_name> for __pattern_walk_n

### DIFF
--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -266,7 +266,8 @@ swap_ranges(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2)
 
     if (is_first_size)
     {
-        oneapi::dpl::__internal::__ranges::__pattern_walk_n<1>(::std::forward<_ExecutionPolicy>(__exec), __f, __v1, __v2);
+        oneapi::dpl::__internal::__ranges::__pattern_walk_n<1>(::std::forward<_ExecutionPolicy>(__exec), __f, __v1,
+                                                               __v2);
         return __v1.size();
     }
 

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -266,14 +266,12 @@ swap_ranges(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2)
 
     if (is_first_size)
     {
-        oneapi::dpl::__internal::__ranges::__pattern_walk_n(::std::forward<_ExecutionPolicy>(__exec), __f, __v1, __v2);
+        oneapi::dpl::__internal::__ranges::__pattern_walk_n<1>(::std::forward<_ExecutionPolicy>(__exec), __f, __v1, __v2);
         return __v1.size();
     }
-    else
-    {
-        oneapi::dpl::__internal::__ranges::__pattern_walk_n(::std::forward<_ExecutionPolicy>(__exec), __f, __v2, __v1);
-        return __v2.size();
-    }
+
+    oneapi::dpl::__internal::__ranges::__pattern_walk_n<2>(::std::forward<_ExecutionPolicy>(__exec), __f, __v2, __v1);
+    return __v2.size();
 }
 
 // [alg.transform]

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -38,16 +38,16 @@ namespace __ranges
 // walk_n
 //------------------------------------------------------------------------
 
-template <int N = 0, typename _ExecutionPolicy, typename _Function, typename... _Ranges>
+template <int _N = 0, typename _ExecutionPolicy, typename _Function, typename... _Ranges>
 oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, void>
 __pattern_walk_n(_ExecutionPolicy&& __exec, _Function __f, _Ranges&&... __rngs)
 {
     auto __n = oneapi::dpl::__ranges::__get_first_range_size(__rngs...);
     if (__n > 0)
     {
-        using __new_name = oneapi::dpl::__par_backend_hetero::new_kernel_name<_ExecutionPolicy, N>;
+        using __new_name = oneapi::dpl::__par_backend_hetero::__new_kernel_name<_ExecutionPolicy, _N>;
         auto __new_exec =
-            oneapi::dpl::execution::make_device_policy<__new_name>(::std::forward<_ExecutionPolicy>(__exec));
+            oneapi::dpl::execution::make_hetero_policy<__new_name>(::std::forward<_ExecutionPolicy>(__exec));
         oneapi::dpl::__par_backend_hetero::__parallel_for(__new_exec,
                                                           unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f}, __n,
                                                           ::std::forward<_Ranges>(__rngs)...)

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -46,7 +46,8 @@ __pattern_walk_n(_ExecutionPolicy&& __exec, _Function __f, _Ranges&&... __rngs)
     if (__n > 0)
     {
         using __new_name = oneapi::dpl::__par_backend_hetero::new_kernel_name<_ExecutionPolicy, N>;
-        auto __new_exec = oneapi::dpl::execution::make_device_policy<__new_name>(::std::forward<_ExecutionPolicy>(__exec));
+        auto __new_exec =
+            oneapi::dpl::execution::make_device_policy<__new_name>(::std::forward<_ExecutionPolicy>(__exec));
         oneapi::dpl::__par_backend_hetero::__parallel_for(__new_exec,
                                                           unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f}, __n,
                                                           ::std::forward<_Ranges>(__rngs)...)

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -22,6 +22,7 @@
 #if _ONEDPL_BACKEND_SYCL
 #    include "dpcpp/utils_ranges_sycl.h"
 #    include "dpcpp/unseq_backend_sycl.h"
+#    include "dpcpp/parallel_backend_sycl_utils.h"
 #endif
 
 namespace oneapi
@@ -37,16 +38,20 @@ namespace __ranges
 // walk_n
 //------------------------------------------------------------------------
 
-template <typename _ExecutionPolicy, typename _Function, typename... _Ranges>
+template <int N = 0, typename _ExecutionPolicy, typename _Function, typename... _Ranges>
 oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, void>
 __pattern_walk_n(_ExecutionPolicy&& __exec, _Function __f, _Ranges&&... __rngs)
 {
     auto __n = oneapi::dpl::__ranges::__get_first_range_size(__rngs...);
     if (__n > 0)
-        oneapi::dpl::__par_backend_hetero::__parallel_for(::std::forward<_ExecutionPolicy>(__exec),
+    {
+        using __new_name = oneapi::dpl::__par_backend_hetero::new_kernel_name<_ExecutionPolicy, N>;
+        auto __new_exec = oneapi::dpl::execution::make_device_policy<__new_name>(::std::forward<_ExecutionPolicy>(__exec));
+        oneapi::dpl::__par_backend_hetero::__parallel_for(__new_exec,
                                                           unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f}, __n,
                                                           ::std::forward<_Ranges>(__rngs)...)
             .wait();
+    }
 }
 
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -177,6 +177,13 @@ make_device_policy(const device_policy<OldKernelName>& policy
     return device_policy<NewKernelName>(policy);
 }
 
+template <typename NewKernelName, typename OldKernelName = DefaultKernelName>
+device_policy<NewKernelName>
+make_hetero_policy(const device_policy<OldKernelName>& policy)
+{
+    return device_policy<NewKernelName>(policy);
+}
+
 #if _ONEDPL_FPGA_DEVICE
 template <unsigned int unroll_factor = 1, typename KernelName = DefaultKernelNameFPGA>
 fpga_policy<unroll_factor, KernelName>
@@ -200,6 +207,14 @@ make_fpga_policy(const fpga_policy<old_unroll_factor, OldKernelName>& policy
                  = dpcpp_fpga
 #    endif // _ONEDPL_USE_PREDEFINED_POLICIES
 )
+{
+    return fpga_policy<new_unroll_factor, NewKernelName>(policy);
+}
+
+template <unsigned int new_unroll_factor, typename NewKernelName, unsigned int old_unroll_factor = 1,
+          typename OldKernelName = DefaultKernelNameFPGA>
+fpga_policy<new_unroll_factor, NewKernelName>
+make_hetero_policy(const fpga_policy<old_unroll_factor, OldKernelName>& policy)
 {
     return fpga_policy<new_unroll_factor, NewKernelName>(policy);
 }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -83,12 +83,10 @@ struct explicit_wait_if<true>
 };
 
 template <typename Op, ::std::size_t CallNumber>
-struct unique_kernel_name
-{
-};
+struct __unique_kernel_name;
 
 template <typename Policy, int idx>
-using new_kernel_name = unique_kernel_name<typename ::std::decay<Policy>::type, idx>;
+using __new_kernel_name = __unique_kernel_name<typename ::std::decay<Policy>::type, idx>;
 
 // function is needed to wrap kernel name into another class
 template <template <typename> class _NewKernelName, typename _Policy,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -82,6 +82,12 @@ struct explicit_wait_if<true>
     }
 };
 
+template<typename Op, ::std::size_t CallNumber>
+struct unique_kernel_name {};
+
+template<typename Policy, int idx>
+using new_kernel_name = unique_kernel_name<typename ::std::decay<Policy>::type, idx>;
+
 // function is needed to wrap kernel name into another class
 template <template <typename> class _NewKernelName, typename _Policy,
           oneapi::dpl::__internal::__enable_if_device_execution_policy<_Policy, int> = 0>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -82,10 +82,12 @@ struct explicit_wait_if<true>
     }
 };
 
-template<typename Op, ::std::size_t CallNumber>
-struct unique_kernel_name {};
+template <typename Op, ::std::size_t CallNumber>
+struct unique_kernel_name
+{
+};
 
-template<typename Policy, int idx>
+template <typename Policy, int idx>
 using new_kernel_name = unique_kernel_name<typename ::std::decay<Policy>::type, idx>;
 
 // function is needed to wrap kernel name into another class

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -58,11 +58,8 @@ namespace TestUtils
             [&val](const T& x) { return x == val; });
     }
 
-    template<typename Op, ::std::size_t CallNumber>
-    struct unique_kernel_name {};
-
-    template<typename Policy, int idx>
-    using new_kernel_name = unique_kernel_name<typename ::std::decay<Policy>::type, idx>;
+    using oneapi::dpl::__par_backend_hetero::unique_kernel_name;
+    using oneapi::dpl::__par_backend_hetero::new_kernel_name;
 
     auto async_handler = [](sycl::exception_list ex_list) {
         for (auto& ex : ex_list) {

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -58,8 +58,10 @@ namespace TestUtils
             [&val](const T& x) { return x == val; });
     }
 
-    using oneapi::dpl::__par_backend_hetero::unique_kernel_name;
-    using oneapi::dpl::__par_backend_hetero::new_kernel_name;
+    template <typename Op, ::std::size_t CallNumber>
+    using unique_kernel_name = oneapi::dpl::__par_backend_hetero::__unique_kernel_name<Op, CallNumber> ;
+    template <typename Policy, int idx>
+    using new_kernel_name = oneapi::dpl::__par_backend_hetero::__new_kernel_name<Policy, idx>;
 
     auto async_handler = [](sycl::exception_list ex_list) {
         for (auto& ex : ex_list) {


### PR DESCRIPTION
[dpc++][ranges] + usage of make_device_policy<__new_name> for __pattern_walk_n.

It fixes "the same mangled name issue" for same range-based algorithms