### PR TITLE
CMake: set ONEDPL_USE_OPENMP_BACKEND=0 explicitly for serial backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,6 +219,7 @@ elseif(ONEDPL_BACKEND MATCHES "^(serial)$")
     target_compile_definitions(oneDPL INTERFACE
         ONEDPL_USE_TBB_BACKEND=0
         ONEDPL_USE_DPCPP_BACKEND=0
+        ONEDPL_USE_OPENMP_BACKEND=0
         )
     message(STATUS "Compilation for the host due to serial backend")
 


### PR DESCRIPTION
DPC++ compiler defines `_OPENMP` macro when `-fopenmp-simd` (not `-fopenmp`) is specified. This leads to linkage errors due to incorrect setting of the macros values that control the selection of the backend.

Signed-off-by: Zheltov, Sergey1 <sergey1.zheltov@intel.com>