### PR TITLE
Clang format github runner running on ubuntu 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   clang-format:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Fixing clang-format check to run on ubuntu 20, so we still have access to clang-format-6.0.

