### PR TITLE
Return fpga default kernel name back

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -83,7 +83,8 @@ class device_policy
 };
 
 #if _ONEDPL_FPGA_DEVICE
-template <unsigned int factor = 1, typename KernelName = DefaultKernelName>
+struct DefaultKernelNameFPGA;
+template <unsigned int factor = 1, typename KernelName = DefaultKernelNameFPGA>
 class fpga_policy : public device_policy<KernelName>
 {
     using base = device_policy<KernelName>;
@@ -185,14 +186,14 @@ make_hetero_policy(const device_policy<OldKernelName>& policy)
 }
 
 #if _ONEDPL_FPGA_DEVICE
-template <unsigned int unroll_factor = 1, typename KernelName = DefaultKernelName>
+template <unsigned int unroll_factor = 1, typename KernelName = DefaultKernelNameFPGA>
 fpga_policy<unroll_factor, KernelName>
 make_fpga_policy(sycl::queue q)
 {
     return fpga_policy<unroll_factor, KernelName>(q);
 }
 
-template <unsigned int unroll_factor = 1, typename KernelName = DefaultKernelName>
+template <unsigned int unroll_factor = 1, typename KernelName = DefaultKernelNameFPGA>
 fpga_policy<unroll_factor, KernelName>
 make_fpga_policy(sycl::device d)
 {
@@ -200,7 +201,7 @@ make_fpga_policy(sycl::device d)
 }
 
 template <unsigned int new_unroll_factor, typename NewKernelName, unsigned int old_unroll_factor = 1,
-          typename OldKernelName = DefaultKernelName>
+          typename OldKernelName = DefaultKernelNameFPGA>
 fpga_policy<new_unroll_factor, NewKernelName>
 make_fpga_policy(const fpga_policy<old_unroll_factor, OldKernelName>& policy
 #    if _ONEDPL_USE_PREDEFINED_POLICIES
@@ -212,7 +213,7 @@ make_fpga_policy(const fpga_policy<old_unroll_factor, OldKernelName>& policy
 }
 
 template <unsigned int new_unroll_factor, typename NewKernelName, unsigned int old_unroll_factor = 1,
-          typename OldKernelName = DefaultKernelName>
+          typename OldKernelName = DefaultKernelNameFPGA>
 fpga_policy<new_unroll_factor, NewKernelName>
 make_hetero_policy(const fpga_policy<old_unroll_factor, OldKernelName>& policy)
 {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -127,7 +127,11 @@ namespace __internal
 template <typename _CustomName>
 struct _HasDefaultName
 {
-    static constexpr bool value = ::std::is_same<_CustomName, oneapi::dpl::execution::DefaultKernelName>::value;
+    static constexpr bool value = ::std::is_same<_CustomName, oneapi::dpl::execution::DefaultKernelName>::value
+#if _ONEDPL_FPGA_DEVICE
+                                  || ::std::is_same<_CustomName, oneapi::dpl::execution::DefaultKernelNameFPGA>::value
+#endif
+        ;
 };
 
 template <template <typename...> class _ExternalName, typename _InternalName>


### PR DESCRIPTION
Decided to return it back because we have two global policy objects and their default names should be independent.

The fix for `_HasDefaultName` still required. 