### PR TITLE
Replace internal API in the tests (__sycl_defs entities)

### DIFF
--- a/test/general/buffer_wrapper.pass.cpp
+++ b/test/general/buffer_wrapper.pass.cpp
@@ -55,8 +55,8 @@ main()
 
     test(oneapi::dpl::begin(buf), oneapi::dpl::end(buf), data_ptr, size);
     test(oneapi::dpl::begin(buf, sycl::write_only), oneapi::dpl::end(buf, sycl::write_only), data_ptr, size);
-    test(oneapi::dpl::begin(buf, sycl::write_only, __dpl_sycl::__no_init{}), oneapi::dpl::end(buf, sycl::write_only, __dpl_sycl::__no_init{}), data_ptr, size);
-    test(oneapi::dpl::begin(buf, __dpl_sycl::__no_init{}), oneapi::dpl::end(buf, __dpl_sycl::__no_init{}), data_ptr, size);
+    test(oneapi::dpl::begin(buf, sycl::write_only, TestUtils::no_init{}), oneapi::dpl::end(buf, sycl::write_only, TestUtils::no_init{}), data_ptr, size);
+    test(oneapi::dpl::begin(buf, TestUtils::no_init{}), oneapi::dpl::end(buf, TestUtils::no_init{}), data_ptr, size);
 
 #endif
     return done(TEST_DPCPP_BACKEND_PRESENT);

--- a/test/general/buffer_wrapper.pass.cpp
+++ b/test/general/buffer_wrapper.pass.cpp
@@ -55,8 +55,10 @@ main()
 
     test(oneapi::dpl::begin(buf), oneapi::dpl::end(buf), data_ptr, size);
     test(oneapi::dpl::begin(buf, sycl::write_only), oneapi::dpl::end(buf, sycl::write_only), data_ptr, size);
-    test(oneapi::dpl::begin(buf, sycl::write_only, TestUtils::no_init{}), oneapi::dpl::end(buf, sycl::write_only, TestUtils::no_init{}), data_ptr, size);
-    test(oneapi::dpl::begin(buf, TestUtils::no_init{}), oneapi::dpl::end(buf, TestUtils::no_init{}), data_ptr, size);
+    test(oneapi::dpl::begin(buf, sycl::write_only, sycl::property::no_init{}),
+         oneapi::dpl::end(buf, sycl::write_only, sycl::property::no_init{}), data_ptr, size);
+    test(oneapi::dpl::begin(buf, sycl::property::no_init{}),
+         oneapi::dpl::end(buf, sycl::property::no_init{}), data_ptr, size);
 
 #endif
     return done(TEST_DPCPP_BACKEND_PRESENT);

