### PR TITLE
Fix definition of SYCL_2020_NOINIT_MACRO

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -23,6 +23,13 @@
 #    include <CL/sycl/INTEL/fpga_extensions.hpp>
 #endif
 
+// Combine SYCL runtime library version
+#if defined(__LIBSYCL_MAJOR_VERSION) && defined(__LIBSYCL_MINOR_VERSION) && defined(__LIBSYCL_PATCH_VERSION)
+#define __LIBSYCL_VERSION (__LIBSYCL_MAJOR_VERSION * 10000 + __LIBSYCL_MINOR_VERSION * 100 + __LIBSYCL_PATCH_VERSION)
+#else
+#define __LIBSYCL_VERSION 0
+#endif
+
 namespace oneapi
 {
 namespace dpl

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -25,9 +25,10 @@
 
 // Combine SYCL runtime library version
 #if defined(__LIBSYCL_MAJOR_VERSION) && defined(__LIBSYCL_MINOR_VERSION) && defined(__LIBSYCL_PATCH_VERSION)
-#define __LIBSYCL_VERSION (__LIBSYCL_MAJOR_VERSION * 10000 + __LIBSYCL_MINOR_VERSION * 100 + __LIBSYCL_PATCH_VERSION)
+#    define __LIBSYCL_VERSION                                                                                          \
+        (__LIBSYCL_MAJOR_VERSION * 10000 + __LIBSYCL_MINOR_VERSION * 100 + __LIBSYCL_PATCH_VERSION)
 #else
-#define __LIBSYCL_VERSION 0
+#    define __LIBSYCL_VERSION 0
 #endif
 
 namespace oneapi

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -154,12 +154,12 @@ __internal::sycl_iterator<Mode, T, Allocator> begin(sycl::buffer<T, /*dim=*/1, A
     return __internal::sycl_iterator<Mode, T, Allocator>{buf, 0};
 }
 
-#define SYCL_2020_NOINIT_MACRO (__LIBSYCL_VERSION >= 50300)
+#define _ONEDPL_NO_INIT_PRESENT (__LIBSYCL_VERSION >= 50300)
 
 template <typename T, typename Allocator, access_mode Mode>
 __internal::sycl_iterator<__internal::_ModeConverter<Mode>::__value, T, Allocator>
     begin(sycl::buffer<T, /*dim=*/1, Allocator> buf, sycl::mode_tag_t<Mode>,
-#if SYCL_2020_NOINIT_MACRO
+#if _ONEDPL_NO_INIT_PRESENT
           sycl::property::no_init)
 #else
           sycl::property::noinit)
@@ -171,7 +171,7 @@ __internal::sycl_iterator<__internal::_ModeConverter<Mode>::__value, T, Allocato
 template <typename T, typename Allocator>
 __internal::sycl_iterator<access_mode::discard_read_write, T, Allocator>
     begin(sycl::buffer<T, /*dim=*/1, Allocator> buf,
-#if SYCL_2020_NOINIT_MACRO
+#if _ONEDPL_NO_INIT_PRESENT
           sycl::property::no_init)
 #else
           sycl::property::noinit)
@@ -190,7 +190,7 @@ __internal::sycl_iterator<Mode, T, Allocator> end(sycl::buffer<T, /*dim=*/1, All
 template <typename T, typename Allocator, access_mode Mode>
 __internal::sycl_iterator<__internal::_ModeConverter<Mode>::__value, T, Allocator>
     end(sycl::buffer<T, /*dim=*/1, Allocator> buf, sycl::mode_tag_t<Mode>,
-#if SYCL_2020_NOINIT_MACRO
+#if _ONEDPL_NO_INIT_PRESENT
         sycl::property::no_init)
 #else
         sycl::property::noinit)
@@ -201,7 +201,7 @@ __internal::sycl_iterator<__internal::_ModeConverter<Mode>::__value, T, Allocato
 
 template <typename T, typename Allocator>
 __internal::sycl_iterator<access_mode::discard_read_write, T, Allocator> end(sycl::buffer<T, /*dim=*/1, Allocator> buf,
-#if SYCL_2020_NOINIT_MACRO
+#if _ONEDPL_NO_INIT_PRESENT
                                                                              sycl::property::no_init)
 #else
                                                                              sycl::property::noinit)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -18,7 +18,7 @@
 
 #include <CL/sycl.hpp>
 
-#define SYCL_2020_NOINIT_MACRO (__LIBSYCL_MAJOR_VERSION >= 5 && __LIBSYCL_MINOR_VERSION >= 2)
+#define SYCL_2020_NOINIT_MACRO (__LIBSYCL_MAJOR_VERSION >= 5 && __LIBSYCL_MINOR_VERSION >= 3)
 
 #include <iterator>
 #include "../../onedpl_config.h"

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -18,8 +18,6 @@
 
 #include <CL/sycl.hpp>
 
-#define SYCL_2020_NOINIT_MACRO (__LIBSYCL_MAJOR_VERSION >= 5 && __LIBSYCL_MINOR_VERSION >= 3)
-
 #include <iterator>
 #include "../../onedpl_config.h"
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -154,6 +154,8 @@ __internal::sycl_iterator<Mode, T, Allocator> begin(sycl::buffer<T, /*dim=*/1, A
     return __internal::sycl_iterator<Mode, T, Allocator>{buf, 0};
 }
 
