### PR TITLE
[oneDPL] Fix include guard names in header files

### DIFF
--- a/include/oneapi/dpl/array
+++ b/include/oneapi/dpl/array
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __ONEDPL_array
-#define __ONEDPL_array
+#ifndef __ONEDPL_ARRAY
+#define __ONEDPL_ARRAY
 
 #include "oneapi/dpl/internal/common_config.h"
 #include <array>
@@ -33,4 +33,4 @@ using ::std::tuple_size;
 
 namespace dpl = oneapi::dpl;
 
-#endif // __ONEDPL_array
+#endif // __ONEDPL_ARRAY

--- a/include/oneapi/dpl/cmath
+++ b/include/oneapi/dpl/cmath
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __ONEDPL_cmath
-#define __ONEDPL_cmath
+#ifndef __ONEDPL_CMATH
+#define __ONEDPL_CMATH
 
 #include "oneapi/dpl/internal/common_config.h"
 #include <cmath>
@@ -92,4 +92,4 @@ using ::std::truncf;
 
 namespace dpl = oneapi::dpl;
 
-#endif // __ONEDPL_cmath
+#endif // __ONEDPL_CMATH

--- a/include/oneapi/dpl/complex
+++ b/include/oneapi/dpl/complex
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __ONEDPL_complex
-#define __ONEDPL_complex
+#ifndef __ONEDPL_COMPLEX
+#define __ONEDPL_COMPLEX
 
 #include "oneapi/dpl/internal/common_config.h"
 #include <complex>
@@ -56,4 +56,4 @@ using ::std::tanh;
 
 namespace dpl = oneapi::dpl;
 
-#endif // __ONEDPL_complex
+#endif // __ONEDPL_COMPLEX

--- a/include/oneapi/dpl/cstddef
+++ b/include/oneapi/dpl/cstddef
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __ONEDPL_cstddef
-#define __ONEDPL_cstddef
+#ifndef __ONEDPL_CSTDDEF
+#define __ONEDPL_CSTDDEF
 
 #include "oneapi/dpl/internal/common_config.h"
 #include <cstddef>
@@ -32,4 +32,4 @@ using ::std::size_t;
 
 namespace dpl = oneapi::dpl;
 
-#endif // __ONEDPL_cstddef
+#endif // __ONEDPL_CSTDDEF

--- a/include/oneapi/dpl/cstring
+++ b/include/oneapi/dpl/cstring
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __ONEDPL_cstring
-#define __ONEDPL_cstring
+#ifndef __ONEDPL_CSTRING
+#define __ONEDPL_CSTRING
 
 #include "oneapi/dpl/internal/common_config.h"
 #include <cstring>
@@ -31,4 +31,4 @@ using ::std::memset;
 
 namespace dpl = oneapi::dpl;
 
-#endif // __ONEDPL_cstring
+#endif // __ONEDPL_CSTRING

--- a/include/oneapi/dpl/functional
+++ b/include/oneapi/dpl/functional
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __ONEDPL_functional
-#define __ONEDPL_functional
+#ifndef __ONEDPL_FUNCTIONAL
+#define __ONEDPL_FUNCTIONAL
 
 #include "oneapi/dpl/internal/common_config.h"
 #include <functional>
@@ -91,4 +91,4 @@ struct minimum
 
 namespace dpl = oneapi::dpl;
 
-#endif // __DPSTD_functional
+#endif // __ONEDPL_FUNCTIONAL

--- a/include/oneapi/dpl/limits
+++ b/include/oneapi/dpl/limits
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __ONEDPL_limits
-#define __ONEDPL_limits
+#ifndef __ONEDPL_LIMITS
+#define __ONEDPL_LIMITS
 
 #include "oneapi/dpl/internal/common_config.h"
 #include <limits>
@@ -30,4 +30,4 @@ using numeric_limits = ::std::numeric_limits<T>;
 
 namespace dpl = oneapi::dpl;
 
-#endif // __ONEDPL_limits
+#endif // __ONEDPL_LIMITS