--- a/test/general/lambda_naming.pass.cpp
+++ b/test/general/lambda_naming.pass.cpp
@@ -34,7 +34,7 @@ int main() {
     auto buf_end = buf_begin + n;
 
     const auto policy = TestUtils::default_dpcpp_policy;
-    auto buf_begin_discard_write = oneapi::dpl::begin(buf, sycl::write_only, __dpl_sycl::__no_init{});
+    auto buf_begin_discard_write = oneapi::dpl::begin(buf, sycl::write_only, TestUtils::no_init{});
 
     ::std::fill(policy, buf_begin_discard_write, buf_begin_discard_write + n, 1);
 #if __SYCL_UNNAMED_LAMBDA__

--- a/test/general/lambda_naming.pass.cpp
+++ b/test/general/lambda_naming.pass.cpp
@@ -34,7 +34,7 @@ int main() {
     auto buf_end = buf_begin + n;
 
     const auto policy = TestUtils::default_dpcpp_policy;
-    auto buf_begin_discard_write = oneapi::dpl::begin(buf, sycl::write_only, TestUtils::no_init{});
+    auto buf_begin_discard_write = oneapi::dpl::begin(buf, sycl::write_only, sycl::property::no_init{});
 
     ::std::fill(policy, buf_begin_discard_write, buf_begin_discard_write + n, 1);
 #if __SYCL_UNNAMED_LAMBDA__

--- a/test/parallel_api/experimental/asynch-scan.pass.cpp
+++ b/test/parallel_api/experimental/asynch-scan.pass.cpp
@@ -46,48 +46,48 @@ test_with_buffers()
         // transform inclusive (2 overloads)
         auto my_policy1 = TestUtils::make_device_policy<class Scan1>(my_policy);
         auto alpha = dpl::experimental::transform_inclusive_scan_async(my_policy1, dpl::begin(x), dpl::end(x), dpl::begin(y), std::plus<int>(), [](auto x) { return x * 10; });
-        auto result1 = __dpl_sycl::__get_host_access(alpha.get().get_buffer())[n-1];
+        auto result1 = TestUtils::get_host_access(alpha.get().get_buffer())[n-1];
         EXPECT_TRUE(result1 == (expected1 * 10), "wrong effect from async scan test (Ia) with sycl buffer");
 
         auto my_policy2 = TestUtils::make_device_policy<class Scan2>(my_policy);
         auto fut1b = dpl::experimental::transform_inclusive_scan_async(my_policy2, dpl::begin(x), dpl::end(x), dpl::begin(y), std::plus<int>(), [](auto x) { return x * 10; }, 1);
-        auto result1b = __dpl_sycl::__get_host_access(fut1b.get().get_buffer())[n-1];
+        auto result1b = TestUtils::get_host_access(fut1b.get().get_buffer())[n-1];
         EXPECT_TRUE(result1b == (expected1 * 10 + 1), "wrong effect from async scan test (Ib) with sycl buffer");
 
         // transform exclusive
         auto my_policy3 = TestUtils::make_device_policy<class Scan3>(my_policy);
         auto beta = dpl::experimental::transform_exclusive_scan_async(my_policy3, dpl::begin(x), dpl::end(x), dpl::begin(y), 0, std::plus<int>(), [](auto x) { return x * 10; });
-        auto result2 = __dpl_sycl::__get_host_access(beta.get().get_buffer())[n-1];
+        auto result2 = TestUtils::get_host_access(beta.get().get_buffer())[n-1];
         EXPECT_TRUE(result2 == expected2 * 10, "wrong effect from async scan test (II) with sycl buffer");
 
         // inclusive (3 overloads)
         auto my_policy4 = TestUtils::make_device_policy<class Scan4>(my_policy);
         auto gamma = dpl::experimental::inclusive_scan_async(my_policy4, dpl::begin(x), dpl::end(x), dpl::begin(y));
-        auto result3 = __dpl_sycl::__get_host_access(gamma.get().get_buffer())[n-1];
+        auto result3 = TestUtils::get_host_access(gamma.get().get_buffer())[n-1];
         EXPECT_TRUE(result3 == expected1, "wrong effect from async scan test (IIIa) with sycl buffer");
 
         auto my_policy5 = TestUtils::make_device_policy<class Scan5>(my_policy);
         auto fut3b = dpl::experimental::inclusive_scan_async(my_policy5, dpl::begin(x), dpl::end(x), dpl::begin(y), std::plus<int>(), gamma);
-        auto result3b = __dpl_sycl::__get_host_access(fut3b.get().get_buffer())[n-1];
+        auto result3b = TestUtils::get_host_access(fut3b.get().get_buffer())[n-1];
         EXPECT_TRUE(result3b == expected1, "wrong effect from async scan test (IIIb) with sycl buffer");
 
         auto my_policy6 = TestUtils::make_device_policy<class Scan6>(my_policy);
         auto fut3c = dpl::experimental::inclusive_scan_async(my_policy6, dpl::begin(x), dpl::end(x), dpl::begin(y), std::plus<int>(), 1, fut3b);
-        auto result3c = __dpl_sycl::__get_host_access(fut3c.get().get_buffer())[n-1];
+        auto result3c = TestUtils::get_host_access(fut3c.get().get_buffer())[n-1];
         EXPECT_TRUE(result3c == (expected1 + 1), "wrong effect from async scan test (IIIc) with sycl buffer");
 
         // exclusive (2 overloads)
         auto my_policy7 = TestUtils::make_device_policy<class Scan7>(my_policy);
         auto delta = dpl::experimental::exclusive_scan_async(my_policy7, dpl::begin(x), dpl::end(x), dpl::begin(y), 0);
-        auto result4 = __dpl_sycl::__get_host_access(delta.get().get_buffer())[n-1];
+        auto result4 = TestUtils::get_host_access(delta.get().get_buffer())[n-1];
         EXPECT_TRUE(result4 == expected2, "wrong effect from async scan test (IV) with sycl buffer");
 
         auto my_policy8 = TestUtils::make_device_policy<class Scan8>(my_policy);
         auto fut4b = dpl::experimental::exclusive_scan_async(my_policy8, dpl::begin(x), dpl::end(x), dpl::begin(y), 1, std::plus<int>(), delta);
-        auto result4b = __dpl_sycl::__get_host_access(fut4b.get().get_buffer())[n-1];
+        auto result4b = TestUtils::get_host_access(fut4b.get().get_buffer())[n-1];
         EXPECT_TRUE(result4b == (expected2 + 1), "wrong effect from async scan test (IV) with sycl buffer");
 
-        oneapi::dpl::experimental::wait_for_all(alpha,beta,gamma,delta); 
+        oneapi::dpl::experimental::wait_for_all(alpha,beta,gamma,delta);
     }
 }
 #endif

