### PR TITLE
Add human readable kernel names for "unnamed lambda" case

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -142,8 +142,8 @@ using __kernel_name_provider =
     __optional_kernel_name<_CustomName>;
 #endif
 
-template <char...>
-struct __composite_kernel_name
+template <typename _KernelName, int...>
+struct __composite
 {
 };
 
@@ -151,31 +151,34 @@ struct __composite_kernel_name
 // and instantiate template with variadic non-type template parameters.
 // This approach is required to get reliable work group size when kernel is unnamed
 #if _ONEDPL_BUILT_IN_STABLE_NAME_PRESENT
-template <typename _Tp>
+template <typename _KernelName, typename _Tp>
 class __kernel_name_composer
 {
     static constexpr auto __name = __builtin_sycl_unique_stable_name(_Tp);
     static constexpr ::std::size_t __name_size = __builtin_strlen(__name);
 
     template <::std::size_t... _Is>
-    static __composite_kernel_name<__name[_Is]...>
+    static __composite<_KernelName, __name[_Is]...>
     __compose_kernel_name(::std::index_sequence<_Is...>);
 
   public:
     using type = decltype(__compose_kernel_name(::std::make_index_sequence<__name_size>{}));
 };
+
+template <typename _KernelName, typename _Tp>
+using __kernel_name_composer_t = typename __kernel_name_composer<_KernelName, _Tp>::type;
 #endif // _ONEDPL_BUILT_IN_STABLE_NAME_PRESENT
 
 template <template <typename...> class _BaseName, typename _CustomName, typename... _Args>
 using __kernel_name_generator =
 #if __SYCL_UNNAMED_LAMBDA__
-    typename ::std::conditional<_HasDefaultName<_CustomName>::value,
+    ::std::conditional_t<_HasDefaultName<_CustomName>::value,
 #    if _ONEDPL_BUILT_IN_STABLE_NAME_PRESENT
-                                typename __kernel_name_composer<_BaseName<_CustomName, _Args...>>::type,
+                         __kernel_name_composer_t<_BaseName<>, _BaseName<_CustomName, _Args...>>,
 #    else // _ONEDPL_BUILT_IN_STABLE_NAME_PRESENT
-                                _BaseName<_CustomName, _Args...>,
+                         _BaseName<_CustomName, _Args...>,
 #    endif
-                                _BaseName<_CustomName>>::type;
+                         _BaseName<_CustomName>>;
 #else // __SYCL_UNNAMED_LAMBDA__
     _BaseName<_CustomName>;
 #endif
@@ -185,6 +188,8 @@ class __kernel_compiler
 {
     static constexpr ::std::size_t __kernel_count = sizeof...(_KernelNames);
     using __kernel_array_type = ::std::array<sycl::kernel, __kernel_count>;
+
+    static_assert(__kernel_count > 0, "At least one kernel name should be provided");
 
   public:
 #if _ONEDPL_KERNEL_BUNDLE_PRESENT
@@ -197,7 +202,7 @@ class __kernel_compiler
         auto __kernel_bundle = sycl::get_kernel_bundle<sycl::bundle_state::executable>(
             __exec.queue().get_context(), {__exec.queue().get_device()}, __kernel_ids);
 
-        if constexpr (sizeof...(_KernelNames) > 1)
+        if constexpr (__kernel_count > 1)
             return __make_kernels_array(__kernel_bundle, __kernel_ids, ::std::make_index_sequence<__kernel_count>());
         else
             return __kernel_bundle.template get_kernel(__kernel_ids[0]);
@@ -217,8 +222,7 @@ class __kernel_compiler
     {
         sycl::program __program(__exec.queue().get_context());
 
-        using __return_type =
-            typename std::conditional<(sizeof...(_KernelNames) > 1), __kernel_array_type, sycl::kernel>::type;
+        using __return_type = std::conditional_t<(__kernel_count > 1), __kernel_array_type, sycl::kernel>;
         return __return_type{
             (__program.build_with_kernel_type<_KernelNames>(), __program.get_kernel<_KernelNames>())...};
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -142,7 +142,7 @@ using __kernel_name_provider =
     __optional_kernel_name<_CustomName>;
 #endif
 
-template <typename _KernelName, int...>
+template <typename _KernelName, char...>
 struct __composite
 {
 };
@@ -165,8 +165,6 @@ class __kernel_name_composer
     using type = decltype(__compose_kernel_name(::std::make_index_sequence<__name_size>{}));
 };
 
-template <typename _KernelName, typename _Tp>
-using __kernel_name_composer_t = typename __kernel_name_composer<_KernelName, _Tp>::type;
 #endif // _ONEDPL_BUILT_IN_STABLE_NAME_PRESENT
 
 template <template <typename...> class _BaseName, typename _CustomName, typename... _Args>
@@ -174,7 +172,7 @@ using __kernel_name_generator =
 #if __SYCL_UNNAMED_LAMBDA__
     ::std::conditional_t<_HasDefaultName<_CustomName>::value,
 #    if _ONEDPL_BUILT_IN_STABLE_NAME_PRESENT
-                         __kernel_name_composer_t<_BaseName<>, _BaseName<_CustomName, _Args...>>,
+                         typename __kernel_name_composer<_BaseName<>, _BaseName<_CustomName, _Args...>>::type,
 #    else // _ONEDPL_BUILT_IN_STABLE_NAME_PRESENT
                          _BaseName<_CustomName, _Args...>,
 #    endif

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -164,7 +164,6 @@ class __kernel_name_composer
   public:
     using type = decltype(__compose_kernel_name(::std::make_index_sequence<__name_size>{}));
 };
-
 #endif // _ONEDPL_BUILT_IN_STABLE_NAME_PRESENT
 
 template <template <typename...> class _BaseName, typename _CustomName, typename... _Args>


### PR DESCRIPTION
oneDPL has to provide kernel names even for "unnamed lambda" case in certain conditions.

Add type template parameter in addition to generated kernel name to be able to set human readable kernel name explicitly.