### PR TITLE
Restore backward compatibility with the older compiler (library only)

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -55,13 +55,26 @@ using __no_init =
     sycl::property::noinit;
 #endif
 
-template <typename _T>
-using __plus =
 #if _ONEDPL_SYCL2020_FUNCTIONAL_OBJECTS_PRESENT
-    sycl::plus<_T>;
+template <typename _T>
+using __plus = sycl::plus<_T>;
+
+template <typename _T>
+using __maximum = sycl::maximum<_T>;
+
+template <typename _T>
+using __minimum = sycl::minimum<_T>;
+
 #else
-    sycl::ONEAPI::plus<_T>;
-#endif
+template <typename _T>
+using __plus = sycl::ONEAPI::plus<_T>;
+
+template <typename _T>
+using __maximum = sycl::ONEAPI::maximum<_T>;
+
+template <typename _T>
+using __minimum = sycl::ONEAPI::minimum<_T>;
+#endif // _ONEDPL_SYCL2020_FUNCTIONAL_OBJECTS_PRESENT
 
 template <typename _Buffer>
 constexpr auto
@@ -92,7 +105,7 @@ __group_barrier(_Item __item)
 #if 0 //__LIBSYCL_VERSION >= 50300
     //TODO: usage of sycl::group_barrier: probably, we have to revise SYCL parallel patterns which use a group_barrier.
     // 1) sycl::group_barrier() implementation is not ready
-    // 2) sycl::group_barrier and sycl::item::group_barrier are not quite equivalent 
+    // 2) sycl::group_barrier and sycl::item::group_barrier are not quite equivalent
     sycl::group_barrier(__item.get_group(), sycl::memory_scope::work_group);
 #else
     __item.barrier(sycl::access::fence_space::local_space);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -63,7 +63,7 @@ using __known_identity = sycl::known_identity<_BinaryOp, _T>;
 template <typename _BinaryOp, typename _T>
 using __has_known_identity = sycl::has_known_identity<_BinaryOp, _T>;
 
-#else  // _ONEDPL_SYCL2020_KNOWN_IDENTITY_PRESENT
+#elif __LIBSYCL_VERSION == 50200
 template <typename _BinaryOp, typename _T>
 using __known_identity = sycl::ONEAPI::known_identity<_BinaryOp, _T>;
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -43,6 +43,7 @@
 #define _ONEDPL_NO_INIT_PRESENT (__LIBSYCL_VERSION >= 50300)
 #define _ONEDPL_KERNEL_BUNDLE_PRESENT (__LIBSYCL_VERSION >= 50300)
 #define _ONEDPL_SYCL2020_COLLECTIVES_PRESENT (__LIBSYCL_VERSION >= 50300)
+#define _ONEDPL_SYCL2020_KNOWN_IDENTITY_PRESENT (__LIBSYCL_VERSION >= 50300)
 #define _ONEDPL_SYCL2020_FUNCTIONAL_OBJECTS_PRESENT (__LIBSYCL_VERSION >= 50300)
 
 namespace __dpl_sycl
@@ -55,6 +56,21 @@ using __no_init =
     sycl::property::noinit;
 #endif
 
+#if _ONEDPL_SYCL2020_KNOWN_IDENTITY_PRESENT
+template <typename _BinaryOp, typename _T>
+using __known_identity = sycl::known_identity<_BinaryOp, _T>;
+
+template <typename _BinaryOp, typename _T>
+using __has_known_identity = sycl::has_known_identity<_BinaryOp, _T>;
+
+#else  // _ONEDPL_SYCL2020_KNOWN_IDENTITY_PRESENT
+template <typename _BinaryOp, typename _T>
+using __known_identity = sycl::ONEAPI::known_identity<_BinaryOp, _T>;
+
+template <typename _BinaryOp, typename _T>
+using __has_known_identity = sycl::ONEAPI::has_known_identity<_BinaryOp, _T>;
+#endif // _ONEDPL_SYCL2020_KNOWN_IDENTITY_PRESENT
+
 #if _ONEDPL_SYCL2020_FUNCTIONAL_OBJECTS_PRESENT
 template <typename _T>
 using __plus = sycl::plus<_T>;
@@ -65,7 +81,7 @@ using __maximum = sycl::maximum<_T>;
 template <typename _T>
 using __minimum = sycl::minimum<_T>;
 
-#else
+#else  // _ONEDPL_SYCL2020_FUNCTIONAL_OBJECTS_PRESENT
 template <typename _T>
 using __plus = sycl::ONEAPI::plus<_T>;
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -45,14 +45,14 @@ using __has_known_identity =
     typename ::std::conjunction<
         ::std::is_arithmetic<_Tp>, __dpl_sycl::__has_known_identity<_BinaryOp, _Tp>,
         ::std::disjunction<::std::is_same<typename ::std::decay<_BinaryOp>::type, ::std::plus<_Tp>>,