--- a/include/oneapi/dpl/optional
+++ b/include/oneapi/dpl/optional
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __ONEDPL_optional
-#define __ONEDPL_optional
+#ifndef __ONEDPL_OPTIONAL
+#define __ONEDPL_OPTIONAL
 
 #include "oneapi/dpl/internal/common_config.h"
 #include <optional>
@@ -32,4 +32,4 @@ using ::std::optional;
 
 namespace dpl = oneapi::dpl;
 
-#endif // __ONEDPL_optional
+#endif // __ONEDPL_OPTIONAL

--- a/include/oneapi/dpl/pstl/experimental/algorithm
+++ b/include/oneapi/dpl/pstl/experimental/algorithm
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_experimental_algorithm
-#define _ONEDPL_experimental_algorithm
+#ifndef _ONEDPL_EXPERIMENTAL_ALGORITHM
+#define _ONEDPL_EXPERIMENTAL_ALGORITHM
 
 #define __cpp_lib_experimental_parallel_for_loop 201711
 
@@ -50,4 +50,4 @@ using oneapi::dpl::experimental::reduction_plus;
 } // namespace experimental
 } // namespace std
 
-#endif /* _ONEDPL_experimental_algorithm */
+#endif /* _ONEDPL_EXPERIMENTAL_ALGORITHM */

--- a/include/oneapi/dpl/pstl/experimental/internal/for_loop.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/for_loop.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_experimental_for_loop_H
-#define _ONEDPL_experimental_for_loop_H
+#ifndef _ONEDPL_EXPERIMENTAL_FOR_LOOP_H
+#define _ONEDPL_EXPERIMENTAL_FOR_LOOP_H
 
 #include <tuple>
 
@@ -124,4 +124,4 @@ for_loop_n_strided(_Ip __start, _Size __n, _Sp __stride, _Rest&&... __rest)
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_experimental_for_loop_H */
+#endif /* _ONEDPL_EXPERIMENTAL_FOR_LOOP_H */

--- a/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_experimental_for_loop_impl_H
-#define _ONEDPL_experimental_for_loop_impl_H
+#ifndef _ONEDPL_EXPERIMENTAL_FOR_LOOP_IMPL_H
+#define _ONEDPL_EXPERIMENTAL_FOR_LOOP_IMPL_H
 
 #include <iterator>
 #include <type_traits>
