### PR TITLE
[oneDPL] + a fix of passing sycl::buffer to a sycl::accessor

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -119,7 +119,7 @@ struct iter_mode
     // for common heterogeneous iterator
     template <template <access_mode, typename...> class Iter, access_mode inMode, typename... Types>
     Iter<iter_mode_resolver<inMode, outMode>::value, Types...>
-    operator()(const Iter<inMode, Types...>& it)
+    operator()(Iter<inMode, Types...>& it)
     {
         constexpr access_mode preferredMode = iter_mode_resolver<inMode, outMode>::value;
         if (inMode == preferredMode)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -328,8 +328,8 @@ struct __buffer<_ExecutionPolicy, _T, sycl::buffer<_BValueT, __dim, _AllocT>>
         return oneapi::dpl::begin(__container);
     }
 
-    __container_t
-    get_buffer() const
+    __container_t&
+    get_buffer()
     {
         return __container;
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -53,7 +53,7 @@ struct sycl_iterator
     sycl_iterator(sycl::buffer<T, dim, Allocator> vec, Size index) : buffer(vec), idx(index) {}
     // required for iter_mode
     template <access_mode inMode>
-    sycl_iterator(const sycl_iterator<inMode, T, Allocator>& in) : buffer(in.get_buffer())
+    sycl_iterator(sycl_iterator<inMode, T, Allocator>& in) : buffer(in.get_buffer())
     {
         auto old_iter = sycl_iterator<inMode, T, Allocator>{in.get_buffer(), 0};
         idx = in - old_iter;
@@ -106,8 +106,8 @@ struct sycl_iterator
         return *this - it < 0;
     }
 
-    sycl::buffer<T, dim, Allocator>
-    get_buffer() const
+    sycl::buffer<T, dim, Allocator>&
+    get_buffer()
     {
         return buffer;
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -42,7 +42,9 @@ class all_view
     using __accessor_t = sycl::accessor<_T, 1, _AccMode, _Target, _Placeholder>;
 
   public:
-    all_view(sycl::buffer<_T, 1> __buf = sycl::buffer<_T, 1>(0), __diff_type __offset = 0, __diff_type __n = 0)
+    all_view() {}
+
+    all_view(sycl::buffer<_T, 1>& __buf, __diff_type __offset = 0, __diff_type __n = 0)
         : __m_acc(__create_accessor(__buf, __offset, __n))
     {
     }


### PR DESCRIPTION
[oneDPL] + a fix of passing sycl::buffer to a sycl::accessor