### PR TITLE
Adding Visual Studio 2022 Support

### DIFF
--- a/documentation/library_guide/api_for_dpcpp_kernels/tested_standard_cpp_api.rst
+++ b/documentation/library_guide/api_for_dpcpp_kernels/tested_standard_cpp_api.rst
@@ -367,8 +367,9 @@ libstdc++(GNU)                                Provided with GCC*-7.5.0, GCC*-9.3
 --------------------------------------------- ---------------------------------------------
 libc++(LLVM)                                  Provided with Clang*-11.0
 --------------------------------------------- ---------------------------------------------
-Microsoft Visual C++* (MSVC) Standard Library Provided with Microsoft Visual Studio* 2017
-                                              and Microsoft Visual Studio 2019
+Microsoft Visual C++* (MSVC) Standard Library Provided with Microsoft Visual Studio* 2017;
+                                              Microsoft Visual Studio 2019; and Microsoft 
+                                              Visual Studio 2022, version 17.0, preview 4.1.
                                               
                                               .. Note::
                                               


### PR DESCRIPTION
Updated tested_standard_cpp_api with VS22 support.

Signed-off-by: Dylan Benito <dylan.benito@intel.com>