### PR TITLE
Reduce_by_segment range implementation with flag predicate

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -687,7 +687,7 @@ __pattern_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2
     // Replicating first element of keys view to be able to compare (i-1)-th and (i)-th key with aligned sequences,
     //  dropping the last key for the i-1 sequence.
     auto __k1 =
-        oneapi::dpl::__ranges::replicate_start_view_simple(oneapi::dpl::__ranges::take_view_simple(__keys, __n - 1), 1);
+        oneapi::dpl::__ranges::take_view_simple(oneapi::dpl::__ranges::replicate_start_view_simple(__keys, 1), __n);
 
     // view1 elements are a tuple of the element index and pairs of adjacent keys
     // view2 elements are a tuple of the elements where key-index pairs will be written by copy_if
@@ -739,8 +739,8 @@ __pattern_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2
     //  dropping the last key for the i-1 sequence.  Only taking the appropriate number of keys to start with here.
     auto __clipped_new_keys = oneapi::dpl::__ranges::take_view_simple(__new_keys, __intermediate_result_end);
 
-    auto __k3 = oneapi::dpl::__ranges::replicate_start_view_simple(
-        oneapi::dpl::__ranges::take_view_simple(__clipped_new_keys, __intermediate_result_end - 1), 1);
+    auto __k3 = oneapi::dpl::__ranges::take_view_simple(
+        oneapi::dpl::__ranges::replicate_start_view_simple(__clipped_new_keys, 1), __intermediate_result_end);
 
     // view3 elements are a tuple of the element index and pairs of adjacent keys
     // view4 elements are a tuple of the elements where key-index pairs will be written by copy_if

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -767,7 +767,7 @@ __pattern_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2
                           },
                           unseq_backend::__brick_assign_key_position{});
 
-    //reduce by segment and copy keys
+    //reduce by segment
     oneapi::dpl::__par_backend_hetero::__parallel_for(
         oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__reduce2_wrapper>(
             ::std::forward<_ExecutionPolicy>(__exec)),

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -726,14 +726,14 @@ __pattern_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2
                           },
                           unseq_backend::__brick_assign_key_position{});
 
