### PR TITLE
codespell suggestions and formatting

### DIFF
--- a/include/oneapi/dpl/pstl/experimental/internal/reduction_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/reduction_impl.h
@@ -36,7 +36,7 @@ class __reduction_object
     // when finalize method is called and accumulated value stored in acc is written
     // to value.
     // TODO: we probably don't need to keep this reference for each object, as we need it
-    // only at the end of execution. Need to check whether it can be impelemented efficiently.
+    // only at the end of execution. Need to check whether it can be implemented efficiently.
     // I.e. by intoducing an internal reduction object on which the operation are applied.
     _Tp& __value_;
     // Current accumulated value.

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1272,7 +1272,7 @@ oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, _
 __pattern_partition(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, _UnaryPredicate __pred,
                     /*vector*/ ::std::true_type, /*parallel*/ ::std::true_type)
 {
-    //TODO: consider nonstable aproaches
+    //TODO: consider nonstable approaches
     return __pattern_stable_partition(::std::forward<_ExecutionPolicy>(__exec), __first, __last, __pred,
                                       ::std::true_type(), ::std::true_type());
 }

--- a/test/parallel_api/algorithm/alg.nonmodifying/for_each.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/for_each.pass.cpp
@@ -20,9 +20,9 @@
 
 #include "support/utils.h"
 
-#if  !defined(FOR_EACH) && !defined(FOR_EACH_N)
-#define FOR_EACH
-#define FOR_EACH_N
+#if !defined(FOR_EACH) && !defined(FOR_EACH_N)
+#    define FOR_EACH
+#    define FOR_EACH_N
 #endif
 
 using namespace TestUtils;
@@ -87,15 +87,15 @@ test()
 {
     for (size_t n = 0; n <= 100000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
-        Sequence<T> inout(n, Gen<T>());
+        Sequence<T> in_out(n, Gen<T>());
         Sequence<T> expected(n, Gen<T>());
 #ifdef FOR_EACH
-        invoke_on_all_policies<>()(test_for_each<T>(), inout.begin(), inout.end(), expected.begin(), expected.end(),
-                                   inout.size());
+        invoke_on_all_policies<>()(test_for_each<T>(), in_out.begin(), in_out.end(), expected.begin(), expected.end(),
+                                   in_out.size());
 #endif
 #ifdef FOR_EACH_N
-        invoke_on_all_policies<>()(test_for_each_n<T>(), inout.begin(), inout.end(), expected.begin(), expected.end(),
-                                   inout.size());
+        invoke_on_all_policies<>()(test_for_each_n<T>(), in_out.begin(), in_out.end(), expected.begin(), expected.end(),
+                                   in_out.size());
 #endif
     }
 }
@@ -134,7 +134,6 @@ main()
     test<std::int32_t>();
     test<std::uint16_t>();
     test<float64_t>();
-
 
 #ifdef FOR_EACH
     test_algo_basic_single<std::int64_t>(run_for_rnd_fw<test_non_const_for_each>());

