### PR TITLE
[oneDPL][ranges][sycl] A fix for header inclusion order in case of ranges

### DIFF
--- a/include/oneapi/dpl/execution
+++ b/include/oneapi/dpl/execution
@@ -29,6 +29,7 @@
 
 #define _ONEDPL_EXECUTION_POLICIES_DEFINED 1
 
+// If the forward declarations have already been processed, pull the implementations
 #if _ONEDPL_ALGORITHM_FORWARD_DECLARED
 #    include "oneapi/dpl/pstl/glue_algorithm_impl.h"
 
@@ -44,6 +45,14 @@
 
 #if _ONEDPL_NUMERIC_FORWARD_DECLARED
 #    include "oneapi/dpl/pstl/glue_numeric_impl.h"
+#endif
+
+#if _ONEDPL_ALGORITHM_RANGES_FORWARD_DECLARED
+#    include "oneapi/dpl/pstl/glue_algorithm_ranges_impl.h"
+#endif
+
+#if _ONEDPL_NUMERIC_RANGES_FORWARD_DECLARED
+#    include "oneapi/dpl/pstl/glue_numeric_ranges_impl.h"
 #endif
 
 #if _ONEDPL_CPP17_EXECUTION_POLICIES_PRESENT

--- a/include/oneapi/dpl/internal/async_impl/async_utils.h
+++ b/include/oneapi/dpl/internal/async_impl/async_utils.h
@@ -80,8 +80,8 @@ class __future : public __par_backend_hetero::__future_base
 #if _ONEDPL_BACKEND_SYCL
 // Specialization for hetero iterator and usm pointer
 template <typename _T>
-class __future<_T, typename std::enable_if<__par_backend_hetero::__internal::is_hetero_iterator<_T>::value ||
-                                           __par_backend_hetero::__internal::is_passed_directly<_T>::value>::type>
+class __future<_T, typename std::enable_if<__internal::is_hetero_iterator<_T>::value ||
+                                           __internal::is_passed_directly<_T>::value>::type>
     : public __par_backend_hetero::__future_base
 {
     _T __data;

--- a/include/oneapi/dpl/internal/function.h
+++ b/include/oneapi/dpl/internal/function.h
@@ -54,8 +54,8 @@ struct rebind_policy<oneapi::dpl::execution::fpga_policy<factor, KernelName>, Ne
 };
 #    endif
 
+using oneapi::dpl::__internal::is_hetero_iterator;
 using oneapi::dpl::__par_backend_hetero::__internal::__buffer;
-using oneapi::dpl::__par_backend_hetero::__internal::is_hetero_iterator;
 #endif
 
 #if _ONEDPL_BACKEND_SYCL

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -18,6 +18,7 @@
 
 #include "../algorithm_fwd.h"
 #include "../parallel_backend.h"
+#include "utils_hetero.h"
 
 #if _ONEDPL_BACKEND_SYCL
 #    include "dpcpp/utils_ranges_sycl.h"

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -230,34 +230,6 @@ inline void __print_device_debug_info(_Policy, size_t = 0, size_t = 0)
 }
 #endif
 
-// struct for checking if iterator is heterogeneous or not
-template <typename Iter, typename Void = void> // for non-heterogeneous iterators
-struct is_hetero_iterator : ::std::false_type
-{
-};
-
-template <typename Iter> // for heterogeneous iterators
-struct is_hetero_iterator<Iter, typename ::std::enable_if<Iter::is_hetero::value, void>::type> : ::std::true_type
-{
-};
-// struct for checking if iterator should be passed directly to device or not
-template <typename Iter, typename Void = void> // for iterators that should not be passed directly
-struct is_passed_directly : ::std::false_type
-{
-};
-
-template <typename Iter> // for iterators defined as direct pass
-struct is_passed_directly<Iter, typename ::std::enable_if<Iter::is_passed_directly::value, void>::type>
-    : ::std::true_type
-{
-};
-
-template <typename Iter> // for pointers to objects on device
-struct is_passed_directly<Iter, typename ::std::enable_if<::std::is_pointer<Iter>::value, void>::type>
-    : ::std::true_type
-{
-};
-
 //-----------------------------------------------------------------------
 // type traits for comparators
 //-----------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -144,10 +144,10 @@ struct is_permutation<Iter, typename ::std::enable_if<Iter::is_permutation::valu
 };
 
 template <typename _Iter>
-using is_hetero_it = oneapi::dpl::__par_backend_hetero::__internal::is_hetero_iterator<_Iter>;
+using is_hetero_it = oneapi::dpl::__internal::is_hetero_iterator<_Iter>;
 
 template <typename _Iter>
