### PR TITLE
[RNG] [Tests] Remove outdated get_cl_code & clean-up

### DIFF
--- a/examples/random/src/main.cpp
+++ b/examples/random/src/main.cpp
@@ -25,12 +25,12 @@ void
 scalar_example(sycl::queue& queue, std::uint32_t seed, std::vector<RealType>& x)
 {
     {
-        sycl::buffer<RealType, 1> x_buffer(x.data(), sycl::range<1>(x.size()));
+        sycl::buffer<RealType> x_buffer(x.data(), x.size());
 
         queue.submit(
             [&](sycl::handler& cgh)
             {
-                auto x_acc = x_buffer.template get_access<sycl::access::mode::write>(cgh);
+                sycl::accessor x_acc(x_buffer, cgh, sycl::write_only);
 
                 cgh.parallel_for(sycl::range<1>(x.size()),
                                  [=](sycl::item<1> idx)
@@ -71,14 +71,14 @@ void
 vector_example(sycl::queue& queue, std::uint32_t seed, std::vector<RealType>& x)
 {
     {
-        sycl::buffer<RealType, 1> x_buffer(x.data(), sycl::range<1>(x.size()));
+        sycl::buffer<RealType> x_buffer(x.data(), x.size());
 
         queue.submit(
             [&](sycl::handler& cgh)
             {
-                auto x_acc = x_buffer.template get_access<sycl::access::mode::write>(cgh);
+                sycl::accessor x_acc(x_buffer, cgh, sycl::write_only);
 
-                cgh.parallel_for<class generate_kernel>(
+                cgh.parallel_for(
                     sycl::range<1>(x.size() / VecSize),
                     [=](sycl::item<1> idx)
                     {

--- a/test/xpu_api/random/conformance_tests/common_for_conformance_tests.hpp
+++ b/test/xpu_api/random/conformance_tests/common_for_conformance_tests.hpp
@@ -53,14 +53,13 @@ typename Engine::scalar_type test(sycl::queue& queue) {
                     res.store(idx.get_linear_id(), dpstd_acc);
                 });
             });
+            queue.wait_and_throw();
         }
         catch(sycl::exception const& e) {
             std::cout << "\t\tSYCL exception during generation\n"
-                      << e.what() << std::endl << "OpenCL status: " << e.get_cl_code() << std::endl;
+                      << e.what() << std::endl;
             return 0;
         }
-
-        queue.wait_and_throw();
     }
 
     return dpstd_samples[REF_SAMPLE_ID];

--- a/test/xpu_api/random/interface_tests/distributions_methods.pass.cpp
+++ b/test/xpu_api/random/interface_tests/distributions_methods.pass.cpp
@@ -278,8 +278,7 @@ test_vec(sycl::queue& queue)
         catch (sycl::exception const& e)
         {
             std::cout << "\t\tSYCL exception during generation\n"
-                      << e.what() << std::endl
-                      << "OpenCL status: " << e.get_cl_code() << std::endl;
+                      << e.what() << std::endl;
             return 1;
         }
 
@@ -328,16 +327,15 @@ test(sycl::queue& queue)
                     acc[offset * 2 + 1] = res1;
                 });
             });
+            queue.wait_and_throw();
         }
         catch (sycl::exception const& e)
         {
             std::cout << "\t\tSYCL exception during generation\n"
-                      << e.what() << std::endl
-                      << "OpenCL status: " << e.get_cl_code() << std::endl;
+                      << e.what() << std::endl;
             return 1;
         }
 
-        queue.wait_and_throw();
         Distr distr;
         sum += check_params(distr);
     }

--- a/test/xpu_api/random/interface_tests/engines_methods.pass.cpp
+++ b/test/xpu_api/random/interface_tests/engines_methods.pass.cpp
@@ -154,8 +154,7 @@ public:
             catch (sycl::exception const& e)
             {
                 std::cout << "\t\tSYCL exception during generation\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << e.what() << std::endl;
                 return 1;
             }
 
@@ -227,16 +226,14 @@ public:
                 {
                     std::cout << "Error occurred in " << sum << " elements" << std::endl;
                 }
+                queue.wait_and_throw();
             }
             catch (sycl::exception const& e)
             {
                 std::cout << "\t\tSYCL exception during generation\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << e.what() << std::endl;
                 return 1;
             }
-
-            queue.wait_and_throw();
             oneapi::dpl::ranlux24_vec<N> engine;
             sum += check_params(engine);
         }
@@ -301,8 +298,7 @@ public:
             catch (sycl::exception const& e)
             {
                 std::cout << "\t\tSYCL exception during generation\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << e.what() << std::endl;
                 return 1;
             }
 
@@ -373,8 +369,7 @@ public:
             catch (sycl::exception const& e)
             {
                 std::cout << "\t\tSYCL exception during generation\n"
-                          << e.what() << std::endl
-                          << "OpenCL status: " << e.get_cl_code() << std::endl;
+                          << e.what() << std::endl;
                 return 1;
             }
 


### PR DESCRIPTION
Tests:

- get_cl_code is removed
- queue wait and throw reordered

Examples:

- sycl::buffer/accessor API updated