### PR TITLE
CI: enable testing via GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,10 +76,6 @@ jobs:
             cxx_compiler: g++
             std: 17
             build_type: release
-          - os: ubuntu-20.04
-            cxx_compiler: icpx
-            std: 17
-            build_type: release
     steps:
       - uses: actions/checkout@v2
       - name: Configure apt repositories

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,10 +90,10 @@ jobs:
           echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
           sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
       - name: Install oneTBB
-        run: apt install -y intel-oneapi-tbb-devel
+        run: sudo apt install -y intel-oneapi-tbb-devel
       - name: Install oneAPI Compiler
         if: matrix.cxx_compiler == 'dpcpp' || matrix.cxx_compiler == 'icpx'
-        run: apt install -y intel-oneapi-compiler-dpcpp-cpp
+        run: sudo apt install -y intel-oneapi-compiler-dpcpp-cpp
       - name: Run testing
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
   linux-host-testing:
     name: ${{ matrix.os }}_${{ matrix.cxx_compiler }}_cxx${{ matrix.std }}_${{ matrix.build_type }}
     runs-on: ['${{ matrix.os }}']
-    timeout-minutes: 45
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,7 @@ on:
 
 env:
   BUILD_CONCURRENCY: 2
-  TEST_TIMEOUT_RELEASE: 360
-  TEST_TIMEOUT_DEBUG: 1200
+  TEST_TIMEOUT: 360
 
 jobs:
   clang-format:
@@ -76,6 +75,14 @@ jobs:
             cxx_compiler: g++
             std: 17
             build_type: release
+            backend: tbb
+            device_type: HOST
+          - os: ubuntu-20.04
+            cxx_compiler: dpcpp
+            std: 17
+            build_type: release
+            backend: dpcpp
+            device_type: CPU
     steps:
       - uses: actions/checkout@v2
       - name: Configure apt repositories
@@ -96,13 +103,8 @@ jobs:
           set -x
           sudo rm -rf /opt/intel/oneapi/dpl || true
           source /opt/intel/oneapi/setvars.sh intel64
-          if [[ "${{ matrix.build_type }}" == "debug" ]]; then
-            TEST_TIMEOUT=${TEST_TIMEOUT_DEBUG}
-          else
-            TEST_TIMEOUT=${TEST_TIMEOUT_RELEASE}
-          fi
           mkdir build && cd build
           cmake -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-            -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DONEDPL_BACKEND=tbb -DONEDPL_DEVICE_TYPE=HOST ..
+            -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DONEDPL_BACKEND=${{ matrix.backend }} -DONEDPL_DEVICE_TYPE=${{ matrix.device_type }} ..
           make VERBOSE=1 -j${BUILD_CONCURRENCY}
           ctest --timeout ${TEST_TIMEOUT} --output-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
             path: html
 
   linux-host-testing:
-    name: ${{ matrix.os }}_${{ matrix.cxx_compiler }}_cxx${{ matrix.std }}_${{ matrix.build_type }}_preview=${{ matrix.preview }}
+    name: ${{ matrix.os }}_${{ matrix.cxx_compiler }}_cxx${{ matrix.std }}_${{ matrix.build_type }}
     runs-on: ['${{ matrix.os }}']
     timeout-minutes: 45
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,12 +77,6 @@ jobs:
             build_type: release
             backend: tbb
             device_type: HOST
-          - os: ubuntu-20.04
-            cxx_compiler: dpcpp
-            std: 17
-            build_type: release
-            backend: dpcpp
-            device_type: CPU
     steps:
       - uses: actions/checkout@v2
       - name: Configure apt repositories

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,5 +106,5 @@ jobs:
           mkdir build && cd build
           cmake -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DONEDPL_BACKEND=${{ matrix.backend }} -DONEDPL_DEVICE_TYPE=${{ matrix.device_type }} ..
-          make VERBOSE=1 -j${BUILD_CONCURRENCY}
+          make VERBOSE=1 -j${BUILD_CONCURRENCY} -k
           ctest --timeout ${TEST_TIMEOUT} --output-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,12 +92,13 @@ jobs:
       - name: Install oneTBB
         run: apt install -y intel-oneapi-tbb-devel
       - name: Install oneAPI Compiler
-        if: matrix.cxx_compiler == "dpcpp" || matrix.cxx_compiler == "icpx"
+        if: matrix.cxx_compiler == 'dpcpp' || matrix.cxx_compiler == 'icpx'
         run: apt install -y intel-oneapi-compiler-dpcpp-cpp
       - name: Run testing
         shell: bash
         run: |
           set -x
