### PR TITLE
Performance Improvement of inclusive_scan_by_segment() and exclusive_scan_by_segment()

### DIFF
--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -55,7 +55,7 @@ exclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIter
 
     typedef typename ::std::iterator_traits<OutputIterator>::value_type OutputType;
     typedef typename ::std::iterator_traits<InputIterator2>::value_type ValueType;
-    typedef unsigned int FlagType;
+    typedef unsigned char FlagType;
     typedef typename ::std::decay<Policy>::type policy_type;
 
     InputIterator2 last2 = first2 + n;
@@ -109,7 +109,7 @@ exclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIter
 
     typedef typename ::std::iterator_traits<OutputIterator>::value_type OutputType;
     typedef typename ::std::iterator_traits<InputIterator2>::value_type ValueType;
-    typedef unsigned int FlagType;
+    typedef unsigned char FlagType;
     typedef typename ::std::decay<Policy>::type policy_type;
 
     InputIterator2 last2 = first2 + n;

--- a/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
@@ -52,7 +52,7 @@ inclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIter
         return result + 1;
     }
 
-    typedef unsigned int FlagType;
+    typedef unsigned char FlagType;
     typedef typename ::std::iterator_traits<InputIterator2>::value_type ValueType;
     typedef typename ::std::decay<Policy>::type policy_type;
 
@@ -79,7 +79,7 @@ oneapi::dpl::__internal::__enable_if_hetero_execution_policy<typename ::std::dec
 inclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                                OutputIterator result, BinaryPredicate binary_pred, BinaryOperator binary_op)
 {
-    typedef unsigned int FlagType;
+    typedef unsigned char FlagType;
     typedef typename ::std::iterator_traits<InputIterator2>::value_type ValueType;
     typedef typename ::std::decay<Policy>::type policy_type;
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -270,7 +270,7 @@ struct reduce
         do
         {
             __dpl_sycl::__group_barrier(__item_id);
-            if (__local_idx % (2 * __k) == 0 && __local_idx + __k < __group_size && __global_idx < __n &&
+            if (__local_idx & (2 * __k - 1) == 0 && __local_idx + __k < __group_size && __global_idx < __n &&
                 __global_idx + __k < __n)
             {
                 __local_mem[__local_idx] = __bin_op1(__local_mem[__local_idx], __local_mem[__local_idx + __k]);
@@ -629,7 +629,7 @@ struct __scan
             {
                 __dpl_sycl::__group_barrier(__item);
 
-                if (__adjusted_global_id < __n && __local_id % (2 * __k) == 2 * __k - 1)
+                if (__adjusted_global_id < __n && __local_id & (2 * __k - 1) == 2 * __k - 1)
                 {
                     __local_acc[__local_id] = __bin_op(__local_acc[__local_id - __k], __local_acc[__local_id]);
                 }
@@ -643,9 +643,9 @@ struct __scan
             do
             {
                 // use signed type to avoid overflowing
-                ::std::int32_t __shifted_local_id = __local_id - __local_id % __k - 1;
-                if (__shifted_local_id >= 0 && __adjusted_global_id < __n && __local_id % (2 * __k) >= __k &&
-                    __local_id % (2 * __k) < 2 * __k - 1)
+                ::std::int32_t __shifted_local_id = __local_id - (__local_id & (__k - 1)) - 1;
+                if (__shifted_local_id >= 0 && __adjusted_global_id < __n && (__local_id & (2 * __k - 1)) >= __k &&
+                    (__local_id & (2 * __k - 1)) < 2 * __k - 1)
                 {
                     __partial_sums = __bin_op(__local_acc[__shifted_local_id], __partial_sums);
                 }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -270,7 +270,7 @@ struct reduce
         do
         {
             __dpl_sycl::__group_barrier(__item_id);
-            if (__local_idx & (2 * __k - 1) == 0 && __local_idx + __k < __group_size && __global_idx < __n &&
+            if ((__local_idx & (2 * __k - 1)) == 0 && __local_idx + __k < __group_size && __global_idx < __n &&
                 __global_idx + __k < __n)
             {
                 __local_mem[__local_idx] = __bin_op1(__local_mem[__local_idx], __local_mem[__local_idx + __k]);
@@ -629,7 +629,7 @@ struct __scan
             {
                 __dpl_sycl::__group_barrier(__item);
 
-                if (__adjusted_global_id < __n && __local_id & (2 * __k - 1) == 2 * __k - 1)
+                if (__adjusted_global_id < __n && (__local_id & (2 * __k - 1)) == 2 * __k - 1)
                 {
                     __local_acc[__local_id] = __bin_op(__local_acc[__local_id - __k], __local_acc[__local_id]);
                 }


### PR DESCRIPTION
In issue #591, it was identified that the modulus calculation in `scan_impl()` is a bottleneck to performance of `inclusive_scan_by_segment()`. Since the remainder is always taken over a power of two in this function, all operations of the form `m % n` can be switched `m & (n-1)`. This yields performance benefit for both `inclusive_scan_by_segment()` and `exclusive_scan_by_segment()`.

Likewise, in both `inclusive_scan_by_segment()` and `exclusive_scan_by_segment()` the mask can be of type `unsigned char` instead of `unsigned int` to reduce the amount of data movement.

Resolves #591 