### PR TITLE
[RNG] Change std::pair to param_type

### DIFF
--- a/include/oneapi/dpl/internal/random_impl/lognormal_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/lognormal_distribution.h
@@ -76,7 +76,7 @@ class lognormal_distribution
     void
     param(const param_type& __param)
     {
-        nd_.param(std::make_pair(__param.m, __param.s));
+        nd_.param(normal_distr_param_type(__param.m, __param.s));
     }
 
     scalar_type
@@ -126,6 +126,8 @@ class lognormal_distribution
 
     using normal_distr = oneapi::dpl::normal_distribution<
         typename ::std::conditional<(size_of_type_ <= 3), scalar_type, result_type>::type>;
+    using normal_distr_param_type = typename oneapi::dpl::normal_distribution<
+        typename ::std::conditional<(size_of_type_ <= 3), scalar_type, result_type>::type>::param_type;
 
     // Static asserts
     static_assert(::std::is_floating_point<scalar_type>::value,
@@ -147,7 +149,7 @@ class lognormal_distribution
     typename ::std::enable_if<(_Ndistr == 0), result_type>::type
     generate(_Engine& __engine, const param_type& __params)
     {
-        return sycl::exp(nd_(__engine, std::make_pair(__params.m, __params.s)));
+        return sycl::exp(nd_(__engine, normal_distr_param_type(__params.m, __params.s)));
     }
 
     // Specialization of the vector generation with size = [1; 2; 3]
@@ -157,7 +159,7 @@ class lognormal_distribution
     {
         result_type __res;
         for (int i = 0; i < __N; i++)
-            __res[i] = sycl::exp(nd_(__engine, std::make_pair(__params.m, __params.s)));
+            __res[i] = sycl::exp(nd_(__engine, normal_distr_param_type(__params.m, __params.s)));
         return __res;
     }
 
@@ -166,7 +168,7 @@ class lognormal_distribution
     typename ::std::enable_if<(__N > 3), result_type>::type
     generate_vec(_Engine& __engine, const param_type& __params)
     {
-        return sycl::exp(nd_(__engine, std::make_pair(__params.m, __params.s)));
+        return sycl::exp(nd_(__engine, normal_distr_param_type(__params.m, __params.s)));
     }
 
     // Implementation for the N vector's elements generation with size = [4; 8; 16]
@@ -174,7 +176,7 @@ class lognormal_distribution
     typename ::std::enable_if<(_Ndistr > 3), result_type>::type
     generate_n_elems(_Engine& __engine, const param_type& __params, unsigned int __N)
     {
-        result_type __res = nd_(__engine, std::make_pair(__params.m, __params.s), __N);
+        result_type __res = nd_(__engine, normal_distr_param_type(__params.m, __params.s), __N);
         for (int i = 0; i < __N; i++)
             __res[i] = sycl::exp(__res[i]);
         return __res;
@@ -187,7 +189,7 @@ class lognormal_distribution
     {
         result_type __res;
         for (int i = 0; i < __N; i++)
-            __res[i] = sycl::exp(nd_(__engine, std::make_pair(__params.m, __params.s)));
+            __res[i] = sycl::exp(nd_(__engine, normal_distr_param_type(__params.m, __params.s)));
         return __res;
     }
 

--- a/include/oneapi/dpl/internal/random_impl/uniform_int_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/uniform_int_distribution.h
@@ -32,15 +32,45 @@ class uniform_int_distribution
     // Distribution types
     using result_type = _IntType;
     using scalar_type = internal::element_type_t<result_type>;
-    using param_type = typename ::std::pair<scalar_type, scalar_type>;
+    class param_type
+    {
+      public:
+        typedef uniform_int_distribution<result_type> distribution_type;
+        param_type() : param_type(scalar_type{0}) {}
+        explicit param_type(scalar_type a, scalar_type b = ::std::numeric_limits<scalar_type>::max()) : a_(a), b_(b) {}
+        scalar_type
+        a() const
+        {
+            return a_;
+        }
+        scalar_type
+        b() const
+        {
+            return b_;
+        }
+        friend bool
+        operator==(const param_type& p1, const param_type& p2)
+        {
+            return p1.a_ == p2.a_ && p1.b_ == p2.b_;
+        }
+        friend bool
+        operator!=(const param_type& p1, const param_type& p2)
+        {
+            return !(p1 == p2);
+        }
+
+      private:
+        scalar_type a_;
+        scalar_type b_;
+    };
 
     // Constructors
-    uniform_int_distribution() : uniform_int_distribution(static_cast<scalar_type>(0)) {}
+    uniform_int_distribution() : uniform_int_distribution(scalar_type{0}) {}
     explicit uniform_int_distribution(scalar_type __a, scalar_type __b = ::std::numeric_limits<scalar_type>::max())
         : a_(__a), b_(__b)
     {
     }
-    explicit uniform_int_distribution(const param_type& __params) : a_(__params.first), b_(__params.second) {}
+    explicit uniform_int_distribution(const param_type& __params) : a_(__params.a()), b_(__params.b()) {}
 
     // Reset function
     void
@@ -68,10 +98,10 @@ class uniform_int_distribution
     }
 
     void
-    param(const param_type& __parm)
+    param(const param_type& __params)
     {
-        a_ = __parm.first;
-        b_ = __parm.second;
+        a_ = __params.a();
+        b_ = __params.b();
     }
 
     scalar_type
@@ -140,8 +170,8 @@ class uniform_int_distribution
     generate(_Engine& __engine, const param_type& __params)
     {
         RealType __res = uniform_real_distribution_(
-            __engine, ::std::pair<double, double>(static_cast<double>(__params.first),
-                                                  static_cast<double>(__params.second) + 1.0));
+            __engine, typename uniform_real_distribution<RealType>::param_type(
+                          static_cast<double>(__params.a()), static_cast<double>(__params.b()) + 1.0));
 
         result_type __res_ret;
         for (int __i = 0; __i < _Ndistr; ++__i)
@@ -155,8 +185,8 @@ class uniform_int_distribution
     generate(_Engine& __engine, const param_type& __params)
     {
         RealType __res = uniform_real_distribution_(
-            __engine, ::std::pair<double, double>(static_cast<double>(__params.first),
-                                                  static_cast<double>(__params.second) + 1.0));
+            __engine, typename uniform_real_distribution<RealType>::param_type(
+                          static_cast<double>(__params.a()), static_cast<double>(__params.b()) + 1.0));
 
         return static_cast<scalar_type>(__res);
     }
