### PR TITLE
Codespell suggestions 

### DIFF
--- a/include/oneapi/dpl/pstl/experimental/internal/reduction_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/reduction_impl.h
@@ -36,7 +36,7 @@ class __reduction_object
     // when finalize method is called and accumulated value stored in acc is written
     // to value.
     // TODO: we probably don't need to keep this reference for each object, as we need it
-    // only at the end of execution. Need to check whether it can be impelemented efficiently.
+    // only at the end of execution. Need to check whether it can be implemented efficiently.
     // I.e. by intoducing an internal reduction object on which the operation are applied.
     _Tp& __value_;
     // Current accumulated value.

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1272,7 +1272,7 @@ oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, _
 __pattern_partition(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, _UnaryPredicate __pred,
                     /*vector*/ ::std::true_type, /*parallel*/ ::std::true_type)
 {
-    //TODO: consider nonstable aproaches
+    //TODO: consider nonstable approaches
     return __pattern_stable_partition(::std::forward<_ExecutionPolicy>(__exec), __first, __last, __pred,
                                       ::std::true_type(), ::std::true_type());
 }

--- a/test/parallel_api/algorithm/alg.nonmodifying/for_each.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/for_each.pass.cpp
@@ -87,15 +87,15 @@ test()
 {
     for (size_t n = 0; n <= 100000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
-        Sequence<T> inout(n, Gen<T>());
+        Sequence<T> in_out(n, Gen<T>());
         Sequence<T> expected(n, Gen<T>());
 #ifdef FOR_EACH
-        invoke_on_all_policies<>()(test_for_each<T>(), inout.begin(), inout.end(), expected.begin(), expected.end(),
-                                   inout.size());
+        invoke_on_all_policies<>()(test_for_each<T>(), in_out.begin(), in_out.end(), expected.begin(), expected.end(),
+                                   in_out.size());
 #endif
 #ifdef FOR_EACH_N
-        invoke_on_all_policies<>()(test_for_each_n<T>(), inout.begin(), inout.end(), expected.begin(), expected.end(),
-                                   inout.size());
+        invoke_on_all_policies<>()(test_for_each_n<T>(), in_out.begin(), in_out.end(), expected.begin(), expected.end(),
+                                   in_out.size());
 #endif
     }
 }

--- a/test/parallel_api/experimental/for_loop.pass.cpp
+++ b/test/parallel_api/experimental/for_loop.pass.cpp
@@ -295,11 +295,11 @@ test_for_loop()
 {
     for (size_t n = 0; n <= 10000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
-        Sequence<T> inout(n, Gen<T>());
-        Sequence<T> expected = inout;
+        Sequence<T> in_out(n, Gen<T>());
+        Sequence<T> expected = in_out;
 
-        invoke_on_all_policies<>()(test_for_loop_impl(), inout.begin(), inout.end(), expected.begin(), expected.end(),
-                               inout.size());
+        invoke_on_all_policies<>()(test_for_loop_impl(), in_out.begin(), in_out.end(), expected.begin(), expected.end(),
+                                   in_out.size());
     }
 }
 
@@ -309,14 +309,14 @@ test_for_loop_strided()
 {
     for (size_t n = 0; n <= 10000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
-        Sequence<T> inout(n, Gen<T>());
-        Sequence<T> expected = inout;
+        Sequence<T> in_out(n, Gen<T>());
+        Sequence<T> expected = in_out;
 
         ::std::vector<size_t> strides = {1, 2, 10, n > 1 ? n - 1 : 1, n > 0 ? n : 1, n + 1};
         for (size_t stride : strides)
         {
-            invoke_on_all_policies<>()(test_for_loop_strided_impl(), inout.begin(), inout.end(), expected.begin(),
-                                   expected.end(), inout.size(), stride);
+            invoke_on_all_policies<>()(test_for_loop_strided_impl(), in_out.begin(), in_out.end(), expected.begin(),
+                                       expected.end(), in_out.size(), stride);
         }
     }
 }

--- a/test/parallel_api/experimental/for_loop_induction.pass.cpp
+++ b/test/parallel_api/experimental/for_loop_induction.pass.cpp
@@ -153,9 +153,10 @@ test()
 {
     for (size_t n = 0; n <= 10000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
-        Sequence<T> inout(n, [](long int k) { return T(k % 5 != 1 ? 3 * k - 7 : 0); });
-        Sequence<T> expected = inout;
-        invoke_on_all_policies<>()(test_body(), inout.begin(), inout.end(), expected.begin(), expected.end(), inout.size());
+        Sequence<T> in_out(n, [](long int k) { return T(k % 5 != 1 ? 3 * k - 7 : 0); });
+        Sequence<T> expected = in_out;
+        invoke_on_all_policies<>()(test_body(), in_out.begin(), in_out.end(), expected.begin(), expected.end(),
+                                   in_out.size());
     }
 }
 

