### PR TITLE
Improve performance of find_or pattern

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -564,7 +564,7 @@ struct __early_exit_find_or
 
         auto __n = oneapi::dpl::__ranges::__get_first_range_size(__rngs...);
 
-        ::std::size_t __shift = 8;
+        ::std::size_t __shift = 16;
         ::std::size_t __local_idx = __item_id.get_local_id(0);
         ::std::size_t __group_idx = __item_id.get_group(0);
 
@@ -674,14 +674,12 @@ __parallel_find_or(_ExecutionPolicy&& __exec, _Brick __f, _BrickTag __brick_tag,
                     sycl::atomic<_AtomicType, sycl::access::address_space::local_space> __found_local(
                         __temp_local.get_pointer());
 
-                    // 1. Set value from global atomic to local atomic
+                    // 1. Set initial value to local atomic
                     if (__local_idx == 0)
-                    {
-                        __found_local.store(__found.load());
-                    }
+                        __found_local.store(__init_value);
                     __item_id.barrier(sycl::access::fence_space::local_space);
 
-                    // 2. find any element that satisfies pred and Set local atomic value to global atomic
+                    // 2. Find any element that satisfies pred and set local atomic value to global atomic
                     constexpr auto __comp = typename _BrickTag::_Compare{};
                     __pred(__item_id, __n_iter, __wgroup_size, __comp, __found_local, __brick_tag, __rngs...);
                     __item_id.barrier(sycl::access::fence_space::local_space);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -209,7 +209,7 @@ struct multiple_match_pred
         const auto __total_shift = __shifted_idx;
 
         using _Size2 = decltype(__s_n);
-        for (_Size2 __ii = 0; __ii < __s_n && __result; ++__ii)
+        for (_Size2 __ii = 0; __ii < __s_n; ++__ii)
         {
             __result = __pred(__acc[__total_shift + __ii], __s_acc[__ii]);
             if (!__result)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -209,11 +209,14 @@ struct multiple_match_pred
         const auto __total_shift = __shifted_idx;
 
         using _Size2 = decltype(__s_n);
-        for (_Size2 __ii = 0; __ii < __s_n; ++__ii)
+        if (__result)
         {
-            __result = __pred(__acc[__total_shift + __ii], __s_acc[__ii]);
-            if (!__result)
-                break;
+            for (_Size2 __ii = 0; __ii < __s_n; ++__ii)
+            {
+                __result = __pred(__acc[__total_shift + __ii], __s_acc[__ii]);
+                if (!__result)
+                    break;
+            }
         }
 
         return __result;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -210,7 +210,11 @@ struct multiple_match_pred
 
         using _Size2 = decltype(__s_n);
         for (_Size2 __ii = 0; __ii < __s_n && __result; ++__ii)
+        {
             __result = __pred(__acc[__total_shift + __ii], __s_acc[__ii]);
+            if(!__result)
+                break;
+        }
 
         return __result;
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -209,6 +209,7 @@ struct multiple_match_pred
         const auto __total_shift = __shifted_idx;
 
         using _Size2 = decltype(__s_n);
+        // Moving __result out of the loop condition produces more optimized code
         if (__result)
         {
             for (_Size2 __ii = 0; __ii < __s_n; ++__ii)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -212,7 +212,7 @@ struct multiple_match_pred
         for (_Size2 __ii = 0; __ii < __s_n && __result; ++__ii)
         {
             __result = __pred(__acc[__total_shift + __ii], __s_acc[__ii]);
-            if(!__result)
+            if (!__result)
                 break;
         }
 


### PR DESCRIPTION
- made shift aligned with SIMD size on GPU devices
- removed unnecessary atomic load
- rewrote loop for better code generation (seems it helps graphics compiler to vectorize code better)