### PR TITLE
[tests] Fix complex tests compile-time error with "i", "if" literals

### DIFF
--- a/test/xpu_api/numerics/complex.number/complex.literals/literals.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.literals/literals.pass.cpp
@@ -28,17 +28,15 @@ ONEDPL_TEST_NUM_MAIN
                            auto c2 = 3il;
                            assert(c1 == c2))
 
-    IF_DOUBLE_SUPPORT(dpl::complex<double> c1 = 3.0i;
-                      assert(c1 == dpl::complex<double>(0, 3.0));
-                      auto c2 = 3i;
-                      assert(c1 == c2));
+    IF_LONG_DOUBLE_SUPPORT(dpl::complex<double> c1 = 3.0i;
+                           assert(c1 == dpl::complex<double>(0, 3.0));
+                           auto c2 = 3i;
+                           assert(c1 == c2))
 
-    {
-    dpl::complex<float> c1 = 3.0if;
-    assert ( c1 == dpl::complex<float>(0, 3.0));
-    auto c2 = 3if;
-    assert ( c1 == c2 );
-    }
+    IF_LONG_DOUBLE_SUPPORT(dpl::complex<float> c1 = 3.0if;
+                           assert(c1 == dpl::complex<float>(0, 3.0));
+                           auto c2 = 3if;
+                           assert(c1 == c2))
 
   return 0;
 }

--- a/test/xpu_api/numerics/complex.number/complex.literals/literals1.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.literals/literals1.pass.cpp
@@ -20,17 +20,15 @@ ONEDPL_TEST_NUM_MAIN
                            auto c2 = 3il;
                            assert(c1 == c2))
 
-    IF_DOUBLE_SUPPORT(dpl::complex<double> c1 = 3.0i;
-                      assert(c1 == dpl::complex<double>(0, 3.0));
-                      auto c2 = 3i;
-                      assert(c1 == c2))
+    IF_LONG_DOUBLE_SUPPORT(dpl::complex<double> c1 = 3.0i;
+                           assert(c1 == dpl::complex<double>(0, 3.0));
+                           auto c2 = 3i;
+                           assert(c1 == c2))
 
-    {
-    dpl::complex<float> c1 = 3.0if;
-    assert ( c1 == dpl::complex<float>(0, 3.0));
-    auto c2 = 3if;
-    assert ( c1 == c2 );
-    }
+    IF_LONG_DOUBLE_SUPPORT(dpl::complex<float> c1 = 3.0if;
+                           assert ( c1 == dpl::complex<float>(0, 3.0));
+                           auto c2 = 3if;
+                           assert ( c1 == c2 ));
 
   return 0;
 }

--- a/test/xpu_api/numerics/complex.number/complex.literals/literals2.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.literals/literals2.pass.cpp
@@ -20,17 +20,15 @@ ONEDPL_TEST_NUM_MAIN
                            auto c2 = 3il;
                            assert(c1 == c2))
 
-    IF_DOUBLE_SUPPORT(dpl::complex<double> c1 = 3.0i;
-                      assert(c1 == dpl::complex<double>(0, 3.0));
-                      auto c2 = 3i;
-                      assert(c1 == c2))
+    IF_LONG_DOUBLE_SUPPORT(dpl::complex<double> c1 = 3.0i;
+                           assert(c1 == dpl::complex<double>(0, 3.0));
+                           auto c2 = 3i;
+                           assert(c1 == c2))
 
-    {
-    dpl::complex<float> c1 = 3.0if;
-    assert ( c1 == dpl::complex<float>(0, 3.0));
-    auto c2 = 3if;
-    assert ( c1 == c2 );
-    }
+    IF_LONG_DOUBLE_SUPPORT(dpl::complex<float> c1 = 3.0if;
+                           assert ( c1 == dpl::complex<float>(0, 3.0));
+                           auto c2 = 3if;
+                           assert ( c1 == c2 ))
 
   return 0;
 }


### PR DESCRIPTION
This change made to fix compile error
'__num' requires 128 bit size 'long double' type support, but target 'spir64-unknown-unknown' does not support it"

The root cause of this error in use complex literal "i" in next string of code:
dpl::complex c1 = 3.0i;

As described at https://en.cppreference.com/w/cpp/numeric/complex/operator%22%22i
complex literal "l" used for long double type: we have compile error in case of compile for device.