### PR TITLE
Fix kernel naming for Range-based APIs

### DIFF
--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -255,24 +255,12 @@ swap_ranges(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2)
     using _ReferenceType1 = oneapi::dpl::__internal::__value_t<_Range1>&;
     using _ReferenceType2 = oneapi::dpl::__internal::__value_t<_Range2>&;
 
-    auto __v1 = views::all(::std::forward<_Range1>(__rng1));
-    auto __v2 = views::all(::std::forward<_Range2>(__rng2));
-    const auto is_first_size = __v1.size() <= __v2.size();
-
-    auto __f = [](_ReferenceType1 __x, _ReferenceType2 __y) {
-        using ::std::swap;
-        swap(__x, __y);
-    };
-
-    if (is_first_size)
-    {
-        oneapi::dpl::__internal::__ranges::__pattern_walk_n<1>(::std::forward<_ExecutionPolicy>(__exec), __f, __v1,
-                                                               __v2);
-        return __v1.size();
-    }
-
-    oneapi::dpl::__internal::__ranges::__pattern_walk_n<2>(::std::forward<_ExecutionPolicy>(__exec), __f, __v2, __v1);
-    return __v2.size();
+    return oneapi::dpl::__internal::__ranges::__pattern_swap(
+        ::std::forward<_ExecutionPolicy>(__exec), views::all(::std::forward<_Range1>(__rng1)),
+        views::all(::std::forward<_Range2>(__rng2)), [](_ReferenceType1 __x, _ReferenceType2 __y) {
+            using ::std::swap;
+            swap(__x, __y);
+        });
 }
 
 // [alg.transform]

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -46,8 +46,9 @@ __pattern_walk_n(_ExecutionPolicy&& __exec, _Function __f, _Ranges&&... __rngs)
     auto __n = oneapi::dpl::__ranges::__get_first_range_size(__rngs...);
     if (__n > 0)
     {
-        oneapi::dpl::__par_backend_hetero::__parallel_for(
-            __exec, unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f}, __n, ::std::forward<_Ranges>(__rngs)...)
+        oneapi::dpl::__par_backend_hetero::__parallel_for(::std::forward<_ExecutionPolicy>(__exec),
+                                                          unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f}, __n,
+                                                          ::std::forward<_Ranges>(__rngs)...)
             .wait();
     }
 }
@@ -70,20 +71,23 @@ template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typenam
 oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, bool>
 __pattern_swap(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _Function __f)
 {
-    if (__rng1.size() <= __rng2.size())
+    const auto __rng1_size = __rng1.size();
+    const auto __rng2_size = __rng2.size();
+
+    if (__rng1_size <= __rng2_size)
     {
         oneapi::dpl::__internal::__ranges::__pattern_walk_n(
             oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__swap1_wrapper>(
                 ::std::forward<_ExecutionPolicy>(__exec)),
-            __f, __rng1, __rng2);
-        return __rng1.size();
+            __f, ::std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2));
+        return __rng1_size;
     }
 
     oneapi::dpl::__internal::__ranges::__pattern_walk_n(
         oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__swap2_wrapper>(
             ::std::forward<_ExecutionPolicy>(__exec)),
-        __f, __rng2, __rng1);
-    return __rng2.size();
+        __f, ::std::forward<_Range2>(__rng2), ::std::forward<_Range1>(__rng1));
+    return __rng2_size;
 }
 
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -472,12 +472,12 @@ __pattern_unique(_ExecutionPolicy&& __exec, _Range&& __rng, _BinaryPredicate __p
 //------------------------------------------------------------------------
 
 template <typename _Name>
-class __copy_first_wrapper
+class __copy1_wrapper
 {
 };
 
 template <typename _Name>
-class __copy_second_wrapper
+class __copy2_wrapper
 {
 };
 
@@ -496,7 +496,7 @@ __pattern_merge(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _
     if (__n1 == 0)
     {
         oneapi::dpl::__internal::__ranges::__pattern_walk_n(
-            oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__copy_first_wrapper>(
+            oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__copy1_wrapper>(
                 ::std::forward<_ExecutionPolicy>(__exec)),
             oneapi::dpl::__internal::__brick_copy<_ExecutionPolicy>{}, ::std::forward<_Range2>(__rng2),
             ::std::forward<_Range3>(__rng3));
@@ -504,7 +504,7 @@ __pattern_merge(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _
     else if (__n2 == 0)
     {
         oneapi::dpl::__internal::__ranges::__pattern_walk_n(
-            oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__copy_second_wrapper>(
+            oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__copy2_wrapper>(
                 ::std::forward<_ExecutionPolicy>(__exec)),
             oneapi::dpl::__internal::__brick_copy<_ExecutionPolicy>{}, ::std::forward<_Range1>(__rng1),
             ::std::forward<_Range3>(__rng3));

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -75,13 +75,15 @@ __pattern_swap(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _F
     {
         oneapi::dpl::__internal::__ranges::__pattern_walk_n(
             oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__swap1_wrapper>(
-                ::std::forward<_ExecutionPolicy>(__exec)), __f, __rng1, __rng2);
+                ::std::forward<_ExecutionPolicy>(__exec)),
+            __f, __rng1, __rng2);
         return __rng1.size();
     }
 
     oneapi::dpl::__internal::__ranges::__pattern_walk_n(
         oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__swap2_wrapper>(
-            ::std::forward<_ExecutionPolicy>(__exec)), __f, __rng2, __rng1);
+            ::std::forward<_ExecutionPolicy>(__exec)),
+        __f, __rng2, __rng1);
     return __rng2.size();
 }
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -71,23 +71,18 @@ template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typenam
 oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, bool>
 __pattern_swap(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _Function __f)
 {
-    const auto __rng1_size = __rng1.size();
-    const auto __rng2_size = __rng2.size();
-
-    if (__rng1_size <= __rng2_size)
+    if (__rng1.size() <= __rng2.size())
     {
         oneapi::dpl::__internal::__ranges::__pattern_walk_n(
             oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__swap1_wrapper>(
-                ::std::forward<_ExecutionPolicy>(__exec)),
-            __f, ::std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2));
-        return __rng1_size;
+                ::std::forward<_ExecutionPolicy>(__exec)), __f, __rng1, __rng2);
+        return __rng1.size();
     }
 
     oneapi::dpl::__internal::__ranges::__pattern_walk_n(
         oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__swap2_wrapper>(
-            ::std::forward<_ExecutionPolicy>(__exec)),
-        __f, ::std::forward<_Range2>(__rng2), ::std::forward<_Range1>(__rng1));
-    return __rng2_size;
+            ::std::forward<_ExecutionPolicy>(__exec)), __f, __rng2, __rng1);
+    return __rng2.size();
 }
 
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -39,21 +39,51 @@ namespace __ranges
 // walk_n
 //------------------------------------------------------------------------
 
