### PR TITLE
[oneDPL][Tests] + Fix error: long_double_float tests fail (long double is not supported)

### DIFF
--- a/test/support/test_complex.h
+++ b/test/support/test_complex.h
@@ -86,14 +86,26 @@ run_test()
 //         // ...
 //     }
 #define IF_DOUBLE_SUPPORT(x)                                                                          \
-    if constexpr (HasDoubleSupportInRuntime::value) { x; }
+    TestUtils::__invoke_test_if<>(HasDoubleSupportInRuntime(), [](){ x; });
 
 // We should use this macros to avoid compile-time error in code with long double type in Kernel.
 #define IF_LONG_DOUBLE_SUPPORT(x)                                                                     \
-    if constexpr (HasLongDoubleSupportInCompiletime::value) { x; }
+    TestUtils::__invoke_test_if<>(HasLongDoubleSupportInCompiletime(), []() { x; });
 
 namespace TestUtils
 {
+    template <typename _FncTest>
+    void
+    __invoke_test_if(::std::true_type, _FncTest __fncTest)
+    {
+        __fncTest();
+    }
+
+    template <typename _FncTest>
+    void __invoke_test_if(::std::false_type, _FncTest)
+    {
+    }
+
     // Run test in Kernel as single task
     template <typename TFncDoubleHasSupportInRuntime, typename TFncDoubleHasntSupportInRuntime>
     void

--- a/test/support/test_complex.h
+++ b/test/support/test_complex.h
@@ -86,23 +86,24 @@ run_test()
 //         // ...
 //     }
 #define IF_DOUBLE_SUPPORT(x)                                                                          \
-    TestUtils::__invoke_test_if<>(HasDoubleSupportInRuntime(), [](){ x; });
+    TestUtils::invoke_test_if<>(HasDoubleSupportInRuntime(), [](){ x; });
 
 // We should use this macros to avoid compile-time error in code with long double type in Kernel.
 #define IF_LONG_DOUBLE_SUPPORT(x)                                                                     \
-    TestUtils::__invoke_test_if<>(HasLongDoubleSupportInCompiletime(), []() { x; });
+    TestUtils::invoke_test_if<>(HasLongDoubleSupportInCompiletime(), []() { x; });
 
 namespace TestUtils
 {
     template <typename _FncTest>
     void
-    __invoke_test_if(::std::true_type, _FncTest __fncTest)
+    invoke_test_if(::std::true_type, _FncTest __fncTest)
     {
         __fncTest();
     }
 
     template <typename _FncTest>
-    void __invoke_test_if(::std::false_type, _FncTest)
+    void
+    invoke_test_if(::std::false_type, _FncTest)
     {
     }
 

--- a/test/xpu_api/numerics/c.math/abs1.pass.cpp
+++ b/test/xpu_api/numerics/c.math/abs1.pass.cpp
@@ -69,10 +69,8 @@ ONEDPL_TEST_NUM_MAIN
     test_abs<std::int32_t, correct_size_int<std::int32_t>::type>();
     test_abs<std::int64_t, correct_size_int<std::int64_t>::type>();
 
-    if constexpr (HasLongDoubleSupportInCompiletime::value)
-        test_abs<long double, long double>();
-    if constexpr (HasDoubleSupportInRuntime::value)
-        test_abs<double, double>();
+    TestUtils::__invoke_test_if<>(HasLongDoubleSupportInCompiletime(), []() { test_abs<long double, long double>(); });
+    TestUtils::__invoke_test_if<>(HasDoubleSupportInRuntime(), []() { test_abs<double, double>(); });
     test_abs<float, float>();
 
     test_big();

--- a/test/xpu_api/numerics/c.math/abs1.pass.cpp
+++ b/test/xpu_api/numerics/c.math/abs1.pass.cpp
@@ -69,8 +69,8 @@ ONEDPL_TEST_NUM_MAIN
     test_abs<std::int32_t, correct_size_int<std::int32_t>::type>();
     test_abs<std::int64_t, correct_size_int<std::int64_t>::type>();
 
-    TestUtils::__invoke_test_if<>(HasLongDoubleSupportInCompiletime(), []() { test_abs<long double, long double>(); });
-    TestUtils::__invoke_test_if<>(HasDoubleSupportInRuntime(), []() { test_abs<double, double>(); });
+    TestUtils::invoke_test_if<>(HasLongDoubleSupportInCompiletime(), []() { test_abs<long double, long double>(); });
+    TestUtils::invoke_test_if<>(HasDoubleSupportInRuntime(), []() { test_abs<double, double>(); });
     test_abs<float, float>();
 
     test_big();

--- a/test/xpu_api/numerics/complex.number/cmplx.over/pow.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/pow.pass.cpp
@@ -81,35 +81,22 @@ test(typename std::enable_if<!std::is_integral<T>::value>::type* = 0, typename s
 ONEDPL_TEST_NUM_MAIN
 {
     test<int, float>();
-    if constexpr (EnableDouble::value)
-        test<int, double>();
-    if constexpr (EnableLongDouble::value)
-        test<int, long double>();
+    TestUtils::__invoke_test_if<>(HasDoubleSupportInRuntime(), []() { test<int, double>(); });
     test<unsigned, float>();
-    if constexpr (EnableDouble::value)
-        test<unsigned, double>();
-    if constexpr (EnableLongDouble::value)
-        test<unsigned, long double>();
+    TestUtils::__invoke_test_if<>(HasDoubleSupportInRuntime(), []() { test<unsigned, double>(); });
+    TestUtils::__invoke_test_if<>(HasLongDoubleSupportInCompiletime(), []() { test<unsigned, long double>(); });
     test<long long, float>();
-    if constexpr (EnableDouble::value)
-        test<long long, double>();
-    if constexpr (EnableLongDouble::value)
-        test<long long, long double>();
+    TestUtils::__invoke_test_if<>(HasDoubleSupportInRuntime(), []() { test<long long, double>(); });
+    TestUtils::__invoke_test_if<>(HasLongDoubleSupportInCompiletime(), []() { test<long long, long double>(); });
 
-    if constexpr (EnableDouble::value)
-        test<float, double>();
-    if constexpr (EnableLongDouble::value)
-        test<float, long double>();
+    TestUtils::__invoke_test_if<>(HasDoubleSupportInRuntime(), []() { test<float, double>(); });
+    TestUtils::__invoke_test_if<>(HasLongDoubleSupportInCompiletime(), []() { test<float, long double>(); });
 
-    if constexpr (EnableDouble::value)
-        test<double, float>();
-    if constexpr (EnableLongDouble::value)
-        test<double, long double>();
+    TestUtils::__invoke_test_if<>(HasDoubleSupportInRuntime(), []() { test<double, float>(); });
+    TestUtils::__invoke_test_if<>(HasLongDoubleSupportInCompiletime(), []() { test<double, long double>(); });
 
-    if constexpr (EnableLongDouble::value)
-        test<long double, float>();
-    if constexpr (EnableLongDouble::value)
-        test<long double, double>();
+    TestUtils::__invoke_test_if<>(HasLongDoubleSupportInCompiletime(), []() { test<long double, float>(); });
+    TestUtils::__invoke_test_if<>(HasLongDoubleSupportInCompiletime(), []() { test<long double, double>(); });
 
   return 0;
 }

--- a/test/xpu_api/numerics/complex.number/cmplx.over/pow.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/pow.pass.cpp
@@ -81,22 +81,22 @@ test(typename std::enable_if<!std::is_integral<T>::value>::type* = 0, typename s
 ONEDPL_TEST_NUM_MAIN
 {
     test<int, float>();
-    TestUtils::__invoke_test_if<>(HasDoubleSupportInRuntime(), []() { test<int, double>(); });
+    TestUtils::invoke_test_if<>(HasDoubleSupportInRuntime(), []() { test<int, double>(); });
     test<unsigned, float>();
-    TestUtils::__invoke_test_if<>(HasDoubleSupportInRuntime(), []() { test<unsigned, double>(); });
-    TestUtils::__invoke_test_if<>(HasLongDoubleSupportInCompiletime(), []() { test<unsigned, long double>(); });
+    TestUtils::invoke_test_if<>(HasDoubleSupportInRuntime(), []() { test<unsigned, double>(); });
+    TestUtils::invoke_test_if<>(HasLongDoubleSupportInCompiletime(), []() { test<unsigned, long double>(); });
     test<long long, float>();
-    TestUtils::__invoke_test_if<>(HasDoubleSupportInRuntime(), []() { test<long long, double>(); });
-    TestUtils::__invoke_test_if<>(HasLongDoubleSupportInCompiletime(), []() { test<long long, long double>(); });
+    TestUtils::invoke_test_if<>(HasDoubleSupportInRuntime(), []() { test<long long, double>(); });
+    TestUtils::invoke_test_if<>(HasLongDoubleSupportInCompiletime(), []() { test<long long, long double>(); });
 
-    TestUtils::__invoke_test_if<>(HasDoubleSupportInRuntime(), []() { test<float, double>(); });
-    TestUtils::__invoke_test_if<>(HasLongDoubleSupportInCompiletime(), []() { test<float, long double>(); });
+    TestUtils::invoke_test_if<>(HasDoubleSupportInRuntime(), []() { test<float, double>(); });
+    TestUtils::invoke_test_if<>(HasLongDoubleSupportInCompiletime(), []() { test<float, long double>(); });
 
-    TestUtils::__invoke_test_if<>(HasDoubleSupportInRuntime(), []() { test<double, float>(); });
-    TestUtils::__invoke_test_if<>(HasLongDoubleSupportInCompiletime(), []() { test<double, long double>(); });
+    TestUtils::invoke_test_if<>(HasDoubleSupportInRuntime(), []() { test<double, float>(); });
+    TestUtils::invoke_test_if<>(HasLongDoubleSupportInCompiletime(), []() { test<double, long double>(); });
 
-    TestUtils::__invoke_test_if<>(HasLongDoubleSupportInCompiletime(), []() { test<long double, float>(); });
-    TestUtils::__invoke_test_if<>(HasLongDoubleSupportInCompiletime(), []() { test<long double, double>(); });
+    TestUtils::invoke_test_if<>(HasLongDoubleSupportInCompiletime(), []() { test<long double, float>(); });
+    TestUtils::invoke_test_if<>(HasLongDoubleSupportInCompiletime(), []() { test<long double, double>(); });
 
   return 0;
 }

--- a/test/xpu_api/numerics/complex.number/complex.special/float_double_explicit.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.special/float_double_explicit.pass.cpp
@@ -21,7 +21,7 @@ ONEDPL_TEST_NUM_MAIN
     IF_DOUBLE_SUPPORT(const dpl::complex<double> cd(2.5, 3.5);
                       dpl::complex<float> cf(cd);
                       assert(cf.real() == cd.real());
-                      assert(cf.imag() == cd.imag())
+                      assert(cf.imag() == cd.imag()))
 
     IF_DOUBLE_SUPPORT(constexpr dpl::complex<double> cd(2.5, 3.5);
                       constexpr dpl::complex<float> cf(cd);


### PR DESCRIPTION
Fixed error in tests of std::complex: long_double_float tests fail (long double is not supported)