### PR TITLE
Additional checks for __cplusplus define

### DIFF
--- a/include/oneapi/dpl/internal/common_config.h
+++ b/include/oneapi/dpl/internal/common_config.h
@@ -22,7 +22,6 @@
 
 #if __cplusplus < 201703L
 #    error "oneDPL requires the C++ language version not less than C++17"
-#    error __cplusplus
 #endif
 
 // Workarounds for libstdc++9, libstdc++10 when new TBB version is found in the environment

--- a/include/oneapi/dpl/internal/common_config.h
+++ b/include/oneapi/dpl/internal/common_config.h
@@ -22,6 +22,7 @@
 
 #if __cplusplus < 201703L
 #    error "oneDPL requires the C++ language version not less than C++17"
+#    error __cplusplus
 #endif
 
 // Workarounds for libstdc++9, libstdc++10 when new TBB version is found in the environment

--- a/include/oneapi/dpl/internal/common_config.h
+++ b/include/oneapi/dpl/internal/common_config.h
@@ -17,7 +17,11 @@
 #define _ONEDPL_COMMON_CONFIG_H
 
 #if !defined(__cplusplus)
-#    error "C++ compiler required or please define __cplusplus state"
+#    error "oneDPL requires correct state of __cplusplus : it's undefined"
+#endif
+
+#if __cplusplus == 199711L
+#    error "oneDPL requires correct state of __cplusplus : use /Zc:__cplusplus for Microsoft C++ compiler"
 #endif
 
 #if __cplusplus < 201703L

--- a/include/oneapi/dpl/internal/common_config.h
+++ b/include/oneapi/dpl/internal/common_config.h
@@ -16,6 +16,10 @@
 #ifndef _ONEDPL_COMMON_CONFIG_H
 #define _ONEDPL_COMMON_CONFIG_H
 
+#if !defined(__cplusplus)
+#    error "C++ compiler required or please define __cplusplus state"
+#endif
+
 #if __cplusplus < 201703L
 #    error "oneDPL requires the C++ language version not less than C++17"
 #endif


### PR DESCRIPTION
In this PR we implement additional checks for __cplusplus define : 
#if !defined(__cplusplus)
#    error "oneDPL requires correct state of __cplusplus : it's undefined"
#endif

#if __cplusplus == 199711L
#    error "oneDPL requires correct state of __cplusplus : use /Zc:__cplusplus for Microsoft C++ compiler"
#endif