### PR TITLE
Bugfix for clashing kernel name generation with radix sort (ascending + descending)

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -608,17 +608,17 @@ __parallel_radix_sort_iteration(_ExecutionPolicy&& __exec, ::std::size_t __segme
 {
     // Injecting ascending / descending status into custom name to prevent clashing kernel names
     using _Ascending = std::conditional_t<__is_comp_asc, std::true_type, std::false_type>;
-    using _CustomName = typename std::pair<typename __decay_t<_ExecutionPolicy>::kernel_name, _Ascending>;
+    using _CustomName = typename  __decay_t<_ExecutionPolicy>::kernel_name;
     using _RadixCountKernel =
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<__radix_sort_count_kernel, _CustomName,
-                                                                               __decay_t<_InRange>, __decay_t<_TmpBuf>>;
+                                                                               __decay_t<_InRange>, __decay_t<_TmpBuf>, _Ascending>;
     using _RadixLocalScanKernel =
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<__radix_sort_scan_kernel_1, _CustomName,
                                                                                __decay_t<_TmpBuf>>;
     using _RadixGlobalScanKernel =
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<__radix_sort_scan_kernel_2<_CustomName>>;
     using _RadixReorderKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
-        __radix_sort_reorder_kernel, _CustomName, __decay_t<_InRange>, __decay_t<_OutRange>>;
+        __radix_sort_reorder_kernel, _CustomName, __decay_t<_InRange>, __decay_t<_OutRange>, _Ascending>;
 
     ::std::size_t __max_sg_size = oneapi::dpl::__internal::__max_sub_group_size(__exec);
     ::std::size_t __scan_wg_size = oneapi::dpl::__internal::__max_work_group_size(__exec);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -606,17 +606,19 @@ __parallel_radix_sort_iteration(_ExecutionPolicy&& __exec, ::std::size_t __segme
                                 _InRange&& __in_rng, _OutRange&& __out_rng, _TmpBuf& __tmp_buf,
                                 sycl::event __dependency_event)
 {
+    // Injecting ascending / descending status into custom name to prevent clashing kernel names
     using _Ascending = std::conditional_t<__is_comp_asc, std::true_type, std::false_type>;
-    using _CustomName = typename __decay_t<_ExecutionPolicy>::kernel_name;
-    using _RadixCountKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
-        __radix_sort_count_kernel, _CustomName, __decay_t<_InRange>, __decay_t<_TmpBuf>, _Ascending>;
+    using _CustomName = typename std::pair<typename __decay_t<_ExecutionPolicy>::kernel_name, _Ascending>;
+    using _RadixCountKernel =
+        oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<__radix_sort_count_kernel, _CustomName,
+                                                                               __decay_t<_InRange>, __decay_t<_TmpBuf>>;
     using _RadixLocalScanKernel =
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<__radix_sort_scan_kernel_1, _CustomName,
                                                                                __decay_t<_TmpBuf>>;
     using _RadixGlobalScanKernel =
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<__radix_sort_scan_kernel_2<_CustomName>>;
     using _RadixReorderKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
-        __radix_sort_reorder_kernel, _CustomName, __decay_t<_InRange>, __decay_t<_OutRange>, _Ascending>;
+        __radix_sort_reorder_kernel, _CustomName, __decay_t<_InRange>, __decay_t<_OutRange>>;
 
     ::std::size_t __max_sg_size = oneapi::dpl::__internal::__max_sub_group_size(__exec);
     ::std::size_t __scan_wg_size = oneapi::dpl::__internal::__max_work_group_size(__exec);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -606,17 +606,19 @@ __parallel_radix_sort_iteration(_ExecutionPolicy&& __exec, ::std::size_t __segme
                                 _InRange&& __in_rng, _OutRange&& __out_rng, _TmpBuf& __tmp_buf,
                                 sycl::event __dependency_event)
 {
+    using _Ascending = std::conditional_t<__is_comp_asc, std::true_type, std::false_type>;
     using _CustomName = typename __decay_t<_ExecutionPolicy>::kernel_name;
     using _RadixCountKernel =
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<__radix_sort_count_kernel, _CustomName,
-                                                                               __decay_t<_InRange>, __decay_t<_TmpBuf>>;
+                                                                               __decay_t<_InRange>, __decay_t<_TmpBuf>,
+                                                                               _Ascending>;
     using _RadixLocalScanKernel =
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<__radix_sort_scan_kernel_1, _CustomName,
                                                                                __decay_t<_TmpBuf>>;
     using _RadixGlobalScanKernel =
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<__radix_sort_scan_kernel_2<_CustomName>>;
     using _RadixReorderKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
-        __radix_sort_reorder_kernel, _CustomName, __decay_t<_InRange>, __decay_t<_OutRange>>;
+        __radix_sort_reorder_kernel, _CustomName, __decay_t<_InRange>, __decay_t<_OutRange>, _Ascending>;
 
     ::std::size_t __max_sg_size = oneapi::dpl::__internal::__max_sub_group_size(__exec);
     ::std::size_t __scan_wg_size = oneapi::dpl::__internal::__max_work_group_size(__exec);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -608,10 +608,9 @@ __parallel_radix_sort_iteration(_ExecutionPolicy&& __exec, ::std::size_t __segme
 {
     // Injecting ascending / descending status into custom name to prevent clashing kernel names
     using _Ascending = std::conditional_t<__is_comp_asc, std::true_type, std::false_type>;
-    using _CustomName = typename  __decay_t<_ExecutionPolicy>::kernel_name;
-    using _RadixCountKernel =
-        oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<__radix_sort_count_kernel, _CustomName,
-                                                                               __decay_t<_InRange>, __decay_t<_TmpBuf>, _Ascending>;
+    using _CustomName = typename __decay_t<_ExecutionPolicy>::kernel_name;
+    using _RadixCountKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
+        __radix_sort_count_kernel, _CustomName, __decay_t<_InRange>, __decay_t<_TmpBuf>, _Ascending>;
     using _RadixLocalScanKernel =
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<__radix_sort_scan_kernel_1, _CustomName,
                                                                                __decay_t<_TmpBuf>>;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -392,7 +392,8 @@ struct __radix_global_scan_caller
     {
     }
 
-    void operator()(sycl::nd_item<1> __self_item) const
+    void
+    operator()(sycl::nd_item<1> __self_item) const
     {
         ::std::size_t __self_lidx = __self_item.get_local_id(0);
 
@@ -431,7 +432,7 @@ struct __radix_sort_scan_submitter<_RadixLocalScanName, __internal::__optional_k
                ,
                _LocalScanKernel& __local_scan_kernel
 #endif
-               ) const
+    ) const
     {
         using _CountT = typename _CountBuf::value_type;
 
@@ -608,10 +609,8 @@ __parallel_radix_sort_iteration(_ExecutionPolicy&& __exec, ::std::size_t __segme
 {
     using _Ascending = std::conditional_t<__is_comp_asc, std::true_type, std::false_type>;
     using _CustomName = typename __decay_t<_ExecutionPolicy>::kernel_name;
-    using _RadixCountKernel =
-        oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<__radix_sort_count_kernel, _CustomName,
-                                                                               __decay_t<_InRange>, __decay_t<_TmpBuf>,
-                                                                               _Ascending>;
+    using _RadixCountKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
+        __radix_sort_count_kernel, _CustomName, __decay_t<_InRange>, __decay_t<_TmpBuf>, _Ascending>;
     using _RadixLocalScanKernel =
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<__radix_sort_scan_kernel_1, _CustomName,
                                                                                __decay_t<_TmpBuf>>;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -392,8 +392,7 @@ struct __radix_global_scan_caller
     {
     }
 
-    void
-    operator()(sycl::nd_item<1> __self_item) const
+    void operator()(sycl::nd_item<1> __self_item) const
     {
         ::std::size_t __self_lidx = __self_item.get_local_id(0);
 
@@ -432,7 +431,7 @@ struct __radix_sort_scan_submitter<_RadixLocalScanName, __internal::__optional_k
                ,
                _LocalScanKernel& __local_scan_kernel
 #endif
-    ) const
+               ) const
     {
         using _CountT = typename _CountBuf::value_type;
 

--- a/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
@@ -308,6 +308,7 @@ struct test_sort_op
     }
 };
 
+#if TEST_DPCPP_BACKEND_PRESENT
 template <typename T, typename Convert>
 void
 test_default_name_gen(Convert convert, size_t n)
@@ -328,6 +329,8 @@ test_default_name_gen(Convert convert, size_t n)
                     in.size(), ::std::less<void>());
 
 }
+#endif //TEST_DPCPP_BACKEND_PRESENT
+
 
 template <typename T, typename Compare, typename Convert>
 void

--- a/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
@@ -346,11 +346,11 @@ test_sort(Compare compare, Convert convert)
         TestUtils::Sequence<T> tmp(in);
 #ifdef _PSTL_TEST_WITHOUT_PREDICATE
         TestUtils::invoke_on_all_policies<0>()(test_sort_op<T>(), tmp.begin(), tmp.end(), expected.begin(),
-                                            expected.end(), in.begin(), in.end(), in.size());
+                                               expected.end(), in.begin(), in.end(), in.size());
 #endif // _PSTL_TEST_WITHOUT_PREDICATE
 #ifdef _PSTL_TEST_WITH_PREDICATE
         TestUtils::invoke_on_all_policies<1>()(test_sort_op<T>(), tmp.begin(), tmp.end(), expected.begin(),
-                                            expected.end(), in.begin(), in.end(), in.size(), compare);
+                                               expected.end(), in.begin(), in.end(), in.size(), compare);
 #endif // _PSTL_TEST_WITH_PREDICATE
     }
 }

