### PR TITLE
Fix inclusive_scan_by_segment.pass failure on HOST device, icpc compiler with wrong effect error

### DIFF
--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -243,9 +243,9 @@ int main() {
         test3buffers<ValueType, test_inclusive_scan_by_segment<BinaryOperation>>();
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-#if !_PSTL_ICC_TEST_SIMD_UDS_MACOS_RELEASE_BROKEN
+#if !_PSTL_ICC_TEST_SIMD_UDS_BROKEN
         test_algo_three_sequences<ValueType, test_inclusive_scan_by_segment<BinaryOperation>>();
-#endif // !_PSTL_ICC_TEST_SIMD_UDS_MACOS_RELEASE_BROKEN
+#endif // !_PSTL_ICC_TEST_SIMD_UDS_BROKEN
     }
     return TestUtils::done();
 }

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -41,9 +41,9 @@
     (!PSTL_USE_DEBUG && (__linux__ || __APPLE__) && __INTEL_COMPILER == 1900)
 // ICC 19 generates wrong result with UDS on Windows
 #define _PSTL_ICC_19_TEST_SIMD_UDS_WINDOWS_RELEASE_BROKEN (__INTEL_COMPILER == 1900 && _MSC_VER && !_DEBUG)
-// ICC generates wrong result with UDS on MacOS
-#define _PSTL_ICC_TEST_SIMD_UDS_MACOS_RELEASE_BROKEN                                                                 \
-    (/*__INTEL_COMPILER == 1900 &&*/ !_DEBUG && __APPLE__)
+// ICC generates wrong result with UDS on icpc - 2021.5.0
+#define _PSTL_ICC_TEST_SIMD_UDS_BROKEN                                                                                \
+    (__INTEL_COMPILER && __INTEL_COMPILER_BUILD_DATE < 20211123)
 // ICC 18,19 generate wrong result
 #define _PSTL_ICC_18_19_TEST_SIMD_MONOTONIC_WINDOWS_RELEASE_BROKEN													  \
     ((__INTEL_COMPILER == 1800 || __INTEL_COMPILER == 1900) && _MSC_VER && !_DEBUG)

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -41,7 +41,7 @@
     (!PSTL_USE_DEBUG && (__linux__ || __APPLE__) && __INTEL_COMPILER == 1900)
 // ICC 19 generates wrong result with UDS on Windows
 #define _PSTL_ICC_19_TEST_SIMD_UDS_WINDOWS_RELEASE_BROKEN (__INTEL_COMPILER == 1900 && _MSC_VER && !_DEBUG)
-// ICC generates wrong result with UDS on icpc - 2021.5.0
+// ICPC compiler generates wrong "openMP simd" code for a user defined scan operation(UDS) for MacOS, Linuxand Windows
 #define _PSTL_ICC_TEST_SIMD_UDS_BROKEN                                                                                \
     (__INTEL_COMPILER && __INTEL_COMPILER_BUILD_DATE < 20211123)
 // ICC 18,19 generate wrong result


### PR DESCRIPTION
Fixed inclusive_scan_by_segment.pass failure on HOST device, icpc compiler with wrong effect error