### PR TITLE
Make MyClass trivially copyable to test with DPC++ policies

### DIFF
--- a/test/parallel_api/numeric/numeric.ops/transform_reduce.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/transform_reduce.pass.cpp
@@ -49,7 +49,6 @@ class MyClass
     int32_t my_field;
     MyClass() { my_field = 0; }
     MyClass(int32_t in) { my_field = in; }
-    MyClass(const MyClass& in) { my_field = in.my_field; }
 
     friend MyClass
     operator+(const MyClass& x, const MyClass& y)
@@ -163,11 +162,8 @@ main()
                             [](const float32_t& a, const float32_t& b) -> float32_t { return a + b; },
                             [](const float32_t& x) -> float32_t { return x + 2; },
                             [](::std::size_t) -> float32_t { return rand() % 1000; });
-// MyClass must not be used with DPC++ policies since it is not device copyable
-#if !TEST_DPCPP_BACKEND_PRESENT
     test_by_type<MyClass>(MyClass(), ::std::plus<MyClass>(), ::std::multiplies<MyClass>(),
         [](const MyClass& x) { return MyClass(-x.my_field); },
         [](::std::size_t) -> MyClass { return MyClass(rand() % 1000); });
-#endif
     return done();
 }


### PR DESCRIPTION
This change is inspired by https://github.com/oneapi-src/oneDPL/pull/409#discussion_r746035100

Signed-off-by: Sobolev, Dmitriy <dmitriy.sobolev@intel.com>