### PR TITLE
[dpc++][sycl] + usage of sycl::get_kernel_bundle, sycl::use_kernel_bundle (known as PR263)

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -195,7 +195,7 @@ class __kernel_name_base
 
     __kernel_name_base(const sycl::context& __context): __ctx(__context), __kernel_id(sycl::get_kernel_id<_DerivedKernelName>())
 #if _ONEDPL_KERNEL_BUNDLE_PRESENT
-    , __kernel_bundle(sycl::get_kernel_bundle<sycl::bundle_state::executable>(__ctx/*, __kernel_id*/))
+    , __kernel_bundle(sycl::get_kernel_bundle<sycl::bundle_state::executable>(__context))
 #endif
     {}
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -19,6 +19,13 @@
 
 #include <CL/sycl.hpp>
 
+// Macros to check the new SYCL features
+#if defined(__LIBSYCL_MAJOR_VERSION) && defined(__LIBSYCL_MINOR_VERSION)
+#    define _ONEDPL_KERNEL_BUNDLE_PRESENT (__LIBSYCL_MAJOR_VERSION >= 5 && __LIBSYCL_MINOR_VERSION >= 2)
+#else
+#    define _ONEDPL_KERNEL_BUNDLE_PRESENT 0
+#endif
+
 #include <cassert>
 #include <algorithm>
 #include <type_traits>
