### PR TITLE
[oneDPL] + remove std::unary_function from list of tested functions

### DIFF
--- a/documentation/library_guide/api_for_sycl_kernels/tested_standard_cpp_api.rst
+++ b/documentation/library_guide/api_for_sycl_kernels/tested_standard_cpp_api.rst
@@ -127,8 +127,6 @@ C++ Standard API                     libstdc++  libc++     MSVC
 ------------------------------------ ---------- ---------- ----------
 ``std::not1/2``                      Tested     Tested     Tested
 ------------------------------------ ---------- ---------- ----------
-``std::unary_function``              Tested     Tested     Tested
------------------------------------- ---------- ---------- ----------
 ``std::initializer_list``            Tested     Tested     Tested
 ------------------------------------ ---------- ---------- ----------
 ``std::forward``                     Tested     Tested     Tested


### PR DESCRIPTION
Removed std::unary_function from list of tested functions.
This function was removed from our code in
[oneDPL][tests] + Remove support of C++11 and C++14 from oneDPL #642