### PR TITLE
Remove C++11 testing from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
             device_type: HOST
           - os: ubuntu-20.04
             cxx_compiler: g++
-            std: 11
+            std: 17
             build_type: release
             backend: tbb
             device_type: HOST
@@ -129,7 +129,7 @@ jobs:
             device_type: HOST
           - os: ubuntu-18.04
             cxx_compiler: clang++
-            std: 11
+            std: 17
             build_type: release
             backend: tbb
             device_type: HOST

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,12 +110,6 @@ jobs:
             backend: tbb
             device_type: HOST
           - os: ubuntu-20.04
-            cxx_compiler: g++
-            std: 11
-            build_type: release
-            backend: tbb
-            device_type: HOST
-          - os: ubuntu-20.04
             cxx_compiler: clang++
             std: 17
             build_type: release
@@ -126,12 +120,6 @@ jobs:
             std: 17
             build_type: release
             backend: omp
-            device_type: HOST
-          - os: ubuntu-18.04
-            cxx_compiler: clang++
-            std: 11
-            build_type: release
-            backend: tbb
             device_type: HOST
           - os: ubuntu-20.04
             cxx_compiler: icpx

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,12 @@ jobs:
             backend: tbb
             device_type: HOST
           - os: ubuntu-20.04
+            cxx_compiler: g++
+            std: 11
+            build_type: release
+            backend: tbb
+            device_type: HOST
+          - os: ubuntu-20.04
             cxx_compiler: clang++
             std: 17
             build_type: release
@@ -120,6 +126,12 @@ jobs:
             std: 17
             build_type: release
             backend: omp
+            device_type: HOST
+          - os: ubuntu-18.04
+            cxx_compiler: clang++
+            std: 11
+            build_type: release
+            backend: tbb
             device_type: HOST
           - os: ubuntu-20.04
             cxx_compiler: icpx


### PR DESCRIPTION
Removal of C++11 testing from CI after its support has been removed from product in https://github.com/oneapi-src/oneDPL/commit/5a5b9534bd3446f0fb6a7f10d0499c2a2a6a4332
Signed-off-by: Valentina Kats valentina.kats@intel.com