@@ -179,21 +186,42 @@ make_iter_mode(const _Iterator& __it) -> decltype(iter_mode<outMode>()(__it))
 template <typename _DerivedKernelName>
 class __kernel_name_base
 {
-  public:
-    template <typename _Exec>
-    static sycl::kernel
-    __compile_kernel(_Exec&& __exec)
-    {
-#if 0 //_ONEDPL_KERNEL_BUNDLE_PRESENT
-        auto __kernel_bundle = sycl::get_kernel_bundle<sycl::bundle_state::executable>(__exec.queue().get_context());
-        return __kernel_bundle.get_kernel(sycl::get_kernel_id<_DerivedKernelName>());
-#else
-        sycl::program __program(__exec.queue().get_context());
+    sycl::context __ctx;
+    sycl::kernel_id __kernel_id;
 
+#if _ONEDPL_KERNEL_BUNDLE_PRESENT
+    sycl::kernel_bundle<sycl::bundle_state::executable> __kernel_bundle;
+#endif
+
+    __kernel_name_base(const sycl::context& __context): __ctx(__context), __kernel_id(sycl::get_kernel_id<_DerivedKernelName>())
+#if _ONEDPL_KERNEL_BUNDLE_PRESENT
+    , __kernel_bundle(sycl::get_kernel_bundle<sycl::bundle_state::executable>(__ctx/*, __kernel_id*/))
+#endif
+    {}
+
+  public:
+    static __kernel_name_base<_DerivedKernelName> create(const sycl::context& __context)
+    {
+        return __kernel_name_base<_DerivedKernelName>(__context);
+    }
+
+    sycl::kernel
+    __compile_kernel() const
+    {
+#if _ONEDPL_KERNEL_BUNDLE_PRESENT
+        return __kernel_bundle.get_kernel(__kernel_id);
+#else
+        sycl::program __program(__ctx);
         __program.build_with_kernel_type<_DerivedKernelName>();
         return __program.get_kernel<_DerivedKernelName>();
 #endif
     }
+#if _ONEDPL_KERNEL_BUNDLE_PRESENT
+    auto kernel_bundle() const -> decltype(__kernel_bundle)
+    {
+        return __kernel_bundle;
+    }
+#endif
 };
 
 template <typename... _Name>
@@ -292,7 +320,8 @@ __parallel_transform_reduce(_ExecutionPolicy&& __exec, _Up __u, _Cp __combine, _
     __work_group_size = oneapi::dpl::__internal::__max_local_allocation_size<_ExecutionPolicy, _Tp>(
         ::std::forward<_ExecutionPolicy>(__exec), __work_group_size);
 #if _ONEDPL_COMPILE_KERNEL
-    sycl::kernel __kernel = _ReduceKernel::__compile_kernel(::std::forward<_ExecutionPolicy>(__exec));
+    auto __kernel_stuff = _ReduceKernel::create(__exec.queue().get_context());
+    auto __kernel = __kernel_stuff.__compile_kernel();
     __work_group_size = ::std::min(__work_group_size, oneapi::dpl::__internal::__kernel_work_group_size(
                                                           ::std::forward<_ExecutionPolicy>(__exec), __kernel));
 #endif
@@ -327,8 +356,12 @@ __parallel_transform_reduce(_ExecutionPolicy&& __exec, _Up __u, _Cp __combine, _
             auto __temp_acc = __temp.template get_access<access_mode::read_write>(__cgh);
             sycl::accessor<_Tp, 1, access_mode::read_write, sycl::access::target::local> __temp_local(
                 sycl::range<1>(__work_group_size), __cgh);
+
+#if _ONEDPL_KERNEL_BUNDLE_PRESENT
+            __cgh.use_kernel_bundle(__kernel_stuff.kernel_bundle());
+#endif
             __cgh.parallel_for<_ReduceKernel>(
-#if _ONEDPL_COMPILE_KERNEL
+#if _ONEDPL_COMPILE_KERNEL && !_ONEDPL_KERNEL_BUNDLE_PRESENT
                 __kernel,
 #endif
                 sycl::nd_range<1>(sycl::range<1>(__n_groups * __work_group_size), sycl::range<1>(__work_group_size)),
@@ -403,8 +436,10 @@ __parallel_transform_scan(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&&
         ::std::forward<_ExecutionPolicy>(__exec), __wgroup_size);
 
 #if _ONEDPL_COMPILE_KERNEL
-    auto __kernel_1 = _LocalScanKernel::__compile_kernel(::std::forward<_ExecutionPolicy>(__exec));
-    auto __kernel_2 = _GlobalScanKernel::__compile_kernel(::std::forward<_ExecutionPolicy>(__exec));
+    auto __kernel_stuff_1 = _LocalScanKernel::create(__exec.queue().get_context());
+    auto __kernel_1 = __kernel_stuff_1.__compile_kernel();
+    auto __kernel_stuff_2 = _GlobalScanKernel::create(__exec.queue().get_context());
+    auto __kernel_2 = __kernel_stuff_2.__compile_kernel();
     auto __wgroup_size_kernel_1 =
         oneapi::dpl::__internal::__kernel_work_group_size(::std::forward<_ExecutionPolicy>(__exec), __kernel_1);
     auto __wgroup_size_kernel_2 =
@@ -428,8 +463,11 @@ __parallel_transform_scan(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&&
         sycl::accessor<_Type, 1, access_mode::discard_read_write, sycl::access::target::local> __local_acc(
             __wgroup_size, __cgh);
 
+#if _ONEDPL_KERNEL_BUNDLE_PRESENT
+        __cgh.use_kernel_bundle(__kernel_stuff_1.kernel_bundle());
+#endif
         __cgh.parallel_for<_LocalScanKernel>(
-#if _ONEDPL_COMPILE_KERNEL
+#if _ONEDPL_COMPILE_KERNEL && !_ONEDPL_KERNEL_BUNDLE_PRESENT
             __kernel_1,
 #endif
             sycl::nd_range<1>(__n_groups * __wgroup_size, __wgroup_size), [=](sycl::nd_item<1> __item) {
@@ -448,8 +486,11 @@ __parallel_transform_scan(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&&
             sycl::accessor<_Type, 1, access_mode::discard_read_write, sycl::access::target::local> __local_acc(
                 __wgroup_size, __cgh);
 
+#if _ONEDPL_KERNEL_BUNDLE_PRESENT
+        __cgh.use_kernel_bundle(__kernel_stuff_2.kernel_bundle());
+#endif
             __cgh.parallel_for<_GlobalScanKernel>(
-#if _ONEDPL_COMPILE_KERNEL
+#if _ONEDPL_COMPILE_KERNEL && !_ONEDPL_KERNEL_BUNDLE_PRESENT
                 __kernel_2,
 #endif
                 // TODO: try to balance work between several workgroups instead of one
@@ -629,7 +670,8 @@ __parallel_find_or(_ExecutionPolicy&& __exec, _Brick __f, _BrickTag __brick_tag,
 
     auto __wgroup_size = oneapi::dpl::__internal::__max_work_group_size(::std::forward<_ExecutionPolicy>(__exec));
 #if _ONEDPL_COMPILE_KERNEL
-    auto __kernel = _FindOrKernel::__compile_kernel(::std::forward<_ExecutionPolicy>(__exec));
+    auto __kernel_stuff = _FindOrKernel::create(__exec.queue().get_context());
+    auto __kernel = __kernel_stuff.__compile_kernel();
     __wgroup_size = ::std::min(__wgroup_size, oneapi::dpl::__internal::__kernel_work_group_size(
                                                   ::std::forward<_ExecutionPolicy>(__exec), __kernel));
 #endif
@@ -659,8 +701,12 @@ __parallel_find_or(_ExecutionPolicy&& __exec, _Brick __f, _BrickTag __brick_tag,
 
             // create local accessor to connect atomic with
             sycl::accessor<_AtomicType, 1, access_mode::read_write, sycl::access::target::local> __temp_local(1, __cgh);
+
+#if _ONEDPL_KERNEL_BUNDLE_PRESENT
+        __cgh.use_kernel_bundle(__kernel_stuff.kernel_bundle());
+#endif
             __cgh.parallel_for<_FindOrKernel>(
-#if _ONEDPL_COMPILE_KERNEL
+#if _ONEDPL_COMPILE_KERNEL && !_ONEDPL_KERNEL_BUNDLE_PRESENT
                 __kernel,
 #endif
                 sycl::nd_range</*dim=*/1>(sycl::range</*dim=*/1>(__n_groups * __wgroup_size),

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -193,14 +193,18 @@ class __kernel_name_base
     sycl::kernel_bundle<sycl::bundle_state::executable> __kernel_bundle;
 #endif
 
-    __kernel_name_base(const sycl::context& __context): __ctx(__context), __kernel_id(sycl::get_kernel_id<_DerivedKernelName>())
+    __kernel_name_base(const sycl::context& __context)
+        : __ctx(__context), __kernel_id(sycl::get_kernel_id<_DerivedKernelName>())
 #if _ONEDPL_KERNEL_BUNDLE_PRESENT
-    , __kernel_bundle(sycl::get_kernel_bundle<sycl::bundle_state::executable>(__context))
+          ,
+          __kernel_bundle(sycl::get_kernel_bundle<sycl::bundle_state::executable>(__context))
 #endif
-    {}
+    {
+    }
 
   public:
-    static __kernel_name_base<_DerivedKernelName> create(const sycl::context& __context)
+    static __kernel_name_base<_DerivedKernelName>
+    create(const sycl::context& __context)
     {
         return __kernel_name_base<_DerivedKernelName>(__context);
     }
@@ -217,7 +221,8 @@ class __kernel_name_base
 #endif
     }
 #if _ONEDPL_KERNEL_BUNDLE_PRESENT
-    auto kernel_bundle() const -> decltype(__kernel_bundle)
+    auto
+    kernel_bundle() const -> decltype(__kernel_bundle)
     {
         return __kernel_bundle;
     }
@@ -487,7 +492,7 @@ __parallel_transform_scan(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&&
                 __wgroup_size, __cgh);
 
 #if _ONEDPL_KERNEL_BUNDLE_PRESENT
-        __cgh.use_kernel_bundle(__kernel_stuff_2.kernel_bundle());
+            __cgh.use_kernel_bundle(__kernel_stuff_2.kernel_bundle());
 #endif
             __cgh.parallel_for<_GlobalScanKernel>(
 #if _ONEDPL_COMPILE_KERNEL && !_ONEDPL_KERNEL_BUNDLE_PRESENT
@@ -703,7 +708,7 @@ __parallel_find_or(_ExecutionPolicy&& __exec, _Brick __f, _BrickTag __brick_tag,
             sycl::accessor<_AtomicType, 1, access_mode::read_write, sycl::access::target::local> __temp_local(1, __cgh);
 
 #if _ONEDPL_KERNEL_BUNDLE_PRESENT
-        __cgh.use_kernel_bundle(__kernel_stuff.kernel_bundle());
+            __cgh.use_kernel_bundle(__kernel_stuff.kernel_bundle());
 #endif
             __cgh.parallel_for<_FindOrKernel>(
 #if _ONEDPL_COMPILE_KERNEL && !_ONEDPL_KERNEL_BUNDLE_PRESENT

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -187,17 +187,18 @@ template <typename _DerivedKernelName>
 class __kernel_name_base
 {
     sycl::context __ctx;
-    sycl::kernel_id __kernel_id;
 
 #if _ONEDPL_KERNEL_BUNDLE_PRESENT
+    sycl::kernel_id __kernel_id;
     sycl::kernel_bundle<sycl::bundle_state::executable> __kernel_bundle;
 #endif
 
     __kernel_name_base(const sycl::context& __context)
-        : __ctx(__context), __kernel_id(sycl::get_kernel_id<_DerivedKernelName>())
+        : __ctx(__context)
 #if _ONEDPL_KERNEL_BUNDLE_PRESENT
           ,
-          __kernel_bundle(sycl::get_kernel_bundle<sycl::bundle_state::executable>(__context))
+          __kernel_id(sycl::get_kernel_id<_DerivedKernelName>()),
+          __kernel_bundle(sycl::get_kernel_bundle<sycl::bundle_state::executable>(__ctx, {__kernel_id}))
 #endif
     {
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -186,42 +186,21 @@ make_iter_mode(const _Iterator& __it) -> decltype(iter_mode<outMode>()(__it))
 template <typename _DerivedKernelName>
 class __kernel_name_base
 {
-    sycl::context __ctx;
-    sycl::kernel_id __kernel_id;
-
-#if _ONEDPL_KERNEL_BUNDLE_PRESENT
-    sycl::kernel_bundle<sycl::bundle_state::executable> __kernel_bundle;
-#endif
-
-    __kernel_name_base(const sycl::context& __context): __ctx(__context), __kernel_id(sycl::get_kernel_id<_DerivedKernelName>())
-#if _ONEDPL_KERNEL_BUNDLE_PRESENT
-    , __kernel_bundle(sycl::get_kernel_bundle<sycl::bundle_state::executable>(__ctx/*, __kernel_id*/))
-#endif
-    {}
-
   public:
-    static __kernel_name_base<_DerivedKernelName> create(const sycl::context& __context)
-    {
-        return __kernel_name_base<_DerivedKernelName>(__context);
-    }
-
-    sycl::kernel
-    __compile_kernel() const
+    template <typename _Exec>
+    static sycl::kernel
+    __compile_kernel(_Exec&& __exec)
     {
 #if _ONEDPL_KERNEL_BUNDLE_PRESENT
-        return __kernel_bundle.get_kernel(__kernel_id);
+        auto __kernel_bundle = sycl::get_kernel_bundle<sycl::bundle_state::executable>(__exec.queue().get_context());
+        return __kernel_bundle.get_kernel(sycl::get_kernel_id<_DerivedKernelName>());
 #else
-        sycl::program __program(__ctx);
+        sycl::program __program(__exec.queue().get_context());
+
         __program.build_with_kernel_type<_DerivedKernelName>();
         return __program.get_kernel<_DerivedKernelName>();
 #endif
     }
-#if _ONEDPL_KERNEL_BUNDLE_PRESENT
-    auto kernel_bundle() const -> decltype(__kernel_bundle)
-    {
-        return __kernel_bundle;
-    }
-#endif
 };
 
 template <typename... _Name>
@@ -320,8 +299,7 @@ __parallel_transform_reduce(_ExecutionPolicy&& __exec, _Up __u, _Cp __combine, _
     __work_group_size = oneapi::dpl::__internal::__max_local_allocation_size<_ExecutionPolicy, _Tp>(
         ::std::forward<_ExecutionPolicy>(__exec), __work_group_size);
 #if _ONEDPL_COMPILE_KERNEL
-    auto __kernel_stuff = _ReduceKernel::create(__exec.queue().get_context());
-    auto __kernel = __kernel_stuff.__compile_kernel();
+    sycl::kernel __kernel = _ReduceKernel::__compile_kernel(::std::forward<_ExecutionPolicy>(__exec));
     __work_group_size = ::std::min(__work_group_size, oneapi::dpl::__internal::__kernel_work_group_size(
                                                           ::std::forward<_ExecutionPolicy>(__exec), __kernel));
 #endif
@@ -356,9 +334,8 @@ __parallel_transform_reduce(_ExecutionPolicy&& __exec, _Up __u, _Cp __combine, _
             auto __temp_acc = __temp.template get_access<access_mode::read_write>(__cgh);
             sycl::accessor<_Tp, 1, access_mode::read_write, sycl::access::target::local> __temp_local(
                 sycl::range<1>(__work_group_size), __cgh);
-
 #if _ONEDPL_KERNEL_BUNDLE_PRESENT
-            __cgh.use_kernel_bundle(__kernel_stuff.kernel_bundle());
+            __cgh.use_kernel_bundle(__kernel.get_kernel_bundle());
 #endif
             __cgh.parallel_for<_ReduceKernel>(
 #if _ONEDPL_COMPILE_KERNEL && !_ONEDPL_KERNEL_BUNDLE_PRESENT
@@ -436,10 +413,8 @@ __parallel_transform_scan(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&&
         ::std::forward<_ExecutionPolicy>(__exec), __wgroup_size);
 
 #if _ONEDPL_COMPILE_KERNEL
-    auto __kernel_stuff_1 = _LocalScanKernel::create(__exec.queue().get_context());
-    auto __kernel_1 = __kernel_stuff_1.__compile_kernel();
-    auto __kernel_stuff_2 = _GlobalScanKernel::create(__exec.queue().get_context());
-    auto __kernel_2 = __kernel_stuff_2.__compile_kernel();
+    auto __kernel_1 = _LocalScanKernel::__compile_kernel(::std::forward<_ExecutionPolicy>(__exec));
+    auto __kernel_2 = _GlobalScanKernel::__compile_kernel(::std::forward<_ExecutionPolicy>(__exec));
     auto __wgroup_size_kernel_1 =
         oneapi::dpl::__internal::__kernel_work_group_size(::std::forward<_ExecutionPolicy>(__exec), __kernel_1);
     auto __wgroup_size_kernel_2 =
@@ -462,9 +437,8 @@ __parallel_transform_scan(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&&
         auto __wg_sums_acc = __wg_sums.template get_access<access_mode::discard_write>(__cgh);
         sycl::accessor<_Type, 1, access_mode::discard_read_write, sycl::access::target::local> __local_acc(
             __wgroup_size, __cgh);
-
 #if _ONEDPL_KERNEL_BUNDLE_PRESENT
-        __cgh.use_kernel_bundle(__kernel_stuff_1.kernel_bundle());
+            __cgh.use_kernel_bundle(__kernel_1.get_kernel_bundle());
 #endif
         __cgh.parallel_for<_LocalScanKernel>(
 #if _ONEDPL_COMPILE_KERNEL && !_ONEDPL_KERNEL_BUNDLE_PRESENT
@@ -485,9 +459,8 @@ __parallel_transform_scan(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&&
             auto __wg_sums_acc = __wg_sums.template get_access<access_mode::read_write>(__cgh);
             sycl::accessor<_Type, 1, access_mode::discard_read_write, sycl::access::target::local> __local_acc(
                 __wgroup_size, __cgh);
-
 #if _ONEDPL_KERNEL_BUNDLE_PRESENT
-        __cgh.use_kernel_bundle(__kernel_stuff_2.kernel_bundle());
+            __cgh.use_kernel_bundle(__kernel_2.get_kernel_bundle());
 #endif
             __cgh.parallel_for<_GlobalScanKernel>(
 #if _ONEDPL_COMPILE_KERNEL && !_ONEDPL_KERNEL_BUNDLE_PRESENT
@@ -670,8 +643,7 @@ __parallel_find_or(_ExecutionPolicy&& __exec, _Brick __f, _BrickTag __brick_tag,
 
     auto __wgroup_size = oneapi::dpl::__internal::__max_work_group_size(::std::forward<_ExecutionPolicy>(__exec));
 #if _ONEDPL_COMPILE_KERNEL
-    auto __kernel_stuff = _FindOrKernel::create(__exec.queue().get_context());
-    auto __kernel = __kernel_stuff.__compile_kernel();
+    auto __kernel = _FindOrKernel::__compile_kernel(::std::forward<_ExecutionPolicy>(__exec));
     __wgroup_size = ::std::min(__wgroup_size, oneapi::dpl::__internal::__kernel_work_group_size(
                                                   ::std::forward<_ExecutionPolicy>(__exec), __kernel));
 #endif
@@ -701,9 +673,8 @@ __parallel_find_or(_ExecutionPolicy&& __exec, _Brick __f, _BrickTag __brick_tag,
 
             // create local accessor to connect atomic with
             sycl::accessor<_AtomicType, 1, access_mode::read_write, sycl::access::target::local> __temp_local(1, __cgh);
-
 #if _ONEDPL_KERNEL_BUNDLE_PRESENT
-        __cgh.use_kernel_bundle(__kernel_stuff.kernel_bundle());
+            __cgh.use_kernel_bundle(__kernel.get_kernel_bundle());
 #endif
             __cgh.parallel_for<_FindOrKernel>(
 #if _ONEDPL_COMPILE_KERNEL && !_ONEDPL_KERNEL_BUNDLE_PRESENT

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -187,18 +187,17 @@ template <typename _DerivedKernelName>
 class __kernel_name_base
 {
     sycl::context __ctx;
+    sycl::kernel_id __kernel_id;
 
 #if _ONEDPL_KERNEL_BUNDLE_PRESENT
-    sycl::kernel_id __kernel_id;
     sycl::kernel_bundle<sycl::bundle_state::executable> __kernel_bundle;
 #endif
 
     __kernel_name_base(const sycl::context& __context)
-        : __ctx(__context)
+        : __ctx(__context), __kernel_id(sycl::get_kernel_id<_DerivedKernelName>())
 #if _ONEDPL_KERNEL_BUNDLE_PRESENT
           ,
-          __kernel_id(sycl::get_kernel_id<_DerivedKernelName>()),
-          __kernel_bundle(sycl::get_kernel_bundle<sycl::bundle_state::executable>(__ctx, {__kernel_id}))
+          __kernel_bundle(sycl::get_kernel_bundle<sycl::bundle_state::executable>(__context))
 #endif
     {
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -193,18 +193,14 @@ class __kernel_name_base
     sycl::kernel_bundle<sycl::bundle_state::executable> __kernel_bundle;
 #endif
 
-    __kernel_name_base(const sycl::context& __context)
-        : __ctx(__context), __kernel_id(sycl::get_kernel_id<_DerivedKernelName>())
+    __kernel_name_base(const sycl::context& __context): __ctx(__context), __kernel_id(sycl::get_kernel_id<_DerivedKernelName>())
 #if _ONEDPL_KERNEL_BUNDLE_PRESENT
-          ,
-          __kernel_bundle(sycl::get_kernel_bundle<sycl::bundle_state::executable>(__context))
+    , __kernel_bundle(sycl::get_kernel_bundle<sycl::bundle_state::executable>(__context))
 #endif
-    {
-    }
+    {}
 
   public:
-    static __kernel_name_base<_DerivedKernelName>
-    create(const sycl::context& __context)
+    static __kernel_name_base<_DerivedKernelName> create(const sycl::context& __context)
     {
         return __kernel_name_base<_DerivedKernelName>(__context);
     }
@@ -221,8 +217,7 @@ class __kernel_name_base
 #endif
     }
 #if _ONEDPL_KERNEL_BUNDLE_PRESENT
-    auto
-    kernel_bundle() const -> decltype(__kernel_bundle)
+    auto kernel_bundle() const -> decltype(__kernel_bundle)
     {
         return __kernel_bundle;
     }
@@ -492,7 +487,7 @@ __parallel_transform_scan(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&&
                 __wgroup_size, __cgh);
 
 #if _ONEDPL_KERNEL_BUNDLE_PRESENT
-            __cgh.use_kernel_bundle(__kernel_stuff_2.kernel_bundle());
+        __cgh.use_kernel_bundle(__kernel_stuff_2.kernel_bundle());
 #endif
             __cgh.parallel_for<_GlobalScanKernel>(
 #if _ONEDPL_COMPILE_KERNEL && !_ONEDPL_KERNEL_BUNDLE_PRESENT
@@ -708,7 +703,7 @@ __parallel_find_or(_ExecutionPolicy&& __exec, _Brick __f, _BrickTag __brick_tag,
             sycl::accessor<_AtomicType, 1, access_mode::read_write, sycl::access::target::local> __temp_local(1, __cgh);
 
 #if _ONEDPL_KERNEL_BUNDLE_PRESENT
-            __cgh.use_kernel_bundle(__kernel_stuff.kernel_bundle());
+        __cgh.use_kernel_bundle(__kernel_stuff.kernel_bundle());
 #endif
             __cgh.parallel_for<_FindOrKernel>(
 #if _ONEDPL_COMPILE_KERNEL && !_ONEDPL_KERNEL_BUNDLE_PRESENT

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -20,11 +20,7 @@
 #include <CL/sycl.hpp>
 
 // Macros to check the new SYCL features
-#if defined(__LIBSYCL_MAJOR_VERSION) && defined(__LIBSYCL_MINOR_VERSION)
-#    define _ONEDPL_KERNEL_BUNDLE_PRESENT (__LIBSYCL_MAJOR_VERSION >= 5 && __LIBSYCL_MINOR_VERSION >= 2)
-#else
-#    define _ONEDPL_KERNEL_BUNDLE_PRESENT 0
-#endif
+#define _ONEDPL_KERNEL_BUNDLE_PRESENT (__LIBSYCL_VERSION >= 50300)
 
 #include <cassert>
 #include <algorithm>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -330,7 +330,7 @@ __parallel_transform_reduce(_ExecutionPolicy&& __exec, _Up __u, _Cp __combine, _
             auto __temp_acc = __temp.template get_access<access_mode::read_write>(__cgh);
             sycl::accessor<_Tp, 1, access_mode::read_write, sycl::access::target::local> __temp_local(
                 sycl::range<1>(__work_group_size), __cgh);
-#if _ONEDPL_KERNEL_BUNDLE_PRESENT
+#if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
             __cgh.use_kernel_bundle(__kernel.get_kernel_bundle());
 #endif
             __cgh.parallel_for<_ReduceKernel>(
@@ -433,7 +433,7 @@ __parallel_transform_scan(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&&
         auto __wg_sums_acc = __wg_sums.template get_access<access_mode::discard_write>(__cgh);
         sycl::accessor<_Type, 1, access_mode::discard_read_write, sycl::access::target::local> __local_acc(
             __wgroup_size, __cgh);
-#if _ONEDPL_KERNEL_BUNDLE_PRESENT
+#if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
         __cgh.use_kernel_bundle(__kernel_1.get_kernel_bundle());
 #endif
         __cgh.parallel_for<_LocalScanKernel>(
@@ -455,7 +455,7 @@ __parallel_transform_scan(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&&
             auto __wg_sums_acc = __wg_sums.template get_access<access_mode::read_write>(__cgh);
             sycl::accessor<_Type, 1, access_mode::discard_read_write, sycl::access::target::local> __local_acc(
                 __wgroup_size, __cgh);
-#if _ONEDPL_KERNEL_BUNDLE_PRESENT
+#if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
             __cgh.use_kernel_bundle(__kernel_2.get_kernel_bundle());
 #endif
             __cgh.parallel_for<_GlobalScanKernel>(
@@ -669,7 +669,7 @@ __parallel_find_or(_ExecutionPolicy&& __exec, _Brick __f, _BrickTag __brick_tag,
 
             // create local accessor to connect atomic with
             sycl::accessor<_AtomicType, 1, access_mode::read_write, sycl::access::target::local> __temp_local(1, __cgh);
-#if _ONEDPL_KERNEL_BUNDLE_PRESENT
+#if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
             __cgh.use_kernel_bundle(__kernel.get_kernel_bundle());
 #endif
             __cgh.parallel_for<_FindOrKernel>(

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -438,7 +438,7 @@ __parallel_transform_scan(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&&
         sycl::accessor<_Type, 1, access_mode::discard_read_write, sycl::access::target::local> __local_acc(
             __wgroup_size, __cgh);
 #if _ONEDPL_KERNEL_BUNDLE_PRESENT
-            __cgh.use_kernel_bundle(__kernel_1.get_kernel_bundle());
+        __cgh.use_kernel_bundle(__kernel_1.get_kernel_bundle());
 #endif
         __cgh.parallel_for<_LocalScanKernel>(
 #if _ONEDPL_COMPILE_KERNEL && !_ONEDPL_KERNEL_BUNDLE_PRESENT

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -195,7 +195,7 @@ class __kernel_name_base
 
     __kernel_name_base(const sycl::context& __context): __ctx(__context), __kernel_id(sycl::get_kernel_id<_DerivedKernelName>())
 #if _ONEDPL_KERNEL_BUNDLE_PRESENT
-    , __kernel_bundle(sycl::get_kernel_bundle<sycl::bundle_state::executable>(__context))
+    , __kernel_bundle(sycl::get_kernel_bundle<sycl::bundle_state::executable>(__ctx/*, __kernel_id*/))
 #endif
     {}
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -300,7 +300,7 @@ __radix_sort_count_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments, :
                           sycl::event __dependency_event
 #if _ONEDPL_COMPILE_KERNEL
                           ,
-                          _Kernel& __kernel
+                          _Kernel __kernel
 #endif
 )
 {
@@ -329,8 +329,11 @@ __radix_sort_count_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments, :
         auto __count_lacc = sycl::accessor<_CountT, 1, access_mode::read_write, access_target::local>(
             __block_size * __radix_states, __hdl);
 
+#if _ONEDPL_KERNEL_BUNDLE_PRESENT
+        __hdl.use_kernel_bundle(__kernel);
+#endif
         __hdl.parallel_for<_KernelName>(
-#if _ONEDPL_COMPILE_KERNEL
+#if _ONEDPL_COMPILE_KERNEL && !_ONEDPL_KERNEL_BUNDLE_PRESENT
             __kernel,
 #endif
             sycl::nd_range<1>(__segments * __block_size, __block_size), [=](sycl::nd_item<1> __self_item) {
@@ -464,7 +467,7 @@ __radix_sort_reorder_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments,
                             _OutRange&& __output_rng, _OffsetBuf& __offset_buf, sycl::event __dependency_event
 #if _ONEDPL_COMPILE_KERNEL
                             ,
-                            _Kernel& __kernel
+                            _Kernel __kernel
 #endif
 )
 {
@@ -494,8 +497,11 @@ __radix_sort_reorder_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments,
         // access with values to reorder and reordered values
         oneapi::dpl::__ranges::__require_access(__hdl, __input_rng, __output_rng);
 
+#if _ONEDPL_KERNEL_BUNDLE_PRESENT
+        __hdl.use_kernel_bundle(__kernel);
+#endif
         __hdl.parallel_for<_KernelName>(
-#if _ONEDPL_COMPILE_KERNEL
+#if _ONEDPL_COMPILE_KERNEL && !_ONEDPL_KERNEL_BUNDLE_PRESENT
             __kernel,
 #endif
             sycl::nd_range<1>(__segments * __sg_size, __sg_size), [=](sycl::nd_item<1> __self_item) {
@@ -586,8 +592,10 @@ __parallel_radix_sort_iteration(_ExecutionPolicy&& __exec, ::std::size_t __segme
     ::std::size_t __block_size = __max_sg_size;
     ::std::size_t __reorder_sg_size = __max_sg_size;
 #if _ONEDPL_COMPILE_KERNEL
-    auto __count_kernel = _RadixCountKernel::__compile_kernel(::std::forward<_ExecutionPolicy>(__exec));
-    auto __reorder_kernel = _RadixReorderKernel::__compile_kernel(::std::forward<_ExecutionPolicy>(__exec));
+    auto __count_kernel_stuff = _RadixCountKernel::create(__exec.queue().get_context());
+    auto __count_kernel = __count_kernel_stuff.__compile_kernel();
+    auto __reorder_kernel_stuff = _RadixReorderKernel::create(__exec.queue().get_context());
+    auto __reorder_kernel = __reorder_kernel_stuff.__compile_kernel();
     ::std::size_t __count_sg_size = oneapi::dpl::__internal::__kernel_sub_group_size(__exec, __count_kernel);
     __reorder_sg_size = oneapi::dpl::__internal::__kernel_sub_group_size(__exec, __reorder_kernel);
     __block_size = sycl::max(__count_sg_size, __reorder_sg_size);
@@ -611,8 +619,12 @@ __parallel_radix_sort_iteration(_ExecutionPolicy&& __exec, ::std::size_t __segme
         ::std::forward<_InRange>(__in_rng), __tmp_buf, __dependency_event
 #if _ONEDPL_COMPILE_KERNEL
         ,
+#    if _ONEDPL_KERNEL_BUNDLE_PRESENT
+        __count_kernel_stuff.kernel_bundle()
+#    else
         __count_kernel
-#endif
+#    endif
+#endif //_ONEDPL_COMPILE_KERNEL
     );
 
     // 2. Scan Phase
@@ -625,8 +637,12 @@ __parallel_radix_sort_iteration(_ExecutionPolicy&& __exec, ::std::size_t __segme
         ::std::forward<_InRange>(__in_rng), ::std::forward<_OutRange>(__out_rng), __tmp_buf, __scan_event
 #if _ONEDPL_COMPILE_KERNEL
         ,
+#    if _ONEDPL_KERNEL_BUNDLE_PRESENT
+        __reorder_kernel_stuff.kernel_bundle()
+#    else
         __reorder_kernel
-#endif
+#    endif
+#endif //_ONEDPL_COMPILE_KERNEL
     );
 
     return __reorder_event;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -328,9 +328,11 @@ __radix_sort_count_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments, :
         // an accessor per work-group with value counters from each work-item
         auto __count_lacc = sycl::accessor<_CountT, 1, access_mode::read_write, access_target::local>(
             __block_size * __radix_states, __hdl);
-
+#if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
+        __hdl.use_kernel_bundle(__kernel.get_kernel_bundle());
+#endif
         __hdl.parallel_for<_KernelName>(
-#if _ONEDPL_COMPILE_KERNEL
+#if _ONEDPL_COMPILE_KERNEL && !_ONEDPL_KERNEL_BUNDLE_PRESENT
             __kernel,
 #endif
             sycl::nd_range<1>(__segments * __block_size, __block_size), [=](sycl::nd_item<1> __self_item) {
@@ -493,9 +495,11 @@ __radix_sort_reorder_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments,
 
         // access with values to reorder and reordered values
         oneapi::dpl::__ranges::__require_access(__hdl, __input_rng, __output_rng);
-
+#if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
+        __hdl.use_kernel_bundle(__kernel.get_kernel_bundle());
+#endif
         __hdl.parallel_for<_KernelName>(
-#if _ONEDPL_COMPILE_KERNEL
+#if _ONEDPL_COMPILE_KERNEL && !_ONEDPL_KERNEL_BUNDLE_PRESENT
             __kernel,
 #endif
             sycl::nd_range<1>(__segments * __sg_size, __sg_size), [=](sycl::nd_item<1> __self_item) {


### PR DESCRIPTION
"Re-opened" https://github.com/oneapi-src/oneDPL/pull/263
(was closed by a mistake)