### PR TITLE
bugfix for guard_view and zip_view bracket operator 

### DIFF
--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -122,6 +122,7 @@ class zip_view
         return ::std::get<0>(__m_ranges).size();
     }
 
+    //TODO: C++ Standard states that the operator[] index should be the diff_type of the underlying range.
     template <typename Idx>
     constexpr auto operator[](Idx __i) const
         -> decltype(make_reference(::std::declval<_tuple_ranges_t>(), __i, ::std::make_index_sequence<__num_ranges>()))
@@ -181,6 +182,7 @@ class guard_view
         return begin() + size();
     }
 
+    //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying iterator
     template <typename Idx>
     auto operator[](Idx i) const -> decltype(begin()[i])
     {
@@ -209,6 +211,7 @@ struct reverse_view_simple
 {
     _R __r;
 
+    //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range
     template <typename Idx>
     auto operator[](Idx __i) const -> decltype(__r[__i])
     {
@@ -243,6 +246,7 @@ struct take_view_simple
 
     take_view_simple(_R __rng, _Size __size) : __r(__rng), __n(__size) { assert(__n >= 0 && __n < __r.size()); }
 
+    //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range
     template <typename Idx>
     auto operator[](Idx __i) const -> decltype(__r[__i])
     {
@@ -277,6 +281,7 @@ struct drop_view_simple
 
     drop_view_simple(_R __rng, _Size __size) : __r(__rng), __n(__size) { assert(__n >= 0 && __n < __r.size()); }
 
+    //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range
     template <typename Idx>
     auto operator[](Idx __i) const -> decltype(__r[__i])
     {
@@ -309,6 +314,7 @@ struct transform_view_simple
     _R __r;
     _F __f;
 
+    //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range
     template <typename Idx>
     auto operator[](Idx __i) const -> decltype(__f(__r[__i]))
     {
@@ -369,6 +375,7 @@ struct permutation_view_simple<_R, _M, typename ::std::enable_if<is_map_functor<
 
     permutation_view_simple(_R __rng, _M __m) : __r(__rng), __map_fn(__m) {}
 
+    //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range
     template <typename Idx>
     auto operator[](Idx __i) const -> decltype(__r[__map_fn[__i]])
     {
@@ -402,6 +409,7 @@ struct permutation_view_simple<_R, _M, typename ::std::enable_if<is_map_view<_M>
 
     permutation_view_simple(_R __r, _M __m) : __data(__r, __m) {}
 
+    //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range
     template <typename Idx>
     auto operator[](Idx __i) const -> decltype(::std::get<0>(__data.tuple())[::std::get<1>(__data.tuple())[__i]])
     {

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -100,9 +100,9 @@ class zip_view
 
     using _tuple_ranges_t = oneapi::dpl::__internal::tuple<_Ranges...>;
 
-    template <::std::size_t... _Ip>
+    template <typename Idx, ::std::size_t... _Ip>
     auto
-    make_reference(_tuple_ranges_t __t, int32_t __i, ::std::index_sequence<_Ip...>) const
+    make_reference(_tuple_ranges_t __t, Idx __i, ::std::index_sequence<_Ip...>) const
         -> decltype(oneapi::dpl::__internal::tuple<decltype(::std::declval<_Ranges&>().operator[](__i))...>(
             ::std::get<_Ip>(__t).operator[](__i)...))
     {
@@ -122,7 +122,8 @@ class zip_view
         return ::std::get<0>(__m_ranges).size();
     }
 
-    constexpr auto operator[](int32_t __i) const
+    template <typename Idx>
+    constexpr auto operator[](Idx __i) const
         -> decltype(make_reference(::std::declval<_tuple_ranges_t>(), __i, ::std::make_index_sequence<__num_ranges>()))
     {
         return make_reference(__m_ranges, __i, ::std::make_index_sequence<__num_ranges>());
@@ -180,7 +181,11 @@ class guard_view
         return begin() + size();
     }
 
-    auto operator[](int32_t i) const -> decltype(begin()[i]) { return begin()[i]; }
+    template <typename Idx>
+    auto operator[](Idx i) const -> decltype(begin()[i])
+    {
+        return begin()[i];
+    }
 
     diff_type
     size() const

--- a/test/parallel_api/ranges/guard_view.pass.cpp
+++ b/test/parallel_api/ranges/guard_view.pass.cpp
@@ -41,8 +41,9 @@ main()
     {
         EXPECT_TRUE(gview[i] == i, "wrong effect with guard_view");
     }
+    const size_t last_idx = gview.size() - 1;
     //check access with index greater than 32 bit integer max
-    EXPECT_TRUE(gview[max_int32p2] == max_int32p2, "wrong effect with guard_view with index greater than max int32");
+    EXPECT_TRUE(gview[last_idx] == last_idx, "wrong effect with guard_view with index greater than max int32");
 
 #endif //_ENABLE_RANGES_TESTING
 

--- a/test/parallel_api/ranges/guard_view.pass.cpp
+++ b/test/parallel_api/ranges/guard_view.pass.cpp
@@ -1,0 +1,52 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#include <oneapi/dpl/execution>
+
+#include "support/test_config.h"
+
+#if _ENABLE_RANGES_TESTING
+#    include <oneapi/dpl/ranges>
+#endif
+
+#include "support/utils.h"
+
+#include <iostream>
+
+std::int32_t
+main()
+{
+#if _ENABLE_RANGES_TESTING
+    using CountItr = oneapi::dpl::counting_iterator<uint64_t>;
+    CountItr count_itr(0UL);
+
+    const size_t max_int32p2 = (size_t)::std::numeric_limits<int32_t>::max() + 2UL;
+
+    oneapi::dpl::__ranges::guard_view<CountItr> gview{count_itr, max_int32p2};
+
+    using namespace oneapi::dpl::experimental::ranges;
+
+    //check access
+    for (int i = 0; i < 10; i++)
+    {
+        EXPECT_TRUE(gview[i] == i, "wrong effect with guard_view");
+    }
+
+    EXPECT_TRUE(gview[max_int32p2] == max_int32p2, "wrong effect with guard_view with index greater than max int32");
+
+#endif //_ENABLE_RANGES_TESTING
+
+    return TestUtils::done(_ENABLE_RANGES_TESTING);
+}

--- a/test/parallel_api/ranges/guard_view.pass.cpp
+++ b/test/parallel_api/ranges/guard_view.pass.cpp
@@ -36,14 +36,12 @@ main()
 
     oneapi::dpl::__ranges::guard_view<CountItr> gview{count_itr, max_int32p2};
 
-    using namespace oneapi::dpl::experimental::ranges;
-
-    //check access
+    //check simple access
     for (int i = 0; i < 10; i++)
     {
         EXPECT_TRUE(gview[i] == i, "wrong effect with guard_view");
     }
-
+    //check access with index greater than 32 bit integer max
     EXPECT_TRUE(gview[max_int32p2] == max_int32p2, "wrong effect with guard_view with index greater than max int32");
 
 #endif //_ENABLE_RANGES_TESTING

--- a/test/parallel_api/ranges/zip_view.pass.cpp
+++ b/test/parallel_api/ranges/zip_view.pass.cpp
@@ -46,7 +46,6 @@ main()
     ::std::vector<char> large_keys(max_int32p2);
 
     auto large_z = zip_view(nano::views::all(large_data), nano::views::all(large_keys));
-    sycl::queue q{};
 
     //check that zip_view ranges can be larger than a signed 32 bit integer
     size_t i = large_data.size() - 1;

--- a/test/parallel_api/ranges/zip_view.pass.cpp
+++ b/test/parallel_api/ranges/zip_view.pass.cpp
@@ -18,7 +18,7 @@
 #include "support/test_config.h"
 
 #if _ENABLE_RANGES_TESTING
-#include <oneapi/dpl/ranges>
+#    include <oneapi/dpl/ranges>
 #endif
 
 #include "support/utils.h"
@@ -40,6 +40,27 @@ main()
 
     //check access
     EXPECT_TRUE(::std::get<0>(z[2]) == 'g', "wrong effect with zip_view");
+
+    const size_t max_int32p2 = (size_t)::std::numeric_limits<int32_t>::max() + 2UL;
+    ::std::vector<char> large_data(max_int32p2);
+    ::std::vector<size_t> large_keys(max_int32p2);
+
+    auto large_z = zip_view(nano::views::all(large_data), nano::views::all(large_keys));
+    sycl::queue q{};
+
+    //check that zip_view ranges can be larger than a signed 32 bit integer
+    size_t i = large_data.size() - 1;
+
+    large_data[i] = i % ::std::numeric_limits<char>::max();
+    large_keys[i] = i;
+
+    auto expected_key = i;
+    auto actual_key = ::std::get<1>(large_z[i]);
+    EXPECT_EQ(expected_key, actual_key, "wrong effect with zip_view bracket operator");
+    char expected_data = i % ::std::numeric_limits<char>::max();
+    char actual_data = ::std::get<0>(large_z[i]);
+    EXPECT_EQ(expected_data, actual_data, "wrong effect with zip_view bracket operator");
+
 #endif //_ENABLE_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_RANGES_TESTING);

--- a/test/parallel_api/ranges/zip_view.pass.cpp
+++ b/test/parallel_api/ranges/zip_view.pass.cpp
@@ -43,7 +43,7 @@ main()
 
     const size_t max_int32p2 = (size_t)::std::numeric_limits<int32_t>::max() + 2UL;
     ::std::vector<char> large_data(max_int32p2);
-    ::std::vector<size_t> large_keys(max_int32p2);
+    ::std::vector<char> large_keys(max_int32p2);
 
     auto large_z = zip_view(nano::views::all(large_data), nano::views::all(large_keys));
     sycl::queue q{};
@@ -52,12 +52,12 @@ main()
     size_t i = large_data.size() - 1;
 
     large_data[i] = i % ::std::numeric_limits<char>::max();
-    large_keys[i] = i;
+    large_keys[i] = (i + 1) % ::std::numeric_limits<char>::max();
 
-    auto expected_key = i;
-    auto actual_key = ::std::get<1>(large_z[i]);
+    char expected_key = large_keys[i];
+    char actual_key = ::std::get<1>(large_z[i]);
     EXPECT_EQ(expected_key, actual_key, "wrong effect with zip_view bracket operator");
-    char expected_data = i % ::std::numeric_limits<char>::max();
+    char expected_data = large_data[i];
     char actual_data = ::std::get<0>(large_z[i]);
     EXPECT_EQ(expected_data, actual_data, "wrong effect with zip_view bracket operator");
 


### PR DESCRIPTION
The guard_view and zip_view bracket operator was previously using signed int32 for the type of the index.  

The fix changes this index to be a template argument which is in line with other views in this file.  

I've added some tests to cover the overflow case for signed int32 for zip_view and guard_view.  They fail without the changes, and pass after the changes.

This PR impacts https://github.com/oneapi-src/oneDPL/pull/608 ,  guard_view's bracket operator is used in the by_segment routines and this bug impacts correctness of those algorithms as they are written.