@@ -174,8 +204,8 @@ class uniform_int_distribution
 
         RealType __res =
             uniform_real_distribution_(__engine,
-                                       ::std::pair<double, double>(static_cast<double>(__params.first),
-                                                                   static_cast<double>(__params.second) + 1.0),
+                                       typename uniform_real_distribution<RealType>::param_type(
+                                           static_cast<double>(__params.a()), static_cast<double>(__params.b()) + 1.0),
                                        __N);
 
         for (unsigned int __i = 0; __i < __N; ++__i)

--- a/include/oneapi/dpl/internal/random_impl/uniform_real_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/uniform_real_distribution.h
@@ -32,15 +32,42 @@ class uniform_real_distribution
     // Distribution types
     using result_type = _RealType;
     using scalar_type = internal::element_type_t<_RealType>;
-    using param_type = typename ::std::pair<scalar_type, scalar_type>;
+    class param_type
+    {
+      public:
+        typedef uniform_real_distribution<result_type> distribution_type;
+        param_type() : param_type(scalar_type{0.0}) {}
+        explicit param_type(scalar_type a, scalar_type b = scalar_type{1.0}) : a_(a), b_(b) {}
+        scalar_type
+        a() const
+        {
+            return a_;
+        }
+        scalar_type
+        b() const
+        {
+            return b_;
+        }
+        friend bool
+        operator==(const param_type& p1, const param_type& p2)
+        {
+            return p1.a_ == p2.a_ && p1.b_ == p2.b_;
+        }
+        friend bool
+        operator!=(const param_type& p1, const param_type& p2)
+        {
+            return !(p1 == p2);
+        }
+
+      private:
+        scalar_type a_;
+        scalar_type b_;
+    };
 
     // Constructors
-    uniform_real_distribution() : uniform_real_distribution(static_cast<scalar_type>(0.0)) {}
-    explicit uniform_real_distribution(scalar_type __a, scalar_type __b = static_cast<scalar_type>(1.0))
-        : a_(__a), b_(__b)
-    {
-    }
-    explicit uniform_real_distribution(const param_type& __params) : a_(__params.first), b_(__params.second) {}
+    uniform_real_distribution() : uniform_real_distribution(scalar_type{0.0}) {}
+    explicit uniform_real_distribution(scalar_type __a, scalar_type __b = scalar_type{1.0}) : a_(__a), b_(__b) {}
+    explicit uniform_real_distribution(const param_type& __params) : a_(__params.a()), b_(__params.b()) {}
 
     // Reset function
     void