--- a/test/parallel_api/experimental/for_loop.pass.cpp
+++ b/test/parallel_api/experimental/for_loop.pass.cpp
@@ -136,7 +136,8 @@ test_body_for_loop_strided_n(Policy&& exec, Iterator first, Iterator /* last */,
 
     auto num_iters = n / loop_stride + !!(n % loop_stride);
 
-    ::std::experimental::for_loop_n_strided(exec, first, num_iters, loop_stride, [&flip](Iterator iter) { flip(*iter); });
+    ::std::experimental::for_loop_n_strided(exec, first, num_iters, loop_stride,
+                                            [&flip](Iterator iter) { flip(*iter); });
 
     size_t idx = 0;
     for (auto iter = expected_first; iter != expected_last; ++iter, ++idx)
@@ -259,8 +260,9 @@ template <typename Policy, typename Iterator, typename Size, typename S>
 typename ::std::enable_if<
     ::std::is_same<typename ::std::iterator_traits<Iterator>::iterator_category, ::std::forward_iterator_tag>::value,
     void>::type
-test_body_for_loop_strided_neg(Policy&& /* exec */, Iterator /* first */, Iterator /* last */, Iterator /* expected_first */,
-                               Iterator /* expected_last */, Size /* n */, S /* loop_stride */)
+test_body_for_loop_strided_neg(Policy&& /* exec */, Iterator /* first */, Iterator /* last */,
+                               Iterator /* expected_first */, Iterator /* expected_last */, Size /* n */,
+                               S /* loop_stride */)
 {
     // no-op for forward iterators. As it's not possible to iterate backwards.
 }
@@ -273,17 +275,18 @@ struct test_for_loop_strided_impl
                size_t stride)
     {
         test_body_for_loop_strided(::std::forward<Policy>(exec), first, last, expected_first, expected_last, n, stride);
-        test_body_for_loop_strided_n(::std::forward<Policy>(exec), first, last, expected_first, expected_last, n, stride);
+        test_body_for_loop_strided_n(::std::forward<Policy>(exec), first, last, expected_first, expected_last, n,
+                                     stride);
 
         test_body_for_loop_strided_integral(::std::forward<Policy>(exec), first, last, expected_first, expected_last, n,
                                             stride);
 
-        test_body_for_loop_strided_n_integral(::std::forward<Policy>(exec), first, last, expected_first, expected_last, n,
-                                              (long)stride);
+        test_body_for_loop_strided_n_integral(::std::forward<Policy>(exec), first, last, expected_first, expected_last,
+                                              n, (long)stride);
 
         // Additionally check negative stride with integral and iterator sequence.
-        test_body_for_loop_strided_n_integral(::std::forward<Policy>(exec), first, last, expected_first, expected_last, n,
-                                              -(long)stride);
+        test_body_for_loop_strided_n_integral(::std::forward<Policy>(exec), first, last, expected_first, expected_last,
+                                              n, -(long)stride);
         test_body_for_loop_strided_neg(::std::forward<Policy>(exec), first, last, expected_first, expected_last, n,
                                        -(long)stride);
     }
@@ -295,11 +298,11 @@ test_for_loop()
 {
     for (size_t n = 0; n <= 10000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
-        Sequence<T> inout(n, Gen<T>());
-        Sequence<T> expected = inout;
+        Sequence<T> in_out(n, Gen<T>());
+        Sequence<T> expected = in_out;
 
-        invoke_on_all_policies<>()(test_for_loop_impl(), inout.begin(), inout.end(), expected.begin(), expected.end(),
-                               inout.size());
+        invoke_on_all_policies<>()(test_for_loop_impl(), in_out.begin(), in_out.end(), expected.begin(), expected.end(),
+                                   in_out.size());
     }
 }
 
@@ -309,14 +312,14 @@ test_for_loop_strided()
 {
     for (size_t n = 0; n <= 10000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
-        Sequence<T> inout(n, Gen<T>());
-        Sequence<T> expected = inout;
+        Sequence<T> in_out(n, Gen<T>());
+        Sequence<T> expected = in_out;
 
         ::std::vector<size_t> strides = {1, 2, 10, n > 1 ? n - 1 : 1, n > 0 ? n : 1, n + 1};
         for (size_t stride : strides)
         {
-            invoke_on_all_policies<>()(test_for_loop_strided_impl(), inout.begin(), inout.end(), expected.begin(),
-                                   expected.end(), inout.size(), stride);
+            invoke_on_all_policies<>()(test_for_loop_strided_impl(), in_out.begin(), in_out.end(), expected.begin(),
+                                       expected.end(), in_out.size(), stride);
         }
     }
 }

