### PR TITLE
[oneDPL] + projection support for radix_sort pattern, ranges::sort API

### DIFF
--- a/include/oneapi/dpl/internal/async_impl/glue_async_impl.h
+++ b/include/oneapi/dpl/internal/async_impl/glue_async_impl.h
@@ -89,7 +89,7 @@ sort_async(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, _Comp
     auto __buf = __keep(__first, __last);
 
     return __par_backend_hetero::__parallel_stable_sort(::std::forward<_ExecutionPolicy>(__exec), __buf.all_view(),
-                                                        __comp);
+                                                        __comp, oneapi::dpl::identity{});
 }
 
 // [async.for_each]

--- a/include/oneapi/dpl/pstl/execution_defs.h
+++ b/include/oneapi/dpl/pstl/execution_defs.h
@@ -211,23 +211,6 @@ __check_size(...) -> decltype(::std::declval<_R&>().get_count());
 template <typename _R>
 using __difference_t = typename ::std::make_signed<decltype(__check_size<_R>(0))>::type;
 
-template <typename _R>
-auto
-__check_subscript(int) -> typename ::std::decay<decltype(::std::declval<_R&>()[0])>::type;
-
-template <typename _R>
-auto
-__check_subscript(...) -> typename ::std::decay<_R>::type::value_type;
-
-template <typename _R>
-struct __range_traits
-{
-    using __value_t = decltype(__check_subscript<_R>(0));
-};
-
-template <typename _R>
-using __value_t = typename __range_traits<_R>::__value_t;
-
 } // namespace __internal
 
 } // namespace dpl

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_defs.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_defs.h
@@ -16,6 +16,7 @@
 #ifndef _ONEDPL_GLUE_ALGORITHM_RANGES_DEFS_H
 #define _ONEDPL_GLUE_ALGORITHM_RANGES_DEFS_H
 
+#include "../functional"
 #include "execution_defs.h"
 
 namespace oneapi
@@ -238,9 +239,9 @@ replace_copy(_ExecutionPolicy&& __exec, _Range1&& __rng, _Range2&& __result, con
 
 // [alg.sort]
 
-template <typename _ExecutionPolicy, typename _Range, typename _Compare>
+template <typename _ExecutionPolicy, typename _Range, typename _Compare, typename _Proj = oneapi::dpl::identity>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
-sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp);
+sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp, _Proj __proj = {});
 
 template <typename _ExecutionPolicy, typename _Range>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -458,12 +458,12 @@ replace_copy(_ExecutionPolicy&& __exec, _Range1&& __rng, _Range2&& __result, con
 
 // [alg.sort]
 
-template <typename _ExecutionPolicy, typename _Range, typename _Compare>
+template <typename _ExecutionPolicy, typename _Range, typename _Compare, typename _Proj>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
-sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp)
+sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp, _Proj __proj)
 {
     oneapi::dpl::__internal::__ranges::__pattern_sort(::std::forward<_ExecutionPolicy>(__exec),
-                                                      views::all(::std::forward<_Range>(__rng)), __comp);
+                                                      views::all(::std::forward<_Range>(__rng)), __comp, __proj);
 }
 
 template <typename _ExecutionPolicy, typename _Range>

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -16,6 +16,7 @@
 #ifndef _ONEDPL_ALGORITHM_IMPL_HETERO_H
 #define _ONEDPL_ALGORITHM_IMPL_HETERO_H
 
+#include "../../functional"
 #include "../algorithm_fwd.h"
 
 #include "../parallel_backend.h"
@@ -1184,7 +1185,8 @@ __pattern_sort(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, _
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read_write, _Iterator>();
     auto __buf = __keep(__first, __last);
 
-    __par_backend_hetero::__parallel_stable_sort(::std::forward<_ExecutionPolicy>(__exec), __buf.all_view(), __comp)
+    __par_backend_hetero::__parallel_stable_sort(::std::forward<_ExecutionPolicy>(__exec), __buf.all_view(), __comp,
+                                                 oneapi::dpl::identity{})
         .wait();
 }
 
@@ -1202,7 +1204,8 @@ __pattern_stable_sort(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read_write, _Iterator>();
     auto __buf = __keep(__first, __last);
 
-    __par_backend_hetero::__parallel_stable_sort(::std::forward<_ExecutionPolicy>(__exec), __buf.all_view(), __comp)
+    __par_backend_hetero::__parallel_stable_sort(::std::forward<_ExecutionPolicy>(__exec), __buf.all_view(), __comp,
+                                                 oneapi::dpl::identity{})
         .wait();
 }
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -520,13 +520,13 @@ __pattern_merge(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _
 // sort
 //------------------------------------------------------------------------
 
-template <typename _ExecutionPolicy, typename _Range, typename _Compare>
+template <typename _ExecutionPolicy, typename _Range, typename _Compare, typename _Proj>
 oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, void>
-__pattern_sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp)
+__pattern_sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp, _Proj __proj)
 {
     if (__rng.size() >= 2)
         __par_backend_hetero::__parallel_stable_sort(::std::forward<_ExecutionPolicy>(__exec),
-                                                     ::std::forward<_Range>(__rng), __comp)
+                                                     ::std::forward<_Range>(__rng), __comp, __proj)
             .wait();
 }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1548,26 +1548,23 @@ struct __is_radix_sort_usable_for_type
 };
 
 #if _USE_RADIX_SORT
