### PR TITLE
Revert Cmake/Make changes done in PR #691

### DIFF
--- a/make/Makefile.common
+++ b/make/Makefile.common
@@ -51,7 +51,6 @@ cfg ?= release
 
 device_type ?= GPU
 use_unnamed_lambda ?= 0
-split_per_kernel ?= 0
 ranges_api ?= 0
 
 ifeq ($(backend), sycl)

--- a/make/dpcpp.inc
+++ b/make/dpcpp.inc
@@ -27,9 +27,6 @@ ifeq ($(os_name), linux)
     ifeq ($(use_unnamed_lambda), 1)
         CPLUS_FLAGS += -fsycl-unnamed-lambda
     endif
-    ifeq ($(split_per_kernel), 1)
-        CPLUS_FLAGS += -fsycl-fsycl-device-code-split=per_kernel
-    endif
     ifneq ($(stdver),)
         CPLUS_FLAGS += $(KEY)std=$(stdver)
     endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,7 +24,7 @@ add_custom_target(run-onedpl-tests
     DEPENDS build-onedpl-tests
     COMMENT "Build and run all oneDPL tests")
 
-macro(onedpl_add_test test_source_file split_kernels)
+macro(onedpl_add_test test_source_file)
     get_filename_component(_test_name ${test_source_file} NAME)
     string(REPLACE "\.cpp" "" _test_name ${_test_name})
 
@@ -38,13 +38,6 @@ macro(onedpl_add_test test_source_file split_kernels)
     # that may break code when using Intel(R) C++ Compiler Classic with -O3 flag on Linux
     if (CMAKE_SYSTEM_NAME MATCHES "Linux" AND CMAKE_CXX_COMPILER_ID STREQUAL Intel)
         target_compile_options(${_test_name} PRIVATE $<$<CONFIG:Release>:-fno-strict-aliasing>)
-    endif()
-
-    # oneDPL tests of std::complex required generates code to do JIT compilation of a kernel only when it is called
-    if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang|IntelLLVM" )
-        if (${split_kernels})
-            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsycl-device-code-split=per_kernel ")
-        endif()
     endif()
 
     target_include_directories(${_test_name} PRIVATE "${CMAKE_CURRENT_LIST_DIR}")
@@ -108,7 +101,6 @@ macro(onedpl_add_test test_source_file split_kernels)
 endmacro()
 
 set(_skip_regex_for_not_dpcpp "(xpu_api/algorithms|xpu_api/functional|xpu_api/numerics)")
-set(_is_complex_test_regexp "(xpu_api/numerics/complex.number)")
 file(GLOB_RECURSE UNIT_TESTS "*.pass.cpp")
 foreach (_file IN LISTS UNIT_TESTS)
     if (_file MATCHES "${_skip_regex_for_not_dpcpp}" AND NOT ONEDPL_BACKEND MATCHES "^(dpcpp|dpcpp_only)$")
@@ -116,12 +108,5 @@ foreach (_file IN LISTS UNIT_TESTS)
         continue()
     endif()
 
-    if (_file MATCHES "${_is_complex_test_regexp}")
-        # compile oneDPL tests with separate Kernel compilation
-        onedpl_add_test(${_file} true)
-    else()
-        # compile oneDPL tests without separate Kernel compilation
-        onedpl_add_test(${_file} false)
-    endif()
-
+        onedpl_add_test(${_file})
 endforeach()

--- a/test/support/test_complex.h
+++ b/test/support/test_complex.h
@@ -132,7 +132,7 @@ namespace TestUtils
 
             // We should run fncDoubleHasSupportInRuntime and fncDoubleHasntSupportInRuntime
             // in two separate Kernels to have ability compile these Kernels separatelly
-            // by using dpcpp compiler option -fsycl-device-code-split=per_kernel
+            // by using Intel(R) oneAPI DPC++/C++ Compiler option -fsycl-device-code-split=per_kernel
             // which described at
             // https://www.intel.com/content/www/us/en/develop/documentation/oneapi-gpu-optimization-guide/top/compilation/jitting.html
             if (has_type_support<double>(device))


### PR DESCRIPTION
There are some issues that have arisen after applying PR #691:
- Multiple `-fsycl-device-code-split=per_kernel` options
- This option is not essential; however, it is used when compiling all the tests by default
- Now we enable `-fsycl-device-code-split=per_kernel` when a compiler supports `-fsycl` regardless of the support of `-fsycl-device-code-split` option. That produces errors when using clang 11 and newer (it has `-fsycl`, but does not have `-fsycl-device-code-split`)

Let's revert these changes for now.

Example of a command when using clang++ 14 (Ubuntu 22.04):
```bash
cmake -DCMAKE_CXX_STANDARD=17 -DCMAKE_BUILD_TYPE=release -DCMAKE_CXX_COMPILER=clang++ <path/to>/oneDPL && make for_each.pass VERBOSE=1
>> cd /tmp/b/test && /usr/bin/clang++ -DTBB_USE_GLIBCXX_VERSION=70300 -D_PSTL_TEST_SUCCESSFUL_KEYWORD=1 -I/tmp/oneDPL/test -I/tmp/oneDPL/include -isystem 
/tmp/tbb/2021.5.0/include -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -fsycl-device-code-split=per_kernel  -O3 -DNDEBUG -fopenmp-simd -std=c++17 -MD -MT test/CMakeFiles/for_each.pass.dir/parallel_api/algorithm/alg.nonmodifying/for_each.pass.cpp.o -MF CMakeFiles/for_each.pass.dir/parallel_api/algorithm/alg.nonmodifying/for_each.pass.cpp.o.d -o CMakeFiles/for_each.pass.dir/parallel_api/algorithm/alg.nonmodifying/for_each.pass.cpp.o -c /tmp/oneDPL/test/parallel_api/algorithm/alg.nonmodifying/for_each.pass.cpp
>> clang: error: unknown argument: '-fsycl-device-code-split=per_kernel'
```