### PR TITLE
CMake: add install instructions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ option(ONEDPL_ENABLE_SIMD "Enable SIMD vectorization by passing an OpenMP SIMD f
 
 include(CMakePackageConfigHelpers)
 include(CheckCXXCompilerFlag)
+include(GNUInstallDirs)
 
 # Set default back-end in according with compiler (DPC++ or others)
 check_cxx_compiler_flag("-fsycl" _fsycl_option)
@@ -238,3 +239,12 @@ target_include_directories(oneDPL
 ###############################################################################
 enable_testing()
 add_subdirectory(test)
+
+###############################################################################
+# Installation instructions
+###############################################################################
+install(CODE "set(OUTPUT_DIR \"${CMAKE_INSTALL_FULL_LIBDIR}/cmake/oneDPL\")")
+install(CODE "set(SKIP_HEADERS_SUBDIR TRUE)")
+install(SCRIPT cmake/scripts/generate_config.cmake)
+install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+install(DIRECTORY licensing DESTINATION ${CMAKE_INSTALL_DOCDIR})

--- a/cmake/scripts/generate_config.cmake
+++ b/cmake/scripts/generate_config.cmake
@@ -16,6 +16,22 @@ if (NOT OUTPUT_DIR)
     set(OUTPUT_DIR "output")
 endif()
 
+if (SKIP_HEADERS_SUBDIR)
+    set(HANDLE_HEADERS_PATH "
+get_filename_component(_onedpl_headers \"\${_onedpl_root}/include\" ABSOLUTE)
+")
+else()
+    set(HANDLE_HEADERS_PATH "
+if (WIN32)
+    set(_onedpl_headers_subdir windows)
+else()
+    set(_onedpl_headers_subdir linux)
+endif()
+
+get_filename_component(_onedpl_headers \"\${_onedpl_root}/\${_onedpl_headers_subdir}/include\" ABSOLUTE)
+")
+endif()
+
 set(ONEDPL_ROOT "${CMAKE_CURRENT_LIST_DIR}/../..")
 
 file(READ ${ONEDPL_ROOT}/include/oneapi/dpl/pstl/onedpl_config.h _onedpl_version_info LIMIT 1024)
@@ -27,7 +43,7 @@ set(PROJECT_VERSION "${_onedpl_ver_major}.${_onedpl_ver_minor}.${_onedpl_ver_pat
 
 configure_file("${ONEDPL_ROOT}/cmake/templates/oneDPLConfig.cmake.in"
                "${OUTPUT_DIR}/oneDPLConfig.cmake"
-               COPYONLY)
+               @ONLY)
 configure_file("${ONEDPL_ROOT}/cmake/templates/oneDPLConfigVersion.cmake.in"
                "${OUTPUT_DIR}/oneDPLConfigVersion.cmake"
                @ONLY)

--- a/cmake/templates/oneDPLConfig.cmake.in
+++ b/cmake/templates/oneDPLConfig.cmake.in
@@ -15,15 +15,7 @@
 # Installation path: <onedpl_root>/lib/cmake/oneDPL/
 get_filename_component(_onedpl_root "${CMAKE_CURRENT_LIST_DIR}" REALPATH)
 get_filename_component(_onedpl_root "${_onedpl_root}/../../../" ABSOLUTE)
-
-if (WIN32)
-    set(_onedpl_headers_subdir windows)
-else()
-    set(_onedpl_headers_subdir linux)
-endif()
-
-get_filename_component(_onedpl_headers "${_onedpl_root}/${_onedpl_headers_subdir}/include" ABSOLUTE)
-
+@HANDLE_HEADERS_PATH@
 if (EXISTS "${_onedpl_headers}")
     if (NOT TARGET oneDPL)
         add_library(oneDPL INTERFACE IMPORTED)


### PR DESCRIPTION
Signed-off-by: Veprev, Alexey <alexey.veprev@intel.com>

Completely inspired by @masterleinad (https://github.com/oneapi-src/oneDPL/pull/237), but with a bit different approach.

Installation results (`<prefix>` is just placeholder here):
```
> cmake -P cmake_install.cmake
-- Install configuration: ""
-- oneDPL 2021.4.0 configuration files were created in '<prefix>/lib/cmake/oneDPL'
-- Installing: <prefix>/include
-- Installing: <prefix>/include/oneapi
-- Installing: <prefix>/include/oneapi/dpl
-- Installing: <prefix>/include/oneapi/dpl/algorithm
-- Installing: <prefix>/include/oneapi/dpl/array
-- Installing: <prefix>/include/oneapi/dpl/async
-- Installing: <prefix>/include/oneapi/dpl/cmath
-- Installing: <prefix>/include/oneapi/dpl/complex
-- Installing: <prefix>/include/oneapi/dpl/cstddef
-- Installing: <prefix>/include/oneapi/dpl/execution
-- Installing: <prefix>/include/oneapi/dpl/functional
-- Installing: <prefix>/include/oneapi/dpl/internal
-- Installing: <prefix>/include/oneapi/dpl/internal/async_extension_defs.h
-- Installing: <prefix>/include/oneapi/dpl/internal/async_impl
-- Installing: <prefix>/include/oneapi/dpl/internal/async_impl/async_impl.h
-- Installing: <prefix>/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
-- Installing: <prefix>/include/oneapi/dpl/internal/async_impl/async_utils.h
-- Installing: <prefix>/include/oneapi/dpl/internal/async_impl/glue_async_impl.h
-- Installing: <prefix>/include/oneapi/dpl/internal/binary_search_extension_defs.h
-- Installing: <prefix>/include/oneapi/dpl/internal/binary_search_impl.h
-- Installing: <prefix>/include/oneapi/dpl/internal/by_segment_extension_defs.h
-- Installing: <prefix>/include/oneapi/dpl/internal/common_config.h
-- Installing: <prefix>/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
-- Installing: <prefix>/include/oneapi/dpl/internal/function.h
-- Installing: <prefix>/include/oneapi/dpl/internal/gcd_impl.h
-- Installing: <prefix>/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
-- Installing: <prefix>/include/oneapi/dpl/internal/iterator_impl.h
-- Installing: <prefix>/include/oneapi/dpl/internal/random_impl
-- Installing: <prefix>/include/oneapi/dpl/internal/random_impl/discard_block_engine.h
-- Installing: <prefix>/include/oneapi/dpl/internal/random_impl/linear_congruential_engine.h
-- Installing: <prefix>/include/oneapi/dpl/internal/random_impl/normal_distribution.h
-- Installing: <prefix>/include/oneapi/dpl/internal/random_impl/random_common.h
-- Installing: <prefix>/include/oneapi/dpl/internal/random_impl/subtract_with_carry_engine.h
-- Installing: <prefix>/include/oneapi/dpl/internal/random_impl/uniform_int_distribution.h
-- Installing: <prefix>/include/oneapi/dpl/internal/random_impl/uniform_real_distribution.h
-- Installing: <prefix>/include/oneapi/dpl/internal/reduce_by_segment_impl.h
-- Installing: <prefix>/include/oneapi/dpl/iterator
-- Installing: <prefix>/include/oneapi/dpl/memory
-- Installing: <prefix>/include/oneapi/dpl/numeric
-- Installing: <prefix>/include/oneapi/dpl/optional
-- Installing: <prefix>/include/oneapi/dpl/pstl
-- Installing: <prefix>/include/oneapi/dpl/pstl/algorithm_fwd.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/algorithm_impl.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/execution_defs.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/execution_impl.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/experimental
-- Installing: <prefix>/include/oneapi/dpl/pstl/experimental/algorithm
-- Installing: <prefix>/include/oneapi/dpl/pstl/experimental/internal
-- Installing: <prefix>/include/oneapi/dpl/pstl/experimental/internal/for_loop.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/experimental/internal/induction.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/experimental/internal/induction_impl.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/experimental/internal/reduction.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/experimental/internal/reduction_impl.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/glue_algorithm_defs.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/glue_algorithm_impl.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/glue_algorithm_ranges_defs.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/glue_execution_defs.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/glue_memory_defs.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/glue_memory_impl.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/glue_numeric_defs.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/glue_numeric_impl.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/glue_numeric_ranges_defs.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/glue_numeric_ranges_impl.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/hetero
-- Installing: <prefix>/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/hetero/dpcpp
-- Installing: <prefix>/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/iterator_defs.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/iterator_impl.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/memory_fwd.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/memory_impl.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/numeric_fwd.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/numeric_impl.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/onedpl_config.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/parallel_backend.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/parallel_backend_serial.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/parallel_backend_tbb.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/parallel_backend_utils.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/parallel_impl.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/pstl_config.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/ranges
-- Installing: <prefix>/include/oneapi/dpl/pstl/ranges/nanorange.hpp
-- Installing: <prefix>/include/oneapi/dpl/pstl/ranges/nanorange_ext.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/ranges_defs.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/tuple_impl.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/unseq_backend_simd.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/utils.h
-- Installing: <prefix>/include/oneapi/dpl/pstl/utils_ranges.h
-- Installing: <prefix>/include/oneapi/dpl/random
-- Installing: <prefix>/include/oneapi/dpl/ranges
-- Installing: <prefix>/include/oneapi/dpl/ratio
-- Installing: <prefix>/include/oneapi/dpl/tuple
-- Installing: <prefix>/include/oneapi/dpl/type_traits
-- Installing: <prefix>/include/oneapi/dpl/utility
-- Installing: <prefix>/share/doc/oneDPL/licensing
-- Installing: <prefix>/share/doc/oneDPL/licensing/LICENSE.txt
-- Installing: <prefix>/share/doc/oneDPL/licensing/support.txt
-- Installing: <prefix>/share/doc/oneDPL/licensing/third-party-programs.txt
```