+#define SYCL_2020_NOINIT_MACRO (__LIBSYCL_VERSION >= 50300)
+
 template <typename T, typename Allocator, access_mode Mode>
 __internal::sycl_iterator<__internal::_ModeConverter<Mode>::__value, T, Allocator>
     begin(sycl::buffer<T, /*dim=*/1, Allocator> buf, sycl::mode_tag_t<Mode>,

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -314,6 +314,10 @@
 #    define ONEDPL_ALLOW_DEFERRED_WAITING 0
 #endif
 
+// Combine SYCL runtime library version
+#define __LIBSYCL_VERSION (__LIBSYCL_MAJOR_VERSION * 10000 + __LIBSYCL_MINOR_VERSION*100 + __LIBSYCL_PATCH_VERSION)
+#define SYCL_2020_NOINIT_MACRO (__LIBSYCL_VERSION >= 50300)
+
 //'present' macros
 // shift_left, shift_right; GCC 10; VS 2019 16.1
 #define _ONEDPL_CPP20_SHIFT_LEFT_RIGHT_PRESENT                                                                         \

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -316,7 +316,6 @@
 
 // Combine SYCL runtime library version
 #define __LIBSYCL_VERSION (__LIBSYCL_MAJOR_VERSION * 10000 + __LIBSYCL_MINOR_VERSION*100 + __LIBSYCL_PATCH_VERSION)
-#define SYCL_2020_NOINIT_MACRO (__LIBSYCL_VERSION >= 50300)
 
 //'present' macros
 // shift_left, shift_right; GCC 10; VS 2019 16.1

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -314,9 +314,6 @@
 #    define ONEDPL_ALLOW_DEFERRED_WAITING 0
 #endif
 
-// Combine SYCL runtime library version
-#define __LIBSYCL_VERSION (__LIBSYCL_MAJOR_VERSION * 10000 + __LIBSYCL_MINOR_VERSION*100 + __LIBSYCL_PATCH_VERSION)
-
 //'present' macros
 // shift_left, shift_right; GCC 10; VS 2019 16.1
 #define _ONEDPL_CPP20_SHIFT_LEFT_RIGHT_PRESENT                                                                         \

--- a/test/general/buffer_wrapper.pass.cpp
+++ b/test/general/buffer_wrapper.pass.cpp
@@ -15,7 +15,7 @@ struct test_buffer_wrapper
 {
     template <typename Iterator, typename T>
     void operator()(Iterator begin, Iterator end, T* expected_data, std::size_t size)
-    {   
+    {
         EXPECT_TRUE(begin == begin, "operator == returned false negative");
         EXPECT_TRUE(!(begin == begin + 1), "operator == returned false positive");
 
@@ -53,7 +53,7 @@ main()
     test(oneapi::dpl::begin(buf), oneapi::dpl::end(buf), data_ptr, size);
     test(oneapi::dpl::begin(buf, sycl::write_only), oneapi::dpl::end(buf, sycl::write_only), data_ptr, size);
     test(oneapi::dpl::begin(buf, sycl::write_only, _ONEDPL_SYCL_NOINIT), oneapi::dpl::end(buf, sycl::write_only, _ONEDPL_SYCL_NOINIT), data_ptr, size);
-#if SYCL_2020_NOINIT_MACRO
+#if TEST_NO_INIT_PRESENT
     test(oneapi::dpl::begin(buf, sycl::property::no_init{}), oneapi::dpl::end(buf, sycl::property::no_init{}), data_ptr, size);
 #else
     test(oneapi::dpl::begin(buf, sycl::property::noinit{}), oneapi::dpl::end(buf, sycl::property::noinit{}), data_ptr, size);

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -37,24 +37,24 @@ namespace TestUtils
 {
 
 #if __cplusplus >= 201703L
-#   if SYCL_2020_NOINIT_MACRO
+#   if TEST_NO_INIT_PRESENT
 #       define _ONEDPL_SYCL_NOINIT sycl::no_init
 #   else
 #       define _ONEDPL_SYCL_NOINIT sycl::noinit
 #   endif
 #else
-#   if SYCL_2020_NOINIT_MACRO
+#   if TEST_NO_INIT_PRESENT
 #       define _ONEDPL_SYCL_NOINIT sycl::property::no_init{}
 #   else
 #       define _ONEDPL_SYCL_NOINIT sycl::property::noinit{}
-#   endif 
+#   endif
 #endif
 
 #define PRINT_DEBUG(message) ::TestUtils::print_debug(message)
 
     inline void
     print_debug(const char*
-#if _ONEDPL_DEBUG_SYCL   
+#if _ONEDPL_DEBUG_SYCL
     message
 #endif
     )


### PR DESCRIPTION
This fixes definition of SYCL_2020_NOINIT_MACRO, which has been introduced in  #286.

We must use ```3```, because ```__LIBSYCL_MINOR_VERSION``` was ```2``` before adding of ```no_init```. 

- ```noinit``` has been deprecated and ```no_init``` has been introduced in https://github.com/intel/llvm/commit/ad46b641972b90da748768678daa7fae4dcc1b78 (May 14th).
- ```__LIBSYCL_MINOR_VERSION``` has been set to ```2``` in https://github.com/intel/llvm/commit/6a49170027fba61cea649ffdd299ed095b5e3d75 (April 13th)
- ```__LIBSYCL_MINOR_VERSION``` has been set to ```3``` in https://github.com/intel/llvm/commit/962909fe9e78bd597594d67c5c5be7eacf8fb10a (July 8th)


PS: ```__LIBSYCL_MINOR_VERSION``` is set as ```SYCL_MINOR_VERSION``` during installation of the compiler: https://github.com/intel/llvm/blob/e9d308e5fc70fd4ca80dfb47a72fbc0b375c11ee/sycl/include/CL/sycl/version.hpp.in#L11

I changed ```SYCL_2020_NOINIT_MACRO```  to ```_ONEDPL_NO_INIT_PRESENT``` to align the macro name with other oneDPL macros indicating that a feature is available.