### PR TITLE
Add asterisks for a trademark in documentation

### DIFF
--- a/documentation/library_guide/api_for_sycl_kernels/random.rst
+++ b/documentation/library_guide/api_for_sycl_kernels/random.rst
@@ -84,7 +84,7 @@ Distribution                   Description
 Usage Model of |onedpl_short| Random Number Generation Functionality
 --------------------------------------------------------------------
 
-Random number generation is available for SYCL device-side and host-side code. For example:
+Random number generation is available for SYCL* device-side and host-side code. For example:
 
 .. code:: cpp
 

--- a/documentation/library_guide/api_for_sycl_kernels/tested_standard_cpp_api.rst
+++ b/documentation/library_guide/api_for_sycl_kernels/tested_standard_cpp_api.rst
@@ -1,7 +1,7 @@
 Tested Standard C++ APIs
 ########################
 
-The basic functionality for several C++ standard APIs has been tested for use in SYCL kernels.
+The basic functionality for several C++ standard APIs has been tested for use in SYCL* kernels.
 These APIs can be employed in device kernels similarly to how they are employed in code for a typical CPU-based platform.
 The Tested Standard C++ APIs are added to the namespace ``oneapi::dpl``. The corresponding headers have been added in the
 |onedpl_long| (|onedpl_short|) package. In order to use these APIs via the namespace ``oneapi::dpl``, the headers in

--- a/documentation/library_guide/api_for_sycl_kernels_main.rst
+++ b/documentation/library_guide/api_for_sycl_kernels_main.rst
@@ -1,7 +1,7 @@
-API for the SYCL Kernels
+API for the SYCL* Kernels
 #########################
 
-|onedpl_long| (|onedpl_short|) includes the following APIs for SYCL kernels:
+|onedpl_long| (|onedpl_short|) includes the following APIs for SYCL* kernels:
 
 * :doc:`Tested Standard C++ APIs <api_for_sycl_kernels/tested_standard_cpp_api>`. The basic
   functionality for several C++ standard APIs has been tested for use in SYCL kernels.

--- a/documentation/library_guide/index.rst
+++ b/documentation/library_guide/index.rst
@@ -2,7 +2,7 @@
 =================================
 
 |onedpl_long| (|onedpl_short|) works with the |dpcpp_cpp| to
-provide high-productivity APIs to developers, which can minimize SYCL programming
+provide high-productivity APIs to developers, which can minimize SYCL* programming
 efforts across devices for high performance parallel applications.
 
 .. toctree::

--- a/documentation/library_guide/onedpl_gsg.rst
+++ b/documentation/library_guide/onedpl_gsg.rst
@@ -3,7 +3,7 @@ Get Started with the |onedpl_long|
 
 |onedpl_long| (|onedpl_short|) works with the
 `Intel® oneAPI DPC++/C++ Compiler <https://software.intel.com/content/www/us/en/develop/documentation/get-started-with-dpcpp-compiler/top.html>`_
-to provide high-productivity APIs to developers, which can minimize SYCL
+to provide high-productivity APIs to developers, which can minimize SYCL*
 
 programming efforts across devices for high performance parallel applications.
 

--- a/documentation/library_guide/parallel_api/async_api.rst
+++ b/documentation/library_guide/parallel_api/async_api.rst
@@ -4,7 +4,7 @@ Asynchronous API Algorithms
 The functions defined in the STL ``<algorithm>`` or ``<numeric>`` headers are traditionally blocking. |onedpl_long| (|onedpl_short|)
 extends the functionality of the C++17 parallel algorithms by providing asynchronous algorithms with non-blocking behavior.
 This experimental feature enables you to express a concurrent control flow by building dependency chains, interleaving algorithm calls,
-and interoperability with SYCL kernels. 
+and interoperability with SYCL* kernels. 
 
 The current implementation for async algorithms is limited to device execution policies.
 All the functionality described below is available in the ``oneapi::dpl::experimental`` namespace.


### PR DESCRIPTION
Add asterisks for first mention of a trademark in documentation.
Signed-off-by: Valentina Kats valentina.kats@intel.com