-
     //reduce by segment and copy keys
     // Views for __idx and __tmp_out_keys adjust for the offset from the previous reversed operation
     oneapi::dpl::__par_backend_hetero::__parallel_for(
         oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__reduce1_wrapper>(
             ::std::forward<_ExecutionPolicy>(__exec)),
         unseq_backend::__brick_reduce_idx<_BinaryOperator, decltype(__n)>(__binary_op, __n), __intermediate_result_end,
-        oneapi::dpl::__ranges::drop_view_simple(experimental::ranges::views::all_read(__idx), __n - __intermediate_result_end),
+        oneapi::dpl::__ranges::drop_view_simple(experimental::ranges::views::all_read(__idx),
+                                                __n - __intermediate_result_end),
         oneapi::dpl::__ranges::drop_view_simple(experimental::ranges::views::all_read(__tmp_out_keys),
                                                 __n - __intermediate_result_end),
         experimental::ranges::views::all_write(__tmp_out_keys2), ::std::forward<_Range2>(__values),
@@ -748,8 +748,8 @@ __pattern_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2
 
     // Reversing keys views to be able to compare (i-1)-th and (i)-th key using drop_view with aligned sequences,
     //  dropping the last key for the i-1 sequence.  Only taking the appropriate number of keys to start with here.
-    auto __r_new_keys =
-        oneapi::dpl::__ranges::reverse_view_simple(oneapi::dpl::__ranges::take_view_simple(__new_keys, __intermediate_result_end));
+    auto __r_new_keys = oneapi::dpl::__ranges::reverse_view_simple(
+        oneapi::dpl::__ranges::take_view_simple(__new_keys, __intermediate_result_end));
 
     auto __r_k3 = oneapi::dpl::__ranges::drop_view_simple(__r_new_keys, 1);
 
@@ -786,7 +786,8 @@ __pattern_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2
     oneapi::dpl::__par_backend_hetero::__parallel_for(
         oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__reduce2_wrapper>(
             ::std::forward<_ExecutionPolicy>(__exec)),
-        unseq_backend::__brick_reduce_idx<_BinaryOperator, decltype(__intermediate_result_end)>(__binary_op, __intermediate_result_end),
+        unseq_backend::__brick_reduce_idx<_BinaryOperator, decltype(__intermediate_result_end)>(
+            __binary_op, __intermediate_result_end),
         __result_end,
         oneapi::dpl::__ranges::drop_view_simple(experimental::ranges::views::all_read(__idx), __n - __result_end),
         oneapi::dpl::__ranges::drop_view_simple(experimental::ranges::views::all_read(__tmp_out_keys),

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -725,8 +725,9 @@ __pattern_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2
         oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__reduce1_wrapper>(
             ::std::forward<_ExecutionPolicy>(__exec)),
         unseq_backend::__brick_reduce_idx<_BinaryOperator, decltype(__n)>(__binary_op, __n), __intermediate_result_end,
-        oneapi::dpl::__ranges::take_view_simple(experimental::ranges::views::all_read(__idx), __intermediate_result_end), ::std::forward<_Range2>(__values),
-        experimental::ranges::views::all_write(__tmp_out_values))
+        oneapi::dpl::__ranges::take_view_simple(experimental::ranges::views::all_read(__idx),
+                                                __intermediate_result_end),
+        ::std::forward<_Range2>(__values), experimental::ranges::views::all_write(__tmp_out_values))
         .wait();
 
     // Round 2: final reduction to get result for each segment of equal adjacent keys
@@ -736,7 +737,7 @@ __pattern_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2
 
     // Replicating first element of key views to be able to compare (i-1)-th and (i)-th key,
     //  dropping the last key for the i-1 sequence.  Only taking the appropriate number of keys to start with here.
-     auto __clipped_new_keys = oneapi::dpl::__ranges::take_view_simple(__new_keys, __intermediate_result_end);
+    auto __clipped_new_keys = oneapi::dpl::__ranges::take_view_simple(__new_keys, __intermediate_result_end);
 
     auto __k3 = oneapi::dpl::__ranges::replicate_start_view_simple(
         oneapi::dpl::__ranges::take_view_simple(__clipped_new_keys, __intermediate_result_end - 1), 1);
@@ -771,9 +772,10 @@ __pattern_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2
         oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__reduce2_wrapper>(
             ::std::forward<_ExecutionPolicy>(__exec)),
         unseq_backend::__brick_reduce_idx<_BinaryOperator, decltype(__intermediate_result_end)>(
-            __binary_op, __intermediate_result_end), __result_end,
-        oneapi::dpl::__ranges::take_view_simple(experimental::ranges::views::all_read(__idx), __result_end), experimental::ranges::views::all_read(__tmp_out_values),
-        ::std::forward<_Range4>(__out_values))
+            __binary_op, __intermediate_result_end),
+        __result_end,
+        oneapi::dpl::__ranges::take_view_simple(experimental::ranges::views::all_read(__idx), __result_end),
+        experimental::ranges::views::all_read(__tmp_out_values), ::std::forward<_Range4>(__out_values))
         .wait();
 
     return __result_end;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -957,22 +957,23 @@ struct __brick_shift_left
 
 struct __brick_assign_key_position
 {
-    // __a is a tuple {i, i-th+1 key, i-th key}
+    // __a is a tuple {i, (i-1)-th key, i-th key}
     // __b is a tuple {key, index} that stores the key and index where a new segment begins
     template <typename _T1, typename _T2>
     void
     operator()(const _T1& __a, _T2&& __b) const
     {
         ::std::get<0>(::std::forward<_T2>(__b)) = ::std::get<2>(__a);     // store new key value
-        ::std::get<1>(::std::forward<_T2>(__b)) = ::std::get<0>(__a) + 1; // store index of new key
+        ::std::get<1>(::std::forward<_T2>(__b)) = ::std::get<0>(__a); // store index of new key
     }
 };
 
+
 // reduce the values in a segment associated with a key
-template <typename _BinaryOperator>
+template <typename _BinaryOperator, typename _Size>
 struct __brick_reduce_idx
 {
-    __brick_reduce_idx(const _BinaryOperator& __b) : __binary_op(__b) {}
+    __brick_reduce_idx(const _BinaryOperator& __b, const _Size __n_) : __binary_op(__b), __n(__n_) {}
 
     template <typename _Idx, typename _Values>
     auto
@@ -981,22 +982,24 @@ struct __brick_reduce_idx
         auto __res = __values[__segment_begin];
         for (++__segment_begin; __segment_begin < __segment_end; ++__segment_begin)
             __res = __binary_op(__res, __values[__segment_begin]);
-
         return __res;
     }
 
-    template <typename _ItemId, typename _ReduceIdx, typename _Values, typename _OutValues>
+    template <typename _ItemId, typename _ReduceIdx, typename _KeysIn, typename _KeysOut, typename _Values, typename _OutValues>
     void
