### PR TITLE
[oneDPL] Add serial all_of, any_of and none_of to oneapi::dpl

### DIFF
--- a/documentation/library_guide/tested_standard_cpp_api.rst
+++ b/documentation/library_guide/tested_standard_cpp_api.rst
@@ -320,6 +320,12 @@ C++ Standard API                     libstdc++  libc++     MSVC
 ``std::optional``                    Tested     Tested     Tested
 ------------------------------------ ---------- ---------- ----------
 ``std::reduce``                      Tested     Tested     Tested
+------------------------------------ ---------- ---------- ----------
+``std::all_of``                      Tested     Tested     Tested
+------------------------------------ ---------- ---------- ----------
+``std::any_of``                      Tested     Tested     Tested
+------------------------------------ ---------- ---------- ----------
+``std::none_of``                     Tested     Tested     Tested
 ==================================== ========== ========== ==========
 
 These tests were done for the following versions of the standard C++ library:

--- a/include/oneapi/dpl/algorithm
+++ b/include/oneapi/dpl/algorithm
@@ -42,9 +42,12 @@ namespace oneapi
 {
 namespace dpl
 {
+using ::std::all_of;
+using ::std::any_of;
 using ::std::binary_search;
 using ::std::equal_range;
 using ::std::lower_bound;
+using ::std::none_of;
 using ::std::upper_bound;
 } // namespace dpl
 

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.all_of/xpu_all_of.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.all_of/xpu_all_of.pass.cpp
@@ -1,0 +1,69 @@
+//===-- xpu_all_of.pass.cpp -----------------------------------------------===//
+//
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#include <oneapi/dpl/algorithm>
+
+#include "support/test_iterators.h"
+
+#include <cassert>
+#include <CL/sycl.hpp>
+
+using oneapi::dpl::all_of;
+
+struct test1
+{
+    constexpr bool
+    operator()(const int& i) const
+    {
+        return i % 2 == 0;
+    }
+};
+
+class KernelTest;
+
+void
+kernel_test(sycl::queue& deviceQueue)
+{
+    bool ret = true;
+    sycl::range<1> item1{1};
+    {
+        sycl::buffer<bool, 1> buffer1(&ret, item1);
+        deviceQueue.submit([&](sycl::handler& cgh) {
+            auto ret_acc = buffer1.get_access<sycl::access::mode::write>(cgh);
+            cgh.single_task<KernelTest>([=]() {
+                {
+                    int ia[] = {2, 4, 6, 8};
+                    const unsigned sa = sizeof(ia) / sizeof(ia[0]);
+                    ret_acc[0] &= all_of(input_iterator<const int*>(ia), input_iterator<const int*>(ia + sa), test1());
+                    ret_acc[0] &= all_of(input_iterator<const int*>(ia), input_iterator<const int*>(ia), test1());
+                }
+                {
+                    const int ia[] = {2, 4, 5, 8};
+                    const unsigned sa = sizeof(ia) / sizeof(ia[0]);
+                    ret_acc[0] &= !all_of(input_iterator<const int*>(ia), input_iterator<const int*>(ia + sa), test1());
+                    ret_acc[0] &= all_of(input_iterator<const int*>(ia), input_iterator<const int*>(ia), test1());
+                }
+            });
+        });
+    }
+    assert(ret);
+}
+
+int
+main()
+{
+    sycl::queue deviceQueue;
+    kernel_test(deviceQueue);
+    return 0;
+}

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.any_of/xpu_any_of.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.any_of/xpu_any_of.pass.cpp
@@ -1,0 +1,73 @@
+//===-- xpu_any_of.pass.cpp -----------------------------------------------===//
+//
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#include <oneapi/dpl/algorithm>
+
+#include "support/test_iterators.h"
+
+#include <cassert>
+#include <CL/sycl.hpp>
+
+using oneapi::dpl::any_of;
+
+struct test1
+{
+    constexpr bool
+    operator()(const int& i) const
+    {
+        return i % 2 == 0;
+    }
+};
+
+void
+kernel_test(sycl::queue& deviceQueue)
+{
+    bool ret = true;
+    sycl::range<1> item1{1};
+    {
+        sycl::buffer<bool, 1> buffer1(&ret, item1);
+        deviceQueue.submit([&](sycl::handler& cgh) {
+            auto ret_acc = buffer1.get_access<sycl::access::mode::write>(cgh);
+            cgh.single_task<class KernelTest>([=]() {
+                {
+                    int ia[] = {2, 4, 6, 8};
+                    const unsigned sa = sizeof(ia) / sizeof(ia[0]);
+                    ret_acc[0] &= any_of(input_iterator<const int*>(ia), input_iterator<const int*>(ia + sa), test1());
+                    ret_acc[0] &= !any_of(input_iterator<const int*>(ia), input_iterator<const int*>(ia), test1());
+                }
+                {
+                    const int ia[] = {2, 4, 5, 8};
+                    const unsigned sa = sizeof(ia) / sizeof(ia[0]);
+                    ret_acc[0] &= any_of(input_iterator<const int*>(ia), input_iterator<const int*>(ia + sa), test1());
+                    ret_acc[0] &= !any_of(input_iterator<const int*>(ia), input_iterator<const int*>(ia), test1());
+                }
+                {
+                    const int ia[] = {1, 3, 5, 7};
+                    const unsigned sa = sizeof(ia) / sizeof(ia[0]);
+                    ret_acc[0] &= !any_of(input_iterator<const int*>(ia), input_iterator<const int*>(ia + sa), test1());
+                    ret_acc[0] &= !any_of(input_iterator<const int*>(ia), input_iterator<const int*>(ia), test1());
+                }
+            });
+        });
+    }
+    assert(ret);
+}
+
+int
+main()
+{
+    sycl::queue deviceQueue;
+    kernel_test(deviceQueue);
+    return 0;
+}

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.none_of/xpu_none_of.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.none_of/xpu_none_of.pass.cpp
@@ -1,0 +1,75 @@
+//===-- xpu_none_of.pass.cpp ----------------------------------------------===//
+//
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#include <oneapi/dpl/algorithm>
+
+#include "support/test_iterators.h"
+
+#include <cassert>
+#include <CL/sycl.hpp>
+
+using oneapi::dpl::none_of;
+
+struct test1
+{
+    constexpr bool
+    operator()(const int& i) const
+    {
+        return i % 2 == 0;
+    }
+};
+
+void
+kernel_test(sycl::queue& deviceQueue)
+{
+    bool ret = true;
+    sycl::range<1> item1{1};
+    {
+        sycl::buffer<bool, 1> buffer1(&ret, item1);
+        deviceQueue.submit([&](sycl::handler& cgh) {
+            auto ret_acc = buffer1.get_access<sycl::access::mode::write>(cgh);
+            cgh.single_task<class KernelTest1>([=]() {
+                {
+                    int ia[] = {2, 4, 6, 8};
+                    const unsigned sa = sizeof(ia) / sizeof(ia[0]);
+                    ret_acc[0] &=
+                        !none_of(input_iterator<const int*>(ia), input_iterator<const int*>(ia + sa), test1());
+                    ret_acc[0] &= none_of(input_iterator<const int*>(ia), input_iterator<const int*>(ia), test1());
+                }
+                {
+                    const int ia[] = {2, 4, 5, 8};
+                    const unsigned sa = sizeof(ia) / sizeof(ia[0]);
+                    ret_acc[0] &=
+                        !none_of(input_iterator<const int*>(ia), input_iterator<const int*>(ia + sa), test1());
+                    ret_acc[0] &= none_of(input_iterator<const int*>(ia), input_iterator<const int*>(ia), test1());
+                }
+                {
+                    const int ia[] = {1, 3, 5, 7};
+                    const unsigned sa = sizeof(ia) / sizeof(ia[0]);
+                    ret_acc[0] &= none_of(input_iterator<const int*>(ia), input_iterator<const int*>(ia + sa), test1());
+                    ret_acc[0] &= none_of(input_iterator<const int*>(ia), input_iterator<const int*>(ia), test1());
+                }
+            });
+        });
+    }
+    assert(ret);
+}
+
+int
+main()
+{
+    sycl::queue deviceQueue;
+    kernel_test(deviceQueue);
+    return 0;
+}


### PR DESCRIPTION
These 3 algorithm are introduced in C++11, so we can inject them to oneapi::dpl namespace directly.
They are available in gcc 7.5.0
Signed-off-by: haonanya <haonan.yang@intel.com>