### PR TITLE
CI: use conda instead of apt to install additional packages on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,27 +121,16 @@ jobs:
             device_type: HOST
     steps:
       - uses: actions/checkout@v2
-      - name: Configure apt repositories
-        run: |
-          wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
-          sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
-          rm GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB
-          echo "deb https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
-          sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
       - name: Install Intel® oneAPI Threading Building Blocks (oneTBB)
-        run: sudo apt install -y intel-oneapi-tbb-devel
+        run: $CONDA/bin/conda install -c intel tbb-devel
       - name: Install Intel® oneAPI DPC++/C++ Compiler
         if: matrix.cxx_compiler == 'dpcpp' || matrix.cxx_compiler == 'icpx'
-        run: sudo apt install -y intel-oneapi-compiler-dpcpp-cpp
-      - name: Install Intel® oneAPI C++ Compiler Classic
-        if: matrix.cxx_compiler == 'icpc'
-        run: sudo apt install -y intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic
+        run: $CONDA/bin/conda install -c intel dpcpp_linux-64
       - name: Run testing
         shell: bash
         run: |
           set -x
-          sudo rm -rf /opt/intel/oneapi/dpl || true
-          source /opt/intel/oneapi/setvars.sh intel64 || true
+          export PATH=$CONDA/bin:$CONDA/include:$CONDA/lib:$PATH
           if [[ "${{ matrix.cxx_compiler }}" == "dpcpp" ]]; then
             echo "::warning::Compiler: $(dpcpp --version)"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,10 +131,13 @@ jobs:
         run: |
           set -x
           export PATH=$CONDA/bin:$CONDA/include:$CONDA/lib:$PATH
+          export LD_LIBRARY_PATH=$CONDA/lib:$LD_LIBRARY_PATH
+          export LIBRARY_PATH=$CONDA/lib:$LIBRARY_PATH
           if [[ "${{ matrix.cxx_compiler }}" == "dpcpp" ]]; then
             echo "::warning::Compiler: $(dpcpp --version)"
           fi
           if [[ "${{ matrix.backend }}" == "dpcpp" ]]; then
+            export OCL_ICD_FILENAMES=libintelocl.so
             make_targets="sycl_iterator.pass"
             ctest_flags="-R sycl_iterator.pass"
             echo "::warning::dpcpp backend is set. Compile and run only sycl_iterator.pass"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,7 @@ jobs:
           export PATH=$CONDA/bin:$CONDA/include:$CONDA/lib:$PATH
           export LD_LIBRARY_PATH=$CONDA/lib:$LD_LIBRARY_PATH
           export LIBRARY_PATH=$CONDA/lib:$LIBRARY_PATH
+          export CPATH=$CONDA/include:$CPATH
           if [[ "${{ matrix.cxx_compiler }}" == "dpcpp" ]]; then
             echo "::warning::Compiler: $(dpcpp --version)"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,15 +130,12 @@ jobs:
         shell: bash
         run: |
           set -x
-          export PATH=$CONDA/bin:$CONDA/include:$CONDA/lib:$PATH
-          export LD_LIBRARY_PATH=$CONDA/lib:$LD_LIBRARY_PATH
-          export LIBRARY_PATH=$CONDA/lib:$LIBRARY_PATH
-          export CPATH=$CONDA/include:$CPATH
+          source $CONDA/bin/activate
+          export PATH=$CONDA/include:$CONDA/lib:$PATH
           if [[ "${{ matrix.cxx_compiler }}" == "dpcpp" ]]; then
             echo "::warning::Compiler: $(dpcpp --version)"
           fi
           if [[ "${{ matrix.backend }}" == "dpcpp" ]]; then
-            export OCL_ICD_FILENAMES=libintelocl.so
             make_targets="sycl_iterator.pass"
             ctest_flags="-R sycl_iterator.pass"
             echo "::warning::dpcpp backend is set. Compile and run only sycl_iterator.pass"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,8 @@ jobs:
         run: |
           set -x
           source $CONDA/bin/activate
-          export PATH=$CONDA/include:$CONDA/lib:$PATH
+          export PATH=$CONDA/lib:$PATH
+          export CPATH=$CONDA/include:$CPATH
           if [[ "${{ matrix.cxx_compiler }}" == "dpcpp" ]]; then
             echo "::warning::Compiler: $(dpcpp --version)"
           fi


### PR DESCRIPTION
Signed-off-by: Zheltov, Sergey1 <sergey1.zheltov@intel.com>