### PR TITLE
Rename __LIBSYCL_VERSION macro

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -356,7 +356,7 @@ __max_compute_units(_ExecutionPolicy&& __policy)
 //-----------------------------------------------------------------------------
 
 // 20201214 value corresponds to Intel(R) oneAPI C++ Compiler Classic 2021.1.2 Patch release
-#define _USE_KERNEL_DEVICE_SPECIFIC_API (__SYCL_COMPILER_VERSION > 20201214) || (__LIBSYCL_VERSION >= 50700)
+#define _USE_KERNEL_DEVICE_SPECIFIC_API (__SYCL_COMPILER_VERSION > 20201214) || (_ONEDPL_LIBSYCL_VERSION >= 50700)
 
 template <typename _ExecutionPolicy>
 ::std::size_t

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -506,7 +506,7 @@ enum class __peer_prefix_algo
 template <typename _OffsetT, __peer_prefix_algo _Algo>
 struct __peer_prefix_helper;
 
-#if (__LIBSYCL_VERSION >= 50700)
+#if (_ONEDPL_LIBSYCL_VERSION >= 50700)
 template <typename _OffsetT>
 struct __peer_prefix_helper<_OffsetT, __peer_prefix_algo::atomic_fetch_or>
 {
@@ -545,7 +545,7 @@ struct __peer_prefix_helper<_OffsetT, __peer_prefix_algo::atomic_fetch_or>
         return __sg_total_offset;
     }
 };
-#endif // (__LIBSYCL_VERSION >= 50700)
+#endif // (_ONEDPL_LIBSYCL_VERSION >= 50700)
 
 template <typename _OffsetT>
 struct __peer_prefix_helper<_OffsetT, __peer_prefix_algo::scan_then_broadcast>
