### PR TITLE
Remove scan req for default constructor to be identity on host with icpc

### DIFF
--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -190,17 +190,11 @@ __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __la
     return ::std::make_pair(__result, __init);
 }
 
-// type is arithmetic and binary operation is a user defined operation.
-template <typename _Tp, typename _BinaryOperation>
-using is_arithmetic_udop =
-    ::std::integral_constant<bool, ::std::is_arithmetic<_Tp>::value &&
-                                       !::std::is_same<_BinaryOperation, ::std::plus<_Tp>>::value>;
-
 // [restriction] - T shall be DefaultConstructible.
 // [violation] - default ctor of T shall set the identity value for binary_op.
 template <class _RandomAccessIterator, class _OutputIterator, class _UnaryOperation, class _Tp, class _BinaryOperation,
           class _Inclusive>
-typename ::std::enable_if<!is_arithmetic_udop<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>::type
+typename ::std::enable_if<is_arithmetic_plus<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>::type
 __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __last, _OutputIterator __result,
                        _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op, _Inclusive,
                        /*is_vector=*/::std::true_type) noexcept
@@ -217,7 +211,7 @@ __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __la
 
 template <class _RandomAccessIterator, class _OutputIterator, class _UnaryOperation, class _Tp, class _BinaryOperation,
           class _Inclusive>
-typename ::std::enable_if<is_arithmetic_udop<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>::type
+typename ::std::enable_if<!is_arithmetic_plus<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>::type
 __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __last, _OutputIterator __result,
                        _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op, _Inclusive,
                        /*is_vector=*/::std::true_type) noexcept

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -194,7 +194,8 @@ __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __la
 // [violation] - default ctor of T shall set the identity value for binary_op.
 template <class _RandomAccessIterator, class _OutputIterator, class _UnaryOperation, class _Tp, class _BinaryOperation,
           class _Inclusive>
-typename ::std::enable_if<is_arithmetic_plus<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>::type
+typename ::std::enable_if<oneapi::dpl::__unseq_backend::is_arithmetic_plus<_Tp, _BinaryOperation>::value,
+                          ::std::pair<_OutputIterator, _Tp>>::type
 __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __last, _OutputIterator __result,
                        _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op, _Inclusive,
                        /*is_vector=*/::std::true_type) noexcept
@@ -211,7 +212,8 @@ __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __la
 
 template <class _RandomAccessIterator, class _OutputIterator, class _UnaryOperation, class _Tp, class _BinaryOperation,
           class _Inclusive>
