### PR TITLE
[oneDPL][sycl] removed usage of the deprecated sycl::vector_class

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -358,15 +358,11 @@ template <typename _ExecutionPolicy>
 ::std::size_t
 __max_sub_group_size(_ExecutionPolicy&& __policy)
 {
-    // TODO: can get_info<sycl::info::device::sub_group_sizes>() return zero-size vector?
-    //       Spec does not say anything about that.
-    sycl::vector_class<::std::size_t> __supported_sg_sizes =
+    auto __supported_sg_sizes = 
         __policy.queue().get_device().template get_info<sycl::info::device::sub_group_sizes>();
-
-    // TODO: Since it is unknown if sycl::vector_class returned
-    //       by get_info<sycl::info::device::sub_group_sizes>() can be empty,
-    //       at() is used instead of operator[] for out of bound check
-    return __supported_sg_sizes.at(__supported_sg_sizes.size() - 1);
+  
+    //The result of get_info<sycl::info::device::sub_group_sizes>() can be empty.
+    return __supported_sg_sizes.empty() ? 0 : __supported_sg_sizes.back();
 }
 #endif
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -358,10 +358,9 @@ template <typename _ExecutionPolicy>
 ::std::size_t
 __max_sub_group_size(_ExecutionPolicy&& __policy)
 {
-    auto __supported_sg_sizes = 
-        __policy.queue().get_device().template get_info<sycl::info::device::sub_group_sizes>();
-  
-    //The result of get_info<sycl::info::device::sub_group_sizes>() can be empty.
+    auto __supported_sg_sizes = __policy.queue().get_device().template get_info<sycl::info::device::sub_group_sizes>();
+
+    //The result of get_info<sycl::info::device::sub_group_sizes>() can be empty - the function returns 0;
     return __supported_sg_sizes.empty() ? 0 : __supported_sg_sizes.back();
 }
 #endif


### PR DESCRIPTION
[oneDPL][sycl] + more robust implementation of __max_sub_group_size and removed usage of the deprecated sycl::vector_class.
Now the function just return 0 instead of throwing "out_of_bound" exception.