-template <
-    typename _ExecutionPolicy, typename _Range, typename _Compare,
+template <typename _ExecutionPolicy, typename _Range, typename _Compare, typename _Proj,
     __enable_if_t<oneapi::dpl::__internal::__is_device_execution_policy<__decay_t<_ExecutionPolicy>>::value &&
-                      __is_radix_sort_usable_for_type<oneapi::dpl::__internal::__value_t<_Range>, _Compare>::value,
-                  int> = 0>
+    __is_radix_sort_usable_for_type<oneapi::dpl::__internal::__key_t<_Proj, _Range>, _Compare>::value, int> = 0>
 auto
-__parallel_stable_sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare)
+__parallel_stable_sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare, _Proj __proj)
 {
     return __parallel_radix_sort<__internal::__is_comp_ascending<__decay_t<_Compare>>::value>(
-        ::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range>(__rng));
+        ::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range>(__rng), __proj);
 }
 #endif
 
 template <
-    typename _ExecutionPolicy, typename _Range, typename _Compare,
+    typename _ExecutionPolicy, typename _Range, typename _Compare, typename _Proj,
     __enable_if_t<oneapi::dpl::__internal::__is_device_execution_policy<__decay_t<_ExecutionPolicy>>::value &&
-                      !__is_radix_sort_usable_for_type<oneapi::dpl::__internal::__value_t<_Range>, _Compare>::value,
-                  int> = 0>
+    !__is_radix_sort_usable_for_type<oneapi::dpl::__internal::__key_t<_Proj, _Range>, _Compare>::value, int> = 0>
 auto
-__parallel_stable_sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp)
+__parallel_stable_sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp, _Proj /*__proj*/)
 {
     return __parallel_sort_impl(::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range>(__rng),
                                 // Pass special tag to choose 'full' merge subroutine at compile-time

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
@@ -231,14 +231,14 @@ __parallel_merge(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, 
 // parallel_stable_sort
 //-----------------------------------------------------------------------
 
-template <typename _ExecutionPolicy, typename _Range, typename _Compare,
+template <typename _ExecutionPolicy, typename _Range, typename _Compare, typename _Proj,
           oneapi::dpl::__internal::__enable_if_fpga_execution_policy<_ExecutionPolicy, int> = 0>
 auto
-__parallel_stable_sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp)
+__parallel_stable_sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp, _Proj __proj)
 {
     // workaround until we implement more performant version for patterns
     return oneapi::dpl::__par_backend_hetero::__parallel_stable_sort(__device_policy(__exec),
-                                                                     ::std::forward<_Range>(__rng), __comp);
+                                                                     ::std::forward<_Range>(__rng), __comp, __proj);
 }
 
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -138,7 +138,7 @@ class __radix_sort_reorder_kernel;
 //-----------------------------------------------------------------------
 
 template <typename _KernelName, ::std::uint32_t __radix_bits, bool __is_ascending, typename _ExecutionPolicy,
-          typename _ValRange, typename _CountBuf
+          typename _ValRange, typename _CountBuf, typename _Proj
 #if _ONEDPL_COMPILE_KERNEL
           ,
           typename _Kernel
@@ -147,7 +147,7 @@ template <typename _KernelName, ::std::uint32_t __radix_bits, bool __is_ascendin
 sycl::event
 __radix_sort_count_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments, ::std::size_t __block_size,
                           ::std::uint32_t __radix_offset, _ValRange&& __val_rng, _CountBuf& __count_buf,
-                          sycl::event __dependency_event
+                          sycl::event __dependency_event, _Proj __proj
 #if _ONEDPL_COMPILE_KERNEL
                           ,
                           _Kernel& __kernel
