### PR TITLE
Avoid extra output from inclusive_scan_by_segment test

### DIFF
--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -29,6 +29,8 @@ using namespace oneapi::dpl::execution;
 #endif
 using namespace TestUtils;
 
+//#define DUMP_CHECK_RESULTS
+
 template <typename BinaryOperation>
 struct test_inclusive_scan_by_segment
 {

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -29,8 +29,6 @@ using namespace oneapi::dpl::execution;
 #endif
 using namespace TestUtils;
 
-#define DUMP_CHECK_RESULTS
-
 template <typename BinaryOperation>
 struct test_inclusive_scan_by_segment
 {


### PR DESCRIPTION
Let's output debugging information on demand