--- a/test/parallel_api/experimental/for_loop_induction.pass.cpp
+++ b/test/parallel_api/experimental/for_loop_induction.pass.cpp
@@ -85,20 +85,20 @@ test_body_induction_strided(Policy&& exec, Iterator first, Iterator last, Iterat
         using Ssize = typename ::std::make_signed<Size>::type;
 
         ::std::experimental::for_loop_n_strided(::std::forward<Policy>(exec), Ssize(0), Ssize(n), loop_stride,
-                                              ::std::experimental::induction(lval_ind),
-                                              [ind_init, loop_stride](Ssize val, T ind) {
-                                                  // We have either 0, stride, 2 * stride, .. or 0, -|stride|, 2 * -|stride|
-                                                  // sequences, so current index can be simply calculated with this.
-                                                  auto real_idx = val / loop_stride;
+                                                ::std::experimental::induction(lval_ind),
+                                                [ind_init, loop_stride](Ssize val, T ind) {
+                                                    // We have either 0, stride, 2 * stride, .. or 0, -|stride|, 2 * -|stride|
+                                                    // sequences, so current index can be simply calculated with this.
+                                                    auto real_idx = val / loop_stride;
 
-                                                  EXPECT_TRUE(ind == (ind_init + real_idx), "wrong induction value");
-                                              });
+                                                    EXPECT_TRUE(ind == (ind_init + real_idx), "wrong induction value");
+                                                });
 
         EXPECT_TRUE(lval_ind == n, "wrong result of induction");
 
         // Negative strides are not allowed with forward iterators
-        if (loop_stride < 0 &&
-            ::std::is_same<typename ::std::iterator_traits<Iterator>::iterator_category, ::std::forward_iterator_tag>::value)
+        if (loop_stride < 0 && ::std::is_same<typename ::std::iterator_traits<Iterator>::iterator_category,
+                                              ::std::forward_iterator_tag>::value)
             continue;
 
         auto new_first = first;
@@ -153,9 +153,10 @@ test()
 {
     for (size_t n = 0; n <= 10000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
-        Sequence<T> inout(n, [](long int k) { return T(k % 5 != 1 ? 3 * k - 7 : 0); });
-        Sequence<T> expected = inout;
-        invoke_on_all_policies<>()(test_body(), inout.begin(), inout.end(), expected.begin(), expected.end(), inout.size());
+        Sequence<T> in_out(n, [](long int k) { return T(k % 5 != 1 ? 3 * k - 7 : 0); });
+        Sequence<T> expected = in_out;
+        invoke_on_all_policies<>()(test_body(), in_out.begin(), in_out.end(), expected.begin(), expected.end(),
+                                   in_out.size());
     }
 }
 