+          rm -rf /opt/intel/oneapi/dpl || true
           source /opt/intel/oneapi/setvars.sh intel64
           if [[ "${{ matrix.build_type }}" == "debug" ]]; then
             TEST_TIMEOUT=${TEST_TIMEOUT_DEBUG}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
             name: onedpl-html-docs-${{ env.GITHUB_SHA_SHORT }}
             path: html
 
-  linux-host-testing:
+  linux-testing:
     name: ${{ matrix.os }}_${{ matrix.cxx_compiler }}_cxx${{ matrix.std }}_${{ matrix.build_type }}
     runs-on: ['${{ matrix.os }}']
     timeout-minutes: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
         run: |
           set -x
           source oneapi*/env/vars.sh intel64
-          if [[ ${build_type} == "debug" ]]; then
+          if [[ "${{ matrix.build_type }}" == "debug" ]]; then
             TEST_TIMEOUT=${TEST_TIMEOUT_DEBUG}
           else
             TEST_TIMEOUT=${TEST_TIMEOUT_RELEASE}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,5 +106,6 @@ jobs:
           mkdir build && cd build
           cmake -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DONEDPL_BACKEND=${{ matrix.backend }} -DONEDPL_DEVICE_TYPE=${{ matrix.device_type }} ..
-          make VERBOSE=1 -j${BUILD_CONCURRENCY} -k
+          make sycl_iterator.pass || true
+          make VERBOSE=1 -j${BUILD_CONCURRENCY}
           ctest --timeout ${TEST_TIMEOUT} --output-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ env:
   BUILD_CONCURRENCY: 2
   TEST_TIMEOUT_RELEASE: 360
   TEST_TIMEOUT_DEBUG: 1200
-  ONETBB_LINUX_LINK: https://github.com/oneapi-src/oneTBB/releases/download/v2021.2.0/oneapi-tbb-2021.2.0-lin.tgz
 
 jobs:
   clang-format:
@@ -77,17 +76,29 @@ jobs:
             cxx_compiler: g++
             std: 17
             build_type: release
+          - os: ubuntu-20.04
+            cxx_compiler: icpx
+            std: 17
+            build_type: release
     steps:
       - uses: actions/checkout@v2
-      - name: Get oneTBB
+      - name: Configure apt repositories
         run: |
-          wget ${ONETBB_LINUX_LINK}
-          tar xf oneapi*
+          wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+          sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+          rm GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
+          echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+          sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
+      - name: Install oneTBB
+        run: apt install -y intel-oneapi-tbb-devel
+      - name: Install oneAPI Compiler
+        if: matrix.cxx_compiler == "dpcpp" || matrix.cxx_compiler == "icpx"
+        run: apt install -y intel-oneapi-compiler-dpcpp-cpp
       - name: Run testing
         shell: bash
         run: |
           set -x
-          source oneapi*/env/vars.sh intel64
+          source /opt/intel/oneapi/setvars.sh intel64
           if [[ "${{ matrix.build_type }}" == "debug" ]]; then
             TEST_TIMEOUT=${TEST_TIMEOUT_DEBUG}
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,7 +94,7 @@ jobs:
         shell: bash
         run: |
           set -x
-          rm -rf /opt/intel/oneapi/dpl || true
+          sudo rm -rf /opt/intel/oneapi/dpl || true
           source /opt/intel/oneapi/setvars.sh intel64
           if [[ "${{ matrix.build_type }}" == "debug" ]]; then
             TEST_TIMEOUT=${TEST_TIMEOUT_DEBUG}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ on:
 env:
   BUILD_CONCURRENCY: 2
   TEST_TIMEOUT_RELEASE: 360
+  TEST_TIMEOUT_DEBUG: 1200
   ONETBB_LINUX_LINK: https://github.com/oneapi-src/oneTBB/releases/download/v2021.2.0/oneapi-tbb-2021.2.0-lin.tgz
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,5 @@ jobs:
           mkdir build && cd build
           cmake -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DONEDPL_BACKEND=${{ matrix.backend }} -DONEDPL_DEVICE_TYPE=${{ matrix.device_type }} ..
-          make sycl_iterator.pass || true
-          make VERBOSE=1 -j${BUILD_CONCURRENCY}
+          make VERBOSE=1
           ctest --timeout ${TEST_TIMEOUT} --output-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
   linux-testing:
     name: ${{ matrix.os }}_${{ matrix.cxx_compiler }}_cxx${{ matrix.std }}_${{ matrix.build_type }}
     runs-on: ['${{ matrix.os }}']
