### PR TITLE
[oneDPL] multiple definition hot fix, __wait_event(..) usage

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -427,8 +427,8 @@ using __repacked_tuple_t = typename __repacked_tuple<T>::type;
 template <typename _ContainerOrIterable>
 using __value_t = typename __internal::__memobj_traits<_ContainerOrIterable>::value_type;
 
-constexpr void
-__wait_event(sycl::event& __e)
+inline void
+__wait_event(sycl::event __e)
 {
 #if !ONEDPL_ALLOW_DEFERRED_WAITING
     __e.wait_and_throw();

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -427,7 +427,7 @@ using __repacked_tuple_t = typename __repacked_tuple<T>::type;
 template <typename _ContainerOrIterable>
 using __value_t = typename __internal::__memobj_traits<_ContainerOrIterable>::value_type;
 
-void
+inline void
 __wait_event(sycl::event __e)
 {
 #if !ONEDPL_ALLOW_DEFERRED_WAITING

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -427,8 +427,8 @@ using __repacked_tuple_t = typename __repacked_tuple<T>::type;
 template <typename _ContainerOrIterable>
 using __value_t = typename __internal::__memobj_traits<_ContainerOrIterable>::value_type;
 
-inline void
-__wait_event(sycl::event __e)
+constexpr void
+__wait_event(sycl::event& __e)
 {
 #if !ONEDPL_ALLOW_DEFERRED_WAITING
     __e.wait_and_throw();


### PR DESCRIPTION
[oneDPL] multiple definition hot fix:
`void  __wait_event(sycl::event __e) => inline void __wait_event(sycl::event __e)`
A variant with 'constexpr ' is not applicable here.