### PR TITLE
Add a link to Intel cookies

### DIFF
--- a/before_you_begin.html
+++ b/before_you_begin.html
@@ -228,6 +228,9 @@ and use the <code class="docutils literal notranslate"><span class="pre">std</sp
           By Intel<br/>
         
             &copy; Copyright Intel Corporation.<br/>
+          <div class="extra_footer">
+            <p align="right"><a href="https://www.intel.com/content/www/us/en/privacy/intel-cookie-notice.html">Cookies</a></p>
+          </div>
       </p>
     </div>
   </footer>

--- a/extension_api.html
+++ b/extension_api.html
@@ -645,6 +645,9 @@ Lifetime of any resources the algorithm allocates (for example: temporary storag
           By Intel<br/>
         
             &copy; Copyright Intel Corporation.<br/>
+          <div class="extra_footer">
+            <p align="right"><a href="https://www.intel.com/content/www/us/en/privacy/intel-cookie-notice.html">Cookies</a></p>
+          </div>
       </p>
     </div>
   </footer>

--- a/genindex.html
+++ b/genindex.html
@@ -195,6 +195,9 @@
           By Intel<br/>
         
             &copy; Copyright Intel Corporation.<br/>
+          <div class="extra_footer">
+            <p align="right"><a href="https://www.intel.com/content/www/us/en/privacy/intel-cookie-notice.html">Cookies</a></p>
+          </div>
       </p>
     </div>
   </footer>

--- a/index.html
+++ b/index.html
@@ -227,6 +227,9 @@ oneDPL consists of the following components:</p>
           By Intel<br/>
         
             &copy; Copyright Intel Corporation.<br/>
+          <div class="extra_footer">
+            <p align="right"><a href="https://www.intel.com/content/www/us/en/privacy/intel-cookie-notice.html">Cookies</a></p>
+          </div>
       </p>
     </div>
   </footer>

--- a/notices_disclaimers.html
+++ b/notices_disclaimers.html
@@ -218,6 +218,9 @@
           By Intel<br/>
         
             &copy; Copyright Intel Corporation.<br/>
+          <div class="extra_footer">
+            <p align="right"><a href="https://www.intel.com/content/www/us/en/privacy/intel-cookie-notice.html">Cookies</a></p>
+          </div>
       </p>
     </div>
   </footer>

--- a/pstl/dpcpp_policies_usage.html
+++ b/pstl/dpcpp_policies_usage.html
@@ -587,6 +587,9 @@ oneDPL parallel algorithms on Linux* (depending on the code, parameters within [
           By Intel<br/>
         
             &copy; Copyright Intel Corporation.<br/>
+          <div class="extra_footer">
+            <p align="right"><a href="https://www.intel.com/content/www/us/en/privacy/intel-cookie-notice.html">Cookies</a></p>
+          </div>
       </p>
     </div>
   </footer>

--- a/pstl/macros.html
+++ b/pstl/macros.html
@@ -359,6 +359,9 @@ Define only the <code class="docutils literal notranslate"><span class="pre">ONE
           By Intel<br/>
         
             &copy; Copyright Intel Corporation.<br/>
+          <div class="extra_footer">
+            <p align="right"><a href="https://www.intel.com/content/www/us/en/privacy/intel-cookie-notice.html">Cookies</a></p>
+          </div>
       </p>
     </div>
   </footer>

--- a/pstl_main.html
+++ b/pstl_main.html
@@ -298,6 +298,9 @@ To use Parallel STL with the C++ standard policies, you must have the following 
           By Intel<br/>
         
             &copy; Copyright Intel Corporation.<br/>
+          <div class="extra_footer">
+            <p align="right"><a href="https://www.intel.com/content/www/us/en/privacy/intel-cookie-notice.html">Cookies</a></p>
+          </div>
       </p>
     </div>
   </footer>

--- a/random.html
+++ b/random.html
@@ -433,6 +433,9 @@ are defined in the header <code class="docutils literal notranslate"><span class
           By Intel<br/>
         
             &copy; Copyright Intel Corporation.<br/>
+          <div class="extra_footer">
+            <p align="right"><a href="https://www.intel.com/content/www/us/en/privacy/intel-cookie-notice.html">Cookies</a></p>
+          </div>
       </p>
     </div>
   </footer>

--- a/search.html
+++ b/search.html
@@ -215,6 +215,9 @@
           By Intel<br/>
         
             &copy; Copyright Intel Corporation.<br/>
+          <div class="extra_footer">
+            <p align="right"><a href="https://www.intel.com/content/www/us/en/privacy/intel-cookie-notice.html">Cookies</a></p>
+          </div>
       </p>
     </div>
   </footer>

--- a/tested_standard_cpp_api.html
+++ b/tested_standard_cpp_api.html
@@ -952,6 +952,9 @@ Visual Studio* 2019</p></td>
           By Intel<br/>
         
             &copy; Copyright Intel Corporation.<br/>
+          <div class="extra_footer">
+            <p align="right"><a href="https://www.intel.com/content/www/us/en/privacy/intel-cookie-notice.html">Cookies</a></p>
+          </div>
       </p>
     </div>
   </footer>


### PR DESCRIPTION
This is the first step in setting up doc usage data collection from github pages

see output: https://outoftardis.github.io/oneDPL/

I'll work with @dcbenito on updating the configs to generate this automatically but we need this change in order to make a request to the WAP team and get an id for the analytics scripts.