### PR TITLE
[dpc++] A hot fix for OneDPL, usage of accessor::get_pointer -  take into account "offset"

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -52,7 +52,7 @@ class all_view
     return_t*
     begin() const
     {
-        return m_acc.get_pointer();
+        return &m_acc[0];
     } //or “honest” iterator over an accessor and a sentinel
 
     return_t*

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -323,7 +323,7 @@ typename ::std::iterator_traits<Iter>::pointer
 get_host_pointer(Iter it)
 {
     auto temp_idx = it - oneapi::dpl::begin(it.get_buffer());
-    return it.get_buffer().template get_access<mode>().get_pointer() + temp_idx;
+    return &it.get_buffer().template get_access<mode>()[0] + temp_idx;
 }
 
 template <typename T, int Dim, sycl::access::mode AccMode, sycl::access::target AccTarget,
@@ -331,7 +331,7 @@ template <typename T, int Dim, sycl::access::mode AccMode, sycl::access::target 
 T*
 get_host_pointer(sycl::accessor<T, Dim, AccMode, AccTarget, Placeholder>& acc)
 {
-    return acc.get_pointer();
+    return &acc[0];
 }
 
 // for USM pointers


### PR DESCRIPTION
[dpc++] A hot fix for OneDPL, usage of accessor::get_pointer; + take into account "offset", according to SYCL 2020 spec.
Eventually,  just a couple of places in OneDPL code had to be corrected. In the rest places an accessor doesn't have offset. 