-template <int _N = 0, typename _ExecutionPolicy, typename _Function, typename... _Ranges>
+template <typename _ExecutionPolicy, typename _Function, typename... _Ranges>
 oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, void>
 __pattern_walk_n(_ExecutionPolicy&& __exec, _Function __f, _Ranges&&... __rngs)
 {
     auto __n = oneapi::dpl::__ranges::__get_first_range_size(__rngs...);
     if (__n > 0)
     {
-        using __new_name = oneapi::dpl::__par_backend_hetero::__new_kernel_name<_ExecutionPolicy, _N>;
-        auto __new_exec =
-            oneapi::dpl::execution::make_hetero_policy<__new_name>(::std::forward<_ExecutionPolicy>(__exec));
-        oneapi::dpl::__par_backend_hetero::__parallel_for(__new_exec,
-                                                          unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f}, __n,
-                                                          ::std::forward<_Ranges>(__rngs)...)
+        oneapi::dpl::__par_backend_hetero::__parallel_for(
+            __exec, unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f}, __n, ::std::forward<_Ranges>(__rngs)...)
             .wait();
     }
+}
+
+//------------------------------------------------------------------------
+// swap
+//------------------------------------------------------------------------
+
+template <typename _Name>
+class __swap1_wrapper
+{
+};
+
+template <typename _Name>
+class __swap2_wrapper
+{
+};
+
+template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Function>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, bool>
+__pattern_swap(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _Function __f)
+{
+    if (__rng1.size() <= __rng2.size())
+    {
+        oneapi::dpl::__internal::__ranges::__pattern_walk_n(
+            oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__swap1_wrapper>(
+                ::std::forward<_ExecutionPolicy>(__exec)),
+            __f, __rng1, __rng2);
+        return __rng1.size();
+    }
+
+    oneapi::dpl::__internal::__ranges::__pattern_walk_n(
+        oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__swap2_wrapper>(
+            ::std::forward<_ExecutionPolicy>(__exec)),
+        __f, __rng2, __rng1);
+    return __rng2.size();
 }
 
 //------------------------------------------------------------------------
