### PR TITLE
Radix sort: loop modifications

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -21,7 +21,7 @@
 #include <utility>
 #include <cstdint>
 
-#if (__cpluslplus >= 202002L || _MSVC_LANG >= 202002L)  && __has_include(<bit>)
+#if (__cpluslplus >= 202002L || _MSVC_LANG >= 202002L) && __has_include(<bit>)
 #    include <bit>
 #else
 #    include <cstring> // memcpy
@@ -164,7 +164,7 @@ template <typename _T>
 constexpr ::std::uint32_t
 __get_buckets_in_type(::std::uint32_t __radix_bits)
 {
-    return __ceiling_div( sizeof(_T) * ::std::numeric_limits<unsigned char>::digits, __radix_bits);
+    return __ceiling_div(sizeof(_T) * ::std::numeric_limits<unsigned char>::digits, __radix_bits);
 }
 
 // get bits value (bucket) in a certain radix position
@@ -539,9 +539,8 @@ __radix_sort_reorder_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments,
                 {
                     _InputT __in_val = __input_rng[__val_idx];
                     // get the bucket for the bit-ordered input value, applying the offset and mask for radix bits
-                    ::std::uint32_t __bucket =
-                        __get_bucket<(1 << __radix_bits) - 1>(__order_preserving_cast<__is_ascending>(__in_val),
-                                                              __radix_offset);
+                    ::std::uint32_t __bucket = __get_bucket<(1 << __radix_bits) - 1>(
+                        __order_preserving_cast<__is_ascending>(__in_val), __radix_offset);
 
                     _OffsetT __new_offset_idx = 0;
                     for (::std::uint32_t __radix_state_idx = 0; __radix_state_idx < __radix_states; ++__radix_state_idx)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -18,6 +18,7 @@
 
 #include <limits>
 #include <type_traits>
+#include <utility>
 #include <cstdint>
 
 #if (__cpluslplus >= 202002L || _MSVC_LANG >= 202002L)  && __has_include(<bit>)
@@ -58,7 +59,7 @@ class __radix_sort_reorder_kernel;
 
 #if (__cpluslplus >= 202002L || _MSVC_LANG >= 202002L) && __has_include(<bit>)
 template <typename _Dst, typename _Src>
-using __dpl_bit_cast = std::bit_cast<_Dst, _Src>;
+using __dpl_bit_cast = ::std::bit_cast<_Dst, _Src>;
 
 #else
 template <typename _Dst, typename _Src>
@@ -71,7 +72,7 @@ __dpl_bit_cast(const _Src& __src)
     return __builtin_bit_cast(_Dst, __src);
 #else
     _Dst __result;
-    std::memcpy(&__result, &__src, sizeof(_Dst));
+    ::std::memcpy(&__result, &__src, sizeof(_Dst));
     return __result;
 #endif
 }
@@ -104,7 +105,7 @@ __order_preserving_cast(_Int __val)
 {
     using _UInt = ::std::make_unsigned_t<_Int>;
     // mask: 100..0 for ascending, 011..1 for descending
-    constexpr _UInt __mask = (__is_ascending) ? 1 << std::numeric_limits<_Int>::digits : ~_UInt(0) >> 1;
+    constexpr _UInt __mask = (__is_ascending) ? 1 << ::std::numeric_limits<_Int>::digits : ~_UInt(0) >> 1;
     return __val ^ __mask;
 }
 
@@ -163,7 +164,7 @@ template <typename _T>
 constexpr ::std::uint32_t
 __get_buckets_in_type(::std::uint32_t __radix_bits)
 {
-    return (sizeof(_T) * std::numeric_limits<unsigned char>::digits) / __radix_bits;
+    return (sizeof(_T) * ::std::numeric_limits<unsigned char>::digits) / __radix_bits;
 }
 
 // get bits value (bucket) in a certain radix position
@@ -393,7 +394,7 @@ struct __peer_prefix_helper<_OffsetT, __peer_prefix_algo::scan_then_broadcast>
 {
     using _TempStorageT = __empty_peer_temp_storage;
     using _ItemType = sycl::nd_item<1>;
-    using _SubGroupType = decltype(std::declval<_ItemType>().get_sub_group());
+    using _SubGroupType = decltype(::std::declval<_ItemType>().get_sub_group());
 
     _SubGroupType __sgroup;
     ::std::uint32_t __sg_size;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -63,9 +63,8 @@ using __dpl_bit_cast = ::std::bit_cast<_Dst, _Src>;
 
 #else
 template <typename _Dst, typename _Src>
-__enable_if_t<sizeof(_Dst) == sizeof(_Src) && ::std::is_trivially_copyable_v<_Dst>
-              && ::std::is_trivially_copyable_v<_Src>,
-              _Dst>
+__enable_if_t<
+    sizeof(_Dst) == sizeof(_Src) && ::std::is_trivially_copyable_v<_Dst> && ::std::is_trivially_copyable_v<_Src>, _Dst>
 __dpl_bit_cast(const _Src& __src)
 {
 #if defined(__has_builtin) && __has_builtin(__builtin_bit_cast)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -145,7 +145,7 @@ __order_preserving_cast(_Float __val)
 
 // get rounded up result of (__number / __divisor)
 template <typename _T1, typename _T2>
-inline auto
+constexpr auto
 __ceiling_div(_T1 __number, _T2 __divisor) -> decltype((__number - 1) / __divisor + 1)
 {
     return (__number - 1) / __divisor + 1;
@@ -164,7 +164,7 @@ template <typename _T>
 constexpr ::std::uint32_t
 __get_buckets_in_type(::std::uint32_t __radix_bits)
 {
-    return (sizeof(_T) * ::std::numeric_limits<unsigned char>::digits) / __radix_bits;
+    return __ceiling_div( sizeof(_T) * ::std::numeric_limits<unsigned char>::digits, __radix_bits);
 }
 
 // get bits value (bucket) in a certain radix position
@@ -697,7 +697,7 @@ __parallel_radix_sort(_ExecutionPolicy&& __exec, _Range&& __in_rng)
 
     // radix bits represent number of processed bits in each value during one iteration
     constexpr ::std::uint32_t __radix_bits = 4;
-    const ::std::uint32_t __radix_iters = __get_buckets_in_type<_T>(__radix_bits);
+    constexpr ::std::uint32_t __radix_iters = __get_buckets_in_type<_T>(__radix_bits);
     const ::std::uint32_t __radix_states = 1 << __radix_bits;
 
     // additional __radix_states elements are used for getting local offsets from count values


### PR DESCRIPTION
These modifications change the loop conditions to combine both out-of-segment and out-of-data-range conditions, computed separately for each work item. This removes several internal checks for out-of-range and simplifies the code quite a lot, but makes the loop boundaries non-uniform. Nevertheless, internal testing shows that performance is slightly (single-digit percent) better with this patch.
