### PR TITLE
Fix deprecation warnings for extensions namespace

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -91,9 +91,9 @@ class fpga_policy : public device_policy<KernelName>
     fpga_policy()
         : base(sycl::queue(
 #    if _ONEDPL_FPGA_EMU
-              __dpl_sycl::fpga_emulator_selector {}
+              __dpl_sycl::__fpga_emulator_selector {}
 #    else
-              __dpl_sycl::fpga_selector {}
+              __dpl_sycl::__fpga_selector {}
 #    endif // _ONEDPL_FPGA_EMU
               ))
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -20,9 +20,6 @@
 #include "../../execution_defs.h"
 
 #include "sycl_defs.h"
-#if _ONEDPL_FPGA_DEVICE
-#    include <CL/sycl/INTEL/fpga_extensions.hpp>
-#endif
 
 namespace oneapi
 {
@@ -94,9 +91,9 @@ class fpga_policy : public device_policy<KernelName>
     fpga_policy()
         : base(sycl::queue(
 #    if _ONEDPL_FPGA_EMU
-              sycl::INTEL::fpga_emulator_selector {}
+              __dpl_sycl::fpga_emulator_selector {}
 #    else
-              sycl::INTEL::fpga_selector {}
+              __dpl_sycl::fpga_selector {}
 #    endif // _ONEDPL_FPGA_EMU
               ))
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -22,6 +22,9 @@
 #define _ONEDPL_sycl_defs_H
 
 #include <CL/sycl.hpp>
+#if _ONEDPL_FPGA_DEVICE
+#    include <CL/sycl/INTEL/fpga_extensions.hpp>
+#endif
 
 // Combine SYCL runtime library version
 #if defined(__LIBSYCL_MAJOR_VERSION) && defined(__LIBSYCL_MINOR_VERSION) && defined(__LIBSYCL_PATCH_VERSION)
@@ -142,6 +145,16 @@ __joint_exclusive_scan(_Args... __args)
     return sycl::ONEAPI::exclusive_scan(__args...);
 #endif
 }
+
+#if _ONEDPL_FPGA_DEVICE
+#    if __LIBSYCL_VERSION >= 50400
+using fpga_emulator_selector = sycl::ext::intel::fpga_emulator_selector;
+using fpga_selector = sycl::ext::intel::fpga_selector;
+#    else
+using fpga_emulator_selector = sycl::INTEL::fpga_emulator_selector;
+using fpga_selector = sycl::INTEL::fpga_selector;
+#    endif
+#endif // _ONEDPL_FPGA_DEVICE
 
 } // namespace __dpl_sycl
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -148,11 +148,11 @@ __joint_exclusive_scan(_Args... __args)
 
 #if _ONEDPL_FPGA_DEVICE
 #    if __LIBSYCL_VERSION >= 50300
-using fpga_emulator_selector = sycl::ext::intel::fpga_emulator_selector;
-using fpga_selector = sycl::ext::intel::fpga_selector;
+using __fpga_emulator_selector = sycl::ext::intel::fpga_emulator_selector;
+using __fpga_selector = sycl::ext::intel::fpga_selector;
 #    else
-using fpga_emulator_selector = sycl::INTEL::fpga_emulator_selector;
-using fpga_selector = sycl::INTEL::fpga_selector;
+using __fpga_emulator_selector = sycl::INTEL::fpga_emulator_selector;
+using __fpga_selector = sycl::INTEL::fpga_selector;
 #    endif
 #endif // _ONEDPL_FPGA_DEVICE
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -147,7 +147,7 @@ __joint_exclusive_scan(_Args... __args)
 }
 
 #if _ONEDPL_FPGA_DEVICE
-#    if __LIBSYCL_VERSION >= 50400
+#    if __LIBSYCL_VERSION >= 50300
 using fpga_emulator_selector = sycl::ext::intel::fpga_emulator_selector;
 using fpga_selector = sycl::ext::intel::fpga_selector;
 #    else

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -101,10 +101,11 @@ namespace TestUtils
 #if ONEDPL_FPGA_DEVICE
     auto default_selector =
 #if ONEDPL_FPGA_EMULATOR
-        sycl::INTEL::fpga_emulator_selector{};
+        __dpl_sycl::fpga_emulator_selector{};
 #else
-        sycl::INTEL::fpga_selector{};
+        __dpl_sycl::fpga_selector{};
 #endif // ONEDPL_FPGA_EMULATOR
+
     auto&& default_dpcpp_policy =
 #if ONEDPL_USE_PREDEFINED_POLICIES
         oneapi::dpl::execution::dpcpp_fpga;

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -101,9 +101,9 @@ namespace TestUtils
 #if ONEDPL_FPGA_DEVICE
     auto default_selector =
 #if ONEDPL_FPGA_EMULATOR
-        __dpl_sycl::fpga_emulator_selector{};
+        __dpl_sycl::__fpga_emulator_selector{};
 #else
-        __dpl_sycl::fpga_selector{};
+        __dpl_sycl::__fpga_selector{};
 #endif // ONEDPL_FPGA_EMULATOR
 
     auto&& default_dpcpp_policy =


### PR DESCRIPTION
This fixes issue: 
```bash
warning: 'INTEL' is deprecated: use 'ext::intel' instead
```
Since the namespace was deprecated after the latest release, that change cannot be detected by __LIBSYCL_VERSION macro for now. 50400 is set tentatively.

50300 is effective since: https://github.com/intel/llvm/commit/962909fe9e78bd597594d67c5c5be7eacf8fb10a (July 8)
deprecation was done in https://github.com/intel/llvm/commit/d703f578fcf7e8fb4716846bdd115add128a345b (July 17)

Waiting for update of https://github.com/intel/llvm/blob/sycl/sycl/CMakeLists.txt#L16

Upd.
Version macro is not going to be updated in the compiler soon, that is why let's use 50300. That will remove deprecation warnings, though it will make oneDPL code invalid for the compiler snapshots between https://github.com/intel/llvm/commit/962909fe9e78bd597594d67c5c5be7eacf8fb10a (July 8) and https://github.com/intel/llvm/commit/d703f578fcf7e8fb4716846bdd115add128a345b (July 17).