### PR TITLE
CI: save artifacts for clang-format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
         name: Save artifacts
         uses: actions/upload-artifact@v2
         with:
+          name: clang-format-diff
           path: clang-format-diff.diff
           retention-days: 3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,15 +29,15 @@ jobs:
           FILES=$(git diff --diff-filter=d --name-only ${{ github.event.pull_request.base.sha }} | grep ^include | grep -v nanorange\.hpp\$ || true)
           echo $FILES | xargs -n1 -t -r clang-format-6.0 --style=file -i
       - name: Creating diff
-        run: git diff > clang-format-diff.diff
+        run: git diff > clang-format.diff
       - name: Checking if diff is empty
-        run: if [ -s clang-format-diff.diff ]; then cat clang-format-diff.diff; exit 1; fi
+        run: if [ -s clang-format.diff ]; then cat clang-format.diff; exit 1; fi
       - if: failure()
         name: Save artifacts
         uses: actions/upload-artifact@v2
         with:
           name: clang-format-diff
-          path: clang-format-diff.diff
+          path: clang-format.diff
           retention-days: 3
 
   codespell:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,12 @@ jobs:
         run: git diff > clang-format-diff.diff
       - name: Checking if diff is empty
         run: if [ -s clang-format-diff.diff ]; then cat clang-format-diff.diff; exit 1; fi
+      - if: failure()
+        name: Save artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          path: clang-format-diff.diff
+          retention-days: 3
 
   codespell:
     runs-on: ubuntu-latest

--- a/include/oneapi/dpl/pstl/glue_algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_impl.h
@@ -114,7 +114,8 @@ find_if_not(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterato
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator> find(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value)
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+find(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value)
 {
     return oneapi::dpl::find_if(
         ::std::forward<_ExecutionPolicy>(__exec), __first, __last,

--- a/include/oneapi/dpl/pstl/glue_algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_impl.h
@@ -114,8 +114,7 @@ find_if_not(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterato
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
-find(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value)
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator> find(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value)
 {
     return oneapi::dpl::find_if(
         ::std::forward<_ExecutionPolicy>(__exec), __first, __last,


### PR DESCRIPTION
Sometimes it is useful to have diff of clang-format as artifact to apply it through `git apply` (requested by @rarutyun)