--- a/test/parallel_api/experimental/for_loop_reduction.pass.cpp
+++ b/test/parallel_api/experimental/for_loop_reduction.pass.cpp
@@ -38,13 +38,13 @@ test_body_reduction(Policy&& exec, Iterator first, Iterator last, Iterator /* ex
     T var1 = var1_init;
     T var2 = var2_init;
 
-    ::std::experimental::for_loop(::std::forward<Policy>(exec), first, last,
-                                ::std::experimental::reduction(var1, T(0), ::std::plus<T>{}),
-                                ::std::experimental::reduction(var2, T(var2_init), oneapi::dpl::__internal::__pstl_min{}),
-                                [](Iterator iter, T& acc1, T& acc2) {
-                                    acc1 += *iter;
-                                    acc2 = ::std::min(acc2, *iter);
-                                });
+    ::std::experimental::for_loop(
+        ::std::forward<Policy>(exec), first, last, ::std::experimental::reduction(var1, T(0), ::std::plus<T>{}),
+        ::std::experimental::reduction(var2, T(var2_init), oneapi::dpl::__internal::__pstl_min{}),
+        [](Iterator iter, T& acc1, T& acc2) {
+            acc1 += *iter;
+            acc2 = ::std::min(acc2, *iter);
+        });
 
     T var1_exp = var1_init;
     T var2_exp = var2_init;
@@ -75,9 +75,10 @@ test()
 {
     for (size_t n = 0; n <= 100000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
-        Sequence<T> inout(n, [](long int k) { return T(k % 5 != 1 ? 3 * k - 7 : 0); });
-        Sequence<T> expected = inout;
-        invoke_on_all_policies<>()(test_body(), inout.begin(), inout.end(), expected.begin(), expected.end(), inout.size());
+        Sequence<T> in_out(n, [](long int k) { return T(k % 5 != 1 ? 3 * k - 7 : 0); });
+        Sequence<T> expected = in_out;
+        invoke_on_all_policies<>()(test_body(), in_out.begin(), in_out.end(), expected.begin(), expected.end(),
+                                   in_out.size());
     }
 }
 
@@ -127,7 +128,7 @@ struct test_body_predefined_bits
 {
     template <typename Policy, typename Iterator, typename Size>
     typename ::std::enable_if<!::std::is_floating_point<typename ::std::iterator_traits<Iterator>::value_type>::value,
-                            void>::type
+                              void>::type
     operator()(Policy&& exec, Iterator first, Iterator last, Iterator /*expected_first*/, Iterator /*expected_last*/,
                Size /* n */)
     {
@@ -162,9 +163,9 @@ struct test_body_predefined_bits
 
     template <typename Policy, typename Iterator, typename Size>
     typename ::std::enable_if<::std::is_floating_point<typename ::std::iterator_traits<Iterator>::value_type>::value,
-                            void>::type
-    operator()(Policy&& /* exec */, Iterator /* first */, Iterator /* last */, Iterator /*expected_first*/, Iterator /*expected_last*/,
-               Size /* n */)
+                              void>::type
+    operator()(Policy&& /* exec */, Iterator /* first */, Iterator /* last */, Iterator /*expected_first*/,
+               Iterator /*expected_last*/, Size /* n */)
     {
         // no-op for floats
     }
@@ -175,12 +176,12 @@ void
 test_predefined(::std::initializer_list<T> init_list)
 {
     // Just arbitrary numbers
-    Sequence<T> inout = init_list;
-    Sequence<T> expected = inout;
-    invoke_on_all_policies<>()(test_body_predefined(), inout.begin(), inout.end(), expected.begin(), expected.end(),
-                           inout.size());
-    invoke_on_all_policies<>()(test_body_predefined_bits(), inout.begin(), inout.end(), expected.begin(), expected.end(),
-                           inout.size());
+    Sequence<T> in_out = init_list;
+    Sequence<T> expected = in_out;
+    invoke_on_all_policies<>()(test_body_predefined(), in_out.begin(), in_out.end(), expected.begin(), expected.end(),
+                               in_out.size());
+    invoke_on_all_policies<>()(test_body_predefined_bits(), in_out.begin(), in_out.end(), expected.begin(),
+                               expected.end(), in_out.size());
 }
 
 void

--- a/test/parallel_api/memory/specialized.algorithms/uninitialized_copy_move.pass.cpp
+++ b/test/parallel_api/memory/specialized.algorithms/uninitialized_copy_move.pass.cpp
@@ -22,12 +22,12 @@
 
 #include "support/utils.h"
 
-#if  !defined(UNITIALIZED_COPY) && !defined(UNITIALIZED_COPY_N) &&\
-     !defined(UNITIALIZED_MOVE) && !defined(UNITIALIZED_MOVE_N)
-#define UNITIALIZED_COPY
-#define UNITIALIZED_COPY_N
-#define UNITIALIZED_MOVE
-#define UNITIALIZED_MOVE_N
+#if !defined(UNITIALIZED_COPY) && !defined(UNITIALIZED_COPY_N) && !defined(UNITIALIZED_MOVE) &&                        \
+    !defined(UNITIALIZED_MOVE_N)
+#    define UNITIALIZED_COPY
+#    define UNITIALIZED_COPY_N
+#    define UNITIALIZED_MOVE
+#    define UNITIALIZED_MOVE_N
 #endif
 
 using namespace TestUtils;
@@ -176,7 +176,7 @@ test_uninitialized_copy_move_by_type()
         auto out_begin = p.get();
 #else
         // common pointers are not supported for hetero backend
-        // sycl::buffer<T,1> buf(n); // async nature of buffer requires sycn before EXPECT_ macro
+        // sycl::buffer<T,1> buf(n); // async nature of buffer requires sync before EXPECT_ macro
         // auto out_begin = oneapi::dpl::begin(buf);
         Sequence<T> out(n, [=](size_t) -> T { return T{}; });
         auto out_begin = out.begin();

--- a/test/support/utils_sequence.h
+++ b/test/support/utils_sequence.h
@@ -24,7 +24,7 @@
 
 #include "iterator_utils.h"
 
-// Please uncomment this define if required to print full contect of sequence.
+// Please uncomment this define if required to print full context of sequence.
 // Otherwise only first 100 sequence items will be printed.
 //#define PRINT_FULL_SEQUENCE_CONTEXT 1
 
@@ -40,17 +40,16 @@ class Sequence
 {
     ::std::vector<T> m_storage;
 
-public:
-
+  public:
     using value_type = T;
 
-    using iterator       = typename ::std::vector<T>::iterator;
+    using iterator = typename ::std::vector<T>::iterator;
     using const_iterator = typename ::std::vector<T>::const_iterator;
 
-    using forward_iterator       = ForwardIterator<iterator, ::std::forward_iterator_tag>;
+    using forward_iterator = ForwardIterator<iterator, ::std::forward_iterator_tag>;
     using const_forward_iterator = ForwardIterator<const_iterator, ::std::forward_iterator_tag>;
 
-    using bidirectional_iterator       = BidirectionalIterator<iterator, ::std::bidirectional_iterator_tag>;
+    using bidirectional_iterator = BidirectionalIterator<iterator, ::std::bidirectional_iterator_tag>;
     using const_bidirectional_iterator = BidirectionalIterator<const_iterator, ::std::bidirectional_iterator_tag>;
 
     explicit Sequence(size_t size);
@@ -61,37 +60,107 @@ public:
     Sequence(size_t size, Func f);
     Sequence(const ::std::initializer_list<T>& data);
 
-    const_iterator               begin   () const { return m_storage.begin();                                };
-    const_iterator               end     () const { return m_storage.end();                                  };
-    iterator                     begin   ()       { return m_storage.begin();                                };
-    iterator                     end     ()       { return m_storage.end();                                  };
-    const_iterator               cbegin  () const { return m_storage.cbegin();                               };
-    const_iterator               cend    () const { return m_storage.cend();                                 };
-    forward_iterator             fbegin  ()       { return forward_iterator(m_storage.begin());              };
-    forward_iterator             fend    ()       { return forward_iterator(m_storage.end());                };
-    const_forward_iterator       cfbegin () const { return const_forward_iterator(m_storage.cbegin());       };
-    const_forward_iterator       cfend   () const { return const_forward_iterator(m_storage.cend());         };
-    const_forward_iterator       fbegin  () const { return const_forward_iterator(m_storage.cbegin());       };
-    const_forward_iterator       fend    () const { return const_forward_iterator(m_storage.cend());         };
-    const_bidirectional_iterator cbibegin() const { return const_bidirectional_iterator(m_storage.cbegin()); };
-    const_bidirectional_iterator cbiend  () const { return const_bidirectional_iterator(m_storage.cend());   };
-    bidirectional_iterator       bibegin ()       { return bidirectional_iterator(m_storage.begin());        };
-    bidirectional_iterator       biend   ()       { return bidirectional_iterator(m_storage.end());          };
+    const_iterator
+    begin() const
+    {
+        return m_storage.begin();
+    };
+    const_iterator
+    end() const
+    {
+        return m_storage.end();
+    };
+    iterator
+    begin()
+    {
+        return m_storage.begin();
+    };
+    iterator
+    end()
+    {
+        return m_storage.end();
+    };
+    const_iterator
+    cbegin() const
+    {
+        return m_storage.cbegin();
+    };
+    const_iterator
+    cend() const
+    {
+        return m_storage.cend();
+    };
+    forward_iterator
+    fbegin()
+    {
+        return forward_iterator(m_storage.begin());
+    };
+    forward_iterator
+    fend()
+    {
+        return forward_iterator(m_storage.end());
+    };
+    const_forward_iterator
+    cfbegin() const
+    {
+        return const_forward_iterator(m_storage.cbegin());
+    };
+    const_forward_iterator
+    cfend() const
+    {
+        return const_forward_iterator(m_storage.cend());
+    };
+    const_forward_iterator
+    fbegin() const
+    {
+        return const_forward_iterator(m_storage.cbegin());
+    };
+    const_forward_iterator
+    fend() const
+    {
+        return const_forward_iterator(m_storage.cend());
+    };
+    const_bidirectional_iterator
+    cbibegin() const
+    {
+        return const_bidirectional_iterator(m_storage.cbegin());
+    };
+    const_bidirectional_iterator
+    cbiend() const
+    {
+        return const_bidirectional_iterator(m_storage.cend());
+    };
+    bidirectional_iterator
+    bibegin()
+    {
+        return bidirectional_iterator(m_storage.begin());
+    };
+    bidirectional_iterator
+    biend()
+    {
+        return bidirectional_iterator(m_storage.end());
+    };
 
-    ::std::size_t size() const;
-    T* data();
-    const T* data() const;
+    ::std::size_t
+    size() const;
+    T*
+    data();
+    const T*
+    data() const;
 
     typename ::std::vector<T>::reference operator[](size_t j);
     typename ::std::vector<T>::const_reference operator[](size_t j) const;
 
     // Fill with given value
-    void fill(const T& value);
+    void
+    fill(const T& value);
 
     template <typename Func>
-    void fill(Func f);
+    void
+    fill(Func f);
 
-    void print() const;
+    void
+    print() const;
 };
 
 //--------------------------------------------------------------------------------------------------------------------//
@@ -108,8 +177,7 @@ fill_data(Iterator first, Iterator last, F f)
 
 //--------------------------------------------------------------------------------------------------------------------//
 template <typename T>
-Sequence<T>::Sequence(size_t size)
-    : m_storage(size)
+Sequence<T>::Sequence(size_t size) : m_storage(size)
 {
 }
 
@@ -126,8 +194,7 @@ Sequence<T>::Sequence(size_t size, Func f)
 
 //--------------------------------------------------------------------------------------------------------------------//
 template <typename T>
-Sequence<T>::Sequence(const ::std::initializer_list<T>& data)
-    : m_storage(data)
+Sequence<T>::Sequence(const ::std::initializer_list<T>& data) : m_storage(data)
 {
 }
 
@@ -157,16 +224,14 @@ Sequence<T>::data() const
 
 //--------------------------------------------------------------------------------------------------------------------//
 template <typename T>
-typename ::std::vector<T>::reference
-Sequence<T>::operator[](size_t j)
+typename ::std::vector<T>::reference Sequence<T>::operator[](size_t j)
 {
     return m_storage[j];
 }
 
 //--------------------------------------------------------------------------------------------------------------------//
 template <typename T>
-typename ::std::vector<T>::const_reference
-Sequence<T>::operator[](size_t j) const
+typename ::std::vector<T>::const_reference Sequence<T>::operator[](size_t j) const
 {
     return m_storage[j];
 }


### PR DESCRIPTION
Something changed in the codespell github action check, and it started complaining about some misspellings in comments and hard to understand variable names as of 11/30/2022 9am EST.  This PR should resolve all those complaints, and includes some formatting suggested by clang-format on those affected files.  

This commit should not change anything functionally, but it should get the codespell check passing again.