### PR TITLE
Choosing parallel backend fix

### DIFF
--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -64,16 +64,16 @@
 #    define _DPSTD_DEPRECATED_MSG(msg)
 #endif
 
-#define _ONEDPL_PAR_BACKEND_SERIAL 1
-
 #if ONEDPL_USE_TBB_BACKEND || (!defined(ONEDPL_USE_TBB_BACKEND) && !ONEDPL_USE_OPENMP_BACKEND)
-#    undef _ONEDPL_PAR_BACKEND_SERIAL
 #    define _ONEDPL_PAR_BACKEND_TBB 1
 #endif
 
 #if ONEDPL_USE_OPENMP_BACKEND || (!defined(ONEDPL_USE_OPENMP_BACKEND) && defined(_OPENMP))
-#    undef _ONEDPL_PAR_BACKEND_SERIAL
 #    define _ONEDPL_PAR_BACKEND_OPENMP 1
+#endif
+
+#if !_ONEDPL_PAR_BACKEND_TBB && !_ONEDPL_PAR_BACKEND_OPENMP
+#    define _ONEDPL_PAR_BACKEND_SERIAL 1
 #endif
 
 // TODO: This is the define to support use-cases in tests. It is not really required

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -64,36 +64,22 @@
 #    define _DPSTD_DEPRECATED_MSG(msg)
 #endif
 
-// Check the user-defined macro for parallel policies
-#if defined(ONEDPL_USE_TBB_BACKEND)
-#    undef _ONEDPL_USE_PAR_POLICIES
-#    define _ONEDPL_USE_PAR_POLICIES ONEDPL_USE_TBB_BACKEND
-// Check the internal macro for parallel policies
-#elif !defined(_ONEDPL_USE_PAR_POLICIES)
-#    define _ONEDPL_USE_PAR_POLICIES 1
+#define _ONEDPL_PAR_BACKEND_SERIAL 1
+
+#if ONEDPL_USE_TBB_BACKEND || (!defined(ONEDPL_USE_TBB_BACKEND) && !ONEDPL_USE_OPENMP_BACKEND)
+#    undef _ONEDPL_PAR_BACKEND_SERIAL
+#    define _ONEDPL_PAR_BACKEND_TBB 1
 #endif
 
-#if defined(ONEDPL_USE_OPENMP_BACKEND)
-#    undef _ONEDPL_USE_PAR_POLICIES
-#    define _ONEDPL_USE_PAR_POLICIES ONEDPL_USE_OPENMP_BACKEND
-// Check the internal macro for parallel policies
-#elif !defined(_ONEDPL_USE_PAR_POLICIES)
-#    define _ONEDPL_USE_PAR_POLICIES 1
+#if ONEDPL_USE_OPENMP_BACKEND || (!defined(ONEDPL_USE_OPENMP_BACKEND) && defined(_OPENMP))
+#    undef _ONEDPL_PAR_BACKEND_SERIAL
+#    define _ONEDPL_PAR_BACKEND_OPENMP 1
 #endif
 
-#if _ONEDPL_USE_PAR_POLICIES
-#    if defined(ONEDPL_USE_OPENMP_BACKEND)
-#        undef _ONEDPL_PAR_BACKEND_SERIAL
-#        define _ONEDPL_PAR_BACKEND_OPENMP 1
-#    elif !defined(_ONEDPL_PAR_BACKEND_TBB)
-#        undef _ONEDPL_PAR_BACKEND_SERIAL
-#        define _ONEDPL_PAR_BACKEND_TBB 1
-#    endif
-#else
-#    undef _ONEDPL_PAR_BACKEND_TBB
-#    undef _ONEDPL_PAR_BACKEND_OPENMP
-#    define _ONEDPL_PAR_BACKEND_SERIAL 1
-#endif
+// TODO: This is the define to support use-cases in tests. It is not really required
+// to be defined with new approach. However keep if for now until we figure out
+// what is the right behavior of tests.
+#define _ONEDPL_USE_PAR_POLICIES (_ONEDPL_PAR_BACKEND_TBB || _ONEDPL_PAR_BACKEND_OPENMP)
 
 #if (__cplusplus >= 201703L)
 #    define _ONEDPL_CONSTEXPR_FUN constexpr

--- a/include/oneapi/dpl/pstl/parallel_backend.h
+++ b/include/oneapi/dpl/pstl/parallel_backend.h
@@ -22,16 +22,7 @@
 #    endif
 #endif
 
-#if defined(_ONEDPL_PAR_BACKEND_SERIAL)
-#    include "parallel_backend_serial.h"
-namespace oneapi
-{
-namespace dpl
-{
-namespace __par_backend = __serial_backend;
-}
-} // namespace oneapi
-#elif defined(_ONEDPL_PAR_BACKEND_TBB)
+#if _ONEDPL_PAR_BACKEND_TBB
 #    include "parallel_backend_tbb.h"
 namespace oneapi
 {
@@ -40,13 +31,22 @@ namespace dpl
 namespace __par_backend = __tbb_backend;
 }
 } // namespace oneapi
-#elif defined(_ONEDPL_PAR_BACKEND_OPENMP)
+#elif _ONEDPL_PAR_BACKEND_OPENMP
 #    include "parallel_backend_omp.h"
 namespace oneapi
 {
 namespace dpl
 {
 namespace __par_backend = __omp_backend;
+}
+} // namespace oneapi
+#elif _ONEDPL_PAR_BACKEND_SERIAL
+#    include "parallel_backend_serial.h"
+namespace oneapi
+{
+namespace dpl
+{
+namespace __par_backend = __serial_backend;
 }
 } // namespace oneapi
 #else


### PR DESCRIPTION
The bug root cause: enabling TBB backend (via `ONEDPL_USE_TBB_BACKEND`) and disabling OpenMP backend (both explicitly ) in compiler command line causes disabling parallel policies because the decision about the policies is made by the latest macro in the code (in our case one that enables OpenMP backend).

If the macro that enables OpenMP backend (`ONEDPL_USE_OPENMP_BACKEND`) is defined then the implementation re-establishes the value of the macro `_ONEDPL_USE_PAR_POLICIES` to the value of `ONEDPL_USE_OPENMP_BACKEND` despite if TBB backend was already enabled or not.

Thus, the following macros in command line: 
```cpp
-DONEDPL_USE_TBB_BACKEND=1 -DONEDPL_USE_OPENMP_BACKEND=0
```
causes parallel policies to be disabled.

Keeping in mind that the possible states of `ONEDPL_USE_TBB_BACKEND` and `ONEDPL_USE_OPENMP_BACKEND` could be `0`, `undefined` and `1` and defining the priorities like `0 < undefined < 1` to make both macros opt-out the idea is reflected in the table below:

| OpenMP backend / TBB backend         | 0                                             | Undefined   | 1          |
|:------------------------------------:|:--------------------------------------:|:-----------:|:----------:|
|0                                     |Serial                                                               | TBB           | TBB         |
|Undefined                      |OpenMP if available.</br> Otherwise, serial | TBB            | TBB         |
|1                                     |OpenMP                                                         | OpenMP    | TBB         |