--- a/test/parallel_api/experimental/asynch-scan.pass.cpp
+++ b/test/parallel_api/experimental/asynch-scan.pass.cpp
@@ -46,45 +46,45 @@ test_with_buffers()
         // transform inclusive (2 overloads)
         auto my_policy1 = TestUtils::make_device_policy<class Scan1>(my_policy);
         auto alpha = dpl::experimental::transform_inclusive_scan_async(my_policy1, dpl::begin(x), dpl::end(x), dpl::begin(y), std::plus<int>(), [](auto x) { return x * 10; });
-        auto result1 = TestUtils::get_host_access(alpha.get().get_buffer())[n-1];
+        auto result1 = alpha.get().get_buffer().get_host_access(sycl::read_only)[n-1];
         EXPECT_TRUE(result1 == (expected1 * 10), "wrong effect from async scan test (Ia) with sycl buffer");
 
         auto my_policy2 = TestUtils::make_device_policy<class Scan2>(my_policy);
         auto fut1b = dpl::experimental::transform_inclusive_scan_async(my_policy2, dpl::begin(x), dpl::end(x), dpl::begin(y), std::plus<int>(), [](auto x) { return x * 10; }, 1);
-        auto result1b = TestUtils::get_host_access(fut1b.get().get_buffer())[n-1];
+        auto result1b = fut1b.get().get_buffer().get_host_access(sycl::read_only)[n-1];
         EXPECT_TRUE(result1b == (expected1 * 10 + 1), "wrong effect from async scan test (Ib) with sycl buffer");
 
         // transform exclusive
         auto my_policy3 = TestUtils::make_device_policy<class Scan3>(my_policy);
         auto beta = dpl::experimental::transform_exclusive_scan_async(my_policy3, dpl::begin(x), dpl::end(x), dpl::begin(y), 0, std::plus<int>(), [](auto x) { return x * 10; });
-        auto result2 = TestUtils::get_host_access(beta.get().get_buffer())[n-1];
+        auto result2 = beta.get().get_buffer().get_host_access(sycl::read_only)[n-1];
         EXPECT_TRUE(result2 == expected2 * 10, "wrong effect from async scan test (II) with sycl buffer");
 
         // inclusive (3 overloads)
         auto my_policy4 = TestUtils::make_device_policy<class Scan4>(my_policy);
         auto gamma = dpl::experimental::inclusive_scan_async(my_policy4, dpl::begin(x), dpl::end(x), dpl::begin(y));
