### PR TITLE
[oneDPL] Fix get_info<sycl::info::kernel_device_specific::max_sub_group_size> deprecated warning

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -388,10 +388,16 @@ __kernel_sub_group_size(_ExecutionPolicy&& __policy, const sycl::kernel& __kerne
     const ::std::uint32_t __sg_size =
 #if _USE_KERNEL_DEVICE_SPECIFIC_API
         __kernel.template get_info<sycl::info::kernel_device_specific::max_sub_group_size>(
+            __device
+#    if _ONEDPL_LIBSYCL_VERSION < 60000
+            ,
+            sycl::range<3> { __wg_size, 1, 1 }
+#    endif
+        );
 #else
         __kernel.template get_sub_group_info<sycl::info::kernel_sub_group::max_sub_group_size>(
-#endif
             __device, sycl::range<3>{__wg_size, 1, 1});
+#endif
     return __sg_size;
 }
 


### PR DESCRIPTION
In this PR we fix get_info<sycl::info::kernel_device_specific::max_sub_group_size> deprecated warning for DPC++ compiler:
now required to use get_info<sycl::info::kernel_device_specific::work_group_size>(const sycl::device&) without second param.

Fixed DPC++ compiler warnings:
```
In file included from /include/oneapi/dpl/algorithm:27:
In file included from /include/oneapi/dpl/pstl/glue_algorithm_defs.h:22:
In file included from /include/oneapi/dpl/pstl/hetero/dpcpp/../../execution_defs.h:237:
/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h:390:27: warning: 'get_info<sycl::info::kernel_device_specific::max_sub_group_size>' is deprecated: Use the overload without the second parameter [-Wdeprecated-declarations]
        __kernel.template get_info<sycl::info::kernel_device_specific::max_sub_group_size>(
                          ^						  
/../include/sycl/kernel.hpp:154:3: note: 'get_info<sycl::info::kernel_device_specific::max_sub_group_size>' has been explicitly marked deprecated here
  __SYCL2020_DEPRECATED("Use the overload without the second parameter")
  ^
/../include/sycl/detail/defines_elementary.hpp:52:40: note: expanded from macro '__SYCL2020_DEPRECATED'
#define __SYCL2020_DEPRECATED(message) __SYCL_DEPRECATED(message)
                                       ^
/../include/sycl/detail/defines_elementary.hpp:43:38: note: expanded from macro '__SYCL_DEPRECATED'
#define __SYCL_DEPRECATED(message) [[deprecated(message)]] 
```