### PR TITLE
Check empty input data in binary search functions

### DIFF
--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -173,6 +173,10 @@ binary_search_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, In
 {
     namespace __bknd = __par_backend_hetero;
     const auto size = ::std::distance(start, end);
+
+    if (size <= 0)
+        return result;
+
     const auto value_size = ::std::distance(value_start, value_end);
 
     auto keep_input = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read, InputIterator1>();

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -113,6 +113,10 @@ lower_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, Inpu
 {
     namespace __bknd = __par_backend_hetero;
     const auto size = ::std::distance(start, end);
+
+    if (size <= 0)
+        return result;
+
     const auto value_size = ::std::distance(value_start, value_end);
 
     auto keep_input = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read, InputIterator1>();

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -143,6 +143,10 @@ upper_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, Inpu
 {
     namespace __bknd = __par_backend_hetero;
     const auto size = ::std::distance(start, end);
+
+    if (size <= 0)
+        return result;
+
     const auto value_size = ::std::distance(value_start, value_end);
 
     auto keep_input = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read, InputIterator1>();

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1669,7 +1669,7 @@ __pattern_hetero_set_op(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _
     auto __buf2 = __keep2(__first2, __last2);
 
     auto __keep3 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _OutputIterator>();
-    auto __buf3 = __keep3(__result, __result + __n1 + __n2);
+    auto __buf3 = __keep3(__result, __result + __n1);
 
     auto __result_size =
         __par_backend_hetero::__parallel_transform_scan(


### PR DESCRIPTION
Fixed errors in upper_bound, lower_bound, binary_search algorithms: unable to call these algorithms with empty source data.