### PR TITLE
[dpc++][sycl] undo usage of SYCL2020 feature sycl::group_barrier

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -84,7 +84,10 @@ template <typename _Item>
 constexpr void
 __group_barrier(_Item __item)
 {
-#if __LIBSYCL_VERSION >= 50300
+#if 0 //__LIBSYCL_VERSION >= 50300
+    //TODO: usage of sycl::group_barrier: probably, we have to revise SYCL parallel patterns which use a group_barrier.
+    // 1) sycl::group_barrier() implementation is not ready
+    // 2) sycl::group_barrier and sycl::item::group_barrier are not quite equivalent 
     sycl::group_barrier(__item.get_group(), sycl::memory_scope::work_group);
 #else
     __item.barrier(sycl::access::fence_space::local_space);


### PR DESCRIPTION
Undo usage of sycl::group_barrier by following reasons:
1) sycl::group_barrier() implementation is not ready in the SYCL library.
2) sycl::group_barrier and sycl::item::group_barrier are not quite equivalent. In the future we have to revise SYCL parallel patterns which use a group_barrier.