-        auto result3 = TestUtils::get_host_access(gamma.get().get_buffer())[n-1];
+        auto result3 = gamma.get().get_buffer().get_host_access(sycl::read_only)[n-1];
         EXPECT_TRUE(result3 == expected1, "wrong effect from async scan test (IIIa) with sycl buffer");
 
         auto my_policy5 = TestUtils::make_device_policy<class Scan5>(my_policy);
         auto fut3b = dpl::experimental::inclusive_scan_async(my_policy5, dpl::begin(x), dpl::end(x), dpl::begin(y), std::plus<int>(), gamma);
-        auto result3b = TestUtils::get_host_access(fut3b.get().get_buffer())[n-1];
+        auto result3b = fut3b.get().get_buffer().get_host_access(sycl::read_only)[n-1];
         EXPECT_TRUE(result3b == expected1, "wrong effect from async scan test (IIIb) with sycl buffer");
 
         auto my_policy6 = TestUtils::make_device_policy<class Scan6>(my_policy);
         auto fut3c = dpl::experimental::inclusive_scan_async(my_policy6, dpl::begin(x), dpl::end(x), dpl::begin(y), std::plus<int>(), 1, fut3b);
-        auto result3c = TestUtils::get_host_access(fut3c.get().get_buffer())[n-1];
+        auto result3c = fut3c.get().get_buffer().get_host_access(sycl::read_only)[n-1];
         EXPECT_TRUE(result3c == (expected1 + 1), "wrong effect from async scan test (IIIc) with sycl buffer");
 
         // exclusive (2 overloads)
         auto my_policy7 = TestUtils::make_device_policy<class Scan7>(my_policy);
         auto delta = dpl::experimental::exclusive_scan_async(my_policy7, dpl::begin(x), dpl::end(x), dpl::begin(y), 0);
-        auto result4 = TestUtils::get_host_access(delta.get().get_buffer())[n-1];
+        auto result4 = delta.get().get_buffer().get_host_access(sycl::read_only)[n-1];
         EXPECT_TRUE(result4 == expected2, "wrong effect from async scan test (IV) with sycl buffer");
 
         auto my_policy8 = TestUtils::make_device_policy<class Scan8>(my_policy);
         auto fut4b = dpl::experimental::exclusive_scan_async(my_policy8, dpl::begin(x), dpl::end(x), dpl::begin(y), 1, std::plus<int>(), delta);
-        auto result4b = TestUtils::get_host_access(fut4b.get().get_buffer())[n-1];
+        auto result4b = fut4b.get().get_buffer().get_host_access(sycl::read_only)[n-1];
         EXPECT_TRUE(result4b == (expected2 + 1), "wrong effect from async scan test (IV) with sycl buffer");
 
         oneapi::dpl::experimental::wait_for_all(alpha,beta,gamma,delta);

--- a/test/support/sycl_alloc_utils.h
+++ b/test/support/sycl_alloc_utils.h
@@ -21,7 +21,7 @@
 #include <list>
 #include <memory>
 
-#include "oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h"
+#include "support/utils_sycl_defs.h"
 
 namespace TestUtils
 {
@@ -192,7 +192,7 @@ private:
 
     void copy_data_impl(_ValueType* __src, _ValueType* __ptr, __difference_type __count)
     {
-#if _ONEDPL_LIBSYCL_VERSION >= 50300
+#if TEST_LIBSYCL_VERSION >= 50300
         __queue.copy(__src, __ptr, __count);
 #else
         auto __p = __ptr;
@@ -203,7 +203,7 @@ private:
                 *(__p + __id) = *(__src + __id);
                 });
             });
-#endif // _ONEDPL_LIBSYCL_VERSION >= 50300
+#endif // TEST_LIBSYCL_VERSION >= 50300
         __queue.wait();
     }
 

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -20,14 +20,7 @@
 // Do not #include <algorithm>, because if we do we will not detect accidental dependencies.
 
 #include <iterator>
-#include "oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h"
-#if _ONEDPL_FPGA_DEVICE
-#    if _ONEDPL_LIBSYCL_VERSION >= 50400
-#        include <sycl/ext/intel/fpga_extensions.hpp>
-#    else
-#        include <CL/sycl/INTEL/fpga_extensions.hpp>
-#    endif
-#endif
+#include "utils_sycl_defs.h"
 
 #include "test_config.h"
 