--- a/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
@@ -310,24 +310,31 @@ struct test_sort_op
 
 template <typename T, typename Compare, typename Convert>
 void
+test_sort_n(Compare compare, Convert convert, size_t n)
+{
+    LastIndex = n + 2;
+    // The rand()%(2*n+1) encourages generation of some duplicates.
+    // Sequence is padded with an extra element at front and back, to detect overwrite bugs.
+    TestUtils::Sequence<T> in(n + 2, [=](size_t k) { return convert(k, rand() % (2 * n + 1)); });
+    TestUtils::Sequence<T> expected(in);
+    TestUtils::Sequence<T> tmp(in);
+#ifdef _PSTL_TEST_WITHOUT_PREDICATE
+    TestUtils::invoke_on_all_policies<0>()(test_sort_op<T>(), tmp.begin(), tmp.end(), expected.begin(),
+                                            expected.end(), in.begin(), in.end(), in.size());
+#endif // _PSTL_TEST_WITHOUT_PREDICATE
+#ifdef _PSTL_TEST_WITH_PREDICATE
+    TestUtils::invoke_on_all_policies<1>()(test_sort_op<T>(), tmp.begin(), tmp.end(), expected.begin(),
+                                            expected.end(), in.begin(), in.end(), in.size(), compare);
+#endif // _PSTL_TEST_WITH_PREDICATE
+}
+
+template <typename T, typename Compare, typename Convert>
+void
 test_sort(Compare compare, Convert convert)
 {
     for (size_t n = 0; n < 100000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
-        LastIndex = n + 2;
-        // The rand()%(2*n+1) encourages generation of some duplicates.
-        // Sequence is padded with an extra element at front and back, to detect overwrite bugs.
-        TestUtils::Sequence<T> in(n + 2, [=](size_t k) { return convert(k, rand() % (2 * n + 1)); });
-        TestUtils::Sequence<T> expected(in);
-        TestUtils::Sequence<T> tmp(in);
-#ifdef _PSTL_TEST_WITHOUT_PREDICATE
-        TestUtils::invoke_on_all_policies<0>()(test_sort_op<T>(), tmp.begin(), tmp.end(), expected.begin(),
-                                               expected.end(), in.begin(), in.end(), in.size());
-#endif // _PSTL_TEST_WITHOUT_PREDICATE
-#ifdef _PSTL_TEST_WITH_PREDICATE
-        TestUtils::invoke_on_all_policies<1>()(test_sort_op<T>(), tmp.begin(), tmp.end(), expected.begin(),
-                                               expected.end(), in.begin(), in.end(), in.size(), compare);
-#endif // _PSTL_TEST_WITH_PREDICATE
+        test_sort_n<T>(compare, convert, n);
     }
 }
 
