### PR TITLE
[oneDPL][test] + in_place_scan test fixes

### DIFF
--- a/test/support/scan_serial_impl.h
+++ b/test/support/scan_serial_impl.h
@@ -26,8 +26,9 @@ exclusive_scan_serial(InputIterator first, InputIterator last, OutputIterator re
 {
     for (; first != last; ++first, ++result)
     {
-        *result = init;
+        auto res = init;
         init = init + *first;
+        *result = res;
     }
     return result;
 }
@@ -38,8 +39,9 @@ exclusive_scan_serial(InputIterator first, InputIterator last, OutputIterator re
 {
     for (; first != last; ++first, ++result)
     {
-        *result = init;
+	auto res = init;
         init = binary_op(init, *first);
+        *result = res;
     }
     return result;
 }


### PR DESCRIPTION
[oneDPL][test] + in_place_scan test fixes.
1) + usage of inclusive_scan_serial, exclusive_scan_serial within  in_place_scan.pass.cpp
2) + fixes for "in place" semantic for  inclusive_scan_serial, exclusive_scan_serial (used for the test support only)