@@ -198,7 +198,7 @@ __radix_sort_count_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments, :
                      __val_idx += __block_size)
                 {
                     // get the bucket for the bit-ordered input value, applying the offset and mask for radix bits
-                    auto __val = __order_preserving_cast<__is_ascending>(__val_rng[__val_idx]);
+                    auto __val = __order_preserving_cast<__is_ascending>(__proj(__val_rng[__val_idx]));
                     ::std::uint32_t __bucket = __get_bucket<(1 << __radix_bits) - 1>(__val, __radix_offset);
                     // increment counter for this bit bucket
                     ++__count_arr[__bucket];
@@ -421,7 +421,7 @@ struct __peer_prefix_helper<_OffsetT, __peer_prefix_algo::subgroup_ballot>
 // radix sort: reorder kernel (per iteration)
 //-----------------------------------------------------------------------
 template <typename _KernelName, ::std::uint32_t __radix_bits, bool __is_ascending, __peer_prefix_algo _PeerAlgo,
-          typename _ExecutionPolicy, typename _InRange, typename _OutRange, typename _OffsetBuf
+          typename _ExecutionPolicy, typename _InRange, typename _OutRange, typename _OffsetBuf, typename _Proj
 #if _ONEDPL_COMPILE_KERNEL
           ,
           typename _Kernel
@@ -430,7 +430,8 @@ template <typename _KernelName, ::std::uint32_t __radix_bits, bool __is_ascendin
 sycl::event
 __radix_sort_reorder_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments, ::std::size_t __block_size,
                             ::std::size_t __sg_size, ::std::uint32_t __radix_offset, _InRange&& __input_rng,
-                            _OutRange&& __output_rng, _OffsetBuf& __offset_buf, sycl::event __dependency_event
+                            _OutRange&& __output_rng, _OffsetBuf& __offset_buf, sycl::event __dependency_event,
+                            _Proj __proj
 #if _ONEDPL_COMPILE_KERNEL
                             ,
                             _Kernel& __kernel
@@ -438,8 +439,8 @@ __radix_sort_reorder_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments,
 )
 {
     // typedefs
-    using _InputT = oneapi::dpl::__internal::__value_t<_InRange>;
     using _OffsetT = typename _OffsetBuf::value_type;
+    using _ValueT = oneapi::dpl::__internal::__value_t<_InRange>;
     using _PeerHelper = __peer_prefix_helper<_OffsetT, _PeerAlgo>;
 
     // iteration space info
@@ -504,10 +505,10 @@ __radix_sort_reorder_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments,
                 // find offsets for the same values within a segment and fill the resulting buffer
                 for (::std::size_t __val_idx = __seg_start + __self_lidx; __val_idx < __seg_end; __val_idx += __sg_size)
                 {
-                    _InputT __in_val = __input_rng[__val_idx];
+                    _ValueT __in_val = std::move(__input_rng[__val_idx]);
                     // get the bucket for the bit-ordered input value, applying the offset and mask for radix bits
                     ::std::uint32_t __bucket = __get_bucket<(1 << __radix_bits) - 1>(
-                        __order_preserving_cast<__is_ascending>(__in_val), __radix_offset);
+                        __order_preserving_cast<__is_ascending>(__proj(__in_val)), __radix_offset);
 
                     // TODO: move the whole loop to be a part of peer algorithms
                     _OffsetT __new_offset_idx = 0;
@@ -518,17 +519,21 @@ __radix_sort_reorder_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments,
                             __new_offset_idx, __offset_arr[__radix_state_idx], __is_current_bucket);
                         __offset_arr[__radix_state_idx] += __sg_total_offset;
                     }
-                    __output_rng[__new_offset_idx] = __in_val;
+                    __output_rng[__new_offset_idx] = std::move(__in_val);
                 }
                 if (__residual > 0)
                 {
-                    _InputT __in_val{};
+                    //_ValueT may not have a default constructor, so we create just a storage via union type
+                    union __storage { _ValueT __v; __storage(){} } __in_val;
+
                     ::std::uint32_t __bucket = __radix_states; // greater than any actual radix state
                     if (__self_lidx < __residual)
                     {
-                        __in_val = __input_rng[__seg_end + __self_lidx];
+                        //initialize the storage via move constructor for _ValueT type
+                        new (&__in_val.__v) _ValueT(std::move(__input_rng[__seg_end + __self_lidx]));
+
                         __bucket = __get_bucket<(1 << __radix_bits) - 1>(
-                            __order_preserving_cast<__is_ascending>(__in_val), __radix_offset);
+                            __order_preserving_cast<__is_ascending>(__proj(__in_val.__v)), __radix_offset);
                     }
                     _OffsetT __new_offset_idx = 0;
                     for (::std::uint32_t __radix_state_idx = 0; __radix_state_idx < __radix_states; ++__radix_state_idx)
@@ -539,7 +544,10 @@ __radix_sort_reorder_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments,
                         __offset_arr[__radix_state_idx] += __sg_total_offset;
                     }
                     if (__self_lidx < __residual)
-                        __output_rng[__new_offset_idx] = __in_val;
+                    {
+                        __output_rng[__new_offset_idx] = std::move(__in_val.__v);
+                        __in_val.__v.~_ValueT();
+                    }
                 }
             });
     });
@@ -563,10 +571,10 @@ struct __parallel_radix_sort_iteration
     template <typename... _Name>
     using __reorder_phase = __radix_sort_reorder_kernel<__radix_bits, __is_ascending, __even, _Name...>;
 
-    template <typename _ExecutionPolicy, typename _InRange, typename _OutRange, typename _TmpBuf>
+    template <typename _ExecutionPolicy, typename _InRange, typename _OutRange, typename _TmpBuf, typename _Proj>
     static sycl::event
