### PR TITLE
[oneDPL] + fix "error: constexpr if condition evaluates to 2, which cannot be narrowed to type 'bool'  [-Wc++11-narrowing]

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -477,7 +477,7 @@ class __future : private std::tuple<_Args...>
     get()
     {
         wait();
-        if constexpr (sizeof...(_Args))
+        if constexpr (sizeof...(_Args) > 0)
             return __get_value(std::get<0>(*this));
     }
 


### PR DESCRIPTION
Fix "narrowing to type 'bool'" for clang (and dpcpp) compilers.

 "error: constexpr if condition evaluates to 2, which cannot be narrowed to type 'bool'  [-Wc++11-narrowing]"