-using is_passed_directly_it = oneapi::dpl::__par_backend_hetero::__internal::is_passed_directly<_Iter>;
+using is_passed_directly_it = oneapi::dpl::__internal::is_passed_directly<_Iter>;
 
 //struct for checking if it needs to create a temporary SYCL buffer or not
 

--- a/include/oneapi/dpl/pstl/hetero/utils_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/utils_hetero.h
@@ -1,0 +1,152 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+// This file contains SYCL specific macros and abstractions
+// to support different versions of SYCL and to simplify its interfaces
+//
+// Include this header instead of sycl.hpp throughout the project
+
+#ifndef _ONEDPL_utils_hetero_H
+#define _ONEDPL_utils_hetero_H
+
+namespace oneapi
+{
+namespace dpl
+{
+namespace __internal
+{
+
+template <typename _Pred>
+struct equal_predicate
+{
+    _Pred __pred;
+
+    template <typename _Value>
+    bool
+    operator()(const _Value& __val) const
+    {
+        using ::std::get;
+        return !__pred(get<0>(__val), get<1>(__val));
+    }
+};
+
+template <typename _Predicate>
+struct adjacent_find_fn
+{
+    _Predicate __predicate;
+
+    // the functor is being used instead of a lambda because
+    // at this level we don't know what type we get during zip_iterator unpack
+    // whereas lambdas with auto in arg parameters are supported since C++14
+    template <typename _Pack>
+    bool
+    operator()(const _Pack& __packed_neighbor_values) const
+    {
+        using ::std::get;
+        return __predicate(get<0>(__packed_neighbor_values), get<1>(__packed_neighbor_values));
+    }
+};
+
+template <typename _Predicate, typename _ValueType>
+struct __create_mask_unique_copy
+{
+    _Predicate __predicate;
+
+    template <typename _Idx, typename _Acc>
+    _ValueType
+    operator()(_Idx __idx, _Acc& __acc) const
+    {
+        using ::std::get;
+
+        auto __predicate_result = 1;
+        if (__idx != 0)
+            __predicate_result = __predicate(get<0>(__acc[__idx]), get<0>(__acc[__idx + (-1)]));
+
+        get<1>(__acc[__idx]) = __predicate_result;
+        return _ValueType{__predicate_result};
+    }
+};
+
+template <typename _ReduceValueType>
+struct __acc_handler_minelement
+{
+
+    template <typename _GlobalIdx, typename _Acc>
+    _ReduceValueType
+    operator()(_GlobalIdx __gidx, _Acc __acc) const
+    {
+        // TODO: __acc is tuple<accessors...> when zip_iterators are passed
+        return _ReduceValueType{__gidx, __acc[__gidx]};
+    }
+};
+
+template <typename _ReduceValueType>
+struct __acc_handler_minmaxelement
+{
+
+    template <typename _GlobalIdx, typename _Acc>
+    _ReduceValueType
+    operator()(_GlobalIdx __gidx, _Acc __acc) const
+    {
+        // TODO: Doesn't work with `zip_iterator`.
+        //       In that case the first and the second arguments of `_ReduceValueType` will be
+        //       a `tuple` of `difference_type`, not the `difference_type` itself.
+        return _ReduceValueType{__gidx, __gidx, __acc[__gidx], __acc[__gidx]};
+    }
+};
+
+template <typename _Compare>
+struct __identity_reduce_fn
+{
+    _Compare __comp;
+    template <typename _ReduceValueType>
+    _ReduceValueType
+    operator()(_ReduceValueType __a, _ReduceValueType __b) const
+    {
+        using ::std::get;
+        auto __chosen_for_min = __a;
+        auto __chosen_for_max = __b;
+        // if b "<" a or if b "==" a and b_index < a_index
+        if (__comp(get<2>(__b), get<2>(__a)) || (!__comp(get<2>(__a), get<2>(__b)) && get<0>(__b) < get<0>(__a)))
+            __chosen_for_min = __b;
+        // if a ">" b or if a "==" b and a_index > b_index
+        if (__comp(get<3>(__b), get<3>(__a)) || (!__comp(get<3>(__a), get<3>(__b)) && get<1>(__b) < get<1>(__a)))
+            __chosen_for_max = __a;
+        auto __result = _ReduceValueType{get<0>(__chosen_for_min), get<1>(__chosen_for_max), get<2>(__chosen_for_min),
+                                         get<3>(__chosen_for_max)};
+
+        return __result;
+    }
+};
+
+template <typename _Predicate>
+struct acc_handler_count
+{
+    _Predicate __predicate;
+
+    // int is being implicitly casted to difference_type
+    // otherwise we can only pass the difference_type as a functor template parameter
+    template <typename _Acc, typename _GlobalIdx>
+    int
+    operator()(_GlobalIdx gidx, _Acc acc) const
+    {
+        return (__predicate(acc[gidx]) ? 1 : 0);
+    }
+};
+} // namespace __internal
+} // namespace dpl
+} // namespace oneapi
+
+#endif /* _ONEDPL_utils_hetero_H */