-    submit(_ExecutionPolicy&& __exec, ::std::size_t __segments, ::std::uint32_t __radix_iter, _InRange&& __in_rng,
-           _OutRange&& __out_rng, _TmpBuf& __tmp_buf, sycl::event __dependency_event)
+    submit(_ExecutionPolicy&& __exec, ::std::size_t __segments, ::std::uint32_t __radix_iter,
+           _InRange&& __in_rng, _OutRange&& __out_rng, _TmpBuf& __tmp_buf, sycl::event __dependency_event, _Proj __proj)
     {
         using _CustomName = typename __decay_t<_ExecutionPolicy>::kernel_name;
         using _RadixCountKernel =
@@ -613,8 +621,7 @@ struct __parallel_radix_sort_iteration
 
         // 1. Count Phase
         sycl::event __count_event = __radix_sort_count_submit<_RadixCountKernel, __radix_bits, __is_ascending>(
-            __exec, __segments, __block_size, __radix_offset, ::std::forward<_InRange>(__in_rng), __tmp_buf,
-            __dependency_event
+            __exec, __segments, __block_size, __radix_offset, __in_rng, __tmp_buf, __dependency_event, __proj
 #if _ONEDPL_COMPILE_KERNEL
             ,
             __count_kernel
@@ -644,8 +651,8 @@ struct __parallel_radix_sort_iteration
 
             __reorder_event =
                 __radix_sort_reorder_submit<_RadixReorderPeerKernel, __radix_bits, __is_ascending, __peer_algorithm>(
-                    __exec, __segments, __block_size, __reorder_sg_size, __radix_offset,
-                    ::std::forward<_InRange>(__in_rng), ::std::forward<_OutRange>(__out_rng), __tmp_buf, __scan_event
+                __exec, __segments, __block_size, __reorder_sg_size, __radix_offset, ::std::forward<_InRange>(__in_rng),
+                ::std::forward<_OutRange>(__out_rng), __tmp_buf, __scan_event, __proj
 #if _ONEDPL_COMPILE_KERNEL
                     ,
                     __reorder_peer_kernel
@@ -657,7 +664,7 @@ struct __parallel_radix_sort_iteration
             __reorder_event = __radix_sort_reorder_submit<_RadixReorderKernel, __radix_bits, __is_ascending,
                                                           __peer_prefix_algo::scan_then_broadcast>(
                 __exec, __segments, __block_size, __reorder_sg_size, __radix_offset, ::std::forward<_InRange>(__in_rng),
-                ::std::forward<_OutRange>(__out_rng), __tmp_buf, __scan_event
+                ::std::forward<_OutRange>(__out_rng), __tmp_buf, __scan_event, __proj
 #if _ONEDPL_COMPILE_KERNEL
                 ,
                 __reorder_kernel
@@ -675,22 +682,24 @@ struct __parallel_radix_sort_iteration
 //-----------------------------------------------------------------------
 // radix sort: main function
 //-----------------------------------------------------------------------
-template <bool __is_ascending, typename _Range, typename _ExecutionPolicy>
+template <bool __is_ascending, typename _Range, typename _ExecutionPolicy, typename _Proj>
 auto
-__parallel_radix_sort(_ExecutionPolicy&& __exec, _Range&& __in_rng)
+__parallel_radix_sort(_ExecutionPolicy&& __exec, _Range&& __in_rng, _Proj __proj)
 {
     const ::std::size_t __n = __in_rng.size();
     assert(__n > 1);
 
     // types
     using _DecExecutionPolicy = __decay_t<_ExecutionPolicy>;
-    using _T = oneapi::dpl::__internal::__value_t<_Range>;
+    using _ValueT = oneapi::dpl::__internal::__value_t<_Range>;
+    using _KeyT = oneapi::dpl::__internal::__key_t<_Proj, _Range>;
 
     // radix bits represent number of processed bits in each value during one iteration
     constexpr ::std::uint32_t __radix_bits = 4;
 
+    //sycl::buffer doesn't have a default constructor; so, we have to pass zero-range to create an empty buffer
     sycl::buffer<::std::uint32_t, 1> __tmp_buf(sycl::range<1>(0));
-    sycl::buffer<_T, 1> __val_buf(sycl::range<1>(0));
+    sycl::buffer<_ValueT, 1> __val_buf(sycl::range<1>(0));
     sycl::event __event{};
 
     const auto __max_wg_size = oneapi::dpl::__internal::__max_work_group_size(__exec);
@@ -703,37 +712,37 @@ __parallel_radix_sort(_ExecutionPolicy&& __exec, _Range&& __in_rng)
 
     if (__n <= 64 && __wg_size <= __max_wg_size)
         __event = __subgroup_radix_sort<_RadixSortKernel, __wg_size, 1, __radix_bits, __is_ascending>{}(
-            __exec.queue(), ::std::forward<_Range>(__in_rng));
+            __exec.queue(), ::std::forward<_Range>(__in_rng), __proj);
     else if (__n <= 128 && __wg_size * 2 <= __max_wg_size)
         __event = __subgroup_radix_sort<_RadixSortKernel, __wg_size * 2, 1, __radix_bits, __is_ascending>{}(
-            __exec.queue(), ::std::forward<_Range>(__in_rng));
+            __exec.queue(), ::std::forward<_Range>(__in_rng), __proj);
     else if (__n <= 256 && __wg_size * 2 <= __max_wg_size)
         __event = __subgroup_radix_sort<_RadixSortKernel, __wg_size * 2, 2, __radix_bits, __is_ascending>{}(
-            __exec.queue(), ::std::forward<_Range>(__in_rng));
+            __exec.queue(), ::std::forward<_Range>(__in_rng), __proj);
     else if (__n <= 512 && __wg_size * 2 <= __max_wg_size)
         __event = __subgroup_radix_sort<_RadixSortKernel, __wg_size * 2, 4, __radix_bits, __is_ascending>{}(
-            __exec.queue(), ::std::forward<_Range>(__in_rng));
+            __exec.queue(), ::std::forward<_Range>(__in_rng), __proj);
     else if (__n <= 1024 && __wg_size * 2 <= __max_wg_size)
         __event = __subgroup_radix_sort<_RadixSortKernel, __wg_size * 2, 8, __radix_bits, __is_ascending>{}(
-            __exec.queue(), ::std::forward<_Range>(__in_rng));
+            __exec.queue(), ::std::forward<_Range>(__in_rng), __proj);
     else if (__n <= 2048 && __wg_size * 4 <= __max_wg_size)
         __event = __subgroup_radix_sort<_RadixSortKernel, __wg_size * 4, 8, __radix_bits, __is_ascending>{}(
-            __exec.queue(), ::std::forward<_Range>(__in_rng));
+            __exec.queue(), ::std::forward<_Range>(__in_rng), __proj);
     else if (__n <= 4096 && __wg_size * 4 <= __max_wg_size)
         __event = __subgroup_radix_sort<_RadixSortKernel, __wg_size * 4, 16, __radix_bits, __is_ascending>{}(
-            __exec.queue(), ::std::forward<_Range>(__in_rng));
+            __exec.queue(), ::std::forward<_Range>(__in_rng), __proj);
     else if (__n <= 8192 && __wg_size * 8 <= __max_wg_size)
         __event = __subgroup_radix_sort<_RadixSortKernel, __wg_size * 8, 16, __radix_bits, __is_ascending>{}(
-            __exec.queue(), ::std::forward<_Range>(__in_rng));
+            __exec.queue(), ::std::forward<_Range>(__in_rng), __proj);
     else if (__n <= 16384 && __wg_size * 8 <= __max_wg_size)
         __event = __subgroup_radix_sort<_RadixSortKernel, __wg_size * 8, 32, __radix_bits, __is_ascending>{}(
-            __exec.queue(), ::std::forward<_Range>(__in_rng));
+            __exec.queue(), ::std::forward<_Range>(__in_rng), __proj);
     else if (__n <= 32768 && __wg_size * 16 <= __max_wg_size)
         __event = __subgroup_radix_sort<_RadixSortKernel, __wg_size * 16, 32, __radix_bits, __is_ascending>{}(
-            __exec.queue(), ::std::forward<_Range>(__in_rng));
+            __exec.queue(), ::std::forward<_Range>(__in_rng), __proj);
     else
     {
-        constexpr ::std::uint32_t __radix_iters = __get_buckets_in_type<_T>(__radix_bits);
+        constexpr ::std::uint32_t __radix_iters = __get_buckets_in_type<_KeyT>(__radix_bits);
         const ::std::uint32_t __radix_states = 1 << __radix_bits;
 
         const ::std::size_t __wg_size = __max_wg_size;
@@ -745,9 +754,10 @@ __parallel_radix_sort(_ExecutionPolicy&& __exec, _Range&& __in_rng)
         __tmp_buf = sycl::buffer<::std::uint32_t, 1>(sycl::range<1>(__tmp_buf_size));
 
         // memory for storing values sorted for an iteration
-        __internal::__buffer<_DecExecutionPolicy, _T> __out_buffer_holder{__exec, __n};
+        __internal::__buffer<_DecExecutionPolicy, _ValueT> __out_buffer_holder{__exec, __n};
         __val_buf = __out_buffer_holder.get_buffer();
-        auto __out_rng = oneapi::dpl::__ranges::all_view<_T, __par_backend_hetero::access_mode::read_write>(__val_buf);
+        auto __out_rng = 
+            oneapi::dpl::__ranges::all_view<_ValueT, __par_backend_hetero::access_mode::read_write>(__val_buf);
 
         // iterations per each bucket
         assert("Number of iterations must be even" && __radix_iters % 2 == 0);
@@ -758,11 +768,11 @@ __parallel_radix_sort(_ExecutionPolicy&& __exec, _Range&& __in_rng)
             if (__radix_iter % 2 == 0)
                 __event = __parallel_radix_sort_iteration<__radix_bits, __is_ascending, /*even=*/true>::submit(
                     ::std::forward<_ExecutionPolicy>(__exec), __segments, __radix_iter,
-                    ::std::forward<_Range>(__in_rng), __out_rng, __tmp_buf, __event);
+                    ::std::forward<_Range>(__in_rng), __out_rng, __tmp_buf, __event, __proj);
             else //swap __in_rng and __out_rng
                 __event = __parallel_radix_sort_iteration<__radix_bits, __is_ascending, /*even=*/false>::submit(
                     ::std::forward<_ExecutionPolicy>(__exec), __segments, __radix_iter, __out_rng,
-                    ::std::forward<_Range>(__in_rng), __tmp_buf, __event);
+                    ::std::forward<_Range>(__in_rng), __tmp_buf, __event, __proj);
         }
     }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
