### PR TITLE
Avoid clashes with STL implementations in nanorange

### DIFF
--- a/include/oneapi/dpl/pstl/ranges_defs.h
+++ b/include/oneapi/dpl/pstl/ranges_defs.h
@@ -16,6 +16,12 @@
 #ifndef _ONEDPL_RANGES_DEFS_H
 #define _ONEDPL_RANGES_DEFS_H
 
+// Avoid incompatibilities with STL internals
+// that nanorange tries to forward declare without this.
+#ifndef NANORANGE_NO_STD_FORWARD_DECLARATIONS
+  #define NANORANGE_NO_STD_FORWARD_DECLARATIONS
+#endif
+
 #include "ranges/nanorange.hpp"
 #include "ranges/nanorange_ext.h"
 


### PR DESCRIPTION
Related to https://github.com/arborx/ArborX/pull/769, fixes https://github.com/oneapi-src/oneDPL/issues/576.
Also, see https://github.com/oneapi-src/oneDPL/blob/e27c72efcd32d001eaa966221407977a6e2f8a8c/include/oneapi/dpl/pstl/ranges/nanorange.hpp#L3224-L3248