@@ -806,7 +806,7 @@ __parallel_radix_sort_iteration(_ExecutionPolicy&& __exec, ::std::size_t __segme
     {
 #if _ONEDPL_SYCL_SUB_GROUP_MASK_PRESENT
         constexpr auto __peer_algorithm = __peer_prefix_algo::subgroup_ballot;
-#elif (__LIBSYCL_VERSION >= 50700)
+#elif (_ONEDPL_LIBSYCL_VERSION >= 50700)
         constexpr auto __peer_algorithm = __peer_prefix_algo::atomic_fetch_or;
 #else
         constexpr auto __peer_algorithm = __peer_prefix_algo::scan_then_broadcast;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -27,14 +27,14 @@
 
 // Combine SYCL runtime library version
 #if defined(__LIBSYCL_MAJOR_VERSION) && defined(__LIBSYCL_MINOR_VERSION) && defined(__LIBSYCL_PATCH_VERSION)
-#    define __LIBSYCL_VERSION                                                                                          \
+#    define _ONEDPL_LIBSYCL_VERSION                                                                                    \
         (__LIBSYCL_MAJOR_VERSION * 10000 + __LIBSYCL_MINOR_VERSION * 100 + __LIBSYCL_PATCH_VERSION)
 #else
-#    define __LIBSYCL_VERSION 0
+#    define _ONEDPL_LIBSYCL_VERSION 0
 #endif
 
 #if _ONEDPL_FPGA_DEVICE
-#    if __LIBSYCL_VERSION >= 50400
+#    if _ONEDPL_LIBSYCL_VERSION >= 50400
 #        include <sycl/ext/intel/fpga_extensions.hpp>
 #    else
 #        include <CL/sycl/INTEL/fpga_extensions.hpp>
@@ -42,13 +42,13 @@
 #endif
 
 // Macros to check the new SYCL features
-#define _ONEDPL_NO_INIT_PRESENT (__LIBSYCL_VERSION >= 50300)
-#define _ONEDPL_KERNEL_BUNDLE_PRESENT (__LIBSYCL_VERSION >= 50300)
-#define _ONEDPL_SYCL2020_COLLECTIVES_PRESENT (__LIBSYCL_VERSION >= 50300)
-#define _ONEDPL_SYCL2020_KNOWN_IDENTITY_PRESENT (__LIBSYCL_VERSION >= 50300)
-#define _ONEDPL_SYCL2020_FUNCTIONAL_OBJECTS_PRESENT (__LIBSYCL_VERSION >= 50300)
-#define _ONEDPL_SYCL2023_ATOMIC_REF_PRESENT (__LIBSYCL_VERSION >= 50500)
-#define _ONEDPL_SYCL_SUB_GROUP_MASK_PRESENT (SYCL_EXT_ONEAPI_SUB_GROUP_MASK == 1) && (__LIBSYCL_VERSION >= 50700)
+#define _ONEDPL_NO_INIT_PRESENT (_ONEDPL_LIBSYCL_VERSION >= 50300)
+#define _ONEDPL_KERNEL_BUNDLE_PRESENT (_ONEDPL_LIBSYCL_VERSION >= 50300)
+#define _ONEDPL_SYCL2020_COLLECTIVES_PRESENT (_ONEDPL_LIBSYCL_VERSION >= 50300)
+#define _ONEDPL_SYCL2020_KNOWN_IDENTITY_PRESENT (_ONEDPL_LIBSYCL_VERSION >= 50300)
+#define _ONEDPL_SYCL2020_FUNCTIONAL_OBJECTS_PRESENT (_ONEDPL_LIBSYCL_VERSION >= 50300)
+#define _ONEDPL_SYCL2023_ATOMIC_REF_PRESENT (_ONEDPL_LIBSYCL_VERSION >= 50500)
+#define _ONEDPL_SYCL_SUB_GROUP_MASK_PRESENT (SYCL_EXT_ONEAPI_SUB_GROUP_MASK == 1) && (_ONEDPL_LIBSYCL_VERSION >= 50700)
 
 namespace __dpl_sycl
 {
@@ -67,7 +67,7 @@ using __known_identity = sycl::known_identity<_BinaryOp, _T>;
 template <typename _BinaryOp, typename _T>
 using __has_known_identity = sycl::has_known_identity<_BinaryOp, _T>;
 
-#elif __LIBSYCL_VERSION == 50200
+#elif _ONEDPL_LIBSYCL_VERSION == 50200
 template <typename _BinaryOp, typename _T>
 using __known_identity = sycl::ONEAPI::known_identity<_BinaryOp, _T>;
 
@@ -100,7 +100,7 @@ template <typename _Buffer>
 constexpr auto
 __get_buffer_size(const _Buffer& __buffer)
 {
-#if __LIBSYCL_VERSION >= 50300
+#if _ONEDPL_LIBSYCL_VERSION >= 50300
     return __buffer.size();
 #else
     return __buffer.get_count();
@@ -111,7 +111,7 @@ template <typename _Accessor>
 constexpr auto
 __get_accessor_size(const _Accessor& __accessor)
 {
-#if __LIBSYCL_VERSION >= 50300
+#if _ONEDPL_LIBSYCL_VERSION >= 50300
     return __accessor.size();
 #else
     return __accessor.get_count();
@@ -122,7 +122,7 @@ template <typename _Item>
 constexpr void
 __group_barrier(_Item __item)
 {
-#if 0 //__LIBSYCL_VERSION >= 50300
+#if 0 //_ONEDPL_LIBSYCL_VERSION >= 50300
     //TODO: usage of sycl::group_barrier: probably, we have to revise SYCL parallel patterns which use a group_barrier.
     // 1) sycl::group_barrier() implementation is not ready
     // 2) sycl::group_barrier and sycl::item::group_barrier are not quite equivalent
@@ -188,7 +188,7 @@ __joint_exclusive_scan(_Args... __args)
 }
 
 #if _ONEDPL_FPGA_DEVICE
-#    if __LIBSYCL_VERSION >= 50300
+#    if _ONEDPL_LIBSYCL_VERSION >= 50300
 using __fpga_emulator_selector = sycl::ext::intel::fpga_emulator_selector;
 using __fpga_selector = sycl::ext::intel::fpga_selector;
 #    else
@@ -198,14 +198,14 @@ using __fpga_selector = sycl::INTEL::fpga_selector;
 #endif // _ONEDPL_FPGA_DEVICE
 
 using __target =
-#if __LIBSYCL_VERSION >= 50400
+#if _ONEDPL_LIBSYCL_VERSION >= 50400
     sycl::target;
 #else
     sycl::access::target;
 #endif
 
 constexpr __target __target_device =
-#if __LIBSYCL_VERSION >= 50400
+#if _ONEDPL_LIBSYCL_VERSION >= 50400
     __target::device;
 #else
     __target::global_buffer;
@@ -213,7 +213,7 @@ constexpr __target __target_device =
 
 template <typename _DataT>
 using __buffer_allocator =
-#if __LIBSYCL_VERSION >= 50707
+#if _ONEDPL_LIBSYCL_VERSION >= 50707
     sycl::buffer_allocator<_DataT>;
 #else
     sycl::buffer_allocator;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -44,19 +44,19 @@ using non_void_type = typename ::std::enable_if<!::std::is_void<_Tp>::value, _Tp
 //std::logical_and and std::logical_or are not supported in Intel(R) oneAPI DPC++ Compiler to be used in sycl::inclusive_scan_over_group and sycl::reduce_over_group
 template <typename _BinaryOp, typename _Tp>
 using __has_known_identity =
-#    if __LIBSYCL_VERSION >= 50200
+#    if _ONEDPL_LIBSYCL_VERSION >= 50200
     typename ::std::conjunction<
         ::std::is_arithmetic<_Tp>, __dpl_sycl::__has_known_identity<_BinaryOp, _Tp>,
         ::std::disjunction<::std::is_same<typename ::std::decay<_BinaryOp>::type, ::std::plus<_Tp>>,
                            ::std::is_same<typename ::std::decay<_BinaryOp>::type, __dpl_sycl::__plus<_Tp>>,
                            ::std::is_same<typename ::std::decay<_BinaryOp>::type, __dpl_sycl::__minimum<_Tp>>,
                            ::std::is_same<typename ::std::decay<_BinaryOp>::type, __dpl_sycl::__maximum<_Tp>>>>;
-#    else  //__LIBSYCL_VERSION >= 50200
+#    else  //_ONEDPL_LIBSYCL_VERSION >= 50200
     typename ::std::conjunction<
         ::std::is_arithmetic<_Tp>,
         ::std::disjunction<::std::is_same<typename ::std::decay<_BinaryOp>::type, ::std::plus<_Tp>>,
                            ::std::is_same<typename ::std::decay<_BinaryOp>::type, __dpl_sycl::__plus<_Tp>>>>;
-#    endif //__LIBSYCL_VERSION >= 50200
+#    endif //_ONEDPL_LIBSYCL_VERSION >= 50200
 
 #else //_USE_GROUP_ALGOS && _ONEDPL_SYCL_INTEL_COMPILER
 
@@ -74,11 +74,11 @@ struct __known_identity_for_plus
 
 template <typename _BinaryOp, typename _Tp>
 inline constexpr _Tp __known_identity =
-#if __LIBSYCL_VERSION >= 50200
+#if _ONEDPL_LIBSYCL_VERSION >= 50200
     __dpl_sycl::__known_identity<_BinaryOp, _Tp>::value;
-#else  //__LIBSYCL_VERSION >= 50200
+#else  //_ONEDPL_LIBSYCL_VERSION >= 50200
     __known_identity_for_plus<_BinaryOp, _Tp>::value; //for plus only
-#endif //__LIBSYCL_VERSION >= 50200
+#endif //_ONEDPL_LIBSYCL_VERSION >= 50200
 
 // a way to get value_type from both accessors and USM that is needed for transform_init
 template <typename _Unknown>

--- a/test/support/sycl_alloc_utils.h
+++ b/test/support/sycl_alloc_utils.h
@@ -192,7 +192,7 @@ private:
 
     void copy_data_impl(_ValueType* __src, _ValueType* __ptr, __difference_type __count)
     {
-#if __LIBSYCL_VERSION >= 50300
+#if _ONEDPL_LIBSYCL_VERSION >= 50300
         __queue.copy(__src, __ptr, __count);
 #else
         auto __p = __ptr;
@@ -203,7 +203,7 @@ private:
                 *(__p + __id) = *(__src + __id);
                 });
             });
-#endif // __LIBSYCL_VERSION >= 50300
+#endif // _ONEDPL_LIBSYCL_VERSION >= 50300
         __queue.wait();
     }
 

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -22,7 +22,7 @@
 #include <iterator>
 #include "oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h"
 #if _ONEDPL_FPGA_DEVICE
-#    if __LIBSYCL_VERSION >= 50400
+#    if _ONEDPL_LIBSYCL_VERSION >= 50400
 #        include <sycl/ext/intel/fpga_extensions.hpp>
 #    else
 #        include <CL/sycl/INTEL/fpga_extensions.hpp>


### PR DESCRIPTION
Avoid potential name clashing