### PR TITLE
Fix format in release notes and changes files

### DIFF
--- a/documentation/CHANGES.rst
+++ b/documentation/CHANGES.rst
@@ -13,7 +13,7 @@ Fixed Issues
 ------------
 - Fixed compilation errors with C++20.
 - Fixed ``CL_OUT_OF_RESOURCES`` issue for Radix sort algorithm executed on CPU devices.
-- Fixed crashes in exclusive_scan_by_segment, inclusive_scan_by_segment, reduce_by_segment algorithms applied to
+- Fixed crashes in ``exclusive_scan_by_segment``, ``inclusive_scan_by_segment``, ``reduce_by_segment`` algorithms applied to
   device-allocated USM.
   
 Known Issues and Limitations

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -15,7 +15,7 @@ Fixed Issues
 ------------
 - Fixed compilation errors with C++20.
 - Fixed ``CL_OUT_OF_RESOURCES`` issue for Radix sort algorithm executed on CPU devices.
-- Fixed crashes in exclusive_scan_by_segment, inclusive_scan_by_segment, reduce_by_segment algorithms applied to
+- Fixed crashes in ``exclusive_scan_by_segment``, ``inclusive_scan_by_segment``, ``reduce_by_segment`` algorithms applied to
   device-allocated USM.
 
 Known Issues and Limitations


### PR DESCRIPTION
Added missed verbatim symbols to keep consistent format for algorithms mentioning. 
Signed-off-by: Valentina Kats valentina.kats@intel.com