### PR TITLE
[oneDPL][test] compilation fixes for in_place_scan test

### DIFF
--- a/test/parallel_api/numeric/numeric.ops/in_place_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/in_place_scan.pass.cpp
@@ -13,15 +13,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#define _GLIBCXX_USE_TBB_PAR_BACKEND 0 // libstdc++10
+#include "oneapi/dpl/execution"
+#include "oneapi/dpl/algorithm"
+#include "oneapi/dpl/iterator"
 
 #include "support/test_config.h"
-#include <cassert>
 #include "support/utils.h"
-
-#include _PSTL_TEST_HEADER(execution)
-#include _PSTL_TEST_HEADER(algorithm)
-#include _PSTL_TEST_HEADER(numeric)
 
 #if TEST_DPCPP_BACKEND_PRESENT
 #    include "support/utils_sycl.h"


### PR DESCRIPTION
A fix for 
https://github.com/oneapi-src/oneDPL/runs/7561089789?check_suite_focus=true

```
/usr/include/c++/9/pstl/parallel_backend_tbb.h: In lambda function:
/usr/include/c++/9/pstl/parallel_backend_tbb.h:596:24: error: ‘tbb::task’ has not been declared
  596 |             using tbb::task;
      |                        ^~~~
/usr/include/c++/9/pstl/parallel_backend_tbb.h:597:13: error: ‘task’ has not been declared
  597 |             task::spawn_root_and_wait(*new (task::allocate_root())
      |             ^~~~
/usr/include/c++/9/pstl/parallel_backend_tbb.h:597:45: error: ‘task’ was not declared in this scope; did you mean ‘tbb::detail::d1::task’?
  597 |             task::spawn_root_and_wait(*new (task::allocate_root())
      |                                             ^~~~
      |                                             tbb::detail::d1::task
In file included from /usr/share/miniconda/include/oneapi/tbb/parallel_for.h:23,
                 from /usr/share/miniconda/include/tbb/parallel_for.h:17,
                 from /usr/include/c++/9/pstl/parallel_backend_tbb.h:20,
                 from /usr/include/c++/9/pstl/parallel_backend.h:14,
                 from /usr/include/c++/9/pstl/algorithm_impl.h:25,
                 from /usr/include/c++/9/pstl/glue_execution_defs.h:52,
                 from /usr/include/c++/9/execution:32,
                 from /home/runner/work/oneDPL/oneDPL/include/oneapi/dpl/execution:23,
                 from /home/runner/work/oneDPL/oneDPL/test/support/utils.h:21,
                 from /home/runner/work/oneDPL/oneDPL/test/parallel_api/numeric/numeric.ops/in_place_scan.pass.cpp:20:
```