-typename ::std::enable_if<!is_arithmetic_plus<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>::type
+typename ::std::enable_if<!oneapi::dpl::__unseq_backend::is_arithmetic_plus<_Tp, _BinaryOperation>::value,
+                          ::std::pair<_OutputIterator, _Tp>>::type
 __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __last, _OutputIterator __result,
                        _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op, _Inclusive,
                        /*is_vector=*/::std::true_type) noexcept

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan.pass.cpp
@@ -36,14 +36,6 @@ DEFINE_TEST_1(test_with_vector, BinaryOperation)
 {
     DEFINE_TEST_CONSTRUCTOR(test_with_vector)
 
-    template <typename Iterator1, typename Size>
-    void initialize_data(Iterator1 host_keys, Size n)
-    {
-        for (Size i = 0; i < n; i++)
-        {
-            host_keys[i] = 1;
-        }
-    }
 
 #ifdef DUMP_CHECK_RESULTS
     template <typename Iterator, typename Size>
@@ -74,8 +66,7 @@ DEFINE_TEST_1(test_with_vector, BinaryOperation)
         typedef typename ::std::iterator_traits<Iterator1>::value_type KeyT;
 
         KeyT init{2};
-
-        initialize_data(keys_first, n);
+        ::std::fill_n(keys_first, n, 1);
         oneapi::dpl::exclusive_scan(std::forward<Policy>(exec), keys_first, keys_last, res_first, init,
                                     BinaryOperation());
         exclusive_scan_serial(keys_first, keys_last, exp_first, init, BinaryOperation());
@@ -107,9 +98,7 @@ void
 test_with_usm(sycl::queue& q, const ::std::size_t count, _BinaryOp binary_op = _BinaryOp())
 {
     // Prepare source data
-    std::vector<int> h_idx(count);
-    for (int i = 0; i < count; i++)
-        h_idx[i] = 1;
+    std::vector<int> h_idx(count, 1);
 
     int init = 2;
     

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan.pass.cpp
@@ -100,7 +100,7 @@ DEFINE_TEST_1(test_with_vector, BinaryOperation)
 
 #if TEST_DPCPP_BACKEND_PRESENT
 
-#    include "support/sycl_alloc_utils.h"
+#include "support/sycl_alloc_utils.h"
 
 template <sycl::usm::alloc alloc_type, typename KernelName, typename _BinaryOp = oneapi::dpl::__internal::__pstl_plus>
 void
@@ -197,7 +197,7 @@ main()
     sycl::queue q = TestUtils::get_test_queue();
 #if _ONEDPL_DEBUG_SYCL
     std::cout << "    Device Name = " << q.get_device().get_info<sycl::info::device::name>().c_str() << "\n";
-#    endif // _ONEDPL_DEBUG_SYCL
+#endif // _ONEDPL_DEBUG_SYCL
 
     // Run tests for USM shared memory
     test_with_usm<sycl::usm::alloc::shared, class KernelName1>(q);

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan.pass.cpp
@@ -207,13 +207,20 @@ main()
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
     //test with custom operation and integer type
+#if TEST_DPCPP_BACKEND_PRESENT
     test_algo_three_sequences<int, test_with_vector<int, BinaryOp>>();
+#else
+    test_algo_three_sequences<int, test_with_vector<BinaryOp>>();
+#endif    
 
     //test with custom operation and custom (integer wrapper) type
     using ValType = MyType<int>;
     using BinaryOpCustType = UserBinaryOperation<ValType>;
-
+#if TEST_DPCPP_BACKEND_PRESENT
     test_algo_three_sequences<ValType, test_with_vector<ValType, BinaryOpCustType>>();
+#else
+    test_algo_three_sequences<ValType, test_with_vector<BinaryOpCustType>>();
+#endif
 
     return TestUtils::done();
 }

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan.pass.cpp
@@ -111,6 +111,8 @@ test_with_usm(sycl::queue& q, const ::std::size_t count, _BinaryOp binary_op = _
     for (int i = 0; i < count; i++)
         h_idx[i] = 1;
 
+    int init = 2;
+    
     // Copy source data to USM shared/device memory
     TestUtils::usm_data_transfer<alloc_type, int> dt_helper_h_idx(q, ::std::begin(h_idx), ::std::end(h_idx));
     auto d_idx = dt_helper_h_idx.get_data();
@@ -121,7 +123,7 @@ test_with_usm(sycl::queue& q, const ::std::size_t count, _BinaryOp binary_op = _
     // Run dpl::exclusive_scan algorithm on USM shared-device memory
     auto myPolicy = oneapi::dpl::execution::make_device_policy<
         TestUtils::unique_kernel_name<KernelName, TestUtils::uniq_kernel_index<alloc_type>()>>(q);
-    oneapi::dpl::exclusive_scan(myPolicy, d_idx, d_idx + count, d_val, 0, binary_op);
+    oneapi::dpl::exclusive_scan(myPolicy, d_idx, d_idx + count, d_val, init, binary_op);
 
     // Copy results from USM shared/device memory to host
     std::vector<int> h_val(count);
@@ -129,7 +131,7 @@ test_with_usm(sycl::queue& q, const ::std::size_t count, _BinaryOp binary_op = _
 
     // Check results
     std::vector<int> h_sval_expected(count);
-    exclusive_scan_serial(h_idx.begin(), h_idx.begin() + count, h_sval_expected.begin(), 0, binary_op);
+    exclusive_scan_serial(h_idx.begin(), h_idx.begin() + count, h_sval_expected.begin(), init, binary_op);
 
     EXPECT_EQ_N(h_sval_expected.begin(), h_val.begin(), count, "wrong effect from exclusive_scan");
 }

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan.pass.cpp
@@ -151,7 +151,6 @@ test_with_usm(sycl::queue& q, _BinaryOp binary_op = _BinaryOp())
 template <typename _Tp>
 struct UserBinaryOperation
 {
-
     _Tp
     operator()(const _Tp& __x, const _Tp& __y) const
     {

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan.pass.cpp
@@ -26,35 +26,37 @@
 
 #include "support/scan_serial_impl.h"
 
-template <typename _Policy, typename _BinaryOp = oneapi::dpl::__internal::__pstl_plus>
+template <typename _Policy, typename T, typename _BinaryOp = oneapi::dpl::__internal::__pstl_plus>
 void
-test_with_vector(_Policy policy, const ::std::size_t count, _BinaryOp binary_op = _BinaryOp())
+test_with_vector(_Policy policy, const ::std::size_t count, T init, _BinaryOp binary_op = _BinaryOp())
 {
     // Prepare source data
-    std::vector<int> h_idx(count);
-    std::vector<int> h_val(count);
+    std::vector<T> h_idx(count);
+    std::vector<T> h_val(count);
     for (int i = 0; i < count; i++)
         h_idx[i] = i + 1;
 
-    oneapi::dpl::exclusive_scan(std::forward<_Policy>(policy), h_idx.begin(), h_idx.end(), h_val.begin(), 0, binary_op);
+    oneapi::dpl::exclusive_scan(std::forward<_Policy>(policy), h_idx.begin(), h_idx.end(), h_val.begin(), init,
+                                binary_op);
 
     // Check results
-    std::vector<int> h_sval_expected(count);
-    exclusive_scan_serial(h_idx.begin(), h_idx.end(), h_sval_expected.begin(), 0, binary_op);
+    std::vector<T> h_sval_expected(count);
+    exclusive_scan_serial(h_idx.begin(), h_idx.end(), h_sval_expected.begin(), init, binary_op);
 
     EXPECT_EQ_N(h_sval_expected.begin(), h_val.begin(), count, "wrong effect from exclusive_scan");
 }
 
-template <typename _BinaryOp = oneapi::dpl::__internal::__pstl_plus>
+template <typename T, typename _BinaryOp = oneapi::dpl::__internal::__pstl_plus>
 void
 test_with_vector(_BinaryOp binary_op = _BinaryOp())
 {
+    T init{0};
     for (::std::size_t n = 0; n <= TestUtils::max_n; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
-        test_with_vector(oneapi::dpl::execution::seq, n, binary_op);
-        test_with_vector(oneapi::dpl::execution::unseq, n, binary_op);
-        test_with_vector(oneapi::dpl::execution::par, n, binary_op);
-        test_with_vector(oneapi::dpl::execution::par_unseq, n, binary_op);
+        test_with_vector(oneapi::dpl::execution::seq, n, init, binary_op);
+        test_with_vector(oneapi::dpl::execution::unseq, n, init, binary_op);
+        test_with_vector(oneapi::dpl::execution::par, n, init, binary_op);
+        test_with_vector(oneapi::dpl::execution::par_unseq, n, init, binary_op);
     }
 }
 
@@ -112,15 +114,37 @@ struct UserBinaryOperation
     _Tp
     operator()(const _Tp& __x, const _Tp& __y) const
     {
-        return __x * __y;
+        return _Tp(__x.value * __y.value);
+    }
+};
+
+template <typename T>
+class MyType
+{
+  public:
+    T value;
+    MyType() : value() {}
+    MyType(const T& a) : value(a) {}
+
+    bool
+    operator==(const MyType<T>& a) const
+    {
+        return value == a.value;
+    }
+
+    MyType<T>
+    operator=(const T& a)
+    {
+        value = a;
+        return *this;
     }
 };
 
 int
 main()
 {
-    using BinaryOp = UserBinaryOperation<int>;
-
+    using ValType = MyType<int>;
+    using BinaryOp = UserBinaryOperation<ValType>;
 #if TEST_DPCPP_BACKEND_PRESENT
     sycl::queue q = TestUtils::get_test_queue();
 #if _ONEDPL_DEBUG_SYCL
@@ -131,11 +155,11 @@ main()
     test_with_usm<sycl::usm::alloc::shared, class KernelName1>(q);
     // Run tests for USM device memory
     test_with_usm<sycl::usm::alloc::device, class KernelName2>(q);
-    ;
-    test_with_usm<sycl::usm::alloc::device, class KernelName3, BinaryOp>(q);
+
+    //test_with_usm<sycl::usm::alloc::device, class KernelName3, BinaryOp>(q);
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-    test_with_vector<BinaryOp>();
+    test_with_vector<ValType, BinaryOp>();
 
-    return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT);
+    return TestUtils::done();
 }

--- a/test/support/scan_serial_impl.h
+++ b/test/support/scan_serial_impl.h
@@ -39,7 +39,7 @@ exclusive_scan_serial(InputIterator first, InputIterator last, OutputIterator re
 {
     for (; first != last; ++first, ++result)
     {
-        auto res = init;
+	auto res = init;
         init = binary_op(init, *first);
         *result = res;
     }
@@ -83,9 +83,8 @@ inclusive_scan_serial(InputIterator first, InputIterator last, OutputIterator re
     return inclusive_scan_serial(first, last, result, ::std::plus<input_type>());
 }
 
-template <typename ViewKeys, typename ViewVals, typename Res, typename Size, typename BinaryOperation>
-void
-inclusive_scan_by_segment_serial(ViewKeys keys, ViewVals vals, Res& res, Size n, BinaryOperation binary_op)
+template<typename ViewKeys, typename ViewVals, typename Res, typename Size, typename BinaryOperation>
+void inclusive_scan_by_segment_serial(ViewKeys keys, ViewVals vals, Res& res, Size n, BinaryOperation binary_op)
 {
     for (Size i = 0; i < n; ++i)
         if (i == 0 || keys[i] != keys[i - 1])

--- a/test/support/scan_serial_impl.h
+++ b/test/support/scan_serial_impl.h
@@ -39,7 +39,7 @@ exclusive_scan_serial(InputIterator first, InputIterator last, OutputIterator re
 {
     for (; first != last; ++first, ++result)
     {
-	auto res = init;
+        auto res = init;
         init = binary_op(init, *first);
         *result = res;
     }
@@ -83,8 +83,9 @@ inclusive_scan_serial(InputIterator first, InputIterator last, OutputIterator re
     return inclusive_scan_serial(first, last, result, ::std::plus<input_type>());
 }
 
-template<typename ViewKeys, typename ViewVals, typename Res, typename Size, typename BinaryOperation>
-void inclusive_scan_by_segment_serial(ViewKeys keys, ViewVals vals, Res& res, Size n, BinaryOperation binary_op)
+template <typename ViewKeys, typename ViewVals, typename Res, typename Size, typename BinaryOperation>
+void
+inclusive_scan_by_segment_serial(ViewKeys keys, ViewVals vals, Res& res, Size n, BinaryOperation binary_op)
 {
     for (Size i = 0; i < n; ++i)
         if (i == 0 || keys[i] != keys[i - 1])


### PR DESCRIPTION
Summary
---
For inclusive and exclusive scan, the C++ standard does not require that the default constructor of the value type be the identity for the binary operation.  

https://en.cppreference.com/w/cpp/algorithm/inclusive_scan
https://en.cppreference.com/w/cpp/algorithm/exclusive_scan

However, in certain circumstances, OneDPL imposes that requirement when the following are **all** satisfied:
- Using a non-arithmetic type (user defined type for instance) 
- Using a user defined binary operation
- Using icpc compiler (which has support for omp simd scan)
- Targeting the host using a `unseq` or `par_unseq` policy
 
In that situation, if the default constructor is not the identity, the result is incorrect.  This PR removes that hidden requirement.

Details
---

In `__brick_transform_scan`, OneDPL currently tries to use `__simd_scan` whenever binary operation is `std::plus` **or** a when it is a non arithmetic type.  `__simd_scan` requires that the default constructor is the identity for the binary operation and type.

This fix changes `__brick_transform_scan` to be able to use `__simd_scan` only when the type is an arithmetic type **and** the binary operation is `std::plus`, and otherwise uses a non-vectorized brick.

This PR adds tests to cover some of the host code.  The two tests use a user defined binary operation (multiply), for which default constructors are not the identity.

The first added host test will pass with or without the fix, as it has an arithmetic type, and will therefore be sent to the non-vectorized brick.  
The second added host test uses a custom wrapper type, and fails without the fix as it will be sent to the vectorized brick for which it does not meet the default constructor = identity requirement.  The fix makes it avoid `__simd_scan` and it passes.

Blocking
---
#608 depends on this PR to pass the CI for icpc on the host, as  `{exclusive|inclusive}_scan_by_segment` depends internally on `inclusive_scan` with a `zip_view` as input and a custom binary operation.  Without the fix, it ends up in `__simd_scan` for inputs which don't meet the default constructor = identity requirement and produces incorrect results.
We are currently avoiding a test in `inclusive_scan_by_segment.pass` on icpc because of this bug with the macro `_PSTL_ICC_TEST_SIMD_UDS_BROKEN`.  Test coverage has improved in #608 to also impact `exclusive_scan_by_segment.pass`.