### PR TITLE
Correct permutation_iterator example's index map function.

### DIFF
--- a/documentation/library_guide/parallel_api/iterators.rst
+++ b/documentation/library_guide/parallel_api/iterators.rst
@@ -99,7 +99,7 @@ header.  All iterators are implemented in the ``oneapi::dpl`` namespace.
 
     struct multiply_index_by_two {
         template <typename Index>
-        Index operator()(const Index& i)
+        Index operator[](const Index& i) const
         { return i*2; }
     };
 


### PR DESCRIPTION
The struct used as an index map for `permutation_iterator` must define a const member `operator[]`, not `operator()`. Closes #578.