### PR TITLE
Wrap sycl::buffer_allocator into __dpl_sycl::__buffer_allocator

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -207,6 +207,18 @@ constexpr __target __target_device =
     __target::global_buffer;
 #endif
 
+template <typename DataT>
+using __buffer_allocator =
+#if __LIBSYCL_VERSION >= 50700
+    sycl::buffer_allocator<DataT>;
+#else
+#    ifdef SYCL2020_CONFORMANT_APIS
+    sycl::buffer_allocator<DataT>;
+#    else
+    sycl::buffer_allocator;
+#    endif
+#endif
+
 } // namespace __dpl_sycl
 
 #endif /* _ONEDPL_sycl_defs_H */

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -207,10 +207,10 @@ constexpr __target __target_device =
     __target::global_buffer;
 #endif
 
-template <typename DataT>
+template <typename _DataT>
 using __buffer_allocator =
 #if __LIBSYCL_VERSION >= 50707
-    sycl::buffer_allocator<DataT>;
+    sycl::buffer_allocator<_DataT>;
 #else
     sycl::buffer_allocator;
 #endif

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -209,7 +209,7 @@ constexpr __target __target_device =
 
 template <typename DataT>
 using __buffer_allocator =
-#if __LIBSYCL_VERSION >= 50707 || defined(SYCL2020_CONFORMANT_APIS)
+#if __LIBSYCL_VERSION >= 50707
     sycl::buffer_allocator<DataT>;
 #else
     sycl::buffer_allocator;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -209,7 +209,7 @@ constexpr __target __target_device =
 
 template <typename DataT>
 using __buffer_allocator =
-#if __LIBSYCL_VERSION >= 50704 || defined(SYCL2020_CONFORMANT_APIS)
+#if __LIBSYCL_VERSION >= 50707 || defined(SYCL2020_CONFORMANT_APIS)
     sycl::buffer_allocator<DataT>;
 #else
     sycl::buffer_allocator;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -209,14 +209,10 @@ constexpr __target __target_device =
 
 template <typename DataT>
 using __buffer_allocator =
-#if __LIBSYCL_VERSION >= 50700
+#if __LIBSYCL_VERSION >= 50704 || defined(SYCL2020_CONFORMANT_APIS)
     sycl::buffer_allocator<DataT>;
 #else
-#    ifdef SYCL2020_CONFORMANT_APIS
-    sycl::buffer_allocator<DataT>;
-#    else
     sycl::buffer_allocator;
-#    endif
 #endif
 
 } // namespace __dpl_sycl

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -31,7 +31,7 @@ namespace __internal
 {
 // Iterator that hides sycl::buffer to pass those to algorithms.
 // SYCL iterator is a pair of sycl::buffer and integer value
-template <access_mode Mode, typename T, typename Allocator = sycl::buffer_allocator>
+template <access_mode Mode, typename T, typename Allocator = __dpl_sycl::__buffer_allocator<T>>
 struct sycl_iterator
 {
   private:


### PR DESCRIPTION
Wrap sycl::buffer_allocator into __dpl_sycl::__buffer_allocator alias.
Implementation of __dpl_sycl::__buffer_allocator depends from __LIBSYCL_VERSION:
if __LIBSYCL_VERSION >= 50707 then
    **template <typename _DataT>
    using __buffer_allocator =s ycl::buffer_allocator<_DataT>;**
else
    **template <typename _DataT>
    using __buffer_allocator =s ycl::buffer_allocator;**