@@ -441,6 +471,16 @@ __pattern_unique(_ExecutionPolicy&& __exec, _Range&& __rng, _BinaryPredicate __p
 // merge
 //------------------------------------------------------------------------
 
+template <typename _Name>
+class __copy_first_wrapper
+{
+};
+
+template <typename _Name>
+class __copy_second_wrapper
+{
+};
+
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Compare>
 oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy,
                                                              oneapi::dpl::__internal::__difference_t<_Range3>>
@@ -456,14 +496,18 @@ __pattern_merge(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _
     if (__n1 == 0)
     {
         oneapi::dpl::__internal::__ranges::__pattern_walk_n(
-            ::std::forward<_ExecutionPolicy>(__exec), oneapi::dpl::__internal::__brick_copy<_ExecutionPolicy>{},
-            ::std::forward<_Range2>(__rng2), ::std::forward<_Range3>(__rng3));
+            oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__copy_first_wrapper>(
+                ::std::forward<_ExecutionPolicy>(__exec)),
+            oneapi::dpl::__internal::__brick_copy<_ExecutionPolicy>{}, ::std::forward<_Range2>(__rng2),
+            ::std::forward<_Range3>(__rng3));
     }
     else if (__n2 == 0)
     {
         oneapi::dpl::__internal::__ranges::__pattern_walk_n(
-            ::std::forward<_ExecutionPolicy>(__exec), oneapi::dpl::__internal::__brick_copy<_ExecutionPolicy>{},
-            ::std::forward<_Range1>(__rng1), ::std::forward<_Range3>(__rng3));
+            oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__copy_second_wrapper>(
+                ::std::forward<_ExecutionPolicy>(__exec)),
+            oneapi::dpl::__internal::__brick_copy<_ExecutionPolicy>{}, ::std::forward<_Range1>(__rng1),
+            ::std::forward<_Range3>(__rng3));
     }
     else
     {
@@ -569,6 +613,40 @@ __pattern_minmax_element(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __c
     return ::std::make_pair(get<0>(__ret), get<1>(__ret));
 }
 
+//------------------------------------------------------------------------
+// reduce_by_segment
+//------------------------------------------------------------------------
+
+template <typename _Name>
+class __copy_keys_wrapper
+{
+};
+
+template <typename _Name>
+class __copy_values_wrapper
+{
+};
+
+template <typename _Name>
+class __reduce1_wrapper
+{
+};
+
+template <typename _Name>
+class __reduce2_wrapper
+{
+};
+
+template <typename _Name>
+class __assign_key1_wrapper
+{
+};
+
+template <typename _Name>
+class __assign_key2_wrapper
+{
+};
+
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Range4,
           typename _BinaryPredicate, typename _BinaryOperator>
 oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy,
@@ -594,14 +672,15 @@ __pattern_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2
     {
         __brick_copy<_ExecutionPolicy> __copy_range{};
 
-        // We use 2 and 3 as the kernel names because 0 and 1 are already used by other kernel calls in algorithm implementation
-        oneapi::dpl::__internal::__ranges::__pattern_walk_n<2>(::std::forward<_ExecutionPolicy>(__exec), __copy_range,
-                                                               ::std::forward<_Range1>(__keys),
-                                                               ::std::forward<_Range3>(__out_keys));
+        oneapi::dpl::__internal::__ranges::__pattern_walk_n(
+            oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__copy_keys_wrapper>(
+                ::std::forward<_ExecutionPolicy>(__exec)),
+            __copy_range, ::std::forward<_Range1>(__keys), ::std::forward<_Range3>(__out_keys));
 
-        oneapi::dpl::__internal::__ranges::__pattern_walk_n<3>(::std::forward<_ExecutionPolicy>(__exec), __copy_range,
-                                                               ::std::forward<_Range2>(__values),
-                                                               ::std::forward<_Range4>(__out_values));
+        oneapi::dpl::__internal::__ranges::__pattern_walk_n(
+            oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__copy_values_wrapper>(
+                ::std::forward<_ExecutionPolicy>(__exec)),
+            __copy_range, ::std::forward<_Range2>(__values), ::std::forward<_Range4>(__out_values));
 
         return 1;
     }
@@ -640,7 +719,9 @@ __pattern_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2
     // adjacent element (marks end of real segments)
     // TODO: replace wgroup size with segment size based on platform specifics.
     auto __result_end =
-        __pattern_copy_if(::std::forward<_ExecutionPolicy>(__exec), __view1, __view2,
+        __pattern_copy_if(oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__assign_key1_wrapper>(
+                              ::std::forward<_ExecutionPolicy>(__exec)),
+                          __view1, __view2,
                           [__n, __binary_pred, __wgroup_size](const auto& __a) {
                               return ::std::get<0>(__a) % __wgroup_size == 0 ||              // segment size
                                      !__binary_pred(::std::get<1>(__a), ::std::get<2>(__a)); //keys comparison
@@ -649,8 +730,10 @@ __pattern_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2
 
     //reduce by segment
     oneapi::dpl::__par_backend_hetero::__parallel_for(
-        ::std::forward<_ExecutionPolicy>(__exec), unseq_backend::__brick_reduce_idx<_BinaryOperator>{__binary_op},
-        __result_end, experimental::ranges::views::all_read(__idx), ::std::forward<_Range2>(__values),
+        oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__reduce1_wrapper>(
+            ::std::forward<_ExecutionPolicy>(__exec)),
+        unseq_backend::__brick_reduce_idx<_BinaryOperator>{__binary_op}, __result_end,
+        experimental::ranges::views::all_read(__idx), ::std::forward<_Range2>(__values),
         experimental::ranges::views::all_write(__tmp_out_values))
         .wait();
 
@@ -671,10 +754,10 @@ __pattern_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2
 
     // element is copied if it is the last element (end of final segment), or has a key not equal to
     // the adjacent element (end of a segment). Artificial segments based on wg size are not created.
-    using __new_name = oneapi::dpl::__par_backend_hetero::__new_kernel_name<_ExecutionPolicy, 1>;
-    auto __new_exec = oneapi::dpl::execution::make_hetero_policy<__new_name>(::std::forward<_ExecutionPolicy>(__exec));
     __result_end =
-        __pattern_copy_if(__new_exec, __view3, __view4,
+        __pattern_copy_if(oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__assign_key2_wrapper>(
+                              ::std::forward<_ExecutionPolicy>(__exec)),
+                          __view3, __view4,
                           [__result_end, __binary_pred](const auto& __a) {
                               return !__binary_pred(::std::get<1>(__a), ::std::get<2>(__a)); //keys comparison
                           },
@@ -682,7 +765,9 @@ __pattern_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2
 
     //reduce by segment
     oneapi::dpl::__par_backend_hetero::__parallel_for(
-        __new_exec, unseq_backend::__brick_reduce_idx<_BinaryOperator>{__binary_op}, __result_end,
+        oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__reduce2_wrapper>(
+            ::std::forward<_ExecutionPolicy>(__exec)),
+        unseq_backend::__brick_reduce_idx<_BinaryOperator>{__binary_op}, __result_end,
         experimental::ranges::views::all_read(__idx), experimental::ranges::views::all_read(__tmp_out_values),
         ::std::forward<_Range4>(__out_values))
         .wait();

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -82,12 +82,6 @@ struct explicit_wait_if<true>
     }
 };
 
-template <typename Op, ::std::size_t CallNumber>
-struct __unique_kernel_name;
-
-template <typename Policy, int idx>
-using __new_kernel_name = __unique_kernel_name<typename ::std::decay<Policy>::type, idx>;
-
 // function is needed to wrap kernel name into another class
 template <template <typename> class _NewKernelName, typename _Policy,
           oneapi::dpl::__internal::__enable_if_device_execution_policy<_Policy, int> = 0>

--- a/test/parallel_api/ranges/reduce_by_key_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/reduce_by_key_ranges_sycl.pass.cpp
@@ -48,10 +48,8 @@ main()
 
     auto res = reduce_by_segment(exec, views::all_read(A), views::all_read(B), views::all_write(C), views::all_write(D));
 
-    // The expected keys
-    int key_exp[n_res] = {1, 3, 2, 1};
-    // The expected keys
-    int value_exp[n_res] = {9, 21, 9, 3};
+    int key_exp[n_res] = {1, 3, 2, 1};    // expected keys
+    int value_exp[n_res] = {9, 21, 9, 3}; // expected values
 
 #if _ONEDPL_DEBUG_SYCL
     ::std::cout << "keys: ";

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -70,9 +70,10 @@ uniq_kernel_index()
 }
 
 template <typename Op, ::std::size_t CallNumber>
-using unique_kernel_name = oneapi::dpl::__par_backend_hetero::__unique_kernel_name<Op, CallNumber>;
+struct unique_kernel_name;
+
 template <typename Policy, int idx>
-using new_kernel_name = oneapi::dpl::__par_backend_hetero::__new_kernel_name<Policy, idx>;
+using new_kernel_name = unique_kernel_name<typename ::std::decay<Policy>::type, idx>;
 
 auto async_handler = [](sycl::exception_list ex_list) {
     for (auto& ex : ex_list)


### PR DESCRIPTION
This fixes an issue with uniqueness of kernel names in Range-based APIs.  

Some Range-bases APIs used to rely on a custom way to generate unique kernel names (look at `__new_kernel_name` function).
The generated kernel names used to be treated as externally provided in the lower layer (`_HasDefaultName` recognizes customizations of kernel names made in the library when using `make_wrapped_policy` in contrast to `__new_kernel_name`). That led to issues with uniqueness of kernel names, because we assume externally provided names are unique even if we do not include types of arguments into a kernel name. You can find a code snippet leading to the error in #507. 

Signed-off-by: Sobolev, Dmitriy <dmitriy.sobolev@intel.com>