--- a/include/oneapi/dpl/pstl/iterator_defs.h
+++ b/include/oneapi/dpl/pstl/iterator_defs.h
@@ -77,6 +77,34 @@ struct __is_random_access_iterator<_IteratorType> : __is_random_access_iterator_
 {
 };
 
+// struct for checking if iterator is heterogeneous or not
+template <typename Iter, typename Void = void> // for non-heterogeneous iterators
+struct is_hetero_iterator : ::std::false_type
+{
+};
+
+template <typename Iter> // for heterogeneous iterators
+struct is_hetero_iterator<Iter, typename ::std::enable_if<Iter::is_hetero::value, void>::type> : ::std::true_type
+{
+};
+// struct for checking if iterator should be passed directly to device or not
+template <typename Iter, typename Void = void> // for iterators that should not be passed directly
+struct is_passed_directly : ::std::false_type
+{
+};
+
+template <typename Iter> // for iterators defined as direct pass
+struct is_passed_directly<Iter, typename ::std::enable_if<Iter::is_passed_directly::value, void>::type>
+    : ::std::true_type
+{
+};
+
+template <typename Iter> // for pointers to objects on device
+struct is_passed_directly<Iter, typename ::std::enable_if<::std::is_pointer<Iter>::value, void>::type>
+    : ::std::true_type
+{
+};
+
 } // namespace __internal
 } // namespace dpl
 } // namespace oneapi

--- a/include/oneapi/dpl/pstl/ranges_defs.h
+++ b/include/oneapi/dpl/pstl/ranges_defs.h
@@ -19,6 +19,10 @@
 #include "ranges/nanorange.hpp"
 #include "ranges/nanorange_ext.h"
 
+#if _ONEDPL_BACKEND_SYCL
+#    include "hetero/dpcpp/utils_ranges_sycl.h"
+#endif
+
 namespace oneapi
 {
 namespace dpl

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -19,7 +19,9 @@
 #include <iterator>
 #include <type_traits>
 
+#include "iterator_defs.h"
 #include "iterator_impl.h"
+#include "execution_defs.h"
 
 namespace oneapi
 {

--- a/include/oneapi/dpl/ranges
+++ b/include/oneapi/dpl/ranges
@@ -17,7 +17,6 @@
 #define _ONEDPL_RANGES
 
 // TODO: Figure out the order of headers and add standard header version/ciso646 for library version macros.
-// Also, remove dependency on <execution> header.
 #if defined(_GLIBCXX_RELEASE)
 #    define _ONEDPL_CXX_STANDARD_LIBRARY_CHECK (_GLIBCXX_RELEASE >= 8 && __GLIBCXX__ >= 20180502)
 #elif defined(_LIBCPP_VERSION)

--- a/test/general/header_order_ranges_0.pass.cpp
+++ b/test/general/header_order_ranges_0.pass.cpp
@@ -1,0 +1,34 @@
+// -*- C++ -*-
+//===-- header_inclusion_order_algorithm_0.pass.cpp -----------------------===//
+//
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#include "support/test_config.h"
+
+#if _ENABLE_RANGES_TESTING
+#include _PSTL_TEST_HEADER(execution)
+#include _PSTL_TEST_HEADER(ranges)
+#endif
+
+#include "support/utils.h"
+
+int
+main()
+{
+#if _ENABLE_RANGES_TESTING
+    using namespace oneapi::dpl::experimental::ranges;
+    all_of(TestUtils::default_dpcpp_policy, views::fill(-1, 10), [](auto i) { return i == -1;});
+#endif
+
+    return TestUtils::done(_ENABLE_RANGES_TESTING);
+}

--- a/test/general/header_order_ranges_1.pass.cpp
+++ b/test/general/header_order_ranges_1.pass.cpp
@@ -1,0 +1,34 @@
+// -*- C++ -*-
+//===-- header_inclusion_order_algorithm_0.pass.cpp -----------------------===//
+//
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#include "support/test_config.h"
+
+#if _ENABLE_RANGES_TESTING
+#include _PSTL_TEST_HEADER(ranges)
+#include _PSTL_TEST_HEADER(execution)
+#endif
+
+#include "support/utils.h"
+
+int
+main()
+{
+#if _ENABLE_RANGES_TESTING
+    using namespace oneapi::dpl::experimental::ranges;
+    all_of(TestUtils::default_dpcpp_policy, views::fill(-1, 10), [](auto i) { return i == -1;});
+#endif
+
+    return TestUtils::done(_ENABLE_RANGES_TESTING);
+}


### PR DESCRIPTION
A fix for header inclusion order (`<ranges> / <execution>`)
Also, a couple of tests to cover that situation was added.