### PR TITLE
Remove extra element_type trait from ForwardIterator

### DIFF
--- a/test/support/iterator_utils.h
+++ b/test/support/iterator_utils.h
@@ -37,7 +37,6 @@ class ForwardIterator
 
   protected:
     Iterator my_iterator;
-    typedef value_type element_type;
 
   public:
     ForwardIterator() = default;
@@ -356,9 +355,9 @@ struct iterator_invoker
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::bidirectional_iterator_tag, 
+    typename ::std::enable_if<is_base_of_iterator_category<::std::bidirectional_iterator_tag,
                                             Iterator>::value, void>::type
-    operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n, 
+    operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n,
         Iterator expected, Rest&&... rest)
     {
         op(exec, make_iterator<Iterator>()(begin), n, make_iterator<Iterator>()(expected), ::std::forward<Rest>(rest)...);


### PR DESCRIPTION
The trait causes the following issue with VS 2019 and c++20:
```c++
In file included from test\parallel_api\algorithm\alg.nonmodifying\for_each.pass.cpp:18:
In file included from include\oneapi/dpl/execution:23:
In file included from C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.29.30133\include\execution:15:
In file included from C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.29.30133\include\algorithm:11:
In file included from C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.29.30133\include\xmemory:16:
C:\Program Files (x86)\Microsoft Visual Studio\2019\Professional\VC\Tools\MSVC\14.29.30133\include\xutility(436,85): error: 'element_type' is a protected member of 'TestUtils::ForwardIterator<std::_Vector_iterator<std::_Vector_val<std::_Simple_types<int>>>, std::bidirectional_iterator_tag>'
         && same_as<remove_cv_t<typename _Ty::value_type>, remove_cv_t<typename _Ty::element_type>>
```
Let's remove `element_type` because it is not used in the tests and is not required according to c++ standard (see https://en.cppreference.com/w/cpp/named_req/Iterator).
