### PR TITLE
Add inline for constexpr variables

### DIFF
--- a/include/oneapi/dpl/pstl/execution_defs.h
+++ b/include/oneapi/dpl/pstl/execution_defs.h
@@ -116,10 +116,10 @@ class unsequenced_policy
 };
 
 // 2.8, Execution policy objects
-constexpr sequenced_policy seq{};
-constexpr parallel_policy par{};
-constexpr parallel_unsequenced_policy par_unseq{};
-constexpr unsequenced_policy unseq{};
+inline constexpr sequenced_policy seq{};
+inline constexpr parallel_policy par{};
+inline constexpr parallel_unsequenced_policy par_unseq{};
+inline constexpr unsequenced_policy unseq{};
 
 // 2.3, Execution policy type trait
 template <class T>
@@ -145,7 +145,7 @@ struct is_execution_policy<oneapi::dpl::execution::unsequenced_policy> : ::std::
 };
 
 template <class T>
-constexpr bool is_execution_policy_v = oneapi::dpl::execution::is_execution_policy<T>::value;
+inline constexpr bool is_execution_policy_v = oneapi::dpl::execution::is_execution_policy<T>::value;
 
 } // namespace v1
 } // namespace execution


### PR DESCRIPTION
Since oneDPL minimal required standard is C++17 all execution policy objects and `is_execution_policy_v` utility can be marked `inline` now. This might in theory break the ABI but in practice it's the correction of prior standards limitation for more stable ABI in future because:
- It makes each particular global object the same (symbol-wise or address-wise) in different translation units
- It is aligned with C++ standard definition of corresponding APIs