### PR TITLE
[oneDPL] Range library conflict std names fix (class match_results)

### DIFF
--- a/include/oneapi/dpl/pstl/ranges/nanorange.hpp
+++ b/include/oneapi/dpl/pstl/ranges/nanorange.hpp
@@ -119,7 +119,7 @@
                                     {                                                                                  \
                                     inline constexpr type name{};                                                      \
                                     }
-
+#                                define NANORANGE_NO_STD_FORWARD_DECLARATIONS
 #                                if defined(_LIBCPP_VERSION)
 #                                    define NANO_BEGIN_NAMESPACE_STD _LIBCPP_BEGIN_NAMESPACE_STD
 #                                    define NANO_END_NAMESPACE_STD _LIBCPP_END_NAMESPACE_STD


### PR DESCRIPTION
[oneDPL] Range library conflict std names fix (class match_results).
NanoRange library has recommendation how to fix it - "define the symbol NANORANGE_NO_STD_FORWARD_DECLARATIONS":

```
// Avoid dragging in the large <set> and <unordered_set> headers
// This is technically undefined behaviour: define the symbol
// NANORANGE_NO_STD_FORWARD_DECLARATIONS
// to enforce standard-compliant mode
#                            ifndef NANORANGE_NO_STD_FORWARD_DECLARATIONS
NANO_BEGIN_NAMESPACE_STD
template <typename, typename>
class basic_string_view;
template <typename, typename, typename>
class set;
template <typename, typename, typename>
class multiset;
template <typename, typename, typename, typename>
class unordered_set;
template <typename, typename, typename, typename>
class unordered_multiset;
template <typename, typename>
class match_results;
NANO_END_NAMESPACE_STD
```

Or we can just exclude forward declaration for `class match_results` from the if scope and include `<regex>`.