-    operator()(const _ItemId __idx, const _ReduceIdx& __segment_ends, const _Values& __values,
+    operator()(const _ItemId __idx, const _ReduceIdx& __segment_starts, const _KeysIn& __keys_in, const _KeysOut& __keys_out, const _Values& __values,
                _OutValues& __out_values) const
     {
-        using __value_type = decltype(__segment_ends[__idx]);
-        __value_type __segment_begin = (__idx == 0) ? __value_type(0) : __segment_ends[__idx - 1];
-        __out_values[__idx] = reduce(__segment_begin, __segment_ends[__idx], __values);
+        using __value_type = decltype(__segment_starts[__idx]);
+        __value_type __segment_end = (__idx == __segment_starts.size() - 1) ? __n : __segment_starts[__idx + 1];
+        __out_values[__idx] = reduce(__segment_starts[__idx], __segment_end, __values);
+        __keys_out[__idx] = __keys_in[__idx];
+        
     }
 
   private:
     _BinaryOperator __binary_op;
+    _Size __n;
 };
 
 } // namespace unseq_backend

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -990,7 +990,8 @@ struct __brick_reduce_idx
                _OutValues& __out_values) const
     {
         using __value_type = decltype(__segment_starts[__idx]);
-        __value_type __segment_end = (__idx == __segment_starts.size() - 1) ? __value_type(__n) : __segment_starts[__idx + 1];
+        __value_type __segment_end =
+            (__idx == __segment_starts.size() - 1) ? __value_type(__n) : __segment_starts[__idx + 1];
         __out_values[__idx] = reduce(__segment_starts[__idx], __segment_end, __values);
     }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -984,16 +984,14 @@ struct __brick_reduce_idx
         return __res;
     }
 
-    template <typename _ItemId, typename _ReduceIdx, typename _KeysIn, typename _KeysOut, typename _Values,
-              typename _OutValues>
+    template <typename _ItemId, typename _ReduceIdx, typename _Values, typename _OutValues>
     void
-    operator()(const _ItemId __idx, const _ReduceIdx& __segment_starts, const _KeysIn& __keys_in,
-               const _KeysOut& __keys_out, const _Values& __values, _OutValues& __out_values) const
+    operator()(const _ItemId __idx, const _ReduceIdx& __segment_starts, const _Values& __values,
+               _OutValues& __out_values) const
     {
         using __value_type = decltype(__segment_starts[__idx]);
-        __value_type __segment_end = (__idx == __segment_starts.size() - 1) ? __n : __segment_starts[__idx + 1];
+        __value_type __segment_end = (__idx == __segment_starts.size() - 1) ? __value_type(__n) : __segment_starts[__idx + 1];
         __out_values[__idx] = reduce(__segment_starts[__idx], __segment_end, __values);
-        __keys_out[__idx] = __keys_in[__idx];
     }
 
   private:

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -963,11 +963,10 @@ struct __brick_assign_key_position
     void
     operator()(const _T1& __a, _T2&& __b) const
     {
-        ::std::get<0>(::std::forward<_T2>(__b)) = ::std::get<2>(__a);     // store new key value
+        ::std::get<0>(::std::forward<_T2>(__b)) = ::std::get<2>(__a); // store new key value
         ::std::get<1>(::std::forward<_T2>(__b)) = ::std::get<0>(__a); // store index of new key
     }
 };
-
 
 // reduce the values in a segment associated with a key
 template <typename _BinaryOperator, typename _Size>
@@ -985,16 +984,16 @@ struct __brick_reduce_idx
         return __res;
     }
 
-    template <typename _ItemId, typename _ReduceIdx, typename _KeysIn, typename _KeysOut, typename _Values, typename _OutValues>
+    template <typename _ItemId, typename _ReduceIdx, typename _KeysIn, typename _KeysOut, typename _Values,
+              typename _OutValues>
     void
-    operator()(const _ItemId __idx, const _ReduceIdx& __segment_starts, const _KeysIn& __keys_in, const _KeysOut& __keys_out, const _Values& __values,
-               _OutValues& __out_values) const
+    operator()(const _ItemId __idx, const _ReduceIdx& __segment_starts, const _KeysIn& __keys_in,
+               const _KeysOut& __keys_out, const _Values& __values, _OutValues& __out_values) const
     {
         using __value_type = decltype(__segment_starts[__idx]);
         __value_type __segment_end = (__idx == __segment_starts.size() - 1) ? __n : __segment_starts[__idx + 1];
         __out_values[__idx] = reduce(__segment_starts[__idx], __segment_end, __values);
         __keys_out[__idx] = __keys_in[__idx];
-        
     }
 
   private:

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -356,6 +356,7 @@ struct replicate_start_view_simple
 
     replicate_start_view_simple(_R __rng, _Size __replicate_count) : __r(__rng), __repl_count(__replicate_count)
     {
+        // empty base ranges are not allowed, as you cannot replicate an element that does not exist
         assert(__repl_count >= 0 && __r.size() > 0);
     }
 
