### PR TITLE
Support zip_iterator construction from tuple of iterators

### DIFF
--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -278,6 +278,7 @@ class zip_iterator
 
     zip_iterator() : __my_it_() {}
     explicit zip_iterator(_Types... __args) : __my_it_(::std::make_tuple(__args...)) {}
+    explicit zip_iterator(std::tuple<_Types...> __arg) : __my_it_(__arg) {}
     zip_iterator(const zip_iterator& __input) : __my_it_(__input.__my_it_) {}
     zip_iterator&
     operator=(const zip_iterator& __input)
@@ -401,6 +402,13 @@ zip_iterator<_Tp...>
 make_zip_iterator(_Tp... __args)
 {
     return zip_iterator<_Tp...>(__args...);
+}
+
+template <typename... _Tp>
+zip_iterator<_Tp...>
+make_zip_iterator(std::tuple<_Tp...> __arg)
+{
+    return zip_iterator<_Tp...>(__arg);
 }
 
 template <typename _Iter, typename _UnaryFunc>

--- a/test/parallel_api/iterator/zip_iterator.pass.cpp
+++ b/test/parallel_api/iterator/zip_iterator.pass.cpp
@@ -119,7 +119,7 @@ DEFINE_TEST(test_for_each)
         ::std::fill(host_keys.get(), host_keys.get() + n, value);
         host_keys.update_data();
 
-        auto tuple_first1 = oneapi::dpl::make_zip_iterator(first1, first1);
+        auto tuple_first1 = oneapi::dpl::make_zip_iterator(std::make_tuple(first1, first1));
         auto tuple_last1 = oneapi::dpl::make_zip_iterator(last1, last1);
 
         ::std::for_each(make_new_policy<new_kernel_name<Policy, 0>>(exec), tuple_first1, tuple_last1,


### PR DESCRIPTION
The following use case identified is hand-migrated Thrust code.  The original application has functions that return tuples that are passed directly to `make_zip_iterator`.  Adding the `make_zip_iterator` interface that accepts a `std::tuple` of iterators to support this. Without it the tuple would have to be unpacked and elements passed to `make_zip_iterator` resulting in overly verbose code.