### PR TITLE
CMake: disable tests by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,8 @@ jobs:
             make_targets="sycl_iterator.pass"
             ctest_flags="-R sycl_iterator.pass"
             echo "::warning::dpcpp backend is set. Compile and run only sycl_iterator.pass"
+          else
+            make_targets="build-all-tests"
           fi
           mkdir build && cd build
           lscpu
@@ -222,6 +224,9 @@ jobs:
             set ninja_targets=sycl_iterator.pass
             set ctest_flags=-R sycl_iterator.pass
             echo ::warning::dpcpp backend is set. Compile and run only sycl_iterator.pass
+          )
+          ELSE (
+            set ninja_targets=build-all-tests
           )
           IF "${{ matrix.cxx_compiler }}" == "dpcpp" (
             powershell $output = dpcpp --version; Write-Host ::warning::Compiler: $output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,5 +279,5 @@ jobs:
           mkdir build && cd build
           cmake -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DONEDPL_BACKEND=${{ matrix.backend }} ..
-          make VERBOSE=1 -j${MACOS_BUILD_CONCURRENCY}
+          make VERBOSE=1 build-all-tests -j${MACOS_BUILD_CONCURRENCY}
           ctest --timeout ${TEST_TIMEOUT} --output-on-failure -E "${EXCLUDE_FROM_TESTING}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,7 @@ jobs:
             ctest_flags="-R sycl_iterator.pass"
             echo "::warning::dpcpp backend is set. Compile and run only sycl_iterator.pass"
           else
-            make_targets="build-all-tests"
+            make_targets="build-onedpl-tests"
           fi
           mkdir build && cd build
           lscpu
@@ -226,7 +226,7 @@ jobs:
             echo ::warning::dpcpp backend is set. Compile and run only sycl_iterator.pass
           )
           ELSE (
-            set ninja_targets=build-all-tests
+            set ninja_targets=build-onedpl-tests
           )
           IF "${{ matrix.cxx_compiler }}" == "dpcpp" (
             powershell $output = dpcpp --version; Write-Host ::warning::Compiler: $output
@@ -279,5 +279,5 @@ jobs:
           mkdir build && cd build
           cmake -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DONEDPL_BACKEND=${{ matrix.backend }} ..
-          make VERBOSE=1 build-all-tests -j${MACOS_BUILD_CONCURRENCY}
+          make VERBOSE=1 build-onedpl-tests -j${MACOS_BUILD_CONCURRENCY}
           ctest --timeout ${TEST_TIMEOUT} --output-on-failure -E "${EXCLUDE_FROM_TESTING}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,8 +265,11 @@ target_include_directories(oneDPL
 ###############################################################################
 # Setup tests
 ###############################################################################
-enable_testing()
-add_subdirectory(test)
+get_directory_property(_onedpl_is_subproject PARENT_DIRECTORY)
+if (NOT _onedpl_is_subproject)
+    enable_testing()
+    add_subdirectory(test)
+endif()
 
 ###############################################################################
 # Installation instructions

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -28,17 +28,18 @@ Some useful CMake variables ([here](https://cmake.org/cmake/help/latest/manual/c
 Steps:
 
 1. Configure project using CMake.
-2. Perform build [and run] using build system (e.g. `make`).
+2. Perform build [and run] using build system (e.g. `make build-all-tests`).
 3. (optional) Run tests using CTest.
 
+**NOTE**: tests are not added to `all` target, so they are not built/run by default.
 The following targets are available for build system after configuration:
 
 - `<test-name>` - build specific test, e.g. `for_each.pass`;
 - `run-<test-name>` - build and run specific test, e.g. `run-for_each.pass`;
-- `build-<tests-subdir>` - build all tests from specific subdirectory under `<root>/test`, e.g. `build-std`;
-- `run-<tests-subdir>` - build and run all tests from specific subdirectory under `<root>/test`, e.g. `run-std`;
-- `build-all` - build all tests;
-- `run-all` - build and run all tests.
+- `build-<tests-subdir>` - build all tests from specific subdirectory under `<root>/test`, e.g. `build-general`;
+- `run-<tests-subdir>` - build and run all tests from specific subdirectory under `<root>/test`, e.g. `run-general`;
+- `build-all-tests` - build all tests;
+- `run-all-tests` - build and run all tests.
 
 Sudirectories are added as labels for each test and can be used with `ctest -L <label>`.
 For example, `<root>/test/path/to/test.pass.cpp` will have `path` and `to` labels.
@@ -65,6 +66,8 @@ set(ONEDPL_BACKEND tbb)
 # Add oneDPL to the build.
 add_subdirectory(/path/to/oneDPL build_oneDPL)
 ```
+
+oneDPL tests are not configured if oneDPL in such scenario. So they can't be built and run in this case.
 
 ### Using oneDPL package
 

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -28,7 +28,7 @@ Some useful CMake variables ([here](https://cmake.org/cmake/help/latest/manual/c
 Steps:
 
 1. Configure project using CMake.
-2. Perform build [and run] using build system (e.g. `make build-all-tests`).
+2. Perform build [and run] using build system (e.g. `make build-onedpl-tests`).
 3. (optional) Run tests using CTest.
 
 **NOTE**: tests are not added to `all` target, so they are not built/run by default.
@@ -36,10 +36,10 @@ The following targets are available for build system after configuration:
 
 - `<test-name>` - build specific test, e.g. `for_each.pass`;
 - `run-<test-name>` - build and run specific test, e.g. `run-for_each.pass`;
-- `build-<tests-subdir>` - build all tests from specific subdirectory under `<root>/test`, e.g. `build-general`;
-- `run-<tests-subdir>` - build and run all tests from specific subdirectory under `<root>/test`, e.g. `run-general`;
-- `build-all-tests` - build all tests;
-- `run-all-tests` - build and run all tests.
+- `build-onedpl-<tests-subdir>-tests` - build all tests from specific subdirectory under `<root>/test`, e.g. `build-onedpl-general-tests`;
+- `run-onedpl-<tests-subdir>-tests` - build and run all tests from specific subdirectory under `<root>/test`, e.g. `run-onedpl-general-tests`;
+- `build-onedpl-tests` - build all tests;
+- `run-onedpl-tests` - build and run all tests.
 
 Sudirectories are added as labels for each test and can be used with `ctest -L <label>`.
 For example, `<root>/test/path/to/test.pass.cpp` will have `path` and `to` labels.

--- a/jenkinsfiles/RHEL_Check.groovy
+++ b/jenkinsfiles/RHEL_Check.groovy
@@ -258,7 +258,7 @@ pipeline {
                                                 export PATH=/usr/bin/:$PATH
                                                 dpcpp --version
                                                 cmake -DCMAKE_CXX_COMPILER=dpcpp -DCMAKE_CXX_STANDARD=17 -DONEDPL_BACKEND=dpcpp -DONEDPL_DEVICE_TYPE=GPU -DCMAKE_BUILD_TYPE=release ..
-                                                make VERBOSE=1 build-all-tests -j`nproc` -k || true
+                                                make VERBOSE=1 build-onedpl-tests -j`nproc` -k || true
                                                 ctest --output-on-failure --timeout ${TEST_TIMEOUT}
                                             """, label: "all tests"
                                         }

--- a/jenkinsfiles/RHEL_Check.groovy
+++ b/jenkinsfiles/RHEL_Check.groovy
@@ -258,7 +258,7 @@ pipeline {
                                                 export PATH=/usr/bin/:$PATH
                                                 dpcpp --version
                                                 cmake -DCMAKE_CXX_COMPILER=dpcpp -DCMAKE_CXX_STANDARD=17 -DONEDPL_BACKEND=dpcpp -DONEDPL_DEVICE_TYPE=GPU -DCMAKE_BUILD_TYPE=release ..
-                                                make VERBOSE=1 build-all -j`nproc` -k || true
+                                                make VERBOSE=1 build-all-tests -j`nproc` -k || true
                                                 ctest --output-on-failure --timeout ${TEST_TIMEOUT}
                                             """, label: "all tests"
                                         }

--- a/jenkinsfiles/UB18_Check.groovy
+++ b/jenkinsfiles/UB18_Check.groovy
@@ -262,7 +262,7 @@ pipeline {
                                             sh script: """
                                                 rm -rf *
                                                 cmake -DCMAKE_CXX_COMPILER=icpx -DCMAKE_CXX_STANDARD=17 -DONEDPL_BACKEND=tbb -DONEDPL_DEVICE_TYPE=HOST -DCMAKE_BUILD_TYPE=release ..
-                                                make VERBOSE=1 build-all -j`nproc` -k || true
+                                                make VERBOSE=1 build-all-tests -j`nproc` -k || true
                                                 ctest --output-on-failure --timeout ${TEST_TIMEOUT}
 
                                             """, label: "All tests"

--- a/jenkinsfiles/UB18_Check.groovy
+++ b/jenkinsfiles/UB18_Check.groovy
@@ -262,7 +262,7 @@ pipeline {
                                             sh script: """
                                                 rm -rf *
                                                 cmake -DCMAKE_CXX_COMPILER=icpx -DCMAKE_CXX_STANDARD=17 -DONEDPL_BACKEND=tbb -DONEDPL_DEVICE_TYPE=HOST -DCMAKE_BUILD_TYPE=release ..
-                                                make VERBOSE=1 build-all-tests -j`nproc` -k || true
+                                                make VERBOSE=1 build-onedpl-tests -j`nproc` -k || true
                                                 ctest --output-on-failure --timeout ${TEST_TIMEOUT}
 
                                             """, label: "All tests"

--- a/jenkinsfiles/UB20_Check.groovy
+++ b/jenkinsfiles/UB20_Check.groovy
@@ -241,7 +241,7 @@ pipeline {
                                                 rm -rf *
                                                 dpcpp --version
                                                 cmake -DCMAKE_CXX_COMPILER=dpcpp -DCMAKE_CXX_STANDARD=17 -DONEDPL_BACKEND=dpcpp -DONEDPL_DEVICE_TYPE=CPU -DCMAKE_BUILD_TYPE=release ..
-                                                make VERBOSE=1 build-all-tests -j`nproc` -k || true
+                                                make VERBOSE=1 build-onedpl-tests -j`nproc` -k || true
                                                 ctest --output-on-failure --timeout ${TEST_TIMEOUT}
                                             """, label: "All tests"
                                         }
@@ -274,7 +274,7 @@ pipeline {
                                             sh script: """
                                                 rm -rf *
                                                 cmake -DCMAKE_CXX_COMPILER=g++ -DCMAKE_CXX_STANDARD=11 -DONEDPL_BACKEND=tbb -DONEDPL_DEVICE_TYPE=HOST -DCMAKE_BUILD_TYPE=release ..
-                                                make VERBOSE=1 build-all-tests -j`nproc` -k || true
+                                                make VERBOSE=1 build-onedpl-tests -j`nproc` -k || true
                                                 ctest --output-on-failure --timeout ${TEST_TIMEOUT}
                                             """, label: "All tests"
                                         }

--- a/jenkinsfiles/UB20_Check.groovy
+++ b/jenkinsfiles/UB20_Check.groovy
@@ -274,7 +274,7 @@ pipeline {
                                             sh script: """
                                                 rm -rf *
                                                 cmake -DCMAKE_CXX_COMPILER=g++ -DCMAKE_CXX_STANDARD=11 -DONEDPL_BACKEND=tbb -DONEDPL_DEVICE_TYPE=HOST -DCMAKE_BUILD_TYPE=release ..
-                                                make VERBOSE=1 build-all -j`nproc` -k || true
+                                                make VERBOSE=1 build-all-tests -j`nproc` -k || true
                                                 ctest --output-on-failure --timeout ${TEST_TIMEOUT}
                                             """, label: "All tests"
                                         }

--- a/jenkinsfiles/UB20_Check.groovy
+++ b/jenkinsfiles/UB20_Check.groovy
@@ -241,7 +241,7 @@ pipeline {
                                                 rm -rf *
                                                 dpcpp --version
                                                 cmake -DCMAKE_CXX_COMPILER=dpcpp -DCMAKE_CXX_STANDARD=17 -DONEDPL_BACKEND=dpcpp -DONEDPL_DEVICE_TYPE=CPU -DCMAKE_BUILD_TYPE=release ..
-                                                make VERBOSE=1 build-all -j`nproc` -k || true
+                                                make VERBOSE=1 build-all-tests -j`nproc` -k || true
                                                 ctest --output-on-failure --timeout ${TEST_TIMEOUT}
                                             """, label: "All tests"
                                         }

--- a/jenkinsfiles/Windows_Check.groovy
+++ b/jenkinsfiles/Windows_Check.groovy
@@ -316,7 +316,7 @@ pipeline {
                                                 """, label: "Generate"
                                                 bat script: """
                                                     set MAKE_PROGRAM=%DevEnvDir%CommonExtensions\\Microsoft\\CMake\\Ninja\\ninja.exe
-                                                    "%MAKE_PROGRAM%" build-all -v -k 0
+                                                    "%MAKE_PROGRAM%" build-all-tests -v -k 0
                                                 """, label: "Build"
                                                 bat script: """
                                                     ctest --output-on-failure -C release --timeout %TEST_TIMEOUT%
@@ -360,7 +360,7 @@ pipeline {
                                                 """, label: "Generate"
                                                 bat script: """
                                                     set MAKE_PROGRAM=%DevEnvDir%CommonExtensions\\Microsoft\\CMake\\Ninja\\ninja.exe
-                                                    "%MAKE_PROGRAM%" build-all -v -k 0
+                                                    "%MAKE_PROGRAM%" build-all-tests -v -k 0
                                                 """, label: "Build"
                                                 bat script: """
                                                     ctest --output-on-failure -C release --timeout %TEST_TIMEOUT%

--- a/jenkinsfiles/Windows_Check.groovy
+++ b/jenkinsfiles/Windows_Check.groovy
@@ -316,7 +316,7 @@ pipeline {
                                                 """, label: "Generate"
                                                 bat script: """
                                                     set MAKE_PROGRAM=%DevEnvDir%CommonExtensions\\Microsoft\\CMake\\Ninja\\ninja.exe
-                                                    "%MAKE_PROGRAM%" build-all-tests -v -k 0
+                                                    "%MAKE_PROGRAM%" build-onedpl-tests -v -k 0
                                                 """, label: "Build"
                                                 bat script: """
                                                     ctest --output-on-failure -C release --timeout %TEST_TIMEOUT%
@@ -360,7 +360,7 @@ pipeline {
                                                 """, label: "Generate"
                                                 bat script: """
                                                     set MAKE_PROGRAM=%DevEnvDir%CommonExtensions\\Microsoft\\CMake\\Ninja\\ninja.exe
-                                                    "%MAKE_PROGRAM%" build-all-tests -v -k 0
+                                                    "%MAKE_PROGRAM%" build-onedpl-tests -v -k 0
                                                 """, label: "Build"
                                                 bat script: """
                                                     ctest --output-on-failure -C release --timeout %TEST_TIMEOUT%

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -21,7 +21,7 @@ add_custom_target(build-onedpl-tests
 add_custom_target(run-onedpl-tests
     COMMAND "${CMAKE_CTEST_COMMAND}" --output-on-failure
     USES_TERMINAL
-    DEPENDS build-all
+    DEPENDS build-onedpl-tests
     COMMENT "Build and run all oneDPL tests")
 
 macro(onedpl_add_test test_source_file)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,20 +15,20 @@
 set (ranlux_24_48_test.pass_timeout_debug "900") # 15min
 set (ranlux_24_48_test.pass_timeout_release "720") # 12min
 
-add_custom_target(build-all
-    COMMENT "Build all the pstl tests.")
+add_custom_target(build-all-tests
+    COMMENT "Build all oneDPL tests")
 
-add_custom_target(run-all
+add_custom_target(run-all-tests
     COMMAND "${CMAKE_CTEST_COMMAND}" --output-on-failure
     USES_TERMINAL
     DEPENDS build-all
-    COMMENT "Build and run all the unit tests.")
+    COMMENT "Build and run all oneDPL tests")
 
 macro(onedpl_add_test test_source_file)
     get_filename_component(_test_name ${test_source_file} NAME)
     string(REPLACE "\.cpp" "" _test_name ${_test_name})
 
-    add_executable(${_test_name} "${test_source_file}")
+    add_executable(${_test_name} EXCLUDE_FROM_ALL "${test_source_file}")
     target_compile_definitions(${_test_name} PRIVATE _PSTL_TEST_SUCCESSFUL_KEYWORD=1)
     if (MSVC)
         target_compile_options(${_test_name} PRIVATE /bigobj)
@@ -97,7 +97,7 @@ macro(onedpl_add_test test_source_file)
         endif()
         add_dependencies(build-${_label} ${_test_name})
     endforeach()
-    add_dependencies(build-all ${_test_name})
+    add_dependencies(build-all-tests ${_test_name})
 endmacro()
 
 set(_skip_regex_for_not_dpcpp "(xpu_api/algorithms|xpu_api/functional|xpu_api/numerics)")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,10 +15,10 @@
 set (ranlux_24_48_test.pass_timeout_debug "900") # 15min
 set (ranlux_24_48_test.pass_timeout_release "720") # 12min
 
-add_custom_target(build-all-tests
+add_custom_target(build-onedpl-tests
     COMMENT "Build all oneDPL tests")
 
-add_custom_target(run-all-tests
+add_custom_target(run-onedpl-tests
     COMMAND "${CMAKE_CTEST_COMMAND}" --output-on-failure
     USES_TERMINAL
     DEPENDS build-all
@@ -86,18 +86,18 @@ macro(onedpl_add_test test_source_file)
     endif()
 
     foreach (_label ${_test_labels})
-        if (NOT TARGET build-${_label})
-            add_custom_target(build-${_label} COMMENT "Build tests with label ${_label}")
+        if (NOT TARGET build-onedpl-${_label}-tests)
+            add_custom_target(build-onedpl-${_label}-tests COMMENT "Build tests with label ${_label}")
 
-            add_custom_target(run-${_label}
+            add_custom_target(run-onedpl-${_label}-tests
                 COMMAND "${CMAKE_CTEST_COMMAND}" -L ^${_label}$$ --output-on-failure --no-label-summary
                 USES_TERMINAL
-                DEPENDS build-${_label}
+                DEPENDS build-onedpl-${_label}-tests
                 COMMENT "Build and run tests with label ${_label}")
         endif()
-        add_dependencies(build-${_label} ${_test_name})
+        add_dependencies(build-onedpl-${_label}-tests ${_test_name})
     endforeach()
-    add_dependencies(build-all-tests ${_test_name})
+    add_dependencies(build-onedpl-tests ${_test_name})
 endmacro()
 
 set(_skip_regex_for_not_dpcpp "(xpu_api/algorithms|xpu_api/functional|xpu_api/numerics)")


### PR DESCRIPTION
Signed-off-by: Veprev, Alexey <alexey.veprev@intel.com>

This PR is inspired by #463.

It implements the following:
1. Disables tests configuration if oneDPL is subproject;
2. Removes test targets from `all` target: now tests are not built by default with just `make`, you need to explicitly run `make build-onedpl-tests`

Additional change: targets for tests in subfolders are renamed: `build-onedpl-<subfolder>-tests`

More details are added into cmake/README.md
CI correction were applied, you can see examples there.

@rarutyun @akukanov please take a look.
@alexey-katranov I'd consider the similar approach for oneTBB, but with additional user option TBB_TEST that is already in place.

For oneDPL I don't think the explicit option is useful.