@@ -375,7 +376,8 @@ struct replicate_start_view_simple
     bool
     empty() const
     {
-        return __r.size() == 0;
+        // empty base ranges are not allowed, so replicate_start_view_simple is never empty
+        return false;
     }
 
     auto

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -244,7 +244,7 @@ struct reverse_view_simple
 
     _R __r;
 
-    reverse_view_simple(_R __rng) : __r(__rng){}
+    reverse_view_simple(_R __rng) : __r(__rng) {}
 
     //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range
     template <typename Idx>

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -244,6 +244,8 @@ struct reverse_view_simple
 
     _R __r;
 
+    reverse_view_simple(_R __rng) : __r(__rng){}
+
     //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range
     template <typename Idx>
     auto operator[](Idx __i) const -> decltype(__r[__i])

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -346,28 +346,30 @@ struct drop_view_simple
     }
 };
 
+//replicate_start_view_simple inserts replicates of the first element m times, then continues with the range as normal.
+// For counting iterator range {0,1,2,3,4,5,...}, and __replicate_count = 3, the result is {0,0,0,0,1,2,3,4,5,...} 
 template <typename _R, typename _Size>
 struct replicate_start_view_simple
 {
     _R __r;
-    _Size __n;
+    _Size __repl_count;
 
-    replicate_start_view_simple(_R __rng, _Size __size) : __r(__rng), __n(__size)
+    replicate_start_view_simple(_R __rng, _Size __replicate_count) : __r(__rng), __repl_count(__replicate_count)
     {
-        assert(__n >= 0 && __n < __r.size());
+        assert(__repl_count >= 0 && __r.size() > 0);
     }
 
     //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range
     template <typename Idx>
     auto operator[](Idx __i) const -> decltype(__r[__i])
     {
-        return (__i < __n) ? __r[0] : __r[__i - __n];
+        return (__i < __repl_count) ? __r[0] : __r[__i - __repl_count];
     }
 
     _Size
     size() const
     {
-        return __r.size() + __n;
+        return __r.size() + __repl_count;
     }
 
     bool

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -356,8 +356,7 @@ struct replicate_start_view_simple
 
     replicate_start_view_simple(_R __rng, _Size __replicate_count) : __r(__rng), __repl_count(__replicate_count)
     {
-        // empty base ranges are not allowed, as you cannot replicate an element that does not exist
-        assert(__repl_count >= 0 && __r.size() > 0);
+        assert(__repl_count >= 0);
     }
 
     //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range
@@ -370,14 +369,14 @@ struct replicate_start_view_simple
     _Size
     size() const
     {
-        return __r.size() + __repl_count;
+        // if base range is empty, replication does not extend the valid size
+        return (__r.empty()) ? 0 : __r.size() + __repl_count;
     }
 
     bool
     empty() const
     {
-        // empty base ranges are not allowed, so replicate_start_view_simple is never empty
-        return false;
+        return size() == 0;
     }
 
     auto

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -346,6 +346,43 @@ struct drop_view_simple
     }
 };
 
+template <typename _R, typename _Size>
+struct replicate_start_view_simple
+{
+    _R __r;
+    _Size __n;
+
+    replicate_start_view_simple(_R __rng, _Size __size) : __r(__rng), __n(__size)
+    {
+        assert(__n >= 0 && __n < __r.size());
+    }
+
+    //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range
+    template <typename Idx>
+    auto operator[](Idx __i) const -> decltype(__r[__i])
+    {
+        return (__i < __n) ? __r[0] : __r[__i - __n];
+    }
+
+    _Size
+    size() const
+    {
+        return __r.size() + __n;
+    }
+
+    bool
+    empty() const
+    {
+        return __r.size() == 0;
+    }
+
+    auto
+    base() const -> decltype(__r)
+    {
+        return __r;
+    }
+};
+
 //It is kind of pseudo-view for transfom_iterator support.
 template <typename _R, typename _F>
 struct transform_view_simple

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -347,7 +347,7 @@ struct drop_view_simple
 };
 
 //replicate_start_view_simple inserts replicates of the first element m times, then continues with the range as normal.