@@ -377,6 +384,10 @@ main()
             [](std::int32_t x, std::int32_t y) { return x > y; }, // Reversed so accidental use of < will be detected.
             [](size_t, size_t val) { return std::int32_t(val); });
     }
+
+    // testing potentially clashing naming for radix sort descending / ascending with minimal timing impact
+    test_sort_n<std::int32_t>(std::greater<void>(), [](size_t, size_t val) { return std::int32_t(val); }, 10);
+    test_sort_n<std::int32_t>(std::less<void>(), [](size_t, size_t val) { return std::int32_t(val); }, 10);
 
 #if !ONEDPL_FPGA_DEVICE
     TestUtils::test_algo_basic_single<int32_t>(TestUtils::run_for_rnd<test_non_const<int32_t>>());


### PR DESCRIPTION
To trigger this bug, you can call `oneapi::dpl::stable_sort`  twice with the same policy and same numerical type.  One of those two times should use `std::greater<void>()`, and the other time with no compare operator or with `std::less<void>()`.  The same bug appears with `oneapi::dpl::partial_sort_copy`.  A test has been added to test/parallel_api/algorithm/alg.sorting/sort.pass.cpp to show this.

Without this patch, this would result in the following compiler error:
`error: definition with same mangled name`

This is because radix sort is enabled for both ascending and descending sort for numerical types, but previously the compare operator state has not been included in the kernel name generators.  This results in two different kernels being generated with the same name, as the descending radix sort requires some extra bit flipping operations.

This patch adds the status of `__is_comp_asc` (is compare operator ascending) to the necessary kernel name generators to make them uniquely named.
