### PR TITLE
Add support for USM device memory for reduce_by_segment algorithm

### DIFF
--- a/include/oneapi/dpl/internal/reduce_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/reduce_by_segment_impl.h
@@ -161,24 +161,9 @@ reduce_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIterator1 la
 
     namespace __bknd = __par_backend_hetero;
 
-    ValueType initial_value;
-    {
-        auto first2_acc = internal::get_access<sycl::access::mode::read>(policy, first2);
-        initial_value = first2_acc[0];
-    }
-
     const auto n = ::std::distance(first1, last1);
     if (n <= 0)
         return ::std::make_pair(result1, result2);
-    else if (n == 1)
-    {
-        auto result1_acc = internal::get_access<sycl::access::mode::write>(policy, result1);
-        auto result2_acc = internal::get_access<sycl::access::mode::write>(policy, result2);
-        auto first1_acc = internal::get_access<sycl::access::mode::read>(policy, first1);
-        result1_acc[0] = first1_acc[0];
-        result2_acc[0] = initial_value;
-        return ::std::make_pair(result1 + 1, result2 + 1);
-    }
 
     auto keep_keys = __ranges::__get_sycl_range<__bknd::access_mode::read, InputIterator1>();
     auto key_buf = keep_keys(first1, last1);

--- a/include/oneapi/dpl/internal/reduce_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/reduce_by_segment_impl.h
@@ -162,8 +162,6 @@ reduce_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIterator1 la
     namespace __bknd = __par_backend_hetero;
 
     const auto n = ::std::distance(first1, last1);
-    if (n <= 0)
-        return ::std::make_pair(result1, result2);
 
     auto keep_keys = __ranges::__get_sycl_range<__bknd::access_mode::read, InputIterator1>();
     auto key_buf = keep_keys(first1, last1);

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -594,6 +594,7 @@ __pattern_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2
     {
         __brick_copy<_ExecutionPolicy> __copy_range{};
 
+        // We use 2 and 3 as the kernel names because 0 and 1 are already used by other kernel calls in algorithm implementation
         oneapi::dpl::__internal::__ranges::__pattern_walk_n<2>(::std::forward<_ExecutionPolicy>(__exec), __copy_range,
                                                                ::std::forward<_Range1>(__keys),
                                                                ::std::forward<_Range3>(__out_keys));

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -585,8 +585,25 @@ __pattern_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2
     //          __out_keys   = { 1, 2, 3, 4, 1, 3, 1, 3, 0 }
     //          __out_values = { 1, 2, 3, 4, 2, 6, 2, 6, 0 }
 
-    if (__keys.empty())
+    const auto __n = __keys.size();
+
+    if (__n == 0)
         return 0;
+
+    if (__n == 1)
+    {
+        __brick_copy<_ExecutionPolicy> __copy_range{};
+
+        oneapi::dpl::__internal::__ranges::__pattern_walk_n<2>(::std::forward<_ExecutionPolicy>(__exec), __copy_range,
+                                                               ::std::forward<_Range1>(__keys),
+                                                               ::std::forward<_Range3>(__out_keys));
+
+        oneapi::dpl::__internal::__ranges::__pattern_walk_n<3>(::std::forward<_ExecutionPolicy>(__exec), __copy_range,
+                                                               ::std::forward<_Range2>(__values),
+                                                               ::std::forward<_Range4>(__out_values));
+
+        return 1;
+    }
 
     using __diff_type = oneapi::dpl::__internal::__difference_t<_Range1>;
     using __key_type = oneapi::dpl::__internal::__value_t<_Range1>;
@@ -595,7 +612,6 @@ __pattern_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2
     // Round 1: reduce with extra indices added to avoid long segments
     // TODO: At threshold points check if the key is equal to the key at the previous threshold point, indicating a long sequence.
     // Skip a round of copy_if and reduces if there are none.
-    auto __n = __keys.size();
     auto __idx = oneapi::dpl::__par_backend_hetero::__internal::__buffer<_ExecutionPolicy, __diff_type>(__exec, __n)
                      .get_buffer();
     auto __tmp_out_keys =


### PR DESCRIPTION
Add support for USM device memory for reduce_by_segment algorithm:
 - stop working with input data on the host because we can't rely that the it is always accessible (can be allocated on the device).