@@ -32,9 +32,9 @@ template <typename _KernelNameBase, uint16_t __wg_size = 256 /*work group size*/
           uint16_t __req_sub_group_size = (__block_size < 4 ? 32 : 16)>
 struct __subgroup_radix_sort
 {
-    template <typename _RangeIn>
+    template <typename _RangeIn, typename _Proj>
     auto
-    operator()(sycl::queue __q, _RangeIn&& __src)
+    operator()(sycl::queue __q, _RangeIn&& __src, _Proj __proj)
     {
         using __wg_size_t = ::std::integral_constant<::std::uint16_t, __wg_size>;
         using __block_size_t = ::std::integral_constant<::std::uint16_t, __block_size>;
@@ -49,10 +49,10 @@ struct __subgroup_radix_sort
         using _KeyT = oneapi::dpl::__internal::__value_t<_RangeIn>;
         //check SLM size
         if (__check_slm_size<_KeyT>(__q, __src.size()))
-            return __one_group_submitter<_SortKernelLoc>()(__q, ::std::forward<_RangeIn>(__src),
+            return __one_group_submitter<_SortKernelLoc>()(__q, ::std::forward<_RangeIn>(__src), __proj,
                                                            std::true_type{} /*SLM*/);
         else
-            return __one_group_submitter<_SortKernelGlob>()(__q, ::std::forward<_RangeIn>(__src),
+            return __one_group_submitter<_SortKernelGlob>()(__q, ::std::forward<_RangeIn>(__src), __proj,
                                                             std::false_type{} /*No SLM*/);
     }
 
@@ -88,34 +88,17 @@ struct __subgroup_radix_sort
         }
     };
 
-    template <typename _KeyT, typename _Wi, typename _Src, typename _Keys>
+    template <typename _ValueT, typename _Wi, typename _Src, typename _Values>
     static void
-    __block_load(const _Wi __wi, const _Src& __src, _Keys& __keys, const uint32_t __n, const _KeyT& __default_key)
+    __block_load(const _Wi __wi, const _Src& __src, _Values& __values, const uint32_t __n)
     {
         _ONEDPL_PRAGMA_UNROLL
         for (uint16_t __i = 0; __i < __block_size; ++__i)
         {
-            const uint16_t __offset = __wi * __block_size + __i;
-            if (__offset < __n)
-                __keys[__i] = __src[__offset];
-            else
-                __keys[__i] = __default_key;
+            const uint16_t __idx = __wi * __block_size + __i;
+            if (__idx < __n)
+                new (&__values[__i]) _ValueT(::std::move(__src[__idx]));
         }
-    }
-
-    template <typename _Item, typename _Wi, typename _Lacc, typename _Keys, typename _Indices>
-    static void
-    __to_blocked(_Item __it, const _Wi __wi, _Lacc& __exchange_lacc, _Keys& __keys, const _Indices& __indices)
-    {
-        _ONEDPL_PRAGMA_UNROLL
-        for (uint16_t __i = 0; __i < __block_size; ++__i)
-            __exchange_lacc[__indices[__i]] = __keys[__i];
-
-        __dpl_sycl::__group_barrier(__it);
-
-        _ONEDPL_PRAGMA_UNROLL
-        for (uint16_t __i = 0; __i < __block_size; ++__i)
-            __keys[__i] = __exchange_lacc[__wi * __block_size + __i];
     }
 
     static_assert(__wg_size <= 1024);
@@ -145,16 +128,17 @@ struct __subgroup_radix_sort
     template <typename... _Name>
     struct __one_group_submitter<__internal::__optional_kernel_name<_Name...>>
     {
-        template <typename _RangeIn, typename _SLM_tag>
+        template <typename _RangeIn, typename _Proj, typename _SLM_tag>
         auto
-        operator()(sycl::queue __q, _RangeIn&& __src, _SLM_tag)
+        operator()(sycl::queue __q, _RangeIn&& __src, _Proj __proj, _SLM_tag)
         {
             uint16_t __n = __src.size();
             assert(__n <= __block_size * __wg_size);
 
-            using _KeyT = oneapi::dpl::__internal::__value_t<_RangeIn>;
+            using _ValT = oneapi::dpl::__internal::__value_t<_RangeIn>;
+            using _KeyT = oneapi::dpl::__internal::__key_t<_Proj, _RangeIn>;
 
-            _TempBuf<_KeyT, _SLM_tag> __buf_val(__block_size * __wg_size);
+            _TempBuf<_ValT, _SLM_tag> __buf_val(__block_size * __wg_size);
             _TempBuf<uint32_t, _SLM_tag> __buf_count(__counter_buf_sz);
 
             sycl::nd_range __range{sycl::range{__wg_size}, sycl::range{__wg_size}};
@@ -166,16 +150,13 @@ struct __subgroup_radix_sort
 
                 __cgh.parallel_for<_Name...>(
                     __range, ([=](sycl::nd_item<1> __it)[[_ONEDPL_SYCL_REQD_SUB_GROUP_SIZE(__req_sub_group_size)]] {
-                        _KeyT __keys[__block_size];
+                        union __storage { _ValT __v[__block_size]; __storage(){} } __values;
                         uint16_t __wi = __it.get_local_linear_id();
                         uint16_t __begin_bit = 0;
                         constexpr uint16_t __end_bit = sizeof(_KeyT) * ::std::numeric_limits<unsigned char>::digits;
 
-                        //we use numeric_limits::lowest for floating-point types with denormalization,
-                        //due to numeric_limits::min gets the minimum positive normalized value
-                        const _KeyT __default_key =
-                            __is_asc ? std::numeric_limits<_KeyT>::max() : std::numeric_limits<_KeyT>::lowest();
-                        __block_load<_KeyT>(__wi, __src, __keys, __n, __default_key);
+                        //copy(move) values construction
+                        __block_load<_ValT>(__wi, __src, __values.__v, __n);
 
                         __dpl_sycl::__group_barrier(__it);
                         while (true)
@@ -196,8 +177,10 @@ struct __subgroup_radix_sort
                                 _ONEDPL_PRAGMA_UNROLL
                                 for (uint16_t __i = 0; __i < __block_size; ++__i)
                                 {
-                                    const uint16_t __bin = __get_bucket</*mask*/ __bin_count - 1>(
-                                        __order_preserving_cast<__is_asc>(__keys[__i]), __begin_bit);
+                                    const uint16_t __idx = __wi * __block_size + __i;
+                                    const uint16_t __bin = __idx < __n ? __get_bucket</*mask*/ __bin_count - 1>(
+                                        __order_preserving_cast<__is_asc>(__proj(__values.__v[__i])), __begin_bit)
+                                        : __bin_count - 1/*default bin for out of range elements (when idx >= n)*/;
 
                                     //"counting" and local offset calculation
                                     __counters[__i] = &__pcounter[__bin * __wg_size];
@@ -252,11 +235,57 @@ struct __subgroup_radix_sort
                                 {
                                     const uint16_t __r = __indices[__i];
                                     if (__r < __n)
-                                        __src[__r] = __keys[__i];
+                                    {
+                                        //move the values to source range and destroy the values
+                                        __src[__r] = ::std::move(__values.__v[__i]);
+                                        __values.__v[__i].~_ValT();
+                                    }
                                 }
+
+                                //destroy values in exchange buffer
+                                _ONEDPL_PRAGMA_UNROLL
+                                for (uint16_t __i = 0; __i < __block_size; ++__i)
+                                {
+                                    const uint16_t __idx = __wi * __block_size + __i;
+                                    if (__idx < __n)
+                                        __exchange_lacc[__idx].~_ValT();
+                                }
+
                                 return;
                             }
-                            __to_blocked(__it, __wi, __exchange_lacc, __keys, __indices);
+
+                            //3.1 data exchange
+                            if (__begin_bit == __radix) //the first sort iteration
+                            {
+                                _ONEDPL_PRAGMA_UNROLL
+                                for (uint16_t __i = 0; __i < __block_size; ++__i)
+                                {
+                                    const uint16_t __r = __indices[__i];
+                                    if (__r < __n)
+                                        new (&__exchange_lacc[__r]) _ValT(::std::move(__values.__v[__i]));
+                                }
+                            }
+                            else
+                            {
+                                _ONEDPL_PRAGMA_UNROLL
+                                for (uint16_t __i = 0; __i < __block_size; ++__i)
+                                {
+                                    const uint16_t __r = __indices[__i];
+                                    if (__r < __n)
+                                        __exchange_lacc[__r] = ::std::move(__values.__v[__i]);
+                                }
+                            }
+
+                            __dpl_sycl::__group_barrier(__it);
+
+                            _ONEDPL_PRAGMA_UNROLL
+                            for (uint16_t __i = 0; __i < __block_size; ++__i)
+                            {
+                                const uint16_t __idx = __wi * __block_size + __i;
+                                if (__idx < __n)
+                                    __values.__v[__i] = ::std::move(__exchange_lacc[__idx]);
+                            }
+
                             __dpl_sycl::__group_barrier(__it);
                         }
                     }));

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -42,6 +42,8 @@ class all_view
     using __accessor_t = sycl::accessor<_T, 1, _AccMode, _Target, _Placeholder>;
 
   public:
+    using value_type = _T;
+
     all_view(sycl::buffer<_T, 1> __buf = sycl::buffer<_T, 1>(0), __diff_type __offset = 0, __diff_type __n = 0)
         : __m_acc(__create_accessor(__buf, __offset, __n))
     {

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -27,6 +27,37 @@ namespace oneapi
 {
 namespace dpl
 {
+
+namespace __internal
+{
+
+template <typename _R>
+auto
+get_value_type(int) -> typename ::std::decay_t<_R>::value_type;
+
+template <typename _R>
+auto
+get_value_type(long) ->
+    typename ::std::iterator_traits<::std::decay_t<decltype(::std::declval<_R&>().begin())>>::value_type;
+
+template <typename _R>
+auto
+get_value_type(...)
+{
+    //static_assert should always fail when this overload is chosen, so its condition must depend on
+    //the template parameter and evaluate to false
+    static_assert(std::is_same_v<_R, void>,
+        "error: the range has no 'value_type'; define an alias or typedef named 'value_type' in the range class");
+}
+
+template <typename _R>
+using __value_t = decltype(oneapi::dpl::__internal::get_value_type<_R>(0));
+
+template <typename _Proj, typename _R>
+using __key_t = ::std::remove_cv_t<::std::remove_reference_t<::std::invoke_result_t<_Proj&, __value_t<_R>>>>;
+
+} //namespace __internal
+
 namespace __ranges
 {
 
@@ -111,7 +142,7 @@ class zip_view
     }
 
   public:
-    using __value_t = oneapi::dpl::__internal::tuple<oneapi::dpl::__internal::__value_t<_Ranges>...>;
+    using value_type = oneapi::dpl::__internal::tuple<oneapi::dpl::__internal::__value_t<_Ranges>...>;
     static constexpr ::std::size_t __num_ranges = sizeof...(_Ranges);
 
     explicit zip_view(_Ranges... __args) : __m_ranges(oneapi::dpl::__internal::make_tuple(__args...)) {}
@@ -162,11 +193,11 @@ make_zip_view(_Ranges&&... args) -> decltype(zip_view<_Ranges...>(::std::forward
 template <typename _Iterator>
 class guard_view
 {
-    using value_type = typename ::std::iterator_traits<_Iterator>::value_type;
-    using reference = typename ::std::iterator_traits<_Iterator>::reference;
     using diff_type = typename ::std::iterator_traits<_Iterator>::difference_type;
 
   public:
+    using value_type = typename ::std::iterator_traits<_Iterator>::value_type;
+
     guard_view(_Iterator __first = _Iterator(), diff_type __n = 0) : m_p(__first), m_count(__n) {}
     guard_view(_Iterator __first, _Iterator __last) : m_p(__first), m_count(__last - __first) {}
 
@@ -209,6 +240,8 @@ class guard_view
 template <typename _R>
 struct reverse_view_simple
 {
+    using value_type = typename ::std::decay_t<_R>::value_type;
+
     _R __r;
 
     //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range
@@ -241,6 +274,8 @@ struct reverse_view_simple
 template <typename _R, typename _Size>
 struct take_view_simple
 {
+    using value_type = typename ::std::decay_t<_R>::value_type;
+
     _R __r;
     _Size __n;
 
@@ -276,6 +311,8 @@ struct take_view_simple
 template <typename _R, typename _Size>
 struct drop_view_simple
 {
+    using value_type = typename ::std::decay_t<_R>::value_type;
+
     _R __r;
     _Size __n;
 
@@ -311,6 +348,8 @@ struct drop_view_simple
 template <typename _R, typename _F>
 struct transform_view_simple
 {
+    using value_type = ::std::decay_t<::std::invoke_result_t<_F&, decltype(::std::declval<_R&>()[0])>>;
+
     _R __r;
     _F __f;
 
@@ -362,6 +401,7 @@ struct permutation_view_simple;
 template <typename _R, typename _M>
 struct permutation_view_simple<_R, _M, typename ::std::enable_if<oneapi::dpl::__internal::__is_functor<_M>>::type>
 {
+    using value_type = typename ::std::decay_t<_R>::value_type;
     using _Size = oneapi::dpl::__internal::__difference_t<_R>;
 
     _R __r;
@@ -400,6 +440,8 @@ struct permutation_view_simple<_R, _M, typename ::std::enable_if<oneapi::dpl::__
 template <typename _R, typename _M>
 struct permutation_view_simple<_R, _M, typename ::std::enable_if<is_map_view<_M>::value>::type>
 {
+    using value_type = typename ::std::decay_t<_R>::value_type;
+
     zip_view<_R, _M> __data;
 
     permutation_view_simple(_R __r, _M __m) : __data(__r, __m) {}
@@ -433,6 +475,7 @@ struct permutation_view_simple<_R, _M, typename ::std::enable_if<is_map_view<_M>
 //permutation discard view:
 struct permutation_discard_view
 {
+    using value_type = oneapi::dpl::internal::ignore_copyable;
     using difference_type = ::std::ptrdiff_t;
     difference_type m_count;
 
@@ -454,15 +497,6 @@ struct permutation_discard_view
 };
 
 } // namespace __ranges
-
-namespace __internal
-{
-template <typename... _Ranges>
-struct __range_traits<oneapi::dpl::__ranges::zip_view<_Ranges...>>
-{
-    using __value_t = typename oneapi::dpl::__ranges::zip_view<_Ranges...>::__value_t;
-};
-} // namespace __internal
 } // namespace dpl
 } // namespace oneapi
 


### PR DESCRIPTION
[oneDPL] + projection support for radix_sort pattern, ranges::sort API.

We use oneapi::dpl::__internal::__no_op, because std::identity is available from C++20.