@@ -583,4 +583,4 @@ __for_loop_repack_n(_ExecutionPolicy&& __exec, _Ip __start, _Size __n, _Sp __str
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_experimental_for_loop_impl_H */
+#endif /* _ONEDPL_EXPERIMENTAL_FOR_LOOP_IMPL_H */

--- a/include/oneapi/dpl/pstl/experimental/internal/induction.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/induction.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_experimental_induction_H
-#define _ONEDPL_experimental_induction_H
+#ifndef _ONEDPL_EXPERIMENTAL_INDUCTION_H
+#define _ONEDPL_EXPERIMENTAL_INDUCTION_H
 
 #include <type_traits>
 
@@ -48,4 +48,4 @@ induction(_Tp&& __var, _Sp __stride)
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_experimental_induction_H */
+#endif /* _ONEDPL_EXPERIMENTAL_INDUCTION_H */

--- a/include/oneapi/dpl/pstl/experimental/internal/induction_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/induction_impl.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_experimental_induction_impl_H
-#define _ONEDPL_experimental_induction_impl_H
+#ifndef _ONEDPL_EXPERIMENTAL_INDUCTION_IMPL_H
+#define _ONEDPL_EXPERIMENTAL_INDUCTION_IMPL_H
 
 #include <type_traits>
 
@@ -120,4 +120,4 @@ class __induction_object<_Tp, void>
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_experimental_induction_impl_H */
+#endif /* _ONEDPL_EXPERIMENTAL_INDUCTION_IMPL_H */

--- a/include/oneapi/dpl/pstl/experimental/internal/reduction.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/reduction.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_experimental_reduction_H
-#define _ONEDPL_experimental_reduction_H
+#ifndef _ONEDPL_EXPERIMENTAL_REDUCTION_H
+#define _ONEDPL_EXPERIMENTAL_REDUCTION_H
 
 #include <type_traits>
 #include <functional>
@@ -95,4 +95,4 @@ reduction_max(_Tp& __var)
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_experimental_reduction_H */
+#endif /* _ONEDPL_EXPERIMENTAL_REDUCTION_H */

--- a/include/oneapi/dpl/pstl/experimental/internal/reduction_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/reduction_impl.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_experimental_reduction_impl_H
-#define _ONEDPL_experimental_reduction_impl_H
+#ifndef _ONEDPL_EXPERIMENTAL_REDUCTION_IMPL_H
+#define _ONEDPL_EXPERIMENTAL_REDUCTION_IMPL_H
 
 #include <type_traits>
 #include <algorithm>
@@ -92,4 +92,4 @@ class __reduction_object
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_experimental_reduction_impl_H */
+#endif /* _ONEDPL_EXPERIMENTAL_REDUCTION_IMPL_H */

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_algorithm_impl_hetero_H
-#define _ONEDPL_algorithm_impl_hetero_H
+#ifndef _ONEDPL_ALGORITHM_IMPL_HETERO_H
+#define _ONEDPL_ALGORITHM_IMPL_HETERO_H
 
 #include "../algorithm_fwd.h"
 
@@ -1982,4 +1982,4 @@ __pattern_shift_right(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_algorithm_impl_hetero_H */
+#endif /* _ONEDPL_ALGORITHM_IMPL_HETERO_H */

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_algorithm_ranges_impl_hetero_H
-#define _ONEDPL_algorithm_ranges_impl_hetero_H
+#ifndef _ONEDPL_ALGORITHM_RANGES_IMPL_HETERO_H
+#define _ONEDPL_ALGORITHM_RANGES_IMPL_HETERO_H
 
 #include "../algorithm_fwd.h"
 #include "../parallel_backend.h"
@@ -797,4 +797,4 @@ __pattern_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_algorithm_ranges_impl_hetero_H */
+#endif /* _ONEDPL_ALGORITHM_RANGES_IMPL_HETERO_H */

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_execution_sycl_defs_H
-#define _ONEDPL_execution_sycl_defs_H
+#ifndef _ONEDPL_EXECUTION_SYCL_DEFS_H
+#define _ONEDPL_EXECUTION_SYCL_DEFS_H
 
 #include "../../onedpl_config.h"
 #include "../../execution_defs.h"
@@ -398,4 +398,4 @@ __kernel_sub_group_size(_ExecutionPolicy&& __policy, const sycl::kernel& __kerne
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_execution_sycl_defs_H */
+#endif /* _ONEDPL_EXECUTION_SYCL_DEFS_H */

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -17,8 +17,8 @@
 
 // This header guard is used to check inclusion of DPC++ backend.
 // Changing this macro may result in broken tests.
-#ifndef _ONEDPL_parallel_backend_sycl_H
-#define _ONEDPL_parallel_backend_sycl_H
+#ifndef _ONEDPL_PARALLEL_BACKEND_SYCL_H
+#define _ONEDPL_PARALLEL_BACKEND_SYCL_H
 
 #include <cassert>
 #include <algorithm>
@@ -1452,4 +1452,4 @@ __parallel_partial_sort(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator 
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_parallel_backend_sycl_H */
+#endif /* _ONEDPL_PARALLEL_BACKEND_SYCL_H */

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
@@ -17,8 +17,8 @@
 
 // This header guard is used to check inclusion of DPC++ backend for the FPGA.
 // Changing this macro may result in broken tests.
-#ifndef _ONEDPL_parallel_backend_sycl_fpga_H
-#define _ONEDPL_parallel_backend_sycl_fpga_H
+#ifndef _ONEDPL_PARALLEL_BACKEND_SYCL_FPGA_H
+#define _ONEDPL_PARALLEL_BACKEND_SYCL_FPGA_H
 
 #include <cassert>
 #include <algorithm>
@@ -262,4 +262,4 @@ __parallel_partial_sort(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator 
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_parallel_backend_sycl_fpga_H */
+#endif /* _ONEDPL_PARALLEL_BACKEND_SYCL_FPGA_H */

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_parallel_backend_sycl_radix_sort_H
-#define _ONEDPL_parallel_backend_sycl_radix_sort_H
+#ifndef _ONEDPL_PARALLEL_BACKEND_SYCL_RADIX_SORT_H
+#define _ONEDPL_PARALLEL_BACKEND_SYCL_RADIX_SORT_H
 
 #include <limits>
 
@@ -742,4 +742,4 @@ __parallel_radix_sort(_ExecutionPolicy&& __exec, _Range&& __in_rng)
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_parallel_backend_sycl_radix_sort_H */
+#endif /* _ONEDPL_PARALLEL_BACKEND_SYCL_RADIX_SORT_H */

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_parallel_backend_sycl_utils_H
-#define _ONEDPL_parallel_backend_sycl_utils_H
+#ifndef _ONEDPL_PARALLEL_BACKEND_SYCL_UTILS_H
+#define _ONEDPL_PARALLEL_BACKEND_SYCL_UTILS_H
 
 //!!! NOTE: This file should be included under the macro _ONEDPL_BACKEND_SYCL
 #include <type_traits>
@@ -509,4 +509,4 @@ class __future : private std::tuple<_Args...>
 } // namespace dpl
 } // namespace oneapi
 
-#endif //_ONEDPL_parallel_backend_sycl_utils_H
+#endif //_ONEDPL_PARALLEL_BACKEND_SYCL_UTILS_H

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -18,8 +18,8 @@
 //
 // Include this header instead of sycl.hpp throughout the project
 
-#ifndef _ONEDPL_sycl_defs_H
-#define _ONEDPL_sycl_defs_H
+#ifndef _ONEDPL_SYCL_DEFS_H
+#define _ONEDPL_SYCL_DEFS_H
 
 #include <CL/sycl.hpp>
 
@@ -230,4 +230,4 @@ struct __atomic_ref : sycl::atomic<_AtomicType, _Space>
 
 } // namespace __dpl_sycl
 
-#endif /* _ONEDPL_sycl_defs_H */
+#endif /* _ONEDPL_SYCL_DEFS_H */

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_sycl_iterator_H
-#define _ONEDPL_sycl_iterator_H
+#ifndef _ONEDPL_SYCL_ITERATOR_H
+#define _ONEDPL_SYCL_ITERATOR_H
 
 #include <iterator>
 #include "../../onedpl_config.h"
@@ -192,4 +192,4 @@ __internal::sycl_iterator<access_mode::discard_read_write, T, Allocator> end(syc
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_sycl_iterator_H */
+#endif /* _ONEDPL_SYCL_ITERATOR_H */

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -14,8 +14,8 @@
 //===----------------------------------------------------------------------===//
 
 //!!! NOTE: This file should be included under the macro _ONEDPL_BACKEND_SYCL
-#ifndef _ONEDPL_unseq_backend_sycl_H
-#define _ONEDPL_unseq_backend_sycl_H
+#ifndef _ONEDPL_UNSEQ_BACKEND_SYCL_H
+#define _ONEDPL_UNSEQ_BACKEND_SYCL_H
 
 #include <type_traits>
 
@@ -976,4 +976,4 @@ struct __brick_reduce_idx
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_unseq_backend_sycl_H */
+#endif /* _ONEDPL_UNSEQ_BACKEND_SYCL_H */

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_numeric_impl_hetero_H
-#define _ONEDPL_numeric_impl_hetero_H
+#ifndef _ONEDPL_NUMERIC_IMPL_HETERO_H
+#define _ONEDPL_NUMERIC_IMPL_HETERO_H
 
 #include <iterator>
 #include "../parallel_backend.h"
@@ -254,4 +254,4 @@ __pattern_adjacent_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __fir
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_numeric_impl_hetero_H */
+#endif /* _ONEDPL_NUMERIC_IMPL_HETERO_H */

--- a/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_numeric_ranges_impl_hetero_H
-#define _ONEDPL_numeric_ranges_impl_hetero_H
+#ifndef _ONEDPL_NUMERIC_RANGES_IMPL_HETERO_H
+#define _ONEDPL_NUMERIC_RANGES_IMPL_HETERO_H
 
 #include "../numeric_fwd.h"
 #include "../parallel_backend.h"
@@ -174,4 +174,4 @@ __pattern_transform_scan(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& 
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_numeric_ranges_impl_hetero_H */
+#endif /* _ONEDPL_NUMERIC_RANGES_IMPL_HETERO_H */

--- a/include/oneapi/dpl/pstl/hetero/utils_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/utils_hetero.h
@@ -18,8 +18,8 @@
 //
 // Include this header instead of sycl.hpp throughout the project
 
-#ifndef _ONEDPL_utils_hetero_H
-#define _ONEDPL_utils_hetero_H
+#ifndef _ONEDPL_UTILS_HETERO_H
+#define _ONEDPL_UTILS_HETERO_H
 
 namespace oneapi
 {
@@ -148,4 +148,4 @@ struct acc_handler_count
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_utils_hetero_H */
+#endif /* _ONEDPL_UTILS_HETERO_H */

--- a/include/oneapi/dpl/pstl/iterator_defs.h
+++ b/include/oneapi/dpl/pstl/iterator_defs.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_iterator_defs_H
-#define _ONEDPL_iterator_defs_H
+#ifndef _ONEDPL_ITERATOR_DEFS_H
+#define _ONEDPL_ITERATOR_DEFS_H
 
 #include <iterator>
 #include <type_traits>
@@ -109,4 +109,4 @@ struct is_passed_directly<Iter, typename ::std::enable_if<::std::is_pointer<Iter
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_iterator_defs_H */
+#endif /* _ONEDPL_ITERATOR_DEFS_H */

--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_iterator_impl_H
-#define _ONEDPL_iterator_impl_H
+#ifndef _ONEDPL_ITERATOR_IMPL_H
+#define _ONEDPL_ITERATOR_IMPL_H
 
 #include <iterator>
 #include <tuple>
@@ -884,4 +884,4 @@ map_zip(F f, TBig<T...> in, RestTuples... rest)
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_iterator_impl_H */
+#endif /* _ONEDPL_ITERATOR_IMPL_H */

--- a/include/oneapi/dpl/pstl/memory_fwd.h
+++ b/include/oneapi/dpl/pstl/memory_fwd.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_memory_fwd_H
-#define _ONEDPL_memory_fwd_H
+#ifndef _ONEDPL_MEMORY_FWD_H
+#define _ONEDPL_MEMORY_FWD_H
 
 namespace oneapi
 {
@@ -45,4 +45,4 @@ struct __op_uninitialized_value_construct;
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_memory_fwd_H */
+#endif /* _ONEDPL_MEMORY_FWD_H */

--- a/include/oneapi/dpl/pstl/tuple_impl.h
+++ b/include/oneapi/dpl/pstl/tuple_impl.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_tuple_impl_H
-#define _ONEDPL_tuple_impl_H
+#ifndef _ONEDPL_TUPLE_IMPL_H
+#define _ONEDPL_TUPLE_IMPL_H
 
 #include <iterator>
 #include <tuple>
@@ -650,4 +650,4 @@ get(const oneapi::dpl::__internal::tuple<_Tp...>&& __a)
 }
 } // namespace std
 
-#endif /* _ONEDPL_tuple_impl_H */
+#endif /* _ONEDPL_TUPLE_IMPL_H */

--- a/include/oneapi/dpl/random
+++ b/include/oneapi/dpl/random
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_random
-#define _ONEDPL_random
+#ifndef _ONEDPL_RANDOM
+#define _ONEDPL_RANDOM
 
 #include "oneapi/dpl/internal/common_config.h"
 #include "oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h"
@@ -73,4 +73,4 @@ using ranlux48_vec = discard_block_engine<ranlux48_base_vec<_N>, 389, 11>;
 
 namespace dpl = oneapi::dpl;
 
-#endif // _ONEDPL_random
+#endif // _ONEDPL_RANDOM

--- a/include/oneapi/dpl/ratio
+++ b/include/oneapi/dpl/ratio
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __ONEDPL_ratio
-#define __ONEDPL_ratio
+#ifndef __ONEDPL_RATIO
+#define __ONEDPL_RATIO
 
 #include "oneapi/dpl/internal/common_config.h"
 #include <ratio>
@@ -39,4 +39,4 @@ using ::std::ratio_subtract;
 
 namespace dpl = oneapi::dpl;
 
-#endif // __ONEDPL_ratio
+#endif // __ONEDPL_RATIO

--- a/include/oneapi/dpl/tuple
+++ b/include/oneapi/dpl/tuple
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __ONEDPL_tuple
-#define __ONEDPL_tuple
+#ifndef __ONEDPL_TUPLE
+#define __ONEDPL_TUPLE
 
 #include "oneapi/dpl/internal/common_config.h"
 #include <tuple>
@@ -39,4 +39,4 @@ using ::std::tuple_size;
 
 namespace dpl = oneapi::dpl;
 
-#endif // __ONEDPL_tuple
+#endif // __ONEDPL_TUPLE

--- a/include/oneapi/dpl/type_traits
+++ b/include/oneapi/dpl/type_traits
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __ONEDPL_type_traits
-#define __ONEDPL_type_traits
+#ifndef __ONEDPL_TYPE_TRAITS
+#define __ONEDPL_TYPE_TRAITS
 
 #include "oneapi/dpl/internal/common_config.h"
 #include <type_traits>
@@ -220,4 +220,4 @@ using ::std::result_of_t;       // Deprecated in C++17, removed in C++20
 
 namespace dpl = oneapi::dpl;
 
-#endif // __ONEDPL_type_traits
+#endif // __ONEDPL_TYPE_TRAITS

--- a/include/oneapi/dpl/utility
+++ b/include/oneapi/dpl/utility
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __ONEDPL_utility
-#define __ONEDPL_utility
+#ifndef __ONEDPL_UTILITY
+#define __ONEDPL_UTILITY
 
 #include "oneapi/dpl/internal/common_config.h"
 #include <utility>
@@ -42,4 +42,4 @@ using ::std::tuple_size;
 
 namespace dpl = oneapi::dpl;
 
-#endif // __ONEDPL_utility
+#endif // __ONEDPL_UTILITY

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _TEST_config_H
-#define _TEST_config_H
+#ifndef _TEST_CONFIG_H
+#define _TEST_CONFIG_H
 
 #define _PSTL_TEST_STRING(X) _PSTL_TEST_STRING_AUX(oneapi/dpl/X)
 #define _PSTL_TEST_STRING_AUX(X) #X
@@ -106,4 +106,4 @@
 
 #define TEST_HAS_NO_INT128
 
-#endif /* _TEST_config_H */
+#endif /* _TEST_CONFIG_H */


### PR DESCRIPTION
Normalized include guard names in header files:
- in file https://github.com/oneapi-src/oneDPL/blob/dev/skopienko/fix_include_guard_names_in_oneapi_dpl_headers/.clang-format we have next line: **BasedOnStyle: LLVM**
- This line mean that we should create header file guards as described in 
[Header Guard](https://llvm.org/docs/CodingStandards.html#id10)(https://llvm.org/docs/CodingStandards.html#header-guard)
_The header file’s guard should be the all-caps path that a user of this header would #include, using ‘_’ instead of path separator and extension marker. For example, the header file llvm/include/llvm/Analysis/Utils/Local.h would be #include-ed as #include "llvm/Analysis/Utils/Local.h", so its guard is LLVM_ANALYSIS_UTILS_LOCAL_H._