### PR TITLE
Update for Release Notes 2021.5

### DIFF
--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -61,7 +61,7 @@ Existing Issues
 - Due to specifics of Microsoft* Visual C++, some standard floating-point math functions
   (including ``std::ldexp``, ``std::frexp``, ``std::sqrt(std::complex<float>)``) require device support
   for double precision.
-- The ``oneapi::dpl::experimental::ranges::reverse`` algorithm does not compile with ``-fno-sycl-unnamed-lambda`` option.
+- The ``oneapi::dpl::experimental::ranges::reverse`` algorithm is not available with ``-fno-sycl-unnamed-lambda`` option.
 
 New in 2021.4
 =============

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -61,6 +61,7 @@ Existing Issues
 - Due to specifics of Microsoft* Visual C++, some standard floating-point math functions
   (including ``std::ldexp``, ``std::frexp``, ``std::sqrt(std::complex<float>)``) require device support
   for double precision.
+- The ``oneapi::dpl::experimental::ranges::reverse`` algorithm does not compile with ``-fno-sycl-unnamed-lambda`` option.
 
 New in 2021.4
 =============


### PR DESCRIPTION
 Added the description of ranges::reverse algorithm limitation, firstly discovered in oneDPL 2021.4 release. 
Signed-off-by: Valentina Kats valentina.kats@intel.com