### PR TITLE
Prepare two different Kernels in tests of std::complex - with and without double type usage

### DIFF
--- a/make/Makefile.common
+++ b/make/Makefile.common
@@ -51,6 +51,7 @@ cfg ?= release
 
 device_type ?= GPU
 use_unnamed_lambda ?= 0
+split_per_kernel ?= 0
 ranges_api ?= 0
 
 ifeq ($(backend), sycl)

--- a/make/dpcpp.inc
+++ b/make/dpcpp.inc
@@ -27,6 +27,9 @@ ifeq ($(os_name), linux)
     ifeq ($(use_unnamed_lambda), 1)
         CPLUS_FLAGS += -fsycl-unnamed-lambda
     endif
+    ifeq ($(split_per_kernel), 1)
+        CPLUS_FLAGS += -fsycl-fsycl-device-code-split=per_kernel
+    endif
     ifneq ($(stdver),)
         CPLUS_FLAGS += $(KEY)std=$(stdver)
     endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -41,8 +41,10 @@ macro(onedpl_add_test test_source_file split_kernels)
     endif()
 
     # oneDPL tests of std::complex required generates code to do JIT compilation of a kernel only when it is called
-    if (${split_kernels})
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsycl-device-code-split=per_kernel ")
+    if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang|IntelLLVM" )
+        if (${split_kernels})
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsycl-device-code-split=per_kernel ")
+        endif()
     endif()
 
     target_include_directories(${_test_name} PRIVATE "${CMAKE_CURRENT_LIST_DIR}")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,7 +24,7 @@ add_custom_target(run-onedpl-tests
     DEPENDS build-onedpl-tests
     COMMENT "Build and run all oneDPL tests")
 
-macro(onedpl_add_test test_source_file)
+macro(onedpl_add_test test_source_file split_kernels)
     get_filename_component(_test_name ${test_source_file} NAME)
     string(REPLACE "\.cpp" "" _test_name ${_test_name})
 
@@ -38,6 +38,11 @@ macro(onedpl_add_test test_source_file)
     # that may break code when using Intel(R) C++ Compiler Classic with -O3 flag on Linux
     if (CMAKE_SYSTEM_NAME MATCHES "Linux" AND CMAKE_CXX_COMPILER_ID STREQUAL Intel)
         target_compile_options(${_test_name} PRIVATE $<$<CONFIG:Release>:-fno-strict-aliasing>)
+    endif()
+
+    # oneDPL tests of std::complex required generates code to do JIT compilation of a kernel only when it is called
+    if (${split_kernels})
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsycl-device-code-split=per_kernel ")
     endif()
 
     target_include_directories(${_test_name} PRIVATE "${CMAKE_CURRENT_LIST_DIR}")
@@ -101,6 +106,7 @@ macro(onedpl_add_test test_source_file)
 endmacro()
 
 set(_skip_regex_for_not_dpcpp "(xpu_api/algorithms|xpu_api/functional|xpu_api/numerics)")
+set(_is_complex_test_regexp "(xpu_api/numerics/complex.number)")
 file(GLOB_RECURSE UNIT_TESTS "*.pass.cpp")
 foreach (_file IN LISTS UNIT_TESTS)
     if (_file MATCHES "${_skip_regex_for_not_dpcpp}" AND NOT ONEDPL_BACKEND MATCHES "^(dpcpp|dpcpp_only)$")
@@ -108,5 +114,12 @@ foreach (_file IN LISTS UNIT_TESTS)
         continue()
     endif()
 
-    onedpl_add_test(${_file})
+    if (_file MATCHES "${_is_complex_test_regexp}")
+        # compile oneDPL tests with separate Kernel compilation
+        onedpl_add_test(${_file} true)
+    else()
+        # compile oneDPL tests without separate Kernel compilation
+        onedpl_add_test(${_file} false)
+    endif()
+
 endforeach()

--- a/test/support/test_complex.h
+++ b/test/support/test_complex.h
@@ -129,20 +129,23 @@ namespace TestUtils
             sycl::queue deviceQueue{TestUtils::default_selector};
 
             const auto device = deviceQueue.get_device();
-            const bool double_supported = has_type_support<double>(device);
 
-            deviceQueue.submit(
-                [&](sycl::handler& cgh)
-                {
-                    cgh.single_task<TestUtils::new_kernel_name<class TestType, 0>>(
-                        [=]()
-                        { 
-                            if (double_supported)
-                                fncDoubleHasSupportInRuntime();
-                            else
-                                fncDoubleHasntSupportInRuntime();
-                        });
-                });
+            if (has_type_support<double>(device))
+            {
+                deviceQueue.submit(
+                    [&](sycl::handler& cgh) {
+                        cgh.single_task<TestUtils::new_kernel_name<class TestType, 0>>(
+                            [fncDoubleHasSupportInRuntime]() { fncDoubleHasSupportInRuntime(); });
+                    });
+            }
+            else
+            {
+                deviceQueue.submit(
+                    [&](sycl::handler& cgh) {
+                        cgh.single_task<TestUtils::new_kernel_name<class TestType, 1>>(
+                            [fncDoubleHasntSupportInRuntime]() { fncDoubleHasntSupportInRuntime(); });
+                    });
+            }
         }
         catch (const std::exception& exc)
         {

--- a/test/support/test_complex.h
+++ b/test/support/test_complex.h
@@ -130,6 +130,11 @@ namespace TestUtils
 
             const auto device = deviceQueue.get_device();
 
+            // We should run fncDoubleHasSupportInRuntime and fncDoubleHasntSupportInRuntime
+            // in two separate Kernels to have ability compile these Kernels separatelly
+            // by using dpcpp compiler option -fsycl-device-code-split=per_kernel
+            // which described at
+            // https://www.intel.com/content/www/us/en/develop/documentation/oneapi-gpu-optimization-guide/top/compilation/jitting.html
             if (has_type_support<double>(device))
             {
                 deviceQueue.submit(


### PR DESCRIPTION
Prepare different Kernels in tests of std::complex - with and without double to have ability
to use cmake option (compiler option) -DCMAKE_CXX_FLAGS="-fsycl-device-code-split=per_kernel"
for dpcpp compiler.
In this case we may run tests of std::complex on devices without double type support without run-time errors.