@@ -110,9 +103,9 @@ make_new_policy(_Policy&& __policy)
 #if ONEDPL_FPGA_DEVICE
 inline auto default_selector =
 #    if ONEDPL_FPGA_EMULATOR
-        __dpl_sycl::__fpga_emulator_selector();
+        fpga_emulator_selector{};
 #    else
-        __dpl_sycl::__fpga_selector();
+        fpga_selector{};
 #    endif // ONEDPL_FPGA_EMULATOR
 
 inline auto&& default_dpcpp_policy =
@@ -123,7 +116,7 @@ inline auto&& default_dpcpp_policy =
 #    endif // ONEDPL_USE_PREDEFINED_POLICIES
 #else
 inline auto default_selector =
-#    if _ONEDPL_LIBSYCL_VERSION >= 60000
+#    if TEST_LIBSYCL_VERSION >= 60000
         sycl::default_selector_v;
 #    else
         sycl::default_selector{};

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -103,9 +103,9 @@ make_new_policy(_Policy&& __policy)
 #if ONEDPL_FPGA_DEVICE
 inline auto default_selector =
 #    if ONEDPL_FPGA_EMULATOR
-        fpga_emulator_selector{};
+        sycl::ext::intel::fpga_emulator_selector{};
 #    else
-        fpga_selector{};
+        sycl::ext::intel::fpga_selector{};
 #    endif // ONEDPL_FPGA_EMULATOR
 
 inline auto&& default_dpcpp_policy =

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -20,7 +20,10 @@
 // Do not #include <algorithm>, because if we do we will not detect accidental dependencies.
 
 #include <iterator>
+
+#if TEST_DPCPP_BACKEND_PRESENT
 #include "utils_sycl_defs.h"
+#endif // TEST_DPCPP_BACKEND_PRESENT
 
 #include "test_config.h"
 

--- a/test/support/utils_sycl_defs.h
+++ b/test/support/utils_sycl_defs.h
@@ -24,6 +24,10 @@
 #    include <CL/sycl.hpp>
 #endif
 
+#if ONEDPL_FPGA_DEVICE
+#    include <sycl/ext/intel/fpga_extensions.hpp>
+#endif // ONEDPL_FPGA_DEVICE
+
 // Combine SYCL runtime library version
 #if defined(__LIBSYCL_MAJOR_VERSION) && defined(__LIBSYCL_MINOR_VERSION) && defined(__LIBSYCL_PATCH_VERSION)
 #    define TEST_LIBSYCL_VERSION                                                                                    \
@@ -33,43 +37,8 @@
 #endif
 
 #if ONEDPL_FPGA_DEVICE
-#    if TEST_LIBSYCL_VERSION >= 50400
-#        include <sycl/ext/intel/fpga_extensions.hpp>
-#    else
-#        include <CL/sycl/INTEL/fpga_extensions.hpp>
-#    endif
+#    include <sycl/ext/intel/fpga_extensions.hpp>
 #endif // ONEDPL_FPGA_DEVICE
 
-namespace TestUtils
-{
-using no_init =
-#if TEST_LIBSYCL_VERSION >= 50300
-    sycl::property::no_init;
-#else
-    sycl::property::noinit;
-#endif
-
-#if ONEDPL_FPGA_DEVICE
-#    if TEST_LIBSYCL_VERSION >= 50300
-using fpga_emulator_selector = sycl::ext::intel::fpga_emulator_selector;
-using fpga_selector = sycl::ext::intel::fpga_selector;
-#    else
-using fpga_emulator_selector = sycl::INTEL::fpga_emulator_selector;
-using fpga_selector = sycl::INTEL::fpga_selector;
-#    endif
-#endif // ONEDPL_FPGA_DEVICE
-
-template <typename Buf>
-auto
-get_host_access(Buf&& buf)
-{
-#if TEST_LIBSYCL_VERSION >= 60200
-    return ::std::forward<Buf>(buf).get_host_access(sycl::read_only);
-#else
-    return ::std::forward<_Buf>(buf).template get_access<sycl::access::mode::read>();
-#endif
-}
-
-} // TestUtils
 
 #endif //  _UTILS_SYCL_DEFS_H

