### PR TITLE
[oneDPL] Added support C++ functor/lambda  for permutation_iterator 

### DIFF
--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -570,9 +570,10 @@ template <typename SourceIterator, typename _Permutation>
 class permutation_iterator
 {
   public:
-    typedef typename std::conditional<!__internal::__is_functor<_Permutation>, _Permutation,
+    typedef typename std::conditional<
+        !__internal::__is_functor<_Permutation>, _Permutation,
         transform_iterator<counting_iterator<typename ::std::iterator_traits<SourceIterator>::difference_type>,
-        _Permutation>>::type IndexMap;
+                           _Permutation>>::type IndexMap;
     typedef typename ::std::iterator_traits<SourceIterator>::difference_type difference_type;
     typedef typename ::std::iterator_traits<SourceIterator>::value_type value_type;
     typedef typename ::std::iterator_traits<SourceIterator>::pointer pointer;

--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -607,10 +607,10 @@ class permutation_iterator
         return my_source_it;
     }
 
-    IndexMap
+    auto
     map() const
     {
-        if constexpr (__internal::__is_functor<_T>)
+        if constexpr (__internal::__is_functor<_Permutation>)
             return my_index.functor();
         else
             return my_index;

--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -546,7 +546,30 @@ make_transform_iterator(_Iter __it, _UnaryFunc __unary_func)
     return transform_iterator<_Iter, _UnaryFunc>(__it, __unary_func);
 }
 
-template <typename SourceIterator, typename IndexMap>
+namespace __internal
+{
+
+//functor concept
+struct __functor_concept
+{
+    template <typename _T>
+    static auto
+    test(int) -> decltype(::std::declval<_T>()(0), ::std::true_type{});
+
+    template <typename _T>
+    static auto
+    test(...) -> ::std::false_type;
+};
+
+template <typename _T>
+inline constexpr bool __is_functor = decltype(__functor_concept::test<_T>(0))::value;
+
+} //__internal
+
+template <typename SourceIterator, typename _Permutation, 
+    typename IndexMap = typename std::conditional<!__internal::__is_functor<_Permutation>, _Permutation,
+    transform_iterator<counting_iterator<typename ::std::iterator_traits<SourceIterator>::difference_type>,
+    _Permutation>>::type>
 class permutation_iterator
 {
   public:
@@ -560,24 +583,49 @@ class permutation_iterator
 
     permutation_iterator() = default;
 
-    permutation_iterator(const SourceIterator& input1, const IndexMap& input2, ::std::size_t index = 0)
-        : my_source_it(input1), my_index_map(input2), my_index(index)
+    template <typename _T = _Permutation, typename ::std::enable_if<!__internal::__is_functor<_T>, int>::type = 0>
+    permutation_iterator(SourceIterator input1, _Permutation input2)
+        : my_source_it(input1), my_index(input2)
     {
     }
 
+    template <typename _T = _Permutation, typename ::std::enable_if<__internal::__is_functor<_T>, int>::type = 0>
+    permutation_iterator(SourceIterator input1, _Permutation __f, difference_type __idx = 0)
+        : my_source_it(input1), my_index(counting_iterator<difference_type>(__idx), __f)
+    {
+    }
+  private:
+    template <typename _T = _Permutation, typename ::std::enable_if<__internal::__is_functor<_T>, int>::type = 0>
+    permutation_iterator(SourceIterator input1, IndexMap input2)
+        : my_source_it(input1), my_index(input2)
+    {
+    }
+
+public:
     SourceIterator
     base() const
     {
         return my_source_it;
     }
 
+    template <typename _T = IndexMap, typename ::std::enable_if<!__internal::__is_functor<_T>, int>::type = 0>
     IndexMap
     map() const
     {
-        return my_index_map + my_index;
+        return my_index;
     }
 
-    reference operator*() const { return my_source_it[my_index_map[my_index]]; }
+    template <typename _T = IndexMap, typename ::std::enable_if<__internal::__is_functor<_T>, int>::type = 0>
+    IndexMap
+    map() const
+    {
+        return my_index.functor();
+    }
+
+    reference operator*() const
+    {
+        return my_source_it[*my_index]; 
+    }
 
     reference operator[](difference_type __i) const { return *(*this + __i); }
 
@@ -614,13 +662,13 @@ class permutation_iterator
     permutation_iterator
     operator+(difference_type forward) const
     {
-        return permutation_iterator(my_source_it, my_index_map, my_index + forward);
+        return permutation_iterator(my_source_it, my_index + forward);
     }
 
     permutation_iterator
     operator-(difference_type backward) const
     {
-        return permutation_iterator(my_source_it, my_index_map, my_index - backward);
+        return permutation_iterator(my_source_it, my_index - backward);
     }
 
     permutation_iterator&
@@ -646,7 +694,7 @@ class permutation_iterator
     friend permutation_iterator
     operator+(difference_type forward, const permutation_iterator& it)
     {
-        return permutation_iterator(it.my_source_it, it.my_index_map, it.my_index + forward);
+        return permutation_iterator(it.my_source_it, it.my_index + forward);
     }
 
     bool
@@ -682,15 +730,14 @@ class permutation_iterator
 
   private:
     SourceIterator my_source_it;
-    IndexMap my_index_map;
-    difference_type my_index;
+    IndexMap my_index;
 };
 
