### PR TITLE
__dpl_sycl::__atomic_ref improvements

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -721,9 +721,9 @@ __parallel_find_or(_ExecutionPolicy&& __exec, _Brick __f, _BrickTag __brick_tag,
                     auto __local_idx = __item_id.get_local_id(0);
 
                     __dpl_sycl::__atomic_ref<_AtomicType, sycl::access::address_space::global_space> __found(
-                        __temp_acc.get_pointer());
+                        *__temp_acc.get_pointer());
                     __dpl_sycl::__atomic_ref<_AtomicType, sycl::access::address_space::local_space> __found_local(
-                        __temp_local.get_pointer());
+                        *__temp_local.get_pointer());
 
                     // 1. Set initial value to local atomic
                     if (__local_idx == 0)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -733,9 +733,9 @@ __parallel_find_or(_ExecutionPolicy&& __exec, _Brick __f, _BrickTag __brick_tag,
                     //decltype(__temp_local.get_pointer())::dummy;
 
                     __dpl_sycl::__atomic_ref<_AtomicType, sycl::access::address_space::global_space> __found(
-                        __temp_acc.get_pointer());
+                        __temp_acc.get_pointer().get());
                     __dpl_sycl::__atomic_ref<_AtomicType, sycl::access::address_space::local_space> __found_local(
-                        __temp_local.get_pointer());
+                        __temp_local.get_pointer().get());
 
                     // 1. Set initial value to local atomic
                     if (__local_idx == 0)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -720,10 +720,22 @@ __parallel_find_or(_ExecutionPolicy&& __exec, _Brick __f, _BrickTag __brick_tag,
                 [=](sycl::nd_item</*dim=*/1> __item_id) {
                     auto __local_idx = __item_id.get_local_id(0);
 
+                    // __temp_acc is sycl::accessor<int, 1, sycl::access::mode::read_write, sycl::access::target::global_buffer, sycl::access::placeholder::false_t>
+                    //decltype(__temp_acc)::dummy;
+
+                    // __temp_local is sycl::accessor<int, 1, sycl::access::mode::read_write, sycl::access::target::local, sycl::access::placeholder::false_t>
+                    //decltype(__temp_local)::dummy;
+
+                    // __temp_acc.get_pointer() is sycl::multi_ptr<int, sycl::access::address_space::global_space>
+                    //decltype(__temp_acc.get_pointer())::dummy;
+
+                    // __temp_local.get_pointer() is sycl::multi_ptr<int, sycl::access::address_space::local_space>
+                    //decltype(__temp_local.get_pointer())::dummy;
+
                     __dpl_sycl::__atomic_ref<_AtomicType, sycl::access::address_space::global_space> __found(
-                        *__temp_acc.get_pointer());
+                        __temp_acc.get_pointer());
                     __dpl_sycl::__atomic_ref<_AtomicType, sycl::access::address_space::local_space> __found_local(
-                        *__temp_local.get_pointer());
+                        __temp_local.get_pointer());
 
                     // 1. Set initial value to local atomic
                     if (__local_idx == 0)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -720,18 +720,6 @@ __parallel_find_or(_ExecutionPolicy&& __exec, _Brick __f, _BrickTag __brick_tag,
                 [=](sycl::nd_item</*dim=*/1> __item_id) {
                     auto __local_idx = __item_id.get_local_id(0);
 
-                    // __temp_acc is sycl::accessor<int, 1, sycl::access::mode::read_write, sycl::access::target::global_buffer, sycl::access::placeholder::false_t>
-                    //decltype(__temp_acc)::dummy;
-
-                    // __temp_local is sycl::accessor<int, 1, sycl::access::mode::read_write, sycl::access::target::local, sycl::access::placeholder::false_t>
-                    //decltype(__temp_local)::dummy;
-
-                    // __temp_acc.get_pointer() is sycl::multi_ptr<int, sycl::access::address_space::global_space>
-                    //decltype(__temp_acc.get_pointer())::dummy;
-
-                    // __temp_local.get_pointer() is sycl::multi_ptr<int, sycl::access::address_space::local_space>
-                    //decltype(__temp_local.get_pointer())::dummy;
-
                     __dpl_sycl::__atomic_ref<_AtomicType, sycl::access::address_space::global_space> __found(
                         *__temp_acc.get_pointer());
                     __dpl_sycl::__atomic_ref<_AtomicType, sycl::access::address_space::local_space> __found_local(

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -733,9 +733,9 @@ __parallel_find_or(_ExecutionPolicy&& __exec, _Brick __f, _BrickTag __brick_tag,
                     //decltype(__temp_local.get_pointer())::dummy;
 
                     __dpl_sycl::__atomic_ref<_AtomicType, sycl::access::address_space::global_space> __found(
-                        __temp_acc.get_pointer().get());
+                        *__temp_acc.get_pointer());
                     __dpl_sycl::__atomic_ref<_AtomicType, sycl::access::address_space::local_space> __found_local(
-                        __temp_local.get_pointer().get());
+                        *__temp_local.get_pointer());
 
                     // 1. Set initial value to local atomic
                     if (__local_idx == 0)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -511,7 +511,7 @@ struct __peer_prefix_helper<_OffsetT, __peer_prefix_algo::atomic_fetch_or>
 
     __peer_prefix_helper(sycl::nd_item<1> __self_item, _TempStorageT __lacc)
         : __sgroup(__self_item.get_sub_group()), __self_lidx(__self_item.get_local_linear_id()),
-          __item_mask(~(~0u << (__self_lidx))), __atomic_peer_mask(__lacc.get_pointer())
+          __item_mask(~(~0u << (__self_lidx))), __atomic_peer_mask(*__lacc.get_pointer())
     {
     }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -221,17 +221,12 @@ using __buffer_allocator =
 
 template <typename _AtomicType, sycl::access::address_space _Space>
 #if _ONEDPL_SYCL2023_ATOMIC_REF_PRESENT
-struct __atomic_ref : sycl::atomic_ref<_AtomicType, sycl::memory_order::relaxed, sycl::memory_scope::work_group, _Space>
-{
-    template <typename _PointerT>
-    explicit __atomic_ref(_PointerT data)
-        : sycl::atomic_ref<_AtomicType, sycl::memory_order::relaxed, sycl::memory_scope::work_group, _Space>(*data){};
-
-    __atomic_ref(const __atomic_ref& other) noexcept
-        : sycl::atomic_ref<_AtomicType, sycl::memory_order::relaxed, sycl::memory_scope::work_group, _Space>(other){};
-};
+using __atomic_ref = sycl::atomic_ref<_AtomicType, sycl::memory_order::relaxed, sycl::memory_scope::work_group, _Space>;
 #else
-using __atomic_ref = sycl::atomic<_AtomicType, _Space>;
+struct __atomic_ref : sycl::atomic<_AtomicType, _Space>
+{
+    explicit __atomic_ref(_AtomicType& data) : sycl::atomic<_AtomicType, _Space>(::std::addressof(data)){};
+};
 #endif // _ONEDPL_SYCL2023_ATOMIC_REF_PRESENT
 
 } // namespace __dpl_sycl

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -223,12 +223,7 @@ template <typename _AtomicType, sycl::access::address_space _Space>
 #if _ONEDPL_SYCL2023_ATOMIC_REF_PRESENT
 struct __atomic_ref : sycl::atomic_ref<_AtomicType, sycl::memory_order::relaxed, sycl::memory_scope::work_group, _Space>
 {
-    explicit __atomic_ref(_AtomicType& ref)
-        : sycl::atomic_ref<_AtomicType, sycl::memory_order::relaxed, sycl::memory_scope::work_group, _Space>(ref)
-    {
-    }
-
-    explicit __atomic_ref(sycl::multi_ptr<_AtomicType, _Space> ptr)
+    explicit __atomic_ref(_AtomicType* ptr)
         : sycl::atomic_ref<_AtomicType, sycl::memory_order::relaxed, sycl::memory_scope::work_group, _Space>(*ptr)
     {
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -221,13 +221,7 @@ using __buffer_allocator =
 
 template <typename _AtomicType, sycl::access::address_space _Space>
 #if _ONEDPL_SYCL2023_ATOMIC_REF_PRESENT
-struct __atomic_ref : sycl::atomic_ref<_AtomicType, sycl::memory_order::relaxed, sycl::memory_scope::work_group, _Space>
-{
-    explicit __atomic_ref(_AtomicType& ref)
-        : sycl::atomic_ref<_AtomicType, sycl::memory_order::relaxed, sycl::memory_scope::work_group, _Space>(ref)
-    {
-    }
-};
+using __atomic_ref = sycl::atomic_ref<_AtomicType, sycl::memory_order::relaxed, sycl::memory_scope::work_group, _Space>;
 #else
 struct __atomic_ref : sycl::atomic<_AtomicType, _Space>
 {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -221,11 +221,22 @@ using __buffer_allocator =
 
 template <typename _AtomicType, sycl::access::address_space _Space>
 #if _ONEDPL_SYCL2023_ATOMIC_REF_PRESENT
-using __atomic_ref = sycl::atomic_ref<_AtomicType, sycl::memory_order::relaxed, sycl::memory_scope::work_group, _Space>;
+struct __atomic_ref : sycl::atomic_ref<_AtomicType, sycl::memory_order::relaxed, sycl::memory_scope::work_group, _Space>
+{
+    explicit __atomic_ref(_AtomicType& ref)
+        : sycl::atomic_ref<_AtomicType, sycl::memory_order::relaxed, sycl::memory_scope::work_group, _Space>(ref)
+    {
+    }
+
+    explicit __atomic_ref(sycl::multi_ptr<_AtomicType, _Space> ptr)
+        : sycl::atomic_ref<_AtomicType, sycl::memory_order::relaxed, sycl::memory_scope::work_group, _Space>(*ptr)
+    {
+    }
+};
 #else
 struct __atomic_ref : sycl::atomic<_AtomicType, _Space>
 {
-    explicit __atomic_ref(_AtomicType& data) : sycl::atomic<_AtomicType, _Space>(::std::addressof(data)){};
+    explicit __atomic_ref(sycl::multi_ptr<_AtomicType, _Space> ptr) : sycl::atomic<_AtomicType, _Space>(ptr){};
 };
 #endif // _ONEDPL_SYCL2023_ATOMIC_REF_PRESENT
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -223,15 +223,16 @@ template <typename _AtomicType, sycl::access::address_space _Space>
 #if _ONEDPL_SYCL2023_ATOMIC_REF_PRESENT
 struct __atomic_ref : sycl::atomic_ref<_AtomicType, sycl::memory_order::relaxed, sycl::memory_scope::work_group, _Space>
 {
-    explicit __atomic_ref(_AtomicType* ptr)
-        : sycl::atomic_ref<_AtomicType, sycl::memory_order::relaxed, sycl::memory_scope::work_group, _Space>(*ptr)
+    explicit __atomic_ref(_AtomicType& ref)
+        : sycl::atomic_ref<_AtomicType, sycl::memory_order::relaxed, sycl::memory_scope::work_group, _Space>(ref)
     {
     }
 };
 #else
 struct __atomic_ref : sycl::atomic<_AtomicType, _Space>
 {
-    explicit __atomic_ref(sycl::multi_ptr<_AtomicType, _Space> ptr) : sycl::atomic<_AtomicType, _Space>(ptr){};
+    explicit __atomic_ref(_AtomicType& ref)
+        : sycl::atomic<_AtomicType, _Space>(sycl::multi_ptr<_AtomicType, _Space>(&ref)){};
 };
 #endif // _ONEDPL_SYCL2023_ATOMIC_REF_PRESENT
 


### PR DESCRIPTION
In this PR we __dpl_sycl::__atomic_ref as alias for modern dpcpp compiler:
```
template <typename _AtomicType, sycl::access::address_space _Space>
#if _ONEDPL_SYCL2023_ATOMIC_REF_PRESENT
using __atomic_ref = sycl::atomic_ref<_AtomicType, sycl::memory_order::relaxed, sycl::memory_scope::work_group, _Space>;
#else
struct __atomic_ref : sycl::atomic<_AtomicType, _Space>
{
    explicit __atomic_ref(_AtomicType& ref)
        : sycl::atomic<_AtomicType, _Space>(sycl::multi_ptr<_AtomicType, _Space>(&ref)){};
};
#endif // _ONEDPL_SYCL2023_ATOMIC_REF_PRESENT
```