--- a/test/parallel_api/experimental/for_loop_reduction.pass.cpp
+++ b/test/parallel_api/experimental/for_loop_reduction.pass.cpp
@@ -75,9 +75,10 @@ test()
 {
     for (size_t n = 0; n <= 100000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
-        Sequence<T> inout(n, [](long int k) { return T(k % 5 != 1 ? 3 * k - 7 : 0); });
-        Sequence<T> expected = inout;
-        invoke_on_all_policies<>()(test_body(), inout.begin(), inout.end(), expected.begin(), expected.end(), inout.size());
+        Sequence<T> in_out(n, [](long int k) { return T(k % 5 != 1 ? 3 * k - 7 : 0); });
+        Sequence<T> expected = in_out;
+        invoke_on_all_policies<>()(test_body(), in_out.begin(), in_out.end(), expected.begin(), expected.end(),
+                                   in_out.size());
     }
 }
 
@@ -175,12 +176,12 @@ void
 test_predefined(::std::initializer_list<T> init_list)
 {
     // Just arbitrary numbers
-    Sequence<T> inout = init_list;
-    Sequence<T> expected = inout;
-    invoke_on_all_policies<>()(test_body_predefined(), inout.begin(), inout.end(), expected.begin(), expected.end(),
-                           inout.size());
-    invoke_on_all_policies<>()(test_body_predefined_bits(), inout.begin(), inout.end(), expected.begin(), expected.end(),
-                           inout.size());
+    Sequence<T> in_out = init_list;
+    Sequence<T> expected = in_out;
+    invoke_on_all_policies<>()(test_body_predefined(), in_out.begin(), in_out.end(), expected.begin(), expected.end(),
+                               in_out.size());
+    invoke_on_all_policies<>()(test_body_predefined_bits(), in_out.begin(), in_out.end(), expected.begin(),
+                               expected.end(), in_out.size());
 }
 
 void

--- a/test/parallel_api/memory/specialized.algorithms/uninitialized_copy_move.pass.cpp
+++ b/test/parallel_api/memory/specialized.algorithms/uninitialized_copy_move.pass.cpp
@@ -176,7 +176,7 @@ test_uninitialized_copy_move_by_type()
         auto out_begin = p.get();
 #else
         // common pointers are not supported for hetero backend
-        // sycl::buffer<T,1> buf(n); // async nature of buffer requires sycn before EXPECT_ macro
+        // sycl::buffer<T,1> buf(n); // async nature of buffer requires sync before EXPECT_ macro
         // auto out_begin = oneapi::dpl::begin(buf);
         Sequence<T> out(n, [=](size_t) -> T { return T{}; });
         auto out_begin = out.begin();

--- a/test/support/utils_sequence.h
+++ b/test/support/utils_sequence.h
@@ -24,9 +24,9 @@
 
 #include "iterator_utils.h"
 
-// Please uncomment this define if required to print full context of sequence.
+// Please uncomment this define if required to print full content of sequence.
 // Otherwise only first 100 sequence items will be printed.
-//#define PRINT_FULL_SEQUENCE_CONTEXT 1
+//#define PRINT_FULL_SEQUENCE_CONTENT 1
 
 namespace TestUtils
 {
@@ -197,12 +197,12 @@ Sequence<T>::print() const
     constexpr ::std::size_t max_print_count = 100;
 
     ::std::cout << "size = " << size() << ": { ";
-#if PRINT_FULL_SEQUENCE_CONTEXT
+#if PRINT_FULL_SEQUENCE_CONTENT
     ::std::copy(begin(), end(), ::std::ostream_iterator<T>(::std::cout, " "));
 #else
     const auto printable_size = ::std::min(max_print_count, size());
     ::std::copy(begin(), begin() + printable_size, ::std::ostream_iterator<T>(::std::cout, " "));
-#endif // PRINT_FULL_SEQUENCE_CONTEXT
+#endif // PRINT_FULL_SEQUENCE_CONTENT
     ::std::cout << " } " << ::std::endl;
 }
 

--- a/test/support/utils_sequence.h
+++ b/test/support/utils_sequence.h
@@ -24,7 +24,7 @@
 
 #include "iterator_utils.h"
 
-// Please uncomment this define if required to print full contect of sequence.
+// Please uncomment this define if required to print full context of sequence.
 // Otherwise only first 100 sequence items will be printed.
 //#define PRINT_FULL_SEQUENCE_CONTEXT 1
 


### PR DESCRIPTION
Resolving new codespell suggestions from checks.  

This should only be a variable name and comment spelling change, and should not change any functionality.

Removed any extra formatting changes which aren't in the lines touched.