-template <typename SourceIterator, typename IndexMap>
+template <typename SourceIterator, typename IndexMap, typename ...StartIndex>
 permutation_iterator<SourceIterator, IndexMap>
-make_permutation_iterator(SourceIterator source, IndexMap map)
+make_permutation_iterator(SourceIterator source, IndexMap map, StartIndex... idx)
 {
-    return permutation_iterator<SourceIterator, IndexMap>(source, map);
+    return permutation_iterator<SourceIterator, IndexMap>(source, map, idx...);
 }
 
 namespace internal

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -354,38 +354,33 @@ struct is_map_view : decltype(test_map_view<_Map>(0))
 {
 };
 
-template <typename _Map>
-struct is_map_iterator : oneapi::dpl::__internal::__is_random_access_iterator<_Map>
-{
-};
-
-template <typename _Map>
-using is_map_functor = ::std::integral_constant<bool, !is_map_iterator<_Map>::value && !is_map_view<_Map>::value>;
-
 //It is kind of pseudo-view for permutation_iterator support.
 template <typename _R, typename _M, typename = void>
 struct permutation_view_simple;
 
 //permutation view: specialization for an index map functor
 template <typename _R, typename _M>
-struct permutation_view_simple<_R, _M, typename ::std::enable_if<is_map_functor<_M>::value, void>::type>
+struct permutation_view_simple<_R, _M, typename ::std::enable_if<oneapi::dpl::__internal::__is_functor<_M>>::type>
 {
+    using _Size = oneapi::dpl::__internal::__difference_t<_R>;
+
     _R __r;
     _M __map_fn;
+    _Size __size;
 
-    permutation_view_simple(_R __rng, _M __m) : __r(__rng), __map_fn(__m) {}
+    permutation_view_simple(_R __rng, _M __m, _Size __s) : __r(__rng), __map_fn(__m), __size(__s) {}
 
     //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range
     template <typename Idx>
-    auto operator[](Idx __i) const -> decltype(__r[__map_fn[__i]])
+    auto operator[](Idx __i) const -> decltype(__r[__map_fn(__i)])
     {
-        return __r[__map_fn[__i]];
+        return __r[__map_fn(__i)];
     }
 
     auto
-    size() const -> decltype(__r.size())
+    size() const -> decltype(__size)
     {
-        return __r.size();
+        return __size;
     }
 
     bool

--- a/test/parallel_api/iterator/iterators.pass.cpp
+++ b/test/parallel_api/iterator/iterators.pass.cpp
@@ -301,13 +301,25 @@ struct test_permutation_iterator
                     "wrong result from copy with permutation_iterator");
 
         oneapi::dpl::permutation_iterator<typename ::std::vector<T1>::iterator, typename ::std::vector<T2>::iterator> perm_it1(in1.begin(), in2.begin());
