### PR TITLE
Make kernel names shorter for name generator case

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -83,8 +83,7 @@ class device_policy
 };
 
 #if _ONEDPL_FPGA_DEVICE
-struct DefaultKernelNameFPGA;
-template <unsigned int factor = 1, typename KernelName = DefaultKernelNameFPGA>
+template <unsigned int factor = 1, typename KernelName = DefaultKernelName>
 class fpga_policy : public device_policy<KernelName>
 {
     using base = device_policy<KernelName>;
@@ -186,14 +185,14 @@ make_hetero_policy(const device_policy<OldKernelName>& policy)
 }
 
 #if _ONEDPL_FPGA_DEVICE
-template <unsigned int unroll_factor = 1, typename KernelName = DefaultKernelNameFPGA>
+template <unsigned int unroll_factor = 1, typename KernelName = DefaultKernelName>
 fpga_policy<unroll_factor, KernelName>
 make_fpga_policy(sycl::queue q)
 {
     return fpga_policy<unroll_factor, KernelName>(q);
 }
 
-template <unsigned int unroll_factor = 1, typename KernelName = DefaultKernelNameFPGA>
+template <unsigned int unroll_factor = 1, typename KernelName = DefaultKernelName>
 fpga_policy<unroll_factor, KernelName>
 make_fpga_policy(sycl::device d)
 {
@@ -201,7 +200,7 @@ make_fpga_policy(sycl::device d)
 }
 
 template <unsigned int new_unroll_factor, typename NewKernelName, unsigned int old_unroll_factor = 1,
-          typename OldKernelName = DefaultKernelNameFPGA>
+          typename OldKernelName = DefaultKernelName>
 fpga_policy<new_unroll_factor, NewKernelName>
 make_fpga_policy(const fpga_policy<old_unroll_factor, OldKernelName>& policy
 #    if _ONEDPL_USE_PREDEFINED_POLICIES
@@ -213,7 +212,7 @@ make_fpga_policy(const fpga_policy<old_unroll_factor, OldKernelName>& policy
 }
 
 template <unsigned int new_unroll_factor, typename NewKernelName, unsigned int old_unroll_factor = 1,
-          typename OldKernelName = DefaultKernelNameFPGA>
+          typename OldKernelName = DefaultKernelName>
 fpga_policy<new_unroll_factor, NewKernelName>
 make_hetero_policy(const fpga_policy<old_unroll_factor, OldKernelName>& policy)
 {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
@@ -42,6 +42,7 @@ namespace __par_backend_hetero
 //General version of parallel_for, one additional parameter - __count of iterations of loop __cgh.parallel_for,
 //for some algorithms happens that size of processing range is n, but amount of iterations is n/2.
 
+// Please see the comment for __parallel_for_submitter for optional kernel name explanation
 template <typename _Name>
 struct __parallel_for_fpga_submitter;
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -432,6 +432,7 @@ struct __radix_global_scan_caller
     ::std::size_t __m_scan_size;
 };
 
+// Please see the comment for __parallel_for_submitter for optional kernel name explanation
 template <typename _RadixLocalScanName, typename _RadixGlobalScanName, ::std::uint32_t __radix_bits>
 struct __radix_sort_scan_submitter;
 
@@ -606,15 +607,14 @@ __parallel_radix_sort_iteration(_ExecutionPolicy&& __exec, ::std::size_t __segme
 {
     using _CustomName = typename __decay_t<_ExecutionPolicy>::kernel_name;
     using _RadixCountKernel =
-        oneapi::dpl::__par_backend_hetero::__internal::_KernelName_t<__radix_sort_count_kernel, _CustomName,
-                                                                     __decay_t<_InRange>, __decay_t<_TmpBuf>>;
+        oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<__radix_sort_count_kernel, _CustomName,
+                                                                               __decay_t<_InRange>, __decay_t<_TmpBuf>>;
     using _RadixLocalScanKernel =
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<__radix_sort_scan_kernel_1<_CustomName>>;
     using _RadixGlobalScanKernel =
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<__radix_sort_scan_kernel_2<_CustomName>>;
-    using _RadixReorderKernel =
-        oneapi::dpl::__par_backend_hetero::__internal::_KernelName_t<__radix_sort_reorder_kernel, _CustomName,
-                                                                     __decay_t<_InRange>, __decay_t<_OutRange>>;
+    using _RadixReorderKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
+        __radix_sort_reorder_kernel, _CustomName, __decay_t<_InRange>, __decay_t<_OutRange>>;
 
     ::std::size_t __max_sg_size = oneapi::dpl::__internal::__max_sub_group_size(__exec);
     ::std::size_t __scan_wg_size = oneapi::dpl::__internal::__max_work_group_size(__exec);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -127,11 +127,7 @@ namespace __internal
 template <typename _CustomName>
 struct _HasDefaultName
 {
-    static constexpr bool value = ::std::is_same<_CustomName, oneapi::dpl::execution::DefaultKernelName>::value
-#if _ONEDPL_FPGA_DEVICE
-                                  || ::std::is_same<_CustomName, oneapi::dpl::execution::DefaultKernelNameFPGA>::value
-#endif
-        ;
+    static constexpr bool value = ::std::is_same<_CustomName, oneapi::dpl::execution::DefaultKernelName>::value;
 };
 
 template <template <typename...> class _ExternalName, typename _InternalName>
@@ -157,6 +153,9 @@ struct __composite_kernel_name
 {
 };
 
+// Compose kernel name by transforming the constexpr string to the sequence of chars
+// and instantiate template with variadic non-type template parameters.
+// This approach is required to get reliable work group size when kernel is unnamed
 #if _ONEDPL_BUILT_IN_STABLE_NAME_PRESENT
 template <typename _Tp>
 class __kernel_name_composer
@@ -174,7 +173,7 @@ class __kernel_name_composer
 #endif // _ONEDPL_BUILT_IN_STABLE_NAME_PRESENT
 
 template <template <typename...> class _BaseName, typename _CustomName, typename... _Args>
-using _KernelName_t =
+using __kernel_name_generator =
 #if __SYCL_UNNAMED_LAMBDA__
     typename ::std::conditional<_HasDefaultName<_CustomName>::value,
 #    if _ONEDPL_BUILT_IN_STABLE_NAME_PRESENT


### PR DESCRIPTION
Changes:

- Make kernel names shorter for name generator case. Add aliases for readability.
- Add comments for optional kernel name and for kernel name composer
- Remove `DefaultKernelNameFPGA`