### PR TITLE
CMake: set ONEDPL_USE_OPENMP_BACKEND=0 explicitly for serial backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,6 +219,7 @@ elseif(ONEDPL_BACKEND MATCHES "^(serial)$")
     target_compile_definitions(oneDPL INTERFACE
         ONEDPL_USE_TBB_BACKEND=0
         ONEDPL_USE_DPCPP_BACKEND=0
+        ONEDPL_USE_OPENMP_BACKEND=0
         )
     message(STATUS "Compilation for the host due to serial backend")
 


### PR DESCRIPTION
Cherry-pick of #419 to release branch.

Signed-off-by: Zheltov, Sergey1 <sergey1.zheltov@intel.com>