### PR TITLE
Add oneAPI logo to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![](https://spec.oneapi.io/oneapi-logo-white-scaled.jpg)
+
 oneDPL is part of [oneAPI](https://oneapi.io)
 # oneAPI DPC++ Library (oneDPL)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![](https://spec.oneapi.io/oneapi-logo-white-scaled.jpg)
+oneDPL is part of [oneAPI](https://oneapi.io)
 # oneAPI DPC++ Library (oneDPL)
 
 The oneAPI DPC++ Library (oneDPL) aims to work with the oneAPI DPC++ Compiler


### PR DESCRIPTION
Adding oneAPI logo to README to make it consistent with other oneAPI open source projects.