### PR TITLE
CI: improve codespell check

### DIFF
--- a/.github/scripts/allowed_words.txt
+++ b/.github/scripts/allowed_words.txt
@@ -1,0 +1,2 @@
+copyable
+Copyable

--- a/.github/scripts/codespell.sh
+++ b/.github/scripts/codespell.sh
@@ -16,15 +16,14 @@ SCAN_TARGET=$1
 
 SKIP_PATTERN='*/.github/*'
 
-# Ignored cases
+# # Ignored cases
 IGNORE_COMMAND="sed -e /.*sycl_iterator.pass.cpp.*nd\\s*=.*/d \
--e /.*nanorange.hpp.*copyable\\s*=.*/d \
--e /.*overview.rst.*copyable\\s*=.*/d \
--e /.*iterator_impl.h.*Copyable\\s*=.*/d \
 -e /.*windows.inc.*Od\\s*=.*/d \
 -e /.*README.md.*varN\\s*=.*/d"
 
-SCAN_RESULT=$(codespell --quiet-level=2 --skip "${SKIP_PATTERN}" ${SCAN_TARGET})
+GITHUB_WORKSPACE="."
+
+SCAN_RESULT=$(codespell -I ${GITHUB_WORKSPACE}/.github/scripts/allowed_words.txt --quiet-level=2 --skip "${SKIP_PATTERN}" ${SCAN_TARGET})
 SCAN_RESULT=$(echo -e "${SCAN_RESULT}" | ${IGNORE_COMMAND})
 echo "${SCAN_RESULT}"
 

--- a/.github/scripts/codespell.sh
+++ b/.github/scripts/codespell.sh
@@ -16,7 +16,7 @@ SCAN_TARGET=$1
 
 SKIP_PATTERN='*/.github/*'
 
-# # Ignored cases
+# Ignored cases
 IGNORE_COMMAND="sed -e /.*sycl_iterator.pass.cpp.*nd\\s*=.*/d \
 -e /.*windows.inc.*Od\\s*=.*/d \
 -e /.*README.md.*varN\\s*=.*/d"

--- a/.github/scripts/codespell.sh
+++ b/.github/scripts/codespell.sh
@@ -19,6 +19,7 @@ SKIP_PATTERN='*/.github/*'
 # Ignored cases
 IGNORE_COMMAND="sed -e /.*sycl_iterator.pass.cpp.*nd\\s*=.*/d \
 -e /.*nanorange.hpp.*copyable\\s*=.*/d \
+-e /.*overview.rst.*copyable\\s*=.*/d \
 -e /.*iterator_impl.h.*Copyable\\s*=.*/d \
 -e /.*windows.inc.*Od\\s*=.*/d \
 -e /.*README.md.*varN\\s*=.*/d"

--- a/.github/scripts/codespell.sh
+++ b/.github/scripts/codespell.sh
@@ -21,8 +21,6 @@ IGNORE_COMMAND="sed -e /.*sycl_iterator.pass.cpp.*nd\\s*=.*/d \
 -e /.*windows.inc.*Od\\s*=.*/d \
 -e /.*README.md.*varN\\s*=.*/d"
 
-GITHUB_WORKSPACE="."
-
 SCAN_RESULT=$(codespell -I ${GITHUB_WORKSPACE}/.github/scripts/allowed_words.txt --quiet-level=2 --skip "${SKIP_PATTERN}" ${SCAN_TARGET})
 SCAN_RESULT=$(echo -e "${SCAN_RESULT}" | ${IGNORE_COMMAND})
 echo "${SCAN_RESULT}"


### PR DESCRIPTION
Some repetitive errors moved to a separate file. Specific errors remain in the IGNORE_COMMAND variable.