### PR TITLE
[oneDPL] undo usage of one-element sycl::buffer for return value for …

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -450,6 +450,14 @@ __get_value(_T& __val)
     return __val;
 }
 
+template <typename _T>
+std::false_type
+__do_wait(sycl::buffer<_T>&);
+
+template <typename _T>
+std::true_type
+__do_wait(_T&);
+
 //A contract for future class: <sycl::event or other event, a value or sycl::buffers...>
 //Impl details: inheretance (private) instead of aggregation for enabling the empty base optimization.
 template <typename _Event, typename... _Args>
@@ -476,9 +484,15 @@ class __future : private std::tuple<_Args...>
     auto
     get()
     {
-        wait();
         if constexpr (sizeof...(_Args) > 0)
-            return __get_value(std::get<0>(*this));
+        {
+            auto& __val = std::get<0>(*this);
+            if constexpr (decltype(__do_wait(__val))::value)
+                wait();
+            return __get_value(__val);
+        }
+        else
+            wait();
     }
 
     //The internal API. There are cases where the implementation specifies return value  "higher" than SYCL backend,


### PR DESCRIPTION
…reduce and scan patterns (#541)

* [oneDPL] undo usage of one-elemnt sycl::buffer for return value for reduce and scan patterns (perf reasons)
* [oneDPL] future::get - no wait call if we have synch on get_access<access_mode::read>()[0]  (host)