### PR TITLE
Suppress sycl::exception "Double type is not supported on this platform" and skip current test in tests of std::complex

### DIFF
--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -74,11 +74,13 @@ const_size(const T (&)[N]) noexcept
 // Issue error message from outstr, adding a newline.
 // Real purpose of this routine is to have a place to hang a breakpoint.
 inline void
-issue_error_message(::std::stringstream& outstr)
+issue_error_message(::std::stringstream& outstr, bool bExit = true)
 {
     outstr << ::std::endl;
     ::std::cerr << outstr.str();
-    ::std::exit(EXIT_FAILURE);
+
+    if (bExit)
+        ::std::exit(EXIT_FAILURE);
 }
 
 inline void

--- a/test/xpu_api/numerics/complex.number/complex.special/simple_reproducer.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.special/simple_reproducer.pass.cpp
@@ -1,0 +1,39 @@
+#include <CL/sycl.hpp>
+
+int
+main()
+{
+    sycl::queue deviceQueue;
+
+    // Example from https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:kernel.attributes
+    if (deviceQueue.get_device().has(sycl::aspect::fp64))
+    {
+        deviceQueue.submit(
+            [](sycl::handler & cgh) [[sycl::device_has(sycl::aspect::fp64)]]
+            {
+                cgh.single_task<class Test1>(
+                    []()
+                    {
+                        double d = 1;
+                        d = d + 1;
+                        d = d;
+                    });
+            });
+    }
+    else
+    {
+        deviceQueue.submit(
+            [](sycl::handler& cgh)
+            {
+                cgh.single_task<class Test2>(
+                    []()
+                    {
+                        float f = 1;
+                        f = f + 1;
+                        f = f;
+                    });
+            });
+    }
+
+    return 0;
+}

--- a/test/xpu_api/numerics/complex.number/complex.special/simple_reproducer.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.special/simple_reproducer.pass.cpp
@@ -12,7 +12,7 @@ main()
             [](sycl::handler & cgh) [[sycl::device_has(sycl::aspect::fp64)]]
             {
                 cgh.single_task<class Test1>(
-                    []()
+                    []() [[sycl::device_has(sycl::aspect::fp64)]]
                     {
                         double d = 1;
                         d = d + 1;


### PR DESCRIPTION
In this PR we suppress sycl::exception "Double type is not supported on this platform" and skip current test in tests of std::complex