-        oneapi::dpl::permutation_iterator<typename ::std::vector<T1>::iterator, typename ::std::vector<T2>::iterator> perm_it2(in1.begin(), in2.begin(), in2.size()-1);
-        EXPECT_TRUE(perm_it1 == perm_begin, "wrong result from permutation_iterator(base, map)");
-        EXPECT_TRUE(perm_it2 == perm_begin + in2.size()-1, "wrong result from permutation_iterator(base, map, offset)");
-        EXPECT_TRUE(perm_it1.base() == in1.begin(), "wrong result from permutation_iterator::base");
-        EXPECT_TRUE(perm_it1.map() == in2.begin(), "wrong result from permutation_iterator::map");
+        oneapi::dpl::permutation_iterator<typename ::std::vector<T1>::iterator, typename ::std::vector<T2>::iterator> perm_it2(in1.begin(), in2.begin() + in2.size()-1);
+        EXPECT_TRUE(perm_it1 == perm_begin, "wrong result from permutation_iterator(base_iterator, index_iterator)");
+        EXPECT_TRUE(perm_it2 == perm_begin + in2.size()-1, "wrong result from permutation_iterator(base_iterator, index_iterator)");
+        EXPECT_TRUE(perm_it1.base() == in1.begin(), "wrong result from permutation_iterator::base_iterator");
+        EXPECT_TRUE(perm_it1.map() == in2.begin(), "wrong result from permutation_iterator::index_iterator");
 
         test_random_iterator(perm_begin);
+
+        auto n = in1.size();
+        auto perm_it_fun_rev = oneapi::dpl::make_permutation_iterator(in1.begin(), [n] (auto i) { return n - i - 1;}, 1);
+        EXPECT_TRUE(*++perm_it_fun_rev == *(in1.end()-3), "wrong result from permutation_iterator(base_iterator, functor)");
+
+        test_random_iterator(perm_it_fun_rev);
+
+        ::std::vector<T1> res(n);
+        perm_it_fun_rev -= 2;
+        ::std::copy(perm_it_fun_rev, perm_it_fun_rev + n, res.begin());
+
+        EXPECT_EQ_N(res.begin(), oneapi::dpl::make_reverse_iterator(in1.end()), n, "wrong result from permutation_iterator(base_iterator, functor)");
     }
 };
 

--- a/test/parallel_api/iterator/permutation_iterator.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator.pass.cpp
@@ -3,13 +3,14 @@
 //
 // SPDX-License-Identifier: MIT
 // =============================================================
+
+#include "support/test_config.h"
+
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/iterator>
 
-#if TEST_DPCPP_BACKEND_PRESENT
-#include "support/utils_sycl.h"
-#endif // TEST_DPCPP_BACKEND_PRESENT
+#include "support/utils.h"
 
 #include <iostream>
 

--- a/test/parallel_api/iterator/permutation_iterator.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator.pass.cpp
@@ -1,0 +1,52 @@
+//==============================================================
+// Copyright © 2020 Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+// =============================================================
+#include <oneapi/dpl/execution>
+#include <oneapi/dpl/algorithm>
+#include <oneapi/dpl/iterator>
+
+#if TEST_DPCPP_BACKEND_PRESENT
+#include "support/utils_sycl.h"
+#endif // TEST_DPCPP_BACKEND_PRESENT
+
+#include <iostream>
+
+struct multiply_index_by_two
+{
+    template <typename Index>
+    Index
+    operator()(const Index& i) const
+    {
+        return i * 2;
+    }
+};
+
+int
+main()
+{
+#if TEST_DPCPP_BACKEND_PRESENT
+    const int num_elelemts = 100;
+    std::vector<float> result(num_elelemts, 1);
+    oneapi::dpl::counting_iterator<int> first(0);
+    oneapi::dpl::counting_iterator<int> last(20);
+
+    // first and last are iterators that define a contiguous range of input elements
+    // compute the number of elements in the range between the first and last that are accessed
+    // by the permutation iterator
+    size_t num_elements = std::distance(first, last) / 2 + std::distance(first, last) % 2;
+    auto permutation_first = dpl::make_permutation_iterator(first, multiply_index_by_two());
+    auto permutation_last = permutation_first + num_elements;
+    auto it = std::copy(TestUtils::default_dpcpp_policy, permutation_first, permutation_last, result.begin());
+    auto count = ::std::distance(result.begin(), it);
+
+    for (int i = 0; i < count; i++)
+        ::std::cout << result[i] << " ";
+
+    ::std::cout << ::std::endl;
+
+#endif // TEST_DPCPP_BACKEND_PRESENT
+
+    return 0;
+}


### PR DESCRIPTION
[oneDPL] permutation_iterator and permutation_view improvements
1. Added support usage case like in Boost (https://www.boost.org/doc/libs/1_38_0/libs/iterator/doc/permutation_iterator.html)
2. Aded support C++ functor as an index map  for  permutation_iterator (https://oneapi-src.github.io/oneDPL/parallel_api/iterators.html). 
3. Added support C++ functor as an index map  for  permutation_view
4. The test coverage was extended as well.
5. Added example for permutation_iterator from our documentation as test.