-                           ::std::is_same<typename ::std::decay<_BinaryOp>::type, sycl::plus<_Tp>>,
-                           ::std::is_same<typename ::std::decay<_BinaryOp>::type, sycl::minimum<_Tp>>,
-                           ::std::is_same<typename ::std::decay<_BinaryOp>::type, sycl::maximum<_Tp>>>>;
+                           ::std::is_same<typename ::std::decay<_BinaryOp>::type, __dpl_sycl::__plus<_Tp>>,
+                           ::std::is_same<typename ::std::decay<_BinaryOp>::type, __dpl_sycl::__minimum<_Tp>>,
+                           ::std::is_same<typename ::std::decay<_BinaryOp>::type, __dpl_sycl::__maximum<_Tp>>>>;
 #    else  //__LIBSYCL_VERSION >= 50200
     typename ::std::conjunction<
         ::std::is_arithmetic<_Tp>,
         ::std::disjunction<::std::is_same<typename ::std::decay<_BinaryOp>::type, ::std::plus<_Tp>>,
-                           ::std::is_same<typename ::std::decay<_BinaryOp>::type, sycl::plus<_Tp>>>>;
+                           ::std::is_same<typename ::std::decay<_BinaryOp>::type, __dpl_sycl::__plus<_Tp>>>>;
 #    endif //__LIBSYCL_VERSION >= 50200
 
 #else //_USE_GROUP_ALGOS

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -52,7 +52,7 @@ using __has_known_identity =
     typename ::std::conjunction<
         ::std::is_arithmetic<_Tp>,
         ::std::disjunction<::std::is_same<typename ::std::decay<BinaryOp>::type, ::std::plus<_Tp>>,
-                           ::std::is_same<typename ::std::decay<BinaryOp>::type,  __dpl_sycl::__plus<_Tp>>>>;
+                           ::std::is_same<typename ::std::decay<BinaryOp>::type, __dpl_sycl::__plus<_Tp>>>>;
 #    endif //__LIBSYCL_VERSION >= 50200
 
 #else //_USE_GROUP_ALGOS

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -39,42 +39,42 @@ using non_void_type = typename ::std::enable_if<!::std::is_void<_Tp>::value, _Tp
 //TODO: To change __has_known_identity implementation as soon as the DPC++ compiler implementation issues related to
 //std::multiplies, std::bit_or, std::bit_and and std::bit_xor operations will be fixed.
 //std::logical_and and std::logical_or are not supported in DPC++ compiler to be used in sycl::inclusive_scan_over_group and sycl::reduce_over_group
-template <typename BinaryOp, typename _Tp>
+template <typename _BinaryOp, typename _Tp>
 using __has_known_identity =
-#    if __LIBSYCL_VERSION >= 50300
+#    if __LIBSYCL_VERSION >= 50200
     typename ::std::conjunction<
-        ::std::is_arithmetic<_Tp>, sycl::has_known_identity<BinaryOp, _Tp>,
-        ::std::disjunction<::std::is_same<typename ::std::decay<BinaryOp>::type, ::std::plus<_Tp>>,
-                           ::std::is_same<typename ::std::decay<BinaryOp>::type, __dpl_sycl::__plus<_Tp>>,
-                           ::std::is_same<typename ::std::decay<BinaryOp>::type, __dpl_sycl::__minimum<_Tp>>,
-                           ::std::is_same<typename ::std::decay<BinaryOp>::type, __dpl_sycl::__maximum<_Tp>>>>;
-#    else  //__LIBSYCL_VERSION >= 50300
+        ::std::is_arithmetic<_Tp>, __dpl_sycl::__has_known_identity<_BinaryOp, _Tp>,
+        ::std::disjunction<::std::is_same<typename ::std::decay<_BinaryOp>::type, ::std::plus<_Tp>>,
+                           ::std::is_same<typename ::std::decay<_BinaryOp>::type, sycl::plus<_Tp>>,
+                           ::std::is_same<typename ::std::decay<_BinaryOp>::type, sycl::minimum<_Tp>>,
+                           ::std::is_same<typename ::std::decay<_BinaryOp>::type, sycl::maximum<_Tp>>>>;
+#    else  //__LIBSYCL_VERSION >= 50200
     typename ::std::conjunction<
         ::std::is_arithmetic<_Tp>,
-        ::std::disjunction<::std::is_same<typename ::std::decay<BinaryOp>::type, ::std::plus<_Tp>>,
-                           ::std::is_same<typename ::std::decay<BinaryOp>::type, __dpl_sycl::__plus<_Tp>>>>;
-#    endif //__LIBSYCL_VERSION >= 50300
+        ::std::disjunction<::std::is_same<typename ::std::decay<_BinaryOp>::type, ::std::plus<_Tp>>,
+                           ::std::is_same<typename ::std::decay<_BinaryOp>::type, sycl::plus<_Tp>>>>;
+#    endif //__LIBSYCL_VERSION >= 50200
 
 #else //_USE_GROUP_ALGOS
 
