### PR TITLE
Fix warning: 'global_buffer' is deprecated

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -332,7 +332,7 @@ __parallel_transform_reduce(_ExecutionPolicy&& __exec, _Up __u, _LRp __brick_lea
 
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...); //get an access to data under SYCL buffer
             auto __temp_acc = __temp.template get_access<access_mode::read_write>(__cgh);
-            sycl::accessor<_Tp, 1, access_mode::read_write, sycl::access::target::local> __temp_local(
+            sycl::accessor<_Tp, 1, access_mode::read_write, __dpl_sycl::__target::local> __temp_local(
                 sycl::range<1>(__work_group_size), __cgh);
 #if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
             __cgh.use_kernel_bundle(__kernel.get_kernel_bundle());
@@ -458,7 +458,7 @@ struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name
         auto __submit_event = __exec.queue().submit([&](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rng1, __rng2); //get an access to data under SYCL buffer
             auto __wg_sums_acc = __wg_sums.template get_access<access_mode::discard_write>(__cgh);
-            sycl::accessor<_Type, 1, access_mode::discard_read_write, sycl::access::target::local> __local_acc(
+            sycl::accessor<_Type, 1, access_mode::discard_read_write, __dpl_sycl::__target::local> __local_acc(
                 __wgroup_size, __cgh);
 #if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
             __cgh.use_kernel_bundle(__kernel_1.get_kernel_bundle());
@@ -480,7 +480,7 @@ struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name
             __submit_event = __exec.queue().submit([&](sycl::handler& __cgh) {
                 __cgh.depends_on(__submit_event);
                 auto __wg_sums_acc = __wg_sums.template get_access<access_mode::read_write>(__cgh);
-                sycl::accessor<_Type, 1, access_mode::discard_read_write, sycl::access::target::local> __local_acc(
+                sycl::accessor<_Type, 1, access_mode::discard_read_write, __dpl_sycl::__target::local> __local_acc(
                     __wgroup_size, __cgh);
 #if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
                 __cgh.use_kernel_bundle(__kernel_2.get_kernel_bundle());
@@ -718,7 +718,7 @@ __parallel_find_or(_ExecutionPolicy&& __exec, _Brick __f, _BrickTag __brick_tag,
             auto __temp_acc = __temp.template get_access<access_mode::read_write>(__cgh);
 
             // create local accessor to connect atomic with
-            sycl::accessor<_AtomicType, 1, access_mode::read_write, sycl::access::target::local> __temp_local(1, __cgh);
+            sycl::accessor<_AtomicType, 1, access_mode::read_write, __dpl_sycl::__target::local> __temp_local(1, __cgh);
 #if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
             __cgh.use_kernel_bundle(__kernel.get_kernel_bundle());
 #endif

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -315,7 +315,7 @@ __radix_sort_count_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments, :
         oneapi::dpl::__ranges::__require_access(__hdl, __val_rng,
                                                 __count_rng); //get an access to data under SYCL buffer
         // an accessor per work-group with value counters from each work-item
-        auto __count_lacc = sycl::accessor<_CountT, 1, access_mode::read_write, access_target::local>(
+        auto __count_lacc = sycl::accessor<_CountT, 1, access_mode::read_write, __dpl_sycl::__target::local>(
             __block_size * __radix_states, __hdl);
 #if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
         __hdl.use_kernel_bundle(__kernel.get_kernel_bundle());

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -39,12 +39,7 @@ namespace dpl
 namespace __par_backend_hetero
 {
 
-//-----------------------------------------------------------------------
-// sycl::access::mode and sycl::access::target helpers
-//-----------------------------------------------------------------------
-
 // aliases for faster access to modes
-using access_target = sycl::access::target;
 using access_mode = sycl::access_mode;
 
 template <typename _T>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -193,6 +193,20 @@ using __fpga_selector = sycl::INTEL::fpga_selector;
 #    endif
 #endif // _ONEDPL_FPGA_DEVICE
 
+using __target =
+#if __LIBSYCL_VERSION >= 50400
+    sycl::target;
+#else
+    sycl::access::target;
+#endif
+
+constexpr __target __target_device =
+#if __LIBSYCL_VERSION >= 50400
+    __target::device;
+#else
+    __target::global_buffer;
+#endif
+
 } // namespace __dpl_sycl
 
 #endif /* _ONEDPL_sycl_defs_H */

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -83,7 +83,7 @@ struct __accessor_traits_impl
 {
 };
 
-template <typename _T, int _Dim, sycl::access::mode _AccMode, sycl::access::target _AccTarget,
+template <typename _T, int _Dim, sycl::access::mode _AccMode, __dpl_sycl::__target _AccTarget,
           sycl::access::placeholder _Placeholder>
 struct __accessor_traits_impl<sycl::accessor<_T, _Dim, _AccMode, _AccTarget, _Placeholder>>
 {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -113,8 +113,7 @@ _ONEDPL_CONSTEXPR_VAR
 all_view_fn<sycl::access::mode::read, __dpl_sycl::__target_device, sycl::access::placeholder::true_t> all_read;
 
 _ONEDPL_CONSTEXPR_VAR
-all_view_fn<sycl::access::mode::write, __dpl_sycl::__target_device, sycl::access::placeholder::true_t>
-    all_write;
+all_view_fn<sycl::access::mode::write, __dpl_sycl::__target_device, sycl::access::placeholder::true_t> all_write;
 
 _ONEDPL_CONSTEXPR_VAR
 all_view_fn<sycl::access::mode::read_write, __dpl_sycl::__target::host_buffer, sycl::access::placeholder::false_t>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -33,7 +33,7 @@ namespace __ranges
 
 //A SYCL range over SYCL buffer
 template <typename _T, sycl::access::mode AccMode = sycl::access::mode::read,
-          sycl::access::target _Target = sycl::access::target::global_buffer,
+          __dpl_sycl::__target _Target = __dpl_sycl::__target_device,
           sycl::access::placeholder _Placeholder = sycl::access::placeholder::true_t>
 class all_view
 {
@@ -84,7 +84,7 @@ class all_view
 };
 
 template <sycl::access::mode AccMode = sycl::access::mode::read_write,
-          sycl::access::target _Target = sycl::access::target::global_buffer,
+          __dpl_sycl::__target _Target = __dpl_sycl::__target_device,
           sycl::access::placeholder _Placeholder = sycl::access::placeholder::true_t>
 struct all_view_fn
 {
@@ -107,13 +107,13 @@ struct all_view_fn
 namespace views
 {
 _ONEDPL_CONSTEXPR_VAR
-all_view_fn<sycl::access::mode::read_write, sycl::access::target::global_buffer, sycl::access::placeholder::true_t> all;
+all_view_fn<sycl::access::mode::read_write, __dpl_sycl::__target_device, sycl::access::placeholder::true_t> all;
 
 _ONEDPL_CONSTEXPR_VAR
-all_view_fn<sycl::access::mode::read, sycl::access::target::global_buffer, sycl::access::placeholder::true_t> all_read;
+all_view_fn<sycl::access::mode::read, __dpl_sycl::__target_device, sycl::access::placeholder::true_t> all_read;
 
 _ONEDPL_CONSTEXPR_VAR
-all_view_fn<sycl::access::mode::write, sycl::access::target::global_buffer, sycl::access::placeholder::true_t>
+all_view_fn<sycl::access::mode::write, __dpl_sycl::__target_device, sycl::access::placeholder::true_t>
     all_write;
 
 _ONEDPL_CONSTEXPR_VAR

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -117,7 +117,7 @@ all_view_fn<sycl::access::mode::write, __dpl_sycl::__target_device, sycl::access
     all_write;
 
 _ONEDPL_CONSTEXPR_VAR
-all_view_fn<sycl::access::mode::read_write, sycl::access::target::host_buffer, sycl::access::placeholder::false_t>
+all_view_fn<sycl::access::mode::read_write, __dpl_sycl::__target::host_buffer, sycl::access::placeholder::false_t>
     host_all;
 } // namespace views
 

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -333,7 +333,7 @@ get_host_pointer(Iter it)
     return &it.get_buffer().template get_access<mode>()[0] + temp_idx;
 }
 
-template <typename T, int Dim, sycl::access::mode AccMode, sycl::access::target AccTarget,
+template <typename T, int Dim, sycl::access::mode AccMode, __dpl_sycl::__target AccTarget,
           sycl::access::placeholder Placeholder>
 T*
 get_host_pointer(sycl::accessor<T, Dim, AccMode, AccTarget, Placeholder>& acc)


### PR DESCRIPTION
global_buffer became deprecated since https://github.com/intel/llvm/commit/987427af6a521182ddc1b0e40d84078787af5a2f patch, 

This is deprecated in SYCL 2020 (https://www.khronos.org/registry/SYCL/specs/sycl-2020/pdf/sycl-2020.pdf (rev 4), page 158). as well as sycl::access::target namespace.

There are related deprecations for host_buffer, local, but I suggest fixing them in separate patches in order not to complicate this one.