@@ -68,10 +95,10 @@ class uniform_real_distribution
     }
 
     void
-    param(const param_type& __parm)
+    param(const param_type& __params)
     {
-        a_ = __parm.first;
-        b_ = __parm.second;
+        a_ = __params.a();
+        b_ = __params.b();
     }
 
     scalar_type
@@ -141,8 +168,8 @@ class uniform_real_distribution
             __res[__i] = static_cast<scalar_type>(__engine_output[__i]);
 
         __res = ((__res - __engine.min()) / (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
-                    (__params.second - __params.first) +
-                __params.first;
+                    (__params.b() - __params.a()) +
+                __params.a();
         return __res;
     }
 
@@ -154,8 +181,8 @@ class uniform_real_distribution
         auto __res = static_cast<scalar_type>(__engine_output);
         __res = ((__res - static_cast<scalar_type>(__engine.min())) /
                  (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
-                    (__params.second - __params.first) +
-                __params.first;
+                    (__params.b() - __params.a()) +
+                __params.a();
         return __res;
     }
 
@@ -170,8 +197,8 @@ class uniform_real_distribution
             __res[__i] = static_cast<scalar_type>(__engine_output[__i]);
             __res[__i] =
                 ((__res[__i] - __engine.min()) / (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
-                    (__params.second - __params.first) +
-                __params.first;
+                    (__params.b() - __params.a()) +
+                __params.a();
         }
         return __res;
     }
@@ -182,8 +209,8 @@ class uniform_real_distribution
     {
         scalar_type __res = static_cast<scalar_type>(__engine(1)[0]);
         __res = ((__res - __engine.min()) / (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
-                    (__params.second - __params.first) +
-                __params.first;
+                    (__params.b() - __params.a()) +
+                __params.a();
         return __res;
     }
 
@@ -200,8 +227,8 @@ class uniform_real_distribution
             auto __res_tmp = __engine_output.template convert<scalar_type, sycl::rounding_mode::rte>();
             __res_tmp =
                 ((__res_tmp - __engine.min()) / (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
-                    (__params.second - __params.first) +
-                __params.first;
+                    (__params.b() - __params.a()) +
+                __params.a();
 
             for (int __j = 0; __j < _Nengine; ++__j)
                 __res[__i + __j] = __res_tmp[__j];
@@ -214,8 +241,8 @@ class uniform_real_distribution
             auto __res_tmp = __engine_output.template convert<scalar_type, sycl::rounding_mode::rte>();
             __res_tmp =
                 ((__res_tmp - __engine.min()) / (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
-                    (__params.second - __params.first) +
-                __params.first;
+                    (__params.b() - __params.a()) +
+                __params.a();
             for (int __j = 0; __j < __tail_size; __j++)
                 __res[__i + __j] = __res_tmp[__j];
         }
@@ -232,8 +259,8 @@ class uniform_real_distribution
             __res[__i] = static_cast<scalar_type>(__engine());
             __res[__i] =
                 ((__res[__i] - __engine.min()) / (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
-                    (__params.second - __params.first) +
-                __params.first;
+                    (__params.b() - __params.a()) +
+                __params.a();
         }
         return __res;
     }
@@ -250,8 +277,8 @@ class uniform_real_distribution
             __res[__i] = static_cast<scalar_type>(__engine_output[__i]);
             __res[__i] =
                 ((__res[__i] - __engine.min()) / (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
-                    (__params.second - __params.first) +
-                __params.first;
+                    (__params.b() - __params.a()) +
+                __params.a();
         }
         return __res;
     }
@@ -271,8 +298,8 @@ class uniform_real_distribution
                 __res[__i] = static_cast<scalar_type>(__engine_output[__i]);
                 __res[__i] =
                     ((__res[__i] - __engine.min()) / (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
-                        (__params.second - __params.first) +
-                    __params.first;
+                        (__params.b() - __params.a()) +
+                    __params.a();
             }
         }
         else
@@ -284,8 +311,8 @@ class uniform_real_distribution
                 auto __res_tmp = __engine_output.template convert<scalar_type, sycl::rounding_mode::rte>();
                 __res_tmp =
                     ((__res_tmp - __engine.min()) / (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
-                        (__params.second - __params.first) +
-                    __params.first;
+                        (__params.b() - __params.a()) +
+                    __params.a();
                 for (int __j = 0; __j < _Nengine; ++__j)
                 {
                     __res[__i + __j] = __res_tmp[__j];
@@ -298,8 +325,8 @@ class uniform_real_distribution
                 auto __res_tmp = __engine_output.template convert<scalar_type, sycl::rounding_mode::rte>();
                 __res_tmp =
                     ((__res_tmp - __engine.min()) / (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
-                        (__params.second - __params.first) +
-                    __params.first;
+                        (__params.b() - __params.a()) +
+                    __params.a();
 
                 for (unsigned int __j = 0; __j < __tail_size; ++__j)
                 {
@@ -320,8 +347,8 @@ class uniform_real_distribution
             __res[__i] = static_cast<scalar_type>(__engine());
             __res[__i] =
                 ((__res[__i] - __engine.min()) / (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
-                    (__params.second - __params.first) +
-                __params.first;
+                    (__params.b() - __params.a()) +
+                __params.a();
         }
         return __res;
     }

--- a/test/xpu_api/random/interface_tests/distributions_methods.pass.cpp
+++ b/test/xpu_api/random/interface_tests/distributions_methods.pass.cpp
@@ -39,7 +39,7 @@ check_params(oneapi::dpl::uniform_int_distribution<T>& distr)
     Element_type<T> a = Element_type<T>{0};
     Element_type<T> b = std::numeric_limits<Element_type<T>>::max();
     return ((distr.a() != a) || (distr.b() != b) || (distr.min() != a) || (distr.max() != b) ||
-            (distr.param().first != a) || (distr.param().second != b));
+            (distr.param().a() != a) || (distr.param().b() != b));
 }
 
 template <class T>
@@ -49,7 +49,7 @@ check_params(oneapi::dpl::uniform_real_distribution<T>& distr)
     Element_type<T> a = Element_type<T>{0.0};
     Element_type<T> b = Element_type<T>{1.0};
     return ((distr.a() != a) || (distr.b() != b) || (distr.min() != a) || (distr.max() != b) ||
-            (distr.param().first != a) || (distr.param().second != b));
+            (distr.param().a() != a) || (distr.param().b() != b));
 }
 
 template <class T>
@@ -60,8 +60,8 @@ check_params(oneapi::dpl::normal_distribution<T>& distr)
     Element_type<T> stddev = Element_type<T>{1.0};
     return ((distr.mean() != mean) || (distr.stddev() != stddev) ||
             (distr.min() > -std::numeric_limits<Element_type<T>>::max()) ||
-            (distr.max() < std::numeric_limits<Element_type<T>>::max()) || (distr.param().first != mean) ||
-            (distr.param().second != stddev));
+            (distr.max() < std::numeric_limits<Element_type<T>>::max()) || (distr.param().mean() != mean) ||
+            (distr.param().stddev() != stddev));
 }
 
 template <class T>
@@ -140,14 +140,14 @@ check_params(oneapi::dpl::extreme_value_distribution<T>& distr)
 }
 
 template <typename Distr>
-typename ::std::enable_if<::std::is_same<typename Distr::param_type,
-        ::std::pair<typename Distr::scalar_type, typename Distr::scalar_type>>::value, void>::type
+typename ::std::enable_if<::std::is_same<Distr, 
+             oneapi::dpl::uniform_int_distribution<typename Distr::result_type>>::value ||
+             ::std::is_same<Distr, oneapi::dpl::uniform_real_distribution<typename Distr::result_type>>
+             ::value, void>::type
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
-    params1 =
-        ::std::make_pair(typename Distr::scalar_type{0}, typename Distr::scalar_type{10});
-    params2 =
-        ::std::make_pair(typename Distr::scalar_type{2}, typename Distr::scalar_type{8});
+    params1 = typename Distr::param_type{0, 10};
+    params2 = typename Distr::param_type{2, 8};
 }
 
 template <typename Distr>
@@ -181,7 +181,9 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 
 template <typename Distr>
 typename ::std::enable_if<::std::is_same<Distr, 
-        oneapi::dpl::lognormal_distribution<typename Distr::result_type>>::value, void>::type
+        oneapi::dpl::lognormal_distribution<typename Distr::result_type>>::value ||
+        ::std::is_same<Distr, oneapi::dpl::normal_distribution<typename Distr::result_type>>
+        ::value, void>::type
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{1.5, 3.5};


### PR DESCRIPTION
Change std::pair to param_type in uniform_real, uniform_int and normal distributions