### PR TITLE
[oneDPL] nanorange conflict std names fix: define NANORANGE_NO_STD_FO…

### DIFF
--- a/include/oneapi/dpl/pstl/ranges/nanorange.hpp
+++ b/include/oneapi/dpl/pstl/ranges/nanorange.hpp
@@ -119,7 +119,7 @@
                                     {                                                                                  \
                                     inline constexpr type name{};                                                      \
                                     }
-
+#                                define NANORANGE_NO_STD_FORWARD_DECLARATIONS
 #                                if defined(_LIBCPP_VERSION)
 #                                    define NANO_BEGIN_NAMESPACE_STD _LIBCPP_BEGIN_NAMESPACE_STD
 #                                    define NANO_END_NAMESPACE_STD _LIBCPP_END_NAMESPACE_STD


### PR DESCRIPTION
…RWARD_DECLARATIONS

(cherry picked from commit f751491943ebf05baf23afd25496a3a8c627c5a8)