-// For counting iterator range {0,1,2,3,4,5,...}, and __replicate_count = 3, the result is {0,0,0,0,1,2,3,4,5,...} 
+// For counting iterator range {0,1,2,3,4,5,...}, and __replicate_count = 3, the result is {0,0,0,0,1,2,3,4,5,...}
 template <typename _R, typename _Size>
 struct replicate_start_view_simple
 {

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -260,11 +260,11 @@ test_flag_pred()
     sycl::queue q;
 
     // Initialize data
-    //T keys[n1] = { 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0 };
-    //T vals[n1] = { 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1 };
+    //T keys[n1] = { 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0 };
+    //T vals[n1] = { 1, 2, 3, 4, 1, 2, 3, 4, 1, 2, 3, 4, 1, 2 };
 
-    // keys_result = {1, 2, 3, 4, 1, 3, 1, 3, 0};
-    // vals_result = {1, 2, 3, 4, 2, 6, 2, 6, 0};
+    // keys_result = {1, 1, 1};
+    // vals_result = {11, 12, 10};
 
     auto prepare_data = [](int n, T* key_head, T* val_head, T* key_res_head, T* val_res_head)
         {
@@ -275,7 +275,7 @@ test_flag_pred()
             }
         };
 
-    constexpr int n = 13;
+    constexpr int n = 14;
     T key_head_on_host[n] = {};
     T val_head_on_host[n] = {};
     T key_res_head_on_host[n] = {};
@@ -314,7 +314,7 @@ test_flag_pred()
     ASSERT_EQUAL(key_res_head_on_host[1], T(1));
     ASSERT_EQUAL(val_res_head_on_host[1], T(12));
     ASSERT_EQUAL(key_res_head_on_host[2], T(1));
-    ASSERT_EQUAL(val_res_head_on_host[2], T(8));
+    ASSERT_EQUAL(val_res_head_on_host[2], T(10));
 }
 
 

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -308,13 +308,18 @@ test_flag_pred()
 
     // check values
     auto count = std::distance(key_res_head, res1.first);
-    ASSERT_EQUAL(count, 3);
-    ASSERT_EQUAL(key_res_head_on_host[0], T(1));
-    ASSERT_EQUAL(val_res_head_on_host[0], T(11));
-    ASSERT_EQUAL(key_res_head_on_host[1], T(1));
-    ASSERT_EQUAL(val_res_head_on_host[1], T(12));
-    ASSERT_EQUAL(key_res_head_on_host[2], T(1));
-    ASSERT_EQUAL(val_res_head_on_host[2], T(10));
+    std::int64_t expected_count = 3;
+    EXPECT_EQ(count, expected_count, "reduce_by_segment: incorrect number of segments");
+    T expected_key(1);
+    T expected_value(11);
+    EXPECT_EQ(key_res_head_on_host[0], expected_key, "reduce_by_segment: wrong key");
+    EXPECT_EQ(val_res_head_on_host[0], expected_value, "reduce_by_segment: wrong value");
+    EXPECT_EQ(key_res_head_on_host[1], expected_key, "reduce_by_segment: wrong key");
+    expected_value = T(12);
+    EXPECT_EQ(val_res_head_on_host[1], expected_value, "reduce_by_segment: wrong value");
+    EXPECT_EQ(key_res_head_on_host[2], expected_key, "reduce_by_segment: wrong key");
+    expected_value = T(10);
+    EXPECT_EQ(val_res_head_on_host[2], expected_value, "reduce_by_segment: wrong value");
 }
 
 


### PR DESCRIPTION
Summary
---
One type of predicate that is used for in reduce by segment is a flag predicate, where the start of each segment is marked with a 1.  

The reduce_by_segment range implementation does not work for such a predicate.  The reduce_by_segment range implementation has a pair of issues with such a predicate.  

1. It does not preserve the ordering of the predicate comparisons.  Internally, it calls `binary_pred(i+1, i)`, where such a predicate requires the predicate is always called in order `binary_pred(i, i+1)`.  _Note this is the predicate to determine segments, not the binary reduction operation._
2. It does not copy the first key from each segment to the output, but the last key from each segment.  The implementation is a two round reduction_by_segment limiting segments to the size of the workgroup in the first round.  With the flag predicate, this results in the "1" markers being erased in the second round, and values being incorrect in the result.

This PR allows reduce_by_segment to work with flag predicates, and changes the keys in the output to come from the first element of the segment rather than the last.  

Details
---
This change is accomplished by changing the range implementation to look for the beginnings of segments rather than the ends of segments.  This allows the local comparison tuple which detects the beginning of the segment to have access to the key value which should be copied along to the output (for both rounds).  

To properly align an `(i-1)` and an `(i)` view of the key range, this is a bit of challenge with existing range and view capabilities.  It is possible to do with `reverse_view` and `drop_view`, but complicates the code a lot, and requires extra storage.  To accomplish this, I have added `replicate_start_view_simple`, which replicates the first element of a range  `n` times at the start of a range, then continues the range as normal. 