### PR TITLE
[oneDPL] + outer namespace  for NanoRange library

### DIFF
--- a/include/oneapi/dpl/pstl/ranges/nanorange.hpp
+++ b/include/oneapi/dpl/pstl/ranges/nanorange.hpp
@@ -172,6 +172,9 @@
 
 #                                        include <type_traits>
 
+namespace __nanorange
+{
+
 NANO_BEGIN_NAMESPACE
 
 template <typename T>
@@ -19372,5 +19375,7 @@ NANO_END_NAMESPACE
 #    endif
 
 #endif
+
+} //namespace __nanorange
 
 #endif // NANORANGE_HPP_INCLUDED

--- a/include/oneapi/dpl/pstl/ranges/nanorange_ext.h
+++ b/include/oneapi/dpl/pstl/ranges/nanorange_ext.h
@@ -16,6 +16,9 @@
 #ifndef _ONEDPL_NANO_RANGES_EXT_H
 #define _ONEDPL_NANO_RANGES_EXT_H
 
+namespace __nanorange
+{
+
 NANO_BEGIN_NAMESPACE
 
 template <typename I>
@@ -270,5 +273,7 @@ NANO_INLINE_VAR(nano::detail::fill_view_fn, fill)
 } // namespace views
 
 NANO_END_NAMESPACE
+
+} //namespace __nanorange
 
 #endif //_ONEDPL_NANO_RANGES_EXT_H

--- a/include/oneapi/dpl/pstl/ranges_defs.h
+++ b/include/oneapi/dpl/pstl/ranges_defs.h
@@ -32,6 +32,8 @@ namespace experimental
 namespace ranges
 {
 
+using namespace __nanorange;
+
 //custom views
 using oneapi::dpl::__ranges::all_view;
 using oneapi::dpl::__ranges::guard_view;


### PR DESCRIPTION
[oneDPL] + outer namespace  __nanorange for "namespace nano" (NanoRange Library), to fix a potential name conflict