### PR TITLE
Fix kernel redefinition in scan

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -415,9 +415,9 @@ struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name
     {
         using _Type = typename _InitType::__value_type;
         using _LocalScanKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
-            __parallel_scan_local_kernel, _CustomName, _Range1, _Range2, _Type, _LocalScan>;
+            __parallel_scan_local_kernel, _CustomName, _Range1, _Range2, _Type, _LocalScan, _GroupScan, _GlobalScan>;
         using _GroupScanKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
-            __parallel_scan_group_kernel, _CustomName, _Range1, _Range2, _Type, _GroupScan>;
+            __parallel_scan_group_kernel, _CustomName, _Range1, _Range2, _Type, _LocalScan, _GroupScan, _GlobalScan>;
 
         auto __n = __rng1.size();
         assert(__n > 0);


### PR DESCRIPTION
The instantiation of scan pattern may differ just with one Callable type and that would give two different instantiations of the function. On the other hand, the name for the kernel might be the same because it doesn't take into account all the passed types. Thus, compiler tries to generate two different kernels with the same name.

That patch makes kernel name take into account all the passed types. 