### PR TITLE
Replacing iterator tag checks with is_base_of semantics

### DIFF
--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -595,7 +595,7 @@ struct __next_to_last
 
     template <typename _Iterator>
     typename ::std::enable_if<!::std::is_base_of<::std::random_access_iterator_tag,
-                                                typename ::std::iterator_traits<_Iterator>::iterator_category>::value,
+                                                 typename ::std::iterator_traits<_Iterator>::iterator_category>::value,
                               _Iterator>::type
     operator()(_Iterator __it, _Iterator __last, typename ::std::iterator_traits<_Iterator>::difference_type __n)
     {

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -585,8 +585,8 @@ using __is_const_callable_object =
 struct __next_to_last
 {
     template <typename _Iterator>
-    typename ::std::enable_if<::std::is_same<typename ::std::iterator_traits<_Iterator>::iterator_category,
-                                             ::std::random_access_iterator_tag>::value,
+    typename ::std::enable_if<::std::is_base_of<::std::random_access_iterator_tag,
+                                             typename ::std::iterator_traits<_Iterator>::iterator_category>::value,
                               _Iterator>::type
     operator()(_Iterator __it, _Iterator __last, typename ::std::iterator_traits<_Iterator>::difference_type __n)
     {
@@ -594,8 +594,8 @@ struct __next_to_last
     }
 
     template <typename _Iterator>
-    typename ::std::enable_if<!::std::is_same<typename ::std::iterator_traits<_Iterator>::iterator_category,
-                                              ::std::random_access_iterator_tag>::value,
+    typename ::std::enable_if<!::std::is_base_of<::std::random_access_iterator_tag,
+                                              typename ::std::iterator_traits<_Iterator>::iterator_category>::value,
                               _Iterator>::type
     operator()(_Iterator __it, _Iterator __last, typename ::std::iterator_traits<_Iterator>::difference_type __n)
     {

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -586,7 +586,7 @@ struct __next_to_last
 {
     template <typename _Iterator>
     typename ::std::enable_if<::std::is_base_of<::std::random_access_iterator_tag,
-                              typename ::std::iterator_traits<_Iterator>::iterator_category>::value,
+                                                typename ::std::iterator_traits<_Iterator>::iterator_category>::value,
                               _Iterator>::type
     operator()(_Iterator __it, _Iterator __last, typename ::std::iterator_traits<_Iterator>::difference_type __n)
     {
@@ -595,7 +595,7 @@ struct __next_to_last
 
     template <typename _Iterator>
     typename ::std::enable_if<!::std::is_base_of<::std::random_access_iterator_tag,
-                              typename ::std::iterator_traits<_Iterator>::iterator_category>::value,
+                                                typename ::std::iterator_traits<_Iterator>::iterator_category>::value,
                               _Iterator>::type
     operator()(_Iterator __it, _Iterator __last, typename ::std::iterator_traits<_Iterator>::difference_type __n)
     {

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -586,7 +586,7 @@ struct __next_to_last
 {
     template <typename _Iterator>
     typename ::std::enable_if<::std::is_base_of<::std::random_access_iterator_tag,
-                                             typename ::std::iterator_traits<_Iterator>::iterator_category>::value,
+                              typename ::std::iterator_traits<_Iterator>::iterator_category>::value,
                               _Iterator>::type
     operator()(_Iterator __it, _Iterator __last, typename ::std::iterator_traits<_Iterator>::difference_type __n)
     {
@@ -595,7 +595,7 @@ struct __next_to_last
 
     template <typename _Iterator>
     typename ::std::enable_if<!::std::is_base_of<::std::random_access_iterator_tag,
-                                              typename ::std::iterator_traits<_Iterator>::iterator_category>::value,
+                              typename ::std::iterator_traits<_Iterator>::iterator_category>::value,
                               _Iterator>::type
     operator()(_Iterator __it, _Iterator __last, typename ::std::iterator_traits<_Iterator>::difference_type __n)
     {

--- a/test/parallel_api/algorithm/alg.merge/inplace_merge.pass.cpp
+++ b/test/parallel_api/algorithm/alg.merge/inplace_merge.pass.cpp
@@ -28,7 +28,7 @@ struct test_one_policy
     // inplace_merge works with bidirectional iterators at least
     template <typename Policy, typename BiDirIt1, typename Size, typename Generator1, typename Generator2,
               typename Compare>
-    typename ::std::enable_if<!is_same_iterator_category<BiDirIt1, ::std::forward_iterator_tag>::value, void>::type
+    typename ::std::enable_if<is_base_of_iterator_category<BiDirIt1, ::std::bidirectional_iterator_tag>::value, void>::type
     operator()(Policy&& exec, BiDirIt1 first1, BiDirIt1 last1, BiDirIt1 first2, BiDirIt1 last2, Size n, Size m,
                Generator1 generator1, Generator2 generator2, Compare comp)
     {
@@ -39,7 +39,7 @@ struct test_one_policy
     }
 
     template <typename Policy, typename BiDirIt1, typename Size, typename Generator1, typename Generator2>
-    typename ::std::enable_if<!is_same_iterator_category<BiDirIt1, ::std::forward_iterator_tag>::value, void>::type
+    typename ::std::enable_if<is_base_of_iterator_category<BiDirIt1, ::std::bidirectional_iterator_tag>::value, void>::type
     operator()(Policy&& exec, BiDirIt1 first1, BiDirIt1 last1, BiDirIt1 first2, BiDirIt1 last2, Size n, Size m,
                Generator1 generator1, Generator2 generator2)
     {
@@ -64,14 +64,14 @@ struct test_one_policy
     }
 
     template <typename Policy, typename BiDirIt1, typename Size, typename Generator1, typename Generator2>
-    typename ::std::enable_if<is_same_iterator_category<BiDirIt1, ::std::forward_iterator_tag>::value, void>::type
+    typename ::std::enable_if<!is_base_of_iterator_category<BiDirIt1, ::std::bidirectional_iterator_tag>::value, void>::type
     operator()(Policy&& /* exec */, BiDirIt1 /* first1 */, BiDirIt1 /* last1 */, BiDirIt1 /* first2 */, BiDirIt1 /* last2 */, Size /* n */, Size /* m */,
                Generator1 /* generator1 */, Generator2 /* generator2 */)
     {
     }
     template <typename Policy, typename BiDirIt1, typename Size, typename Generator1, typename Generator2,
               typename Compare>
-    typename ::std::enable_if<is_same_iterator_category<BiDirIt1, ::std::forward_iterator_tag>::value, void>::type
+    typename ::std::enable_if<!is_base_of_iterator_category<BiDirIt1, ::std::bidirectional_iterator_tag>::value, void>::type
     operator()(Policy&& /* exec */, BiDirIt1 /* first1 */, BiDirIt1 /* last1 */, BiDirIt1 /* first2 */, BiDirIt1 /* last2 */, Size /* n */, Size /* m */,
                Generator1 /* generator1 */, Generator2 /* generator2 */, Compare /* comp */)
     {

--- a/test/parallel_api/algorithm/alg.merge/inplace_merge.pass.cpp
+++ b/test/parallel_api/algorithm/alg.merge/inplace_merge.pass.cpp
@@ -28,7 +28,7 @@ struct test_one_policy
     // inplace_merge works with bidirectional iterators at least
     template <typename Policy, typename BiDirIt1, typename Size, typename Generator1, typename Generator2,
               typename Compare>
-    typename ::std::enable_if<is_base_of_iterator_category<BiDirIt1, ::std::bidirectional_iterator_tag>::value, void>::type
+    typename ::std::enable_if<is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt1>::value, void>::type
     operator()(Policy&& exec, BiDirIt1 first1, BiDirIt1 last1, BiDirIt1 first2, BiDirIt1 last2, Size n, Size m,
                Generator1 generator1, Generator2 generator2, Compare comp)
     {
@@ -39,7 +39,7 @@ struct test_one_policy
     }
 
     template <typename Policy, typename BiDirIt1, typename Size, typename Generator1, typename Generator2>
-    typename ::std::enable_if<is_base_of_iterator_category<BiDirIt1, ::std::bidirectional_iterator_tag>::value, void>::type
+    typename ::std::enable_if<is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt1>::value, void>::type
     operator()(Policy&& exec, BiDirIt1 first1, BiDirIt1 last1, BiDirIt1 first2, BiDirIt1 last2, Size n, Size m,
                Generator1 generator1, Generator2 generator2)
     {
@@ -64,14 +64,14 @@ struct test_one_policy
     }
 
     template <typename Policy, typename BiDirIt1, typename Size, typename Generator1, typename Generator2>
-    typename ::std::enable_if<!is_base_of_iterator_category<BiDirIt1, ::std::bidirectional_iterator_tag>::value, void>::type
+    typename ::std::enable_if<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt1>::value, void>::type
     operator()(Policy&& /* exec */, BiDirIt1 /* first1 */, BiDirIt1 /* last1 */, BiDirIt1 /* first2 */, BiDirIt1 /* last2 */, Size /* n */, Size /* m */,
                Generator1 /* generator1 */, Generator2 /* generator2 */)
     {
     }
     template <typename Policy, typename BiDirIt1, typename Size, typename Generator1, typename Generator2,
               typename Compare>
-    typename ::std::enable_if<!is_base_of_iterator_category<BiDirIt1, ::std::bidirectional_iterator_tag>::value, void>::type
+    typename ::std::enable_if<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt1>::value, void>::type
     operator()(Policy&& /* exec */, BiDirIt1 /* first1 */, BiDirIt1 /* last1 */, BiDirIt1 /* first2 */, BiDirIt1 /* last2 */, Size /* n */, Size /* m */,
                Generator1 /* generator1 */, Generator2 /* generator2 */, Compare /* comp */)
     {

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition.pass.cpp
@@ -71,7 +71,7 @@ template<typename T>
 struct test_partition
 {
     template <typename Policy, typename BiDirIt, typename Size, typename UnaryOp, typename Generator>
-    typename ::std::enable_if<!is_same_iterator_category<BiDirIt, ::std::forward_iterator_tag>::value, void>::type
+    typename ::std::enable_if<is_base_of_iterator_category<BiDirIt, ::std::bidirectional_iterator_tag>::value, void>::type
     operator()(Policy&& exec, BiDirIt first, BiDirIt last, BiDirIt /* exp_first */, BiDirIt /* exp_last */, Size /* n */,
                UnaryOp unary_op, Generator generator)
     {
@@ -82,7 +82,7 @@ struct test_partition
     }
 
     template <typename Policy, typename BiDirIt, typename Size, typename UnaryOp, typename Generator>
-    typename ::std::enable_if<is_same_iterator_category<BiDirIt, ::std::forward_iterator_tag>::value, void>::type
+    typename ::std::enable_if<!is_base_of_iterator_category<BiDirIt, ::std::bidirectional_iterator_tag>::value, void>::type
     operator()(Policy&& /* exec */, BiDirIt /* first */, BiDirIt /* last */, BiDirIt /* exp_first */, BiDirIt /* exp_last */, Size /* n */,
                UnaryOp /* unary_op */, Generator /* generator */)
     {

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition.pass.cpp
@@ -71,7 +71,7 @@ template<typename T>
 struct test_partition
 {
     template <typename Policy, typename BiDirIt, typename Size, typename UnaryOp, typename Generator>
-    typename ::std::enable_if<is_base_of_iterator_category<BiDirIt, ::std::bidirectional_iterator_tag>::value, void>::type
+    typename ::std::enable_if<is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt>::value, void>::type
     operator()(Policy&& exec, BiDirIt first, BiDirIt last, BiDirIt /* exp_first */, BiDirIt /* exp_last */, Size /* n */,
                UnaryOp unary_op, Generator generator)
     {
@@ -82,7 +82,7 @@ struct test_partition
     }
 
     template <typename Policy, typename BiDirIt, typename Size, typename UnaryOp, typename Generator>
-    typename ::std::enable_if<!is_base_of_iterator_category<BiDirIt, ::std::bidirectional_iterator_tag>::value, void>::type
+    typename ::std::enable_if<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt>::value, void>::type
     operator()(Policy&& /* exec */, BiDirIt /* first */, BiDirIt /* last */, BiDirIt /* exp_first */, BiDirIt /* exp_last */, Size /* n */,
                UnaryOp /* unary_op */, Generator /* generator */)
     {

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/stable_partition.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/stable_partition.pass.cpp
@@ -71,7 +71,7 @@ template <typename T>
 struct test_stable_partition
 {
     template <typename Policy, typename BiDirIt, typename Size, typename UnaryOp, typename Generator>
-    typename ::std::enable_if<!is_same_iterator_category<BiDirIt, ::std::forward_iterator_tag>::value, void>::type
+    typename ::std::enable_if<is_base_of_iterator_category<BiDirIt, ::std::bidirectional_iterator_tag>::value, void>::type
     operator()(Policy&& exec, BiDirIt first, BiDirIt last, BiDirIt exp_first, BiDirIt exp_last, Size /* n */,
                UnaryOp unary_op, Generator generator)
     {
@@ -86,7 +86,7 @@ struct test_stable_partition
     }
 
     template <typename Policy, typename BiDirIt, typename Size, typename UnaryOp, typename Generator>
-    typename ::std::enable_if<is_same_iterator_category<BiDirIt, ::std::forward_iterator_tag>::value, void>::type
+    typename ::std::enable_if<!is_base_of_iterator_category<BiDirIt, ::std::bidirectional_iterator_tag>::value, void>::type
     operator()(Policy&& /* exec */, BiDirIt /* first */, BiDirIt /* last */, BiDirIt /* exp_first */, BiDirIt /* exp_last */, Size /* n */,
                UnaryOp /* unary_op */, Generator /* generator */)
     {

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/stable_partition.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/stable_partition.pass.cpp
@@ -71,7 +71,7 @@ template <typename T>
 struct test_stable_partition
 {
     template <typename Policy, typename BiDirIt, typename Size, typename UnaryOp, typename Generator>
-    typename ::std::enable_if<is_base_of_iterator_category<BiDirIt, ::std::bidirectional_iterator_tag>::value, void>::type
+    typename ::std::enable_if<is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt>::value, void>::type
     operator()(Policy&& exec, BiDirIt first, BiDirIt last, BiDirIt exp_first, BiDirIt exp_last, Size /* n */,
                UnaryOp unary_op, Generator generator)
     {
@@ -86,7 +86,7 @@ struct test_stable_partition
     }
 
     template <typename Policy, typename BiDirIt, typename Size, typename UnaryOp, typename Generator>
-    typename ::std::enable_if<!is_base_of_iterator_category<BiDirIt, ::std::bidirectional_iterator_tag>::value, void>::type
+    typename ::std::enable_if<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt>::value, void>::type
     operator()(Policy&& /* exec */, BiDirIt /* first */, BiDirIt /* last */, BiDirIt /* exp_first */, BiDirIt /* exp_last */, Size /* n */,
                UnaryOp /* unary_op */, Generator /* generator */)
     {

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse.pass.cpp
@@ -44,7 +44,7 @@ struct test_one_policy
 #endif
 
     template <typename ExecutionPolicy, typename Iterator1, typename Iterator2>
-    typename ::std::enable_if<!is_same_iterator_category<Iterator1, ::std::forward_iterator_tag>::value>::type
+    typename ::std::enable_if<is_base_of_iterator_category<Iterator1, ::std::bidirectional_iterator_tag>::value>::type
     operator()(ExecutionPolicy&& exec, Iterator1 data_b, Iterator1 data_e, Iterator2 actual_b, Iterator2 actual_e)
     {
         using namespace std;
@@ -59,7 +59,7 @@ struct test_one_policy
     }
 
     template <typename ExecutionPolicy, typename Iterator1, typename Iterator2>
-    typename ::std::enable_if<is_same_iterator_category<Iterator1, ::std::forward_iterator_tag>::value>::type
+    typename ::std::enable_if<!is_base_of_iterator_category<Iterator1, ::std::bidirectional_iterator_tag>::value>::type
     operator()(ExecutionPolicy&& /* exec */, Iterator1 /* data_b */, Iterator1 /* data_e */, Iterator2 /* actual_b */, Iterator2 /* actual_e */)
     {
     }

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse.pass.cpp
@@ -29,14 +29,14 @@ struct test_one_policy
 {
 #if _PSTL_ICC_18_VC141_TEST_SIMD_LAMBDA_RELEASE_BROKEN // dummy specialization by policy type, in case of broken configuration
     template <typename Iterator1, typename Iterator2>
-    typename ::std::enable_if<is_same_iterator_category<Iterator1, ::std::random_access_iterator_tag>::value, void>::type
+    typename ::std::enable_if<is_base_of_iterator_category<Iterator1, ::std::random_access_iterator_tag>::value, void>::type
     operator()(oneapi::dpl::execution::unsequenced_policy, Iterator1 data_b, Iterator1 data_e, Iterator2 actual_b,
                Iterator2 actual_e)
     {
     }
 
     template <typename Iterator1, typename Iterator2>
-    typename ::std::enable_if<is_same_iterator_category<Iterator1, ::std::random_access_iterator_tag>::value, void>::type
+    typename ::std::enable_if<is_base_of_iterator_category<Iterator1, ::std::random_access_iterator_tag>::value, void>::type
     operator()(oneapi::dpl::execution::parallel_unsequenced_policy, Iterator1 data_b, Iterator1 data_e, Iterator2 actual_b,
                Iterator2 actual_e)
     {

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse.pass.cpp
@@ -29,14 +29,14 @@ struct test_one_policy
 {
 #if _PSTL_ICC_18_VC141_TEST_SIMD_LAMBDA_RELEASE_BROKEN // dummy specialization by policy type, in case of broken configuration
     template <typename Iterator1, typename Iterator2>
-    typename ::std::enable_if<is_base_of_iterator_category<Iterator1, ::std::random_access_iterator_tag>::value, void>::type
+    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value, void>::type
     operator()(oneapi::dpl::execution::unsequenced_policy, Iterator1 data_b, Iterator1 data_e, Iterator2 actual_b,
                Iterator2 actual_e)
     {
     }
 
     template <typename Iterator1, typename Iterator2>
-    typename ::std::enable_if<is_base_of_iterator_category<Iterator1, ::std::random_access_iterator_tag>::value, void>::type
+    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value, void>::type
     operator()(oneapi::dpl::execution::parallel_unsequenced_policy, Iterator1 data_b, Iterator1 data_e, Iterator2 actual_b,
                Iterator2 actual_e)
     {
@@ -44,7 +44,7 @@ struct test_one_policy
 #endif
 
     template <typename ExecutionPolicy, typename Iterator1, typename Iterator2>
-    typename ::std::enable_if<is_base_of_iterator_category<Iterator1, ::std::bidirectional_iterator_tag>::value>::type
+    typename ::std::enable_if<is_base_of_iterator_category<::std::bidirectional_iterator_tag, Iterator1>::value>::type
     operator()(ExecutionPolicy&& exec, Iterator1 data_b, Iterator1 data_e, Iterator2 actual_b, Iterator2 actual_e)
     {
         using namespace std;
@@ -59,7 +59,7 @@ struct test_one_policy
     }
 
     template <typename ExecutionPolicy, typename Iterator1, typename Iterator2>
-    typename ::std::enable_if<!is_base_of_iterator_category<Iterator1, ::std::bidirectional_iterator_tag>::value>::type
+    typename ::std::enable_if<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, Iterator1>::value>::type
     operator()(ExecutionPolicy&& /* exec */, Iterator1 /* data_b */, Iterator1 /* data_e */, Iterator2 /* actual_b */, Iterator2 /* actual_e */)
     {
     }

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse_copy.pass.cpp
@@ -55,7 +55,7 @@ template<typename T1, typename T2>
 struct test_one_policy
 {
     template <typename ExecutionPolicy, typename Iterator1, typename Iterator2>
-    typename ::std::enable_if<is_base_of_iterator_category<Iterator1, ::std::bidirectional_iterator_tag>::value>::type
+    typename ::std::enable_if<is_base_of_iterator_category<::std::bidirectional_iterator_tag, Iterator1>::value>::type
     operator()(ExecutionPolicy&& exec, Iterator1 data_b, Iterator1 data_e, Iterator2 actual_b, Iterator2 actual_e)
     {
         using namespace std;
@@ -72,7 +72,7 @@ struct test_one_policy
     }
 
     template <typename ExecutionPolicy, typename Iterator1, typename Iterator2>
-    typename ::std::enable_if<!is_base_of_iterator_category<Iterator1, ::std::bidirectional_iterator_tag>::value>::type
+    typename ::std::enable_if<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, Iterator1>::value>::type
     operator()(ExecutionPolicy&& /* exec */, Iterator1 /* data_b */, Iterator1 /* data_e */, Iterator2 /* actual_b */, Iterator2 /* actual_e*/)
     {
     }

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse_copy.pass.cpp
@@ -55,7 +55,7 @@ template<typename T1, typename T2>
 struct test_one_policy
 {
     template <typename ExecutionPolicy, typename Iterator1, typename Iterator2>
-    typename ::std::enable_if<!is_same_iterator_category<Iterator1, ::std::forward_iterator_tag>::value>::type
+    typename ::std::enable_if<is_base_of_iterator_category<Iterator1, ::std::bidirectional_iterator_tag>::value>::type
     operator()(ExecutionPolicy&& exec, Iterator1 data_b, Iterator1 data_e, Iterator2 actual_b, Iterator2 actual_e)
     {
         using namespace std;
@@ -72,7 +72,7 @@ struct test_one_policy
     }
 
     template <typename ExecutionPolicy, typename Iterator1, typename Iterator2>
-    typename ::std::enable_if<is_same_iterator_category<Iterator1, ::std::forward_iterator_tag>::value>::type
+    typename ::std::enable_if<!is_base_of_iterator_category<Iterator1, ::std::bidirectional_iterator_tag>::value>::type
     operator()(ExecutionPolicy&& /* exec */, Iterator1 /* data_b */, Iterator1 /* data_e */, Iterator2 /* actual_b */, Iterator2 /* actual_e*/)
     {
     }

--- a/test/parallel_api/algorithm/alg.modifying.operations/rotate.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/rotate.pass.cpp
@@ -102,7 +102,7 @@ struct test_one_policy
 
     template <typename ExecutionPolicy, typename Iterator, typename Size>
     typename ::std::enable_if<
-        is_base_of_iterator_category<Iterator, ::std::random_access_iterator_tag>::value &&
+        is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
         !::std::is_same<ExecutionPolicy, oneapi::dpl::execution::sequenced_policy>::value &&
         ::std::is_same<typename ::std::iterator_traits<Iterator>::value_type, wrapper<float32_t>>::value,
         bool>::type
@@ -118,7 +118,7 @@ struct test_one_policy
 
     template <typename ExecutionPolicy, typename Iterator, typename Size>
     typename ::std::enable_if<
-        !(is_base_of_iterator_category<Iterator, ::std::random_access_iterator_tag>::value &&
+        !(is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
         !::std::is_same<ExecutionPolicy, oneapi::dpl::execution::sequenced_policy>::value &&
         ::std::is_same<typename ::std::iterator_traits<Iterator>::value_type, wrapper<float32_t>>::value),
         bool>::type

--- a/test/parallel_api/algorithm/alg.modifying.operations/rotate.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/rotate.pass.cpp
@@ -102,7 +102,7 @@ struct test_one_policy
 
     template <typename ExecutionPolicy, typename Iterator, typename Size>
     typename ::std::enable_if<
-        is_same_iterator_category<Iterator, ::std::random_access_iterator_tag>::value &&
+        is_base_of_iterator_category<Iterator, ::std::random_access_iterator_tag>::value &&
         !::std::is_same<ExecutionPolicy, oneapi::dpl::execution::sequenced_policy>::value &&
         ::std::is_same<typename ::std::iterator_traits<Iterator>::value_type, wrapper<float32_t>>::value,
         bool>::type
@@ -118,7 +118,7 @@ struct test_one_policy
 
     template <typename ExecutionPolicy, typename Iterator, typename Size>
     typename ::std::enable_if<
-        !(is_same_iterator_category<Iterator, ::std::random_access_iterator_tag>::value &&
+        !(is_base_of_iterator_category<Iterator, ::std::random_access_iterator_tag>::value &&
         !::std::is_same<ExecutionPolicy, oneapi::dpl::execution::sequenced_policy>::value &&
         ::std::is_same<typename ::std::iterator_traits<Iterator>::value_type, wrapper<float32_t>>::value),
         bool>::type

--- a/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
@@ -132,8 +132,8 @@ struct shift_left_algo
 struct shift_right_algo
 {
     template <typename Policy, typename It>
-    typename ::std::enable_if<TestUtils::is_same_iterator_category<It, ::std::bidirectional_iterator_tag>::value
-                            || TestUtils::is_same_iterator_category<It, ::std::random_access_iterator_tag>::value,
+    typename ::std::enable_if<::std::is_base_of<::std::bidirectional_iterator_tag, It>::value
+                            || ::std::is_base_of<::std::random_access_iterator_tag, It>::value,
                             It>::type
     operator()(Policy&& exec, It first, It last, typename ::std::iterator_traits<It>::difference_type n)
     {
@@ -141,8 +141,8 @@ struct shift_right_algo
     }
     //skip the test for non-bidirectional iterator (forward iterator, etc)
     template <typename Policy, typename It>
-    typename ::std::enable_if<!TestUtils::is_same_iterator_category<It, ::std::bidirectional_iterator_tag>::value
-                            && !TestUtils::is_same_iterator_category<It, ::std::random_access_iterator_tag>::value,
+    typename ::std::enable_if<!::std::is_base_of<::std::bidirectional_iterator_tag, It>::value
+                            && !::std::is_base_of<::std::random_access_iterator_tag, It>::value,
                             It>::type
     operator()(Policy&& exec, It first, It last, typename ::std::iterator_traits<It>::difference_type n)
     {
@@ -150,8 +150,8 @@ struct shift_right_algo
     }
 
     template <typename It, typename ItExp>
-    typename ::std::enable_if<TestUtils::is_same_iterator_category<It, ::std::bidirectional_iterator_tag>::value
-                            || TestUtils::is_same_iterator_category<It, ::std::random_access_iterator_tag>::value,
+    typename ::std::enable_if<::std::is_base_of<::std::bidirectional_iterator_tag, It>::value
+                            || ::std::is_base_of<::std::random_access_iterator_tag, It>::value,
                             void>::type
     check(It res, It first, typename ::std::iterator_traits<It>::difference_type m, ItExp first_exp,
         typename ::std::iterator_traits<It>::difference_type n)
@@ -172,8 +172,8 @@ struct shift_right_algo
     }
     //skip the check for non-bidirectional iterator (forward iterator, etc)
     template <typename It, typename ItExp>
-    typename ::std::enable_if<!TestUtils::is_same_iterator_category<It, ::std::bidirectional_iterator_tag>::value
-                            && !TestUtils::is_same_iterator_category<It, ::std::random_access_iterator_tag>::value,
+    typename ::std::enable_if<!::std::is_base_of<::std::bidirectional_iterator_tag, It>::value
+                            && !::std::is_base_of<::std::random_access_iterator_tag, It>::value,
                             void>::type
     check(It res, It first, typename ::std::iterator_traits<It>::difference_type m, ItExp first_exp,
         typename ::std::iterator_traits<It>::difference_type n)

--- a/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
@@ -133,7 +133,7 @@ struct shift_right_algo
 {
     template <typename Policy, typename It>
     typename ::std::enable_if<::std::is_base_of<::std::bidirectional_iterator_tag, 
-                            typename ::std::iterator_traits<It>::iterator_category>::value>::value,
+                            typename ::std::iterator_traits<It>::iterator_category>::value,
                             It>::type
     operator()(Policy&& exec, It first, It last, typename ::std::iterator_traits<It>::difference_type n)
     {

--- a/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
@@ -132,8 +132,8 @@ struct shift_left_algo
 struct shift_right_algo
 {
     template <typename Policy, typename It>
-    typename ::std::enable_if<::std::is_base_of<::std::bidirectional_iterator_tag, 
-                            typename ::std::iterator_traits<It>::iterator_category>::value,
+    typename ::std::enable_if<TestUtils::is_base_of_iterator_category<It, 
+                            ::std::bidirectional_iterator_tag>::value,
                             It>::type
     operator()(Policy&& exec, It first, It last, typename ::std::iterator_traits<It>::difference_type n)
     {
@@ -141,8 +141,8 @@ struct shift_right_algo
     }
     //skip the test for non-bidirectional iterator (forward iterator, etc)
     template <typename Policy, typename It>
-    typename ::std::enable_if<!::std::is_base_of<::std::bidirectional_iterator_tag,
-                            typename ::std::iterator_traits<It>::iterator_category>::value,
+    typename ::std::enable_if<!TestUtils::is_base_of_iterator_category<It,
+                            ::std::bidirectional_iterator_tag>::value,
                             It>::type
     operator()(Policy&& exec, It first, It last, typename ::std::iterator_traits<It>::difference_type n)
     {
@@ -150,8 +150,8 @@ struct shift_right_algo
     }
 
     template <typename It, typename ItExp>
-    typename ::std::enable_if<::std::is_base_of<::std::bidirectional_iterator_tag, 
-                            typename ::std::iterator_traits<It>::iterator_category>::value,
+    typename ::std::enable_if<TestUtils::is_base_of_iterator_category<It, 
+                            ::std::bidirectional_iterator_tag>::value,
                             void>::type
     check(It res, It first, typename ::std::iterator_traits<It>::difference_type m, ItExp first_exp,
         typename ::std::iterator_traits<It>::difference_type n)
@@ -172,8 +172,8 @@ struct shift_right_algo
     }
     //skip the check for non-bidirectional iterator (forward iterator, etc)
     template <typename It, typename ItExp>
-    typename ::std::enable_if<!::std::is_base_of<::std::bidirectional_iterator_tag, 
-                            typename ::std::iterator_traits<It>::iterator_category>::value,
+    typename ::std::enable_if<!TestUtils::is_base_of_iterator_category<It, 
+                            ::std::bidirectional_iterator_tag>::value,
                             void>::type
     check(It res, It first, typename ::std::iterator_traits<It>::difference_type m, ItExp first_exp,
         typename ::std::iterator_traits<It>::difference_type n)

--- a/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
@@ -132,8 +132,8 @@ struct shift_left_algo
 struct shift_right_algo
 {
     template <typename Policy, typename It>
-    typename ::std::enable_if<TestUtils::is_base_of_iterator_category<It, 
-                            ::std::bidirectional_iterator_tag>::value,
+    typename ::std::enable_if<TestUtils::is_base_of_iterator_category<::std::bidirectional_iterator_tag, 
+                            It>::value,
                             It>::type
     operator()(Policy&& exec, It first, It last, typename ::std::iterator_traits<It>::difference_type n)
     {
@@ -141,8 +141,8 @@ struct shift_right_algo
     }
     //skip the test for non-bidirectional iterator (forward iterator, etc)
     template <typename Policy, typename It>
-    typename ::std::enable_if<!TestUtils::is_base_of_iterator_category<It,
-                            ::std::bidirectional_iterator_tag>::value,
+    typename ::std::enable_if<!TestUtils::is_base_of_iterator_category<::std::bidirectional_iterator_tag, 
+                            It>::value,
                             It>::type
     operator()(Policy&& exec, It first, It last, typename ::std::iterator_traits<It>::difference_type n)
     {
@@ -150,8 +150,8 @@ struct shift_right_algo
     }
 
     template <typename It, typename ItExp>
-    typename ::std::enable_if<TestUtils::is_base_of_iterator_category<It, 
-                            ::std::bidirectional_iterator_tag>::value,
+    typename ::std::enable_if<TestUtils::is_base_of_iterator_category<::std::bidirectional_iterator_tag, 
+                            It>::value,
                             void>::type
     check(It res, It first, typename ::std::iterator_traits<It>::difference_type m, ItExp first_exp,
         typename ::std::iterator_traits<It>::difference_type n)
@@ -172,8 +172,8 @@ struct shift_right_algo
     }
     //skip the check for non-bidirectional iterator (forward iterator, etc)
     template <typename It, typename ItExp>
-    typename ::std::enable_if<!TestUtils::is_base_of_iterator_category<It, 
-                            ::std::bidirectional_iterator_tag>::value,
+    typename ::std::enable_if<!TestUtils::is_base_of_iterator_category<::std::bidirectional_iterator_tag, 
+                            It>::value,
                             void>::type
     check(It res, It first, typename ::std::iterator_traits<It>::difference_type m, ItExp first_exp,
         typename ::std::iterator_traits<It>::difference_type n)

--- a/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
@@ -133,9 +133,7 @@ struct shift_right_algo
 {
     template <typename Policy, typename It>
     typename ::std::enable_if<::std::is_base_of<::std::bidirectional_iterator_tag, 
-                            typename ::std::iterator_traits<It>::iterator_category>::value
-                            || ::std::is_base_of<::std::random_access_iterator_tag, 
-                            typename ::std::iterator_traits<It>::iterator_category>::value,
+                            typename ::std::iterator_traits<It>::iterator_category>::value>::value,
                             It>::type
     operator()(Policy&& exec, It first, It last, typename ::std::iterator_traits<It>::difference_type n)
     {
@@ -144,8 +142,6 @@ struct shift_right_algo
     //skip the test for non-bidirectional iterator (forward iterator, etc)
     template <typename Policy, typename It>
     typename ::std::enable_if<!::std::is_base_of<::std::bidirectional_iterator_tag,
-                            typename ::std::iterator_traits<It>::iterator_category>::value
-                            && !::std::is_base_of<::std::random_access_iterator_tag, 
                             typename ::std::iterator_traits<It>::iterator_category>::value,
                             It>::type
     operator()(Policy&& exec, It first, It last, typename ::std::iterator_traits<It>::difference_type n)
@@ -155,8 +151,6 @@ struct shift_right_algo
 
     template <typename It, typename ItExp>
     typename ::std::enable_if<::std::is_base_of<::std::bidirectional_iterator_tag, 
-                            typename ::std::iterator_traits<It>::iterator_category>::value
-                            || ::std::is_base_of<::std::random_access_iterator_tag, 
                             typename ::std::iterator_traits<It>::iterator_category>::value,
                             void>::type
     check(It res, It first, typename ::std::iterator_traits<It>::difference_type m, ItExp first_exp,
@@ -179,8 +173,6 @@ struct shift_right_algo
     //skip the check for non-bidirectional iterator (forward iterator, etc)
     template <typename It, typename ItExp>
     typename ::std::enable_if<!::std::is_base_of<::std::bidirectional_iterator_tag, 
-                            typename ::std::iterator_traits<It>::iterator_category>::value
-                            && !::std::is_base_of<::std::random_access_iterator_tag, 
                             typename ::std::iterator_traits<It>::iterator_category>::value,
                             void>::type
     check(It res, It first, typename ::std::iterator_traits<It>::difference_type m, ItExp first_exp,

--- a/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
@@ -132,8 +132,10 @@ struct shift_left_algo
 struct shift_right_algo
 {
     template <typename Policy, typename It>
-    typename ::std::enable_if<::std::is_base_of<::std::bidirectional_iterator_tag, It>::value
-                            || ::std::is_base_of<::std::random_access_iterator_tag, It>::value,
+    typename ::std::enable_if<::std::is_base_of<::std::bidirectional_iterator_tag, 
+                            typename ::std::iterator_traits<It>::iterator_category>::value
+                            || ::std::is_base_of<::std::random_access_iterator_tag, 
+                            typename ::std::iterator_traits<It>::iterator_category>::value,
                             It>::type
     operator()(Policy&& exec, It first, It last, typename ::std::iterator_traits<It>::difference_type n)
     {
@@ -141,8 +143,10 @@ struct shift_right_algo
     }
     //skip the test for non-bidirectional iterator (forward iterator, etc)
     template <typename Policy, typename It>
-    typename ::std::enable_if<!::std::is_base_of<::std::bidirectional_iterator_tag, It>::value
-                            && !::std::is_base_of<::std::random_access_iterator_tag, It>::value,
+    typename ::std::enable_if<!::std::is_base_of<::std::bidirectional_iterator_tag,
+                            typename ::std::iterator_traits<It>::iterator_category>::value
+                            && !::std::is_base_of<::std::random_access_iterator_tag, 
+                            typename ::std::iterator_traits<It>::iterator_category>::value,
                             It>::type
     operator()(Policy&& exec, It first, It last, typename ::std::iterator_traits<It>::difference_type n)
     {
@@ -150,8 +154,10 @@ struct shift_right_algo
     }
 
     template <typename It, typename ItExp>
-    typename ::std::enable_if<::std::is_base_of<::std::bidirectional_iterator_tag, It>::value
-                            || ::std::is_base_of<::std::random_access_iterator_tag, It>::value,
+    typename ::std::enable_if<::std::is_base_of<::std::bidirectional_iterator_tag, 
+                            typename ::std::iterator_traits<It>::iterator_category>::value
+                            || ::std::is_base_of<::std::random_access_iterator_tag, 
+                            typename ::std::iterator_traits<It>::iterator_category>::value,
                             void>::type
     check(It res, It first, typename ::std::iterator_traits<It>::difference_type m, ItExp first_exp,
         typename ::std::iterator_traits<It>::difference_type n)
@@ -172,8 +178,10 @@ struct shift_right_algo
     }
     //skip the check for non-bidirectional iterator (forward iterator, etc)
     template <typename It, typename ItExp>
-    typename ::std::enable_if<!::std::is_base_of<::std::bidirectional_iterator_tag, It>::value
-                            && !::std::is_base_of<::std::random_access_iterator_tag, It>::value,
+    typename ::std::enable_if<!::std::is_base_of<::std::bidirectional_iterator_tag, 
+                            typename ::std::iterator_traits<It>::iterator_category>::value
+                            && !::std::is_base_of<::std::random_access_iterator_tag, 
+                            typename ::std::iterator_traits<It>::iterator_category>::value,
                             void>::type
     check(It res, It first, typename ::std::iterator_traits<It>::difference_type m, ItExp first_exp,
         typename ::std::iterator_traits<It>::difference_type n)

--- a/test/parallel_api/algorithm/alg.nonmodifying/nth_element.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/nth_element.pass.cpp
@@ -76,7 +76,7 @@ struct test_without_compare
 {
     // nth_element works only with random access iterators
     template <typename Policy, typename Iterator1, typename Size, typename Generator1, typename Generator2>
-    typename ::std::enable_if<is_base_of_iterator_category<Iterator1, ::std::random_access_iterator_tag>::value &&
+    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value &&
                               can_use_default_less_operator<Type>::value, void>::type
     operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator1 first2, Iterator1 last2, Size n, Size m,
                Generator1 generator1, Generator2 generator2)
@@ -99,7 +99,7 @@ struct test_without_compare
     }
 
     template <typename Policy, typename Iterator1, typename Size, typename Generator1, typename Generator2>
-    typename ::std::enable_if<!is_base_of_iterator_category<Iterator1, ::std::random_access_iterator_tag>::value ||
+    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value ||
                               !can_use_default_less_operator<Type>::value, void>::type
     operator()(Policy&& /* exec */, Iterator1 /* first1 */, Iterator1 /* last1 */, Iterator1 /* first2 */, Iterator1 /* last2 */, Size /* n */, Size /* m */,
                Generator1 /* generator1 */, Generator2 /* generator2 */)
@@ -113,7 +113,7 @@ struct test_with_compare
     // nth_element works only with random access iterators
     template <typename Policy, typename Iterator1, typename Size, typename Generator1, typename Generator2,
               typename Compare>
-    typename ::std::enable_if<is_base_of_iterator_category<Iterator1, ::std::random_access_iterator_tag>::value, void>::type
+    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value, void>::type
     operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator1 first2, Iterator1 last2, Size n, Size m,
                Generator1 generator1, Generator2 generator2, Compare comp)
     {
@@ -136,7 +136,7 @@ struct test_with_compare
 
     template <typename Policy, typename Iterator1, typename Size, typename Generator1, typename Generator2,
               typename Compare>
-    typename ::std::enable_if<!is_base_of_iterator_category<Iterator1, ::std::random_access_iterator_tag>::value, void>::type
+    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value, void>::type
     operator()(Policy&& /* exec */, Iterator1 /* first1 */, Iterator1 /* last1 */, Iterator1 /* first2 */, Iterator1 /* last2 */, Size /* n */, Size /* m */,
                Generator1 /* generator1 */, Generator2 /* generator2 */, Compare /* comp */)
     {

--- a/test/parallel_api/algorithm/alg.nonmodifying/nth_element.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/nth_element.pass.cpp
@@ -76,7 +76,7 @@ struct test_without_compare
 {
     // nth_element works only with random access iterators
     template <typename Policy, typename Iterator1, typename Size, typename Generator1, typename Generator2>
-    typename ::std::enable_if<is_same_iterator_category<Iterator1, ::std::random_access_iterator_tag>::value &&
+    typename ::std::enable_if<is_base_of_iterator_category<Iterator1, ::std::random_access_iterator_tag>::value &&
                               can_use_default_less_operator<Type>::value, void>::type
     operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator1 first2, Iterator1 last2, Size n, Size m,
                Generator1 generator1, Generator2 generator2)
@@ -99,7 +99,7 @@ struct test_without_compare
     }
 
     template <typename Policy, typename Iterator1, typename Size, typename Generator1, typename Generator2>
-    typename ::std::enable_if<!is_same_iterator_category<Iterator1, ::std::random_access_iterator_tag>::value ||
+    typename ::std::enable_if<!is_base_of_iterator_category<Iterator1, ::std::random_access_iterator_tag>::value ||
                               !can_use_default_less_operator<Type>::value, void>::type
     operator()(Policy&& /* exec */, Iterator1 /* first1 */, Iterator1 /* last1 */, Iterator1 /* first2 */, Iterator1 /* last2 */, Size /* n */, Size /* m */,
                Generator1 /* generator1 */, Generator2 /* generator2 */)
@@ -113,7 +113,7 @@ struct test_with_compare
     // nth_element works only with random access iterators
     template <typename Policy, typename Iterator1, typename Size, typename Generator1, typename Generator2,
               typename Compare>
-    typename ::std::enable_if<is_same_iterator_category<Iterator1, ::std::random_access_iterator_tag>::value, void>::type
+    typename ::std::enable_if<is_base_of_iterator_category<Iterator1, ::std::random_access_iterator_tag>::value, void>::type
     operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator1 first2, Iterator1 last2, Size n, Size m,
                Generator1 generator1, Generator2 generator2, Compare comp)
     {
@@ -136,7 +136,7 @@ struct test_with_compare
 
     template <typename Policy, typename Iterator1, typename Size, typename Generator1, typename Generator2,
               typename Compare>
-    typename ::std::enable_if<!is_same_iterator_category<Iterator1, ::std::random_access_iterator_tag>::value, void>::type
+    typename ::std::enable_if<!is_base_of_iterator_category<Iterator1, ::std::random_access_iterator_tag>::value, void>::type
     operator()(Policy&& /* exec */, Iterator1 /* first1 */, Iterator1 /* last1 */, Iterator1 /* first2 */, Iterator1 /* last2 */, Size /* n */, Size /* m */,
                Generator1 /* generator1 */, Generator2 /* generator2 */, Compare /* comp */)
     {

--- a/test/parallel_api/algorithm/alg.sorting/alg.heap.operations/is_heap.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.heap.operations/is_heap.pass.cpp
@@ -48,7 +48,7 @@ template <typename T>
 struct test_is_heap
 {
     template <typename Policy, typename Iterator>
-    typename ::std::enable_if<is_same_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
+    typename ::std::enable_if<is_base_of_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
     operator()(Policy&& exec, Iterator first, Iterator last)
     {
         using namespace std;
@@ -59,7 +59,7 @@ struct test_is_heap
 
     // is_heap works only with random access iterators
     template <typename Policy, typename Iterator>
-    typename ::std::enable_if<!is_same_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
+    typename ::std::enable_if<!is_base_of_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
     operator()(Policy&& /* exec */, Iterator /* first */, Iterator /* last */)
     {
     }
@@ -69,7 +69,7 @@ template <typename T>
 struct test_is_heap_predicate
 {
     template <typename Policy, typename Iterator, typename Predicate>
-    typename ::std::enable_if<is_same_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
+    typename ::std::enable_if<is_base_of_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
     operator()(Policy&& exec, Iterator first, Iterator last, Predicate pred)
     {
         using namespace std;
@@ -80,7 +80,7 @@ struct test_is_heap_predicate
 
     // is_heap works only with random access iterators
     template <typename Policy, typename Iterator, typename Predicate>
-    typename ::std::enable_if<!is_same_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
+    typename ::std::enable_if<!is_base_of_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
     operator()(Policy&& /* exec */, Iterator /* first */, Iterator /* last */, Predicate /* pred */)
     {
     }
@@ -90,7 +90,7 @@ template <typename T>
 struct test_is_heap_until
 {
     template <typename Policy, typename Iterator>
-    typename ::std::enable_if<is_same_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
+    typename ::std::enable_if<is_base_of_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
     operator()(Policy&& exec, Iterator first, Iterator last)
     {
         using namespace std;
@@ -101,7 +101,7 @@ struct test_is_heap_until
 
     // is_heap, is_heap_until works only with random access iterators
     template <typename Policy, typename Iterator>
-    typename ::std::enable_if<!is_same_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
+    typename ::std::enable_if<!is_base_of_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
     operator()(Policy&& /* exec */, Iterator /* first */, Iterator /* last */)
     {
     }
@@ -111,7 +111,7 @@ template <typename T>
 struct test_is_heap_until_predicate
 {
     template <typename Policy, typename Iterator, typename Predicate>
-    typename ::std::enable_if<is_same_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
+    typename ::std::enable_if<is_base_of_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
     operator()(Policy&& exec, Iterator first, Iterator last, Predicate pred)
     {
         using namespace std;
@@ -122,7 +122,7 @@ struct test_is_heap_until_predicate
 
     // is_heap, is_heap_until works only with random access iterators
     template <typename Policy, typename Iterator, typename Predicate>
-    typename ::std::enable_if<!is_same_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
+    typename ::std::enable_if<!is_base_of_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
     operator()(Policy&& /* exec */, Iterator /* first */, Iterator /* last */, Predicate /* pred */)
     {
     }

--- a/test/parallel_api/algorithm/alg.sorting/alg.heap.operations/is_heap.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.heap.operations/is_heap.pass.cpp
@@ -48,7 +48,7 @@ template <typename T>
 struct test_is_heap
 {
     template <typename Policy, typename Iterator>
-    typename ::std::enable_if<is_base_of_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
+    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>::type
     operator()(Policy&& exec, Iterator first, Iterator last)
     {
         using namespace std;
@@ -59,7 +59,7 @@ struct test_is_heap
 
     // is_heap works only with random access iterators
     template <typename Policy, typename Iterator>
-    typename ::std::enable_if<!is_base_of_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
+    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>::type
     operator()(Policy&& /* exec */, Iterator /* first */, Iterator /* last */)
     {
     }
@@ -69,7 +69,7 @@ template <typename T>
 struct test_is_heap_predicate
 {
     template <typename Policy, typename Iterator, typename Predicate>
-    typename ::std::enable_if<is_base_of_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
+    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>::type
     operator()(Policy&& exec, Iterator first, Iterator last, Predicate pred)
     {
         using namespace std;
@@ -80,7 +80,7 @@ struct test_is_heap_predicate
 
     // is_heap works only with random access iterators
     template <typename Policy, typename Iterator, typename Predicate>
-    typename ::std::enable_if<!is_base_of_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
+    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>::type
     operator()(Policy&& /* exec */, Iterator /* first */, Iterator /* last */, Predicate /* pred */)
     {
     }
@@ -90,7 +90,7 @@ template <typename T>
 struct test_is_heap_until
 {
     template <typename Policy, typename Iterator>
-    typename ::std::enable_if<is_base_of_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
+    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>::type
     operator()(Policy&& exec, Iterator first, Iterator last)
     {
         using namespace std;
@@ -101,7 +101,7 @@ struct test_is_heap_until
 
     // is_heap, is_heap_until works only with random access iterators
     template <typename Policy, typename Iterator>
-    typename ::std::enable_if<!is_base_of_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
+    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>::type
     operator()(Policy&& /* exec */, Iterator /* first */, Iterator /* last */)
     {
     }
@@ -111,7 +111,7 @@ template <typename T>
 struct test_is_heap_until_predicate
 {
     template <typename Policy, typename Iterator, typename Predicate>
-    typename ::std::enable_if<is_base_of_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
+    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>::type
     operator()(Policy&& exec, Iterator first, Iterator last, Predicate pred)
     {
         using namespace std;
@@ -122,7 +122,7 @@ struct test_is_heap_until_predicate
 
     // is_heap, is_heap_until works only with random access iterators
     template <typename Policy, typename Iterator, typename Predicate>
-    typename ::std::enable_if<!is_base_of_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
+    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>::type
     operator()(Policy&& /* exec */, Iterator /* first */, Iterator /* last */, Predicate /* pred */)
     {
     }

--- a/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
@@ -58,7 +58,7 @@ template <typename Type>
 struct test_brick_partial_sort
 {
     template <typename Policy, typename InputIterator, typename Compare>
-    typename ::std::enable_if<is_same_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value,
+    typename ::std::enable_if<is_base_of_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value,
                             void>::type
     operator()(Policy&& exec, InputIterator first, InputIterator last, InputIterator exp_first, InputIterator exp_last,
                InputIterator tmp_first, InputIterator tmp_last, Compare compare)
@@ -102,7 +102,7 @@ struct test_brick_partial_sort
     }
 
     template <typename Policy, typename InputIterator, typename Compare>
-    typename ::std::enable_if<!is_same_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value,
+    typename ::std::enable_if<!is_base_of_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value,
                             void>::type
     operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, InputIterator /* exp_first */,
                InputIterator /* exp_last */, InputIterator /* tmp_first */, InputIterator /* tmp_last */, Compare /* compare */)
@@ -110,7 +110,7 @@ struct test_brick_partial_sort
     }
 
     template <typename Policy, typename InputIterator>
-    typename ::std::enable_if<is_same_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value &&
+    typename ::std::enable_if<is_base_of_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value &&
                               can_use_default_less_operator<Type>::value, void>::type
     operator()(Policy&& exec, InputIterator first, InputIterator last, InputIterator exp_first, InputIterator exp_last,
                InputIterator tmp_first, InputIterator tmp_last)
@@ -131,7 +131,7 @@ struct test_brick_partial_sort
     }
 
     template <typename Policy, typename InputIterator>
-    typename ::std::enable_if<!is_same_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value ||
+    typename ::std::enable_if<!is_base_of_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value ||
                               !can_use_default_less_operator<Type>::value, void>::type
     operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, InputIterator /* exp_first */,
                InputIterator /* exp_last */, InputIterator /* tmp_first */, InputIterator /* tmp_last */)

--- a/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
@@ -58,7 +58,7 @@ template <typename Type>
 struct test_brick_partial_sort
 {
     template <typename Policy, typename InputIterator, typename Compare>
-    typename ::std::enable_if<is_base_of_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value,
+    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value,
                             void>::type
     operator()(Policy&& exec, InputIterator first, InputIterator last, InputIterator exp_first, InputIterator exp_last,
                InputIterator tmp_first, InputIterator tmp_last, Compare compare)
@@ -102,7 +102,7 @@ struct test_brick_partial_sort
     }
 
     template <typename Policy, typename InputIterator, typename Compare>
-    typename ::std::enable_if<!is_base_of_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value,
+    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value,
                             void>::type
     operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, InputIterator /* exp_first */,
                InputIterator /* exp_last */, InputIterator /* tmp_first */, InputIterator /* tmp_last */, Compare /* compare */)
@@ -110,7 +110,7 @@ struct test_brick_partial_sort
     }
 
     template <typename Policy, typename InputIterator>
-    typename ::std::enable_if<is_base_of_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value &&
+    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value &&
                               can_use_default_less_operator<Type>::value, void>::type
     operator()(Policy&& exec, InputIterator first, InputIterator last, InputIterator exp_first, InputIterator exp_last,
                InputIterator tmp_first, InputIterator tmp_last)
@@ -131,7 +131,7 @@ struct test_brick_partial_sort
     }
 
     template <typename Policy, typename InputIterator>
-    typename ::std::enable_if<!is_base_of_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value ||
+    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value ||
                               !can_use_default_less_operator<Type>::value, void>::type
     operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, InputIterator /* exp_first */,
                InputIterator /* exp_last */, InputIterator /* tmp_first */, InputIterator /* tmp_last */)

--- a/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
@@ -179,7 +179,7 @@ struct test_sort_with_compare
 {
     template <typename Policy, typename InputIterator, typename OutputIterator, typename OutputIterator2, typename Size,
               typename Compare>
-    typename ::std::enable_if<is_same_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value,
+    typename ::std::enable_if<is_base_of_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value,
                             void>::type
     operator()(Policy&& exec, OutputIterator tmp_first, OutputIterator tmp_last, OutputIterator2 expected_first,
                OutputIterator2 expected_last, InputIterator first, InputIterator /* last */, Size n, Compare compare)
@@ -207,7 +207,7 @@ struct test_sort_with_compare
     }
     template <typename Policy, typename InputIterator, typename OutputIterator, typename OutputIterator2, typename Size,
               typename Compare>
-    typename ::std::enable_if<!is_same_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value,
+    typename ::std::enable_if<!is_base_of_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value,
                             void>::type
     operator()(Policy&& /* exec */, OutputIterator /* tmp_first */, OutputIterator /* tmp_last */, OutputIterator2 /* expected_first */,
                OutputIterator2 /* expected_last */, InputIterator /* first */, InputIterator /* last */, Size /* n */, Compare /* compare */)
@@ -219,7 +219,7 @@ template<typename T>
 struct test_sort_without_compare
 {
     template <typename Policy, typename InputIterator, typename OutputIterator, typename OutputIterator2, typename Size>
-    typename ::std::enable_if<is_same_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value &&
+    typename ::std::enable_if<is_base_of_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value &&
                             can_use_default_less_operator<T>::value, void>::type
     operator()(Policy&& exec, OutputIterator tmp_first, OutputIterator tmp_last, OutputIterator2 expected_first,
                OutputIterator2 expected_last, InputIterator first, InputIterator /* last */, Size n)
@@ -246,7 +246,7 @@ struct test_sort_without_compare
         EXPECT_EQ(count0, count1, "key cleanup error");
     }
     template <typename Policy, typename InputIterator, typename OutputIterator, typename OutputIterator2, typename Size>
-    typename ::std::enable_if<!is_same_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value ||
+    typename ::std::enable_if<!is_base_of_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value ||
                             !can_use_default_less_operator<T>::value, void>::type
     operator()(Policy&& /* exec */, OutputIterator /* tmp_first */, OutputIterator /* tmp_last */, OutputIterator2 /* expected_first */,
                OutputIterator2 /* expected_last */, InputIterator /* first */, InputIterator /* last */, Size /* n */)

--- a/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
@@ -179,7 +179,7 @@ struct test_sort_with_compare
 {
     template <typename Policy, typename InputIterator, typename OutputIterator, typename OutputIterator2, typename Size,
               typename Compare>
-    typename ::std::enable_if<is_base_of_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value,
+    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value,
                             void>::type
     operator()(Policy&& exec, OutputIterator tmp_first, OutputIterator tmp_last, OutputIterator2 expected_first,
                OutputIterator2 expected_last, InputIterator first, InputIterator /* last */, Size n, Compare compare)
@@ -207,7 +207,7 @@ struct test_sort_with_compare
     }
     template <typename Policy, typename InputIterator, typename OutputIterator, typename OutputIterator2, typename Size,
               typename Compare>
-    typename ::std::enable_if<!is_base_of_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value,
+    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value,
                             void>::type
     operator()(Policy&& /* exec */, OutputIterator /* tmp_first */, OutputIterator /* tmp_last */, OutputIterator2 /* expected_first */,
                OutputIterator2 /* expected_last */, InputIterator /* first */, InputIterator /* last */, Size /* n */, Compare /* compare */)
@@ -219,7 +219,7 @@ template<typename T>
 struct test_sort_without_compare
 {
     template <typename Policy, typename InputIterator, typename OutputIterator, typename OutputIterator2, typename Size>
-    typename ::std::enable_if<is_base_of_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value &&
+    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value &&
                             can_use_default_less_operator<T>::value, void>::type
     operator()(Policy&& exec, OutputIterator tmp_first, OutputIterator tmp_last, OutputIterator2 expected_first,
                OutputIterator2 expected_last, InputIterator first, InputIterator /* last */, Size n)
@@ -246,7 +246,7 @@ struct test_sort_without_compare
         EXPECT_EQ(count0, count1, "key cleanup error");
     }
     template <typename Policy, typename InputIterator, typename OutputIterator, typename OutputIterator2, typename Size>
-    typename ::std::enable_if<!is_base_of_iterator_category<InputIterator, ::std::random_access_iterator_tag>::value ||
+    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value ||
                             !can_use_default_less_operator<T>::value, void>::type
     operator()(Policy&& /* exec */, OutputIterator /* tmp_first */, OutputIterator /* tmp_last */, OutputIterator2 /* expected_first */,
                OutputIterator2 /* expected_last */, InputIterator /* first */, InputIterator /* last */, Size /* n */)

--- a/test/support/iterator_utils.h
+++ b/test/support/iterator_utils.h
@@ -356,8 +356,8 @@ struct iterator_invoker
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    typename ::std::enable_if<::std::is_base_of<::std::bidirectional_iterator_tag, 
-                                            typename ::std::iterator_traits<Iterator>::iterator_category>::value, void>::type
+    typename ::std::enable_if<is_base_of_iterator_category<Iterator, 
+                                            ::std::bidirectional_iterator_tag>::value, void>::type
     operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n, 
         Iterator expected, Rest&&... rest)
     {
@@ -469,7 +469,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<Iterator, ::std::bidirectional_iterator_tag>::value, void>::type
+    typename ::std::enable_if<is_same_iterator_category<Iterator, ::std::bidirectional_iterator_tag>::value, void>::type
     operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n, Iterator expected, Rest&&... rest)
     {
         if (n <= sizeLimit)

--- a/test/support/iterator_utils.h
+++ b/test/support/iterator_utils.h
@@ -353,16 +353,9 @@ struct iterator_invoker
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    typename ::std::enable_if<is_same_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
+    typename ::std::enable_if<::std::is_base_of<::std::bidirectional_iterator_tag, 
+                                            typename ::std::iterator_traits<Iterator>::iterator_category>::value, void>::type
     operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n, 
-        Iterator expected, Rest&&... rest)
-    {
-        op(exec, make_iterator<Iterator>()(begin), n, make_iterator<Iterator>()(expected), ::std::forward<Rest>(rest)...);
-    }
-
-    template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    typename ::std::enable_if<is_same_iterator_category<Iterator, ::std::bidirectional_iterator_tag>::value, void>::type
-    operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n,
         Iterator expected, Rest&&... rest)
     {
         op(exec, make_iterator<Iterator>()(begin), n, make_iterator<Iterator>()(expected), ::std::forward<Rest>(rest)...);

--- a/test/support/iterator_utils.h
+++ b/test/support/iterator_utils.h
@@ -240,7 +240,7 @@ struct iterator_traits_<T*>
 template <typename Iter, typename Tag>
 using is_same_iterator_category = ::std::is_same<typename iterator_traits_<Iter>::iterator_category, Tag>;
 
-template <typename Iter, typename Tag>
+template <typename Tag, typename Iter>
 using is_base_of_iterator_category = ::std::is_base_of<Tag, typename iterator_traits_<Iter>::iterator_category>;
 
 // if we run with reverse or const iterators we shouldn't test the large range
@@ -336,7 +336,7 @@ struct iterator_invoker
 
     // A single iterator version which is used for non_const testcases
     template <typename Policy, typename Op, typename Iterator>
-    typename ::std::enable_if<is_base_of_iterator_category<Iterator, ::std::random_access_iterator_tag>::value &&
+    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
                                 ::std::is_base_of<non_const_wrapper, Op>::value,
                             void>::type
     operator()(Policy&& exec, Op op, Iterator iter)
@@ -346,7 +346,7 @@ struct iterator_invoker
 
     // A version with 2 iterators which is used for non_const testcases
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator>
-    typename ::std::enable_if<is_base_of_iterator_category<OutputIterator, ::std::random_access_iterator_tag>::value &&
+    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value &&
                                 ::std::is_base_of<non_const_wrapper, Op>::value,
                             void>::type
     operator()(Policy&& exec, Op op, InputIterator input_iter, OutputIterator out_iter)
@@ -356,8 +356,8 @@ struct iterator_invoker
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<Iterator, 
-                                            ::std::bidirectional_iterator_tag>::value, void>::type
+    typename ::std::enable_if<is_base_of_iterator_category<::std::bidirectional_iterator_tag, 
+                                            Iterator>::value, void>::type
     operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n, 
         Iterator expected, Rest&&... rest)
     {
@@ -365,7 +365,7 @@ struct iterator_invoker
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
+    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>::type
     operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n, Rest&&... rest)
     {
         invoke_if<Iterator>()(n <= sizeLimit, op, exec, make_iterator<Iterator>()(begin), n,
@@ -373,7 +373,7 @@ struct iterator_invoker
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<Iterator, ::std::random_access_iterator_tag>::value &&
+    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
                                 !::std::is_base_of<non_const_wrapper, Op>::value,
                             void>::type
     operator()(Policy&& exec, Op op, Iterator inputBegin, Iterator inputEnd, Rest&&... rest)
@@ -384,7 +384,7 @@ struct iterator_invoker
     }
 
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator, typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<OutputIterator, ::std::random_access_iterator_tag>::value,
+    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value,
                             void>::type
     operator()(Policy&& exec, Op op, InputIterator inputBegin, InputIterator inputEnd, OutputIterator outputBegin,
                Rest&&... rest)
@@ -395,7 +395,7 @@ struct iterator_invoker
     }
 
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator, typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<OutputIterator, ::std::random_access_iterator_tag>::value,
+    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value,
                             void>::type
     operator()(Policy&& exec, Op op, InputIterator inputBegin, InputIterator inputEnd, OutputIterator outputBegin,
                OutputIterator outputEnd, Rest&&... rest)
@@ -408,7 +408,7 @@ struct iterator_invoker
 
     template <typename Policy, typename Op, typename InputIterator1, typename InputIterator2, typename OutputIterator,
               typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<OutputIterator, ::std::random_access_iterator_tag>::value,
+    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value,
                             void>::type
     operator()(Policy&& exec, Op op, InputIterator1 inputBegin1, InputIterator1 inputEnd1, InputIterator2 inputBegin2,
                InputIterator2 inputEnd2, OutputIterator outputBegin, OutputIterator outputEnd, Rest&&... rest)
@@ -432,7 +432,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
 
     // A single iterator version which is used for non_const testcases
     template <typename Policy, typename Op, typename Iterator>
-    typename ::std::enable_if<is_base_of_iterator_category<Iterator, ::std::random_access_iterator_tag>::value &&
+    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
                                 ::std::is_base_of<non_const_wrapper, Op>::value,
                             void>::type
     operator()(Policy&& exec, Op op, Iterator iter)
@@ -442,7 +442,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
 
     // A version with 2 iterators which is used for non_const testcases
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator>
-    typename ::std::enable_if<is_base_of_iterator_category<OutputIterator, ::std::random_access_iterator_tag>::value &&
+    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value &&
                                 ::std::is_base_of<non_const_wrapper, Op>::value,
                             void>::type
     operator()(Policy&& exec, Op op, InputIterator input_iter, OutputIterator out_iter)
@@ -452,7 +452,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
+    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>::type
     operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n, Rest&&... rest)
     {
         if (n <= sizeLimit)
@@ -460,7 +460,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
+    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>::type
     operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n, Iterator expected,
         Rest&&... rest)
     {
@@ -477,7 +477,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<Iterator, ::std::random_access_iterator_tag>::value &&
+    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
                                 !::std::is_base_of<non_const_wrapper, Op>::value,
                             void>::type
     operator()(Policy&& exec, Op op, Iterator inputBegin, Iterator inputEnd, Rest&&... rest)
@@ -488,7 +488,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     }
 
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator, typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<OutputIterator, ::std::random_access_iterator_tag>::value,
+    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value,
                             void>::type
     operator()(Policy&& exec, Op op, InputIterator inputBegin, InputIterator inputEnd, OutputIterator outputBegin,
                Rest&&... rest)
@@ -499,7 +499,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     }
 
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator, typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<OutputIterator, ::std::random_access_iterator_tag>::value,
+    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value,
                             void>::type
     operator()(Policy&& exec, Op op, InputIterator inputBegin, InputIterator inputEnd, OutputIterator outputBegin,
                OutputIterator outputEnd, Rest&&... rest)
@@ -512,7 +512,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
 
     template <typename Policy, typename Op, typename InputIterator1, typename InputIterator2, typename OutputIterator,
               typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<OutputIterator, ::std::random_access_iterator_tag>::value,
+    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value,
                             void>::type
     operator()(Policy&& exec, Op op, InputIterator1 inputBegin1, InputIterator1 inputEnd1, InputIterator2 inputBegin2,
                InputIterator2 inputEnd2, OutputIterator outputBegin, OutputIterator outputEnd, Rest&&... rest)

--- a/test/support/iterator_utils.h
+++ b/test/support/iterator_utils.h
@@ -240,6 +240,9 @@ struct iterator_traits_<T*>
 template <typename Iter, typename Tag>
 using is_same_iterator_category = ::std::is_same<typename iterator_traits_<Iter>::iterator_category, Tag>;
 
+template <typename Iter, typename Tag>
+using is_base_of_iterator_category = ::std::is_base_of<Tag, typename iterator_traits_<Iter>::iterator_category>;
+
 // if we run with reverse or const iterators we shouldn't test the large range
 template <typename IsReverse, typename IsConst>
 struct invoke_if_
@@ -333,7 +336,7 @@ struct iterator_invoker
 
     // A single iterator version which is used for non_const testcases
     template <typename Policy, typename Op, typename Iterator>
-    typename ::std::enable_if<is_same_iterator_category<Iterator, ::std::random_access_iterator_tag>::value &&
+    typename ::std::enable_if<is_base_of_iterator_category<Iterator, ::std::random_access_iterator_tag>::value &&
                                 ::std::is_base_of<non_const_wrapper, Op>::value,
                             void>::type
     operator()(Policy&& exec, Op op, Iterator iter)
@@ -343,7 +346,7 @@ struct iterator_invoker
 
     // A version with 2 iterators which is used for non_const testcases
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator>
-    typename ::std::enable_if<is_same_iterator_category<OutputIterator, ::std::random_access_iterator_tag>::value &&
+    typename ::std::enable_if<is_base_of_iterator_category<OutputIterator, ::std::random_access_iterator_tag>::value &&
                                 ::std::is_base_of<non_const_wrapper, Op>::value,
                             void>::type
     operator()(Policy&& exec, Op op, InputIterator input_iter, OutputIterator out_iter)
@@ -362,7 +365,7 @@ struct iterator_invoker
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    typename ::std::enable_if<is_same_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
+    typename ::std::enable_if<is_base_of_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
     operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n, Rest&&... rest)
     {
         invoke_if<Iterator>()(n <= sizeLimit, op, exec, make_iterator<Iterator>()(begin), n,
@@ -370,7 +373,7 @@ struct iterator_invoker
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    typename ::std::enable_if<is_same_iterator_category<Iterator, ::std::random_access_iterator_tag>::value &&
+    typename ::std::enable_if<is_base_of_iterator_category<Iterator, ::std::random_access_iterator_tag>::value &&
                                 !::std::is_base_of<non_const_wrapper, Op>::value,
                             void>::type
     operator()(Policy&& exec, Op op, Iterator inputBegin, Iterator inputEnd, Rest&&... rest)
@@ -381,7 +384,7 @@ struct iterator_invoker
     }
 
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator, typename... Rest>
-    typename ::std::enable_if<is_same_iterator_category<OutputIterator, ::std::random_access_iterator_tag>::value,
+    typename ::std::enable_if<is_base_of_iterator_category<OutputIterator, ::std::random_access_iterator_tag>::value,
                             void>::type
     operator()(Policy&& exec, Op op, InputIterator inputBegin, InputIterator inputEnd, OutputIterator outputBegin,
                Rest&&... rest)
@@ -392,7 +395,7 @@ struct iterator_invoker
     }
 
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator, typename... Rest>
-    typename ::std::enable_if<is_same_iterator_category<OutputIterator, ::std::random_access_iterator_tag>::value,
+    typename ::std::enable_if<is_base_of_iterator_category<OutputIterator, ::std::random_access_iterator_tag>::value,
                             void>::type
     operator()(Policy&& exec, Op op, InputIterator inputBegin, InputIterator inputEnd, OutputIterator outputBegin,
                OutputIterator outputEnd, Rest&&... rest)
@@ -405,7 +408,7 @@ struct iterator_invoker
 
     template <typename Policy, typename Op, typename InputIterator1, typename InputIterator2, typename OutputIterator,
               typename... Rest>
-    typename ::std::enable_if<is_same_iterator_category<OutputIterator, ::std::random_access_iterator_tag>::value,
+    typename ::std::enable_if<is_base_of_iterator_category<OutputIterator, ::std::random_access_iterator_tag>::value,
                             void>::type
     operator()(Policy&& exec, Op op, InputIterator1 inputBegin1, InputIterator1 inputEnd1, InputIterator2 inputBegin2,
                InputIterator2 inputEnd2, OutputIterator outputBegin, OutputIterator outputEnd, Rest&&... rest)
@@ -429,7 +432,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
 
     // A single iterator version which is used for non_const testcases
     template <typename Policy, typename Op, typename Iterator>
-    typename ::std::enable_if<is_same_iterator_category<Iterator, ::std::random_access_iterator_tag>::value &&
+    typename ::std::enable_if<is_base_of_iterator_category<Iterator, ::std::random_access_iterator_tag>::value &&
                                 ::std::is_base_of<non_const_wrapper, Op>::value,
                             void>::type
     operator()(Policy&& exec, Op op, Iterator iter)
@@ -439,7 +442,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
 
     // A version with 2 iterators which is used for non_const testcases
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator>
-    typename ::std::enable_if<is_same_iterator_category<OutputIterator, ::std::random_access_iterator_tag>::value &&
+    typename ::std::enable_if<is_base_of_iterator_category<OutputIterator, ::std::random_access_iterator_tag>::value &&
                                 ::std::is_base_of<non_const_wrapper, Op>::value,
                             void>::type
     operator()(Policy&& exec, Op op, InputIterator input_iter, OutputIterator out_iter)
@@ -449,7 +452,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    typename ::std::enable_if<is_same_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
+    typename ::std::enable_if<is_base_of_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
     operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n, Rest&&... rest)
     {
         if (n <= sizeLimit)
@@ -457,7 +460,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    typename ::std::enable_if<is_same_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
+    typename ::std::enable_if<is_base_of_iterator_category<Iterator, ::std::random_access_iterator_tag>::value, void>::type
     operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n, Iterator expected,
         Rest&&... rest)
     {
@@ -466,7 +469,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    typename ::std::enable_if<is_same_iterator_category<Iterator, ::std::bidirectional_iterator_tag>::value, void>::type
+    typename ::std::enable_if<is_base_of_iterator_category<Iterator, ::std::bidirectional_iterator_tag>::value, void>::type
     operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n, Iterator expected, Rest&&... rest)
     {
         if (n <= sizeLimit)
@@ -474,7 +477,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    typename ::std::enable_if<is_same_iterator_category<Iterator, ::std::random_access_iterator_tag>::value &&
+    typename ::std::enable_if<is_base_of_iterator_category<Iterator, ::std::random_access_iterator_tag>::value &&
                                 !::std::is_base_of<non_const_wrapper, Op>::value,
                             void>::type
     operator()(Policy&& exec, Op op, Iterator inputBegin, Iterator inputEnd, Rest&&... rest)
@@ -485,7 +488,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     }
 
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator, typename... Rest>
-    typename ::std::enable_if<is_same_iterator_category<OutputIterator, ::std::random_access_iterator_tag>::value,
+    typename ::std::enable_if<is_base_of_iterator_category<OutputIterator, ::std::random_access_iterator_tag>::value,
                             void>::type
     operator()(Policy&& exec, Op op, InputIterator inputBegin, InputIterator inputEnd, OutputIterator outputBegin,
                Rest&&... rest)
@@ -496,7 +499,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     }
 
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator, typename... Rest>
-    typename ::std::enable_if<is_same_iterator_category<OutputIterator, ::std::random_access_iterator_tag>::value,
+    typename ::std::enable_if<is_base_of_iterator_category<OutputIterator, ::std::random_access_iterator_tag>::value,
                             void>::type
     operator()(Policy&& exec, Op op, InputIterator inputBegin, InputIterator inputEnd, OutputIterator outputBegin,
                OutputIterator outputEnd, Rest&&... rest)
@@ -509,7 +512,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
 
     template <typename Policy, typename Op, typename InputIterator1, typename InputIterator2, typename OutputIterator,
               typename... Rest>
-    typename ::std::enable_if<is_same_iterator_category<OutputIterator, ::std::random_access_iterator_tag>::value,
+    typename ::std::enable_if<is_base_of_iterator_category<OutputIterator, ::std::random_access_iterator_tag>::value,
                             void>::type
     operator()(Policy&& exec, Op op, InputIterator1 inputBegin1, InputIterator1 inputEnd1, InputIterator2 inputBegin2,
                InputIterator2 inputEnd2, OutputIterator outputBegin, OutputIterator outputEnd, Rest&&... rest)


### PR DESCRIPTION
Please find the description of the purpose of the patch here https://github.com/oneapi-src/oneDPL/issues/104 