### PR TITLE
[oneDPL][tests] + fix same mangled name in tests

### DIFF
--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment_perm_it.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment_perm_it.pass.cpp
@@ -36,8 +36,11 @@ test_exclusive_scan(sycl::queue q,
     TestUtils::usm_data_transfer<alloc_type, TestValueType> dt_helper_vals(q, srcVals.begin(), N);
     TestUtils::usm_data_transfer<alloc_type, TestValueType> dt_helper_res (q, N);
 
+    auto policy = oneapi::dpl::execution::make_device_policy<TestUtils::unique_kernel_name<
+        TestUtils::unique_kernel_name<class KernelName, 1>, TestUtils::uniq_kernel_index<alloc_type>()>>(q);
+
     oneapi::dpl::exclusive_scan_by_segment(
-        oneapi::dpl::execution::make_device_policy(q),
+        policy,
         dt_helper_keys.get_data(),          /* key begin */
         dt_helper_keys.get_data() + N,      /* key end */
         dt_helper_vals.get_data(),          /* input value begin */
@@ -67,8 +70,11 @@ test_exclusive_scan(sycl::queue q,
     auto it_key_begin = oneapi::dpl::make_permutation_iterator(dt_helper_keys.get_data(), dt_helper_perm.get_data());
     auto it_key_end = it_key_begin + N;
 
+    auto policy = oneapi::dpl::execution::make_device_policy<TestUtils::unique_kernel_name<
+        TestUtils::unique_kernel_name<class KernelName, 2>, TestUtils::uniq_kernel_index<alloc_type>()>>(q);
+
     oneapi::dpl::exclusive_scan_by_segment(
-        oneapi::dpl::execution::make_device_policy(q),
+        policy,
         it_key_begin,               /* key begin */
         it_key_end,                 /* key end */
         dt_helper_vals.get_data(),  /* input value begin */

--- a/test/parallel_api/numeric/numeric.ops/in_place_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/in_place_scan.pass.cpp
@@ -50,7 +50,7 @@ int main()
   inclusive_scan_serial(incl_input_host.begin(),
                       incl_input_host.end(),
                       incl_input_host.begin());
-  oneapi::dpl::inclusive_scan( oneapi::dpl::execution::make_device_policy(syclQue),
+  oneapi::dpl::inclusive_scan(oneapi::dpl::execution::make_device_policy<class TempKernelName1>(syclQue),
                                incl_input_dev,
                                incl_input_dev + v.size(),
                                incl_input_dev );
@@ -66,7 +66,7 @@ int main()
                        excl_input_host.end(),
                        excl_input_host.begin(),
                        0 );
-  oneapi::dpl::exclusive_scan( oneapi::dpl::execution::make_device_policy(syclQue),
+  oneapi::dpl::exclusive_scan( oneapi::dpl::execution::make_device_policy<class TempKernelName2>(syclQue),
                                excl_input_dev,
                                excl_input_dev + v.size(),
                                excl_input_dev,


### PR DESCRIPTION
Fixed some same mangled name in tests:
- test/parallel_api/numeric/numeric.ops/in_place_scan.pass.cpp
- test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment_perm_it.pass.cpp