### PR TITLE
[tests] fix invalid lambda call in test of std::complex

### DIFF
--- a/test/support/test_complex.h
+++ b/test/support/test_complex.h
@@ -85,16 +85,16 @@ run_test()
 //         IF_DOUBLE_SUPPORT(test<int>())
 //         // ...
 //     }
-#define IF_DOUBLE_SUPPORT(x)                                                                          \
-    TestUtils::invoke_test_if(HasDoubleSupportInRuntime(), [](){ x; });
-#define IF_DOUBLE_SUPPORT_L(x)                                                                        \
-    TestUtils::invoke_test_if(HasDoubleSupportInRuntime(), x);
+#define IF_DOUBLE_SUPPORT(...)                                                                        \
+    TestUtils::invoke_test_if(HasDoubleSupportInRuntime(), []() { __VA_ARGS__; });
+#define IF_DOUBLE_SUPPORT_L(...)                                                                      \
+    TestUtils::invoke_test_if(HasDoubleSupportInRuntime(), __VA_ARGS__);
 
 // We should use this macros to avoid compile-time error in code with long double type in Kernel.
-#define IF_LONG_DOUBLE_SUPPORT(x)                                                                     \
-    TestUtils::invoke_test_if(HasLongDoubleSupportInCompiletime(), []() { x; });
-#define IF_LONG_DOUBLE_SUPPORT_L(x)                                                                   \
-    TestUtils::invoke_test_if(HasLongDoubleSupportInCompiletime(), x);
+#define IF_LONG_DOUBLE_SUPPORT(...)                                                                   \
+    TestUtils::invoke_test_if(HasLongDoubleSupportInCompiletime(), []() { __VA_ARGS__; });
+#define IF_LONG_DOUBLE_SUPPORT_L(...)                                                                 \
+    TestUtils::invoke_test_if(HasLongDoubleSupportInCompiletime(), __VA_ARGS__);
 
 namespace TestUtils
 {

--- a/test/xpu_api/numerics/complex.number/cmplx.over/pow.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/pow.pass.cpp
@@ -84,26 +84,18 @@ ONEDPL_TEST_NUM_MAIN
     test<unsigned, float>();
     test<long long, float>();
 
-    auto fnc1 = []()
-    {
-        test<int, double>();
-        test<unsigned, double>();
-        test<long long, double>();
-        test<float, double>();
-        test<double, float>();
-    };
-    IF_DOUBLE_SUPPORT(fnc1);
+    IF_DOUBLE_SUPPORT(test<int, double>();
+                      test<unsigned, double>();
+                      test<long long, double>();
+                      test<float, double>();
+                      test<double, float>())
 
-    auto fnc2 = []()
-    {
-        test<unsigned, long double>();
-        test<long long, long double>();
-        test<float, long double>();
-        test<double, long double>();
-        test<long double, float>();
-        test<long double, double>();
-    };
-    IF_LONG_DOUBLE_SUPPORT(fnc2);
+    IF_LONG_DOUBLE_SUPPORT(test<unsigned, long double>();
+                           test<long long, long double>();
+                           test<float, long double>();
+                           test<double, long double>();
+                           test<long double, float>();
+                           test<long double, double>())
 
   return 0;
 }


### PR DESCRIPTION
In this PR we fix make the next things:
1) fix compile error: variable 'fnc1' cannot be implicitly captured in a lambda with no capture-default specified
2) add ability to send into test defines arguments with comma(s)