--- a/test/support/utils_sycl_defs.h
+++ b/test/support/utils_sycl_defs.h
@@ -1,0 +1,64 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+// This file contains SYCL-specific macros and abstractions to support different versions of SYCL library
+
+#ifndef _UTILS_SYCL_DEFS_H
+#define _UTILS_SYCL_DEFS_H
+
+#if __has_include(<sycl/sycl.hpp>)
+#    include <sycl/sycl.hpp>
+#else
+#    include <CL/sycl.hpp>
+#endif
+
+// Combine SYCL runtime library version
+#if defined(__LIBSYCL_MAJOR_VERSION) && defined(__LIBSYCL_MINOR_VERSION) && defined(__LIBSYCL_PATCH_VERSION)
+#    define TEST_LIBSYCL_VERSION                                                                                    \
+        (__LIBSYCL_MAJOR_VERSION * 10000 + __LIBSYCL_MINOR_VERSION * 100 + __LIBSYCL_PATCH_VERSION)
+#else
+#    define TEST_LIBSYCL_VERSION 0
+#endif
+
+#if ONEDPL_FPGA_DEVICE
+#    if TEST_LIBSYCL_VERSION >= 50400
+#        include <sycl/ext/intel/fpga_extensions.hpp>
+#    else
+#        include <CL/sycl/INTEL/fpga_extensions.hpp>
+#    endif
+#endif // ONEDPL_FPGA_DEVICE
+
+namespace TestUtils
+{
+using no_init =
+#if TEST_LIBSYCL_VERSION >= 50300
+    sycl::property::no_init;
+#else
+    sycl::property::noinit;
+#endif
+
+#if ONEDPL_FPGA_DEVICE
+#    if TEST_LIBSYCL_VERSION >= 50300
+using fpga_emulator_selector = sycl::ext::intel::fpga_emulator_selector;
+using fpga_selector = sycl::ext::intel::fpga_selector;
+#    else
+using fpga_emulator_selector = sycl::INTEL::fpga_emulator_selector;
+using fpga_selector = sycl::INTEL::fpga_selector;
+#    endif
+#endif // ONEDPL_FPGA_DEVICE
+
+} // TestUtils
+
+#endif //  _UTILS_SYCL_DEFS_H

--- a/test/support/utils_sycl_defs.h
+++ b/test/support/utils_sycl_defs.h
@@ -36,9 +36,4 @@
 #    define TEST_LIBSYCL_VERSION 0
 #endif
 
-#if ONEDPL_FPGA_DEVICE
-#    include <sycl/ext/intel/fpga_extensions.hpp>
-#endif // ONEDPL_FPGA_DEVICE
-
-
 #endif //  _UTILS_SYCL_DEFS_H

--- a/test/support/utils_sycl_defs.h
+++ b/test/support/utils_sycl_defs.h
@@ -59,6 +59,17 @@ using fpga_selector = sycl::INTEL::fpga_selector;
 #    endif
 #endif // ONEDPL_FPGA_DEVICE
 
+template <typename Buf>
+auto
+get_host_access(Buf&& buf)
+{
+#if TEST_LIBSYCL_VERSION >= 60200
+    return ::std::forward<Buf>(buf).get_host_access(sycl::read_only);
+#else
+    return ::std::forward<_Buf>(buf).template get_access<sycl::access::mode::read>();
+#endif
+}
+
 } // TestUtils
 
 #endif //  _UTILS_SYCL_DEFS_H


### PR DESCRIPTION
Decouple oneDPL implementation and tests and remove dependencies on the internal API.

It might be useful when the tests are used with newer library headers. This can be treated as a backward compatibility testing. If there is no dependency on internal APIs from the library headers, then such testing is possible.