### PR TITLE
Fix error in exclusive_scan_by_segment algorithm for USM device memory

### DIFF
--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -107,14 +107,6 @@ exclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIter
     if (n <= 0)
         return result;
 
-    // Check for single element ranges
-    if (n == 1)
-    {
-        auto result_acc = internal::get_access<sycl::access::mode::write>(policy, result);
-        result_acc[0] = init;
-        return result + 1;
-    }
-
     typedef typename ::std::iterator_traits<OutputIterator>::value_type OutputType;
     typedef typename ::std::iterator_traits<InputIterator2>::value_type ValueType;
     typedef unsigned int FlagType;

--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -103,9 +103,11 @@ exclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIter
 {
     const auto n = ::std::distance(first1, last1);
 
-    // Check for empty and single element ranges
+    // Check for empty element ranges
     if (n <= 0)
         return result;
+
+    // Check for single element ranges
     if (n == 1)
     {
         auto result_acc = internal::get_access<sycl::access::mode::write>(policy, result);

--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -47,7 +47,7 @@ exclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIter
     // Check for empty and single element ranges
     if (n <= 0)
         return result;
-    else if (n == 1)
+    if (n == 1)
     {
         *result = init;
         return result + 1;
@@ -106,7 +106,7 @@ exclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIter
     // Check for empty and single element ranges
     if (n <= 0)
         return result;
-    else if (n == 1)
+    if (n == 1)
     {
         auto result_acc = internal::get_access<sycl::access::mode::write>(policy, result);
         result_acc[0] = init;


### PR DESCRIPTION
Fixed crash in exclusive_scan_by_segment algorithm for the case when we use algo with USM device memory and count of items equal to 1. Now in this case we don't copy data on a host from USM device memory in exclusive_scan_by_segment_impl function and call hetero algo implementation.