-template <typename BinaryOp, typename _Tp>
+template <typename _BinaryOp, typename _Tp>
 using __has_known_identity = std::false_type;
 
 #endif //_USE_GROUP_ALGOS
 
-template <typename BinaryOp, typename _Tp>
+template <typename _BinaryOp, typename _Tp>
 struct __known_identity_for_plus
 {
-    static_assert(std::is_same_v<typename std::decay<BinaryOp>::type, std::plus<_Tp>>);
+    static_assert(std::is_same_v<typename std::decay<_BinaryOp>::type, std::plus<_Tp>>);
     static constexpr _Tp value = 0;
 };
 
-template <typename BinaryOp, typename _Tp>
+template <typename _BinaryOp, typename _Tp>
 inline constexpr _Tp __known_identity =
 #if __LIBSYCL_VERSION >= 50200
-    sycl::known_identity<BinaryOp, _Tp>::value;
+    __dpl_sycl::__known_identity<_BinaryOp, _Tp>::value;
 #else  //__LIBSYCL_VERSION >= 50200
-    __known_identity_for_plus<BinaryOp, _Tp>::value; //for plus only
+    __known_identity_for_plus<_BinaryOp, _Tp>::value; //for plus only
 #endif //__LIBSYCL_VERSION >= 50200
 
 // a way to get value_type from both accessors and USM that is needed for transform_init

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -41,19 +41,19 @@ using non_void_type = typename ::std::enable_if<!::std::is_void<_Tp>::value, _Tp
 //std::logical_and and std::logical_or are not supported in DPC++ compiler to be used in sycl::inclusive_scan_over_group and sycl::reduce_over_group
 template <typename BinaryOp, typename _Tp>
 using __has_known_identity =
-#    if __LIBSYCL_VERSION >= 50200
+#    if __LIBSYCL_VERSION >= 50300
     typename ::std::conjunction<
         ::std::is_arithmetic<_Tp>, sycl::has_known_identity<BinaryOp, _Tp>,
         ::std::disjunction<::std::is_same<typename ::std::decay<BinaryOp>::type, ::std::plus<_Tp>>,
                            ::std::is_same<typename ::std::decay<BinaryOp>::type, __dpl_sycl::__plus<_Tp>>,
                            ::std::is_same<typename ::std::decay<BinaryOp>::type, __dpl_sycl::__minimum<_Tp>>,
                            ::std::is_same<typename ::std::decay<BinaryOp>::type, __dpl_sycl::__maximum<_Tp>>>>;
-#    else  //__LIBSYCL_VERSION >= 50200
+#    else  //__LIBSYCL_VERSION >= 50300
     typename ::std::conjunction<
         ::std::is_arithmetic<_Tp>,
         ::std::disjunction<::std::is_same<typename ::std::decay<BinaryOp>::type, ::std::plus<_Tp>>,
                            ::std::is_same<typename ::std::decay<BinaryOp>::type, __dpl_sycl::__plus<_Tp>>>>;
-#    endif //__LIBSYCL_VERSION >= 50200
+#    endif //__LIBSYCL_VERSION >= 50300
 
 #else //_USE_GROUP_ALGOS
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -45,14 +45,14 @@ using __has_known_identity =
     typename ::std::conjunction<
         ::std::is_arithmetic<_Tp>, sycl::has_known_identity<BinaryOp, _Tp>,
         ::std::disjunction<::std::is_same<typename ::std::decay<BinaryOp>::type, ::std::plus<_Tp>>,
-                           ::std::is_same<typename ::std::decay<BinaryOp>::type, sycl::plus<_Tp>>,
-                           ::std::is_same<typename ::std::decay<BinaryOp>::type, sycl::minimum<_Tp>>,
-                           ::std::is_same<typename ::std::decay<BinaryOp>::type, sycl::maximum<_Tp>>>>;
+                           ::std::is_same<typename ::std::decay<BinaryOp>::type, __dpl_sycl::__plus<_Tp>>,
+                           ::std::is_same<typename ::std::decay<BinaryOp>::type, __dpl_sycl::__minimum<_Tp>>,
+                           ::std::is_same<typename ::std::decay<BinaryOp>::type, __dpl_sycl::__maximum<_Tp>>>>;
 #    else  //__LIBSYCL_VERSION >= 50200
     typename ::std::conjunction<
         ::std::is_arithmetic<_Tp>,
         ::std::disjunction<::std::is_same<typename ::std::decay<BinaryOp>::type, ::std::plus<_Tp>>,
-                           ::std::is_same<typename ::std::decay<BinaryOp>::type, sycl::plus<_Tp>>>>;
+                           ::std::is_same<typename ::std::decay<BinaryOp>::type,  __dpl_sycl::__plus<_Tp>>>>;
 #    endif //__LIBSYCL_VERSION >= 50200
 
 #else //_USE_GROUP_ALGOS


### PR DESCRIPTION
This fixes compilation issues with Intel oneAPI DPC++/C++ Compiler 2021.1.2