### PR TITLE
+ usage of SYCL_DEVICE_FILTER

### DIFF
--- a/make/Makefile.common
+++ b/make/Makefile.common
@@ -55,7 +55,7 @@ ranges_api ?= 0
 
 ifeq ($(backend), sycl)
     ifeq ($(findstring FPGA, $(device_type)),)
-        export SYCL_DEVICE_TYPE=$(device_type)
+        export SYCL_DEVICE_FILTER=$(device_type)
     endif
 endif
 


### PR DESCRIPTION
+ usage of SYCL_DEVICE_FILTER instead of deprecated SYCL_DEVICE_TYPE