### PR TITLE
Improve radix sort's reorder peer prefix algorithms

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -562,11 +562,9 @@ struct __peer_prefix_helper<_OffsetT, __radix_bits, __peer_prefix_algo::atomic_f
             __offset_arr[__bucket_val] += __num_bucket_peers;
         }
 
-        __new_offset_idx += __sg_total_offset;
-
-        // TODO: is this barrier needed?
         sycl::group_barrier(__sgroup);
 
+        __new_offset_idx += __sg_total_offset;
         return __new_offset_idx;
     }
 };


### PR DESCRIPTION
These changes reduce the peer prefix algorithms' iteration space from all radix states to just the number of radix bits for the `subgroup_ballot` and `atomic_fetch_or` helpers. This decreases the number of subgroup collectives during the peer prefix portion from 16 per input element to 4 per input element.

It also changes the private work-item-local array for offsets to a shared local array, reducing the memory requirement / register pressure for the reorder kernel.