-    timeout-minutes: 20
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -106,5 +106,5 @@ jobs:
           mkdir build && cd build
           cmake -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DONEDPL_BACKEND=${{ matrix.backend }} -DONEDPL_DEVICE_TYPE=${{ matrix.device_type }} ..
-          make VERBOSE=1
+          make VERBOSE=1 -j${BUILD_CONCURRENCY}
           ctest --timeout ${TEST_TIMEOUT} --output-on-failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,11 @@ on:
       - main
       - 'release/**'
 
+env:
+  BUILD_CONCURRENCY: 2
+  TEST_TIMEOUT_RELEASE: 360
+  ONETBB_LINUX_LINK: https://github.com/oneapi-src/oneTBB/releases/download/v2021.2.0/oneapi-tbb-2021.2.0-lin.tgz
+
 jobs:
   clang-format:
     runs-on: ubuntu-latest
@@ -51,7 +56,7 @@ jobs:
           python -m pip install -r documentation/library_guide/requirements.txt
       - name: Build documentation
         run: |
-          mkdir html 
+          mkdir html
           sphinx-build -b html documentation/library_guide/ html/
       - name: Archive build directory
         uses: actions/upload-artifact@v1
@@ -59,3 +64,36 @@ jobs:
             name: onedpl-html-docs-${{ env.GITHUB_SHA_SHORT }}
             path: html
 
+  linux-host-testing:
+    name: ${{ matrix.os }}_${{ matrix.cxx_compiler }}_cxx${{ matrix.std }}_${{ matrix.build_type }}_preview=${{ matrix.preview }}
+    runs-on: ['${{ matrix.os }}']
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-18.04
+            cxx_compiler: g++
+            std: 17
+            build_type: release
+    steps:
+      - uses: actions/checkout@v2
+      - name: Get oneTBB
+        run: |
+          wget ${ONETBB_LINUX_LINK}
+          tar xf oneapi*
+      - name: Run testing
+        shell: bash
+        run: |
+          set -x
+          source oneapi*/env/vars.sh intel64
+          if [[ ${build_type} == "debug" ]]; then
+            TEST_TIMEOUT=${TEST_TIMEOUT_DEBUG}
+          else
+            TEST_TIMEOUT=${TEST_TIMEOUT_RELEASE}
+          fi
+          mkdir build && cd build
+          cmake -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+            -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DONEDPL_BACKEND=tbb -DONEDPL_DEVICE_TYPE=HOST ..
+          make VERBOSE=1 -j${BUILD_CONCURRENCY}
+          ctest --timeout ${TEST_TIMEOUT} --output-on-failure

--- a/jenkinsfiles/UB18_Check.groovy
+++ b/jenkinsfiles/UB18_Check.groovy
@@ -282,40 +282,6 @@ pipeline {
                     }
                 }
 
-                stage('Tests_g++_tbb_cxx_17') {
-                    when {
-                        expression { code_changed }
-                    }
-                    steps {
-                        timeout(time: 2, unit: 'HOURS') {
-                            script {
-                                try {
-                                    dir("./src/build") {
-                                        withEnv(readFile('../../envs_tobe_loaded.txt').split('\n') as List) {
-                                            sh script: """
-                                                rm -rf *
-                                                cmake -DCMAKE_CXX_COMPILER=g++ -DCMAKE_CXX_STANDARD=17 -DONEDPL_BACKEND=tbb -DONEDPL_DEVICE_TYPE=HOST -DCMAKE_BUILD_TYPE=release ..
-                                                make VERBOSE=1 build-all -j`nproc` -k || true
-                                                ctest --output-on-failure --timeout ${TEST_TIMEOUT}
-
-                                            """, label: "All tests"
-                                        }
-                                    }
-                                }
-                                catch(e) {
-                                    build_ok = false
-                                    catchError(buildResult: 'SUCCESS', stageResult: 'FAILURE') {
-                                        sh script: """
-                                            exit -1
-                                        """
-
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-
                 stage('Check_Samples') {
                     when {
                         expression { code_changed }


### PR DESCRIPTION
We want to move some CPU configurations to GitHub Actions because Jenkins CI is often unstable. This will allow us to test at least some of the configurations in case of issues with machines from Jenkins CI runners pool.
Signed-off-by: Zheltov, Sergey1 <sergey1.zheltov@intel.com>