### PR TITLE
Add inclusion of some files due to header dependency changes in GCC 11

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -16,8 +16,8 @@
 #ifndef _ONEDPL_parallel_backend_sycl_radix_sort_H
 #define _ONEDPL_parallel_backend_sycl_radix_sort_H
 
-#include <climits>
 #include <limits>
+
 #include "sycl_defs.h"
 #include "parallel_backend_sycl_utils.h"
 #include "execution_sycl_defs.h"
@@ -159,7 +159,7 @@ __convert_to_ordered(_T __value)
 {
     __ordered_t<_T> __uvalue = *reinterpret_cast<__ordered_t<_T>*>(&__value);
     // check if value negative
-    __ordered_t<_T> __is_negative = __uvalue >> (sizeof(_T) * CHAR_BIT - 1);
+    __ordered_t<_T> __is_negative = __uvalue >> (sizeof(_T) * std::numeric_limits<unsigned char>::digits - 1);
     // for positive: 00..00 -> 00..00 -> 10..00
     // for negative: 00..01 -> 11..11 -> 11..11
     __ordered_t<_T> __ordered_mask =
@@ -205,7 +205,7 @@ template <typename _T>
 constexpr ::std::uint32_t
 __get_buckets_in_type(::std::uint32_t __radix_bits)
 {
-    return (sizeof(_T) * CHAR_BIT) / __radix_bits;
+    return (sizeof(_T) * std::numeric_limits<unsigned char>::digits) / __radix_bits;
 }
 
 // required for descending comparator support

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -17,7 +17,7 @@
 #define _ONEDPL_parallel_backend_sycl_radix_sort_H
 
 #include <climits>
-
+#include <limits>
 #include "sycl_defs.h"
 #include "parallel_backend_sycl_utils.h"
 #include "execution_sycl_defs.h"

--- a/test/parallel_api/iterator/iterators.pass.cpp
+++ b/test/parallel_api/iterator/iterators.pass.cpp
@@ -25,6 +25,7 @@
 #include <iostream>
 #include <algorithm>
 #include <numeric>
+#include <limits>
 #include <type_traits>
 #include <forward_list>
 


### PR DESCRIPTION
> Header dependency changes
Some C++ Standard Library headers have been changed to no longer include other headers that they do need to depend on. As such, C++ programs that used standard library components without including the right headers will no longer compile.
The following headers are used less widely in libstdc++ and may need to be included explicitly when compiled with GCC 11: 
"limits" (for std::numeric_limits) (ect.)

See more [here](https://gcc.gnu.org/gcc-11/porting_to.html) .
Due to these changes in GCC 11, functional test iterators.pass are failing now on Fedora34.