### PR TITLE
Radix sort: simplify bit manipulations

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -291,22 +291,6 @@ __get_buckets_in_type(::std::uint32_t __radix_bits)
     return (sizeof(_T) * std::numeric_limits<unsigned char>::digits) / __radix_bits;
 }
 
-// bitwise inversion for descending sorting
-template <typename _T>
-_T
-__invert(_T __value)
-{
-    return ~__value;
-}
-
-// inversion of bool type has to be logical, not bitwise
-bool
-__invert(bool __value)
-{
-    return !__value;
-}
-
-
 // get bits value (bucket) in a certain radix position
 template <::std::uint32_t __radix_mask, typename _T>
 ::std::uint32_t


### PR DESCRIPTION
Yet another attempt to simplify (and maybe speed up a little) the radix sort implementation. This time, I reworked the type and bit manipulation utilities that prepare values for radix counting (i.e. the "ordered" family in the current implementation).

The idea was to make it less "orthogonal" and combine masking for signed ints and floats with the inversion for descending sort. And I only use one level of generalization (via function overloads) instead of three in the current implementation - so I hope it will also be simpler to understand. As a bonus comes a reasonable and potentially reusable implementation of C++ 20 `bit_cast<>`.

I kept the old code under `#if 0` just to simplify reviewing; will remove it later, once you take a look.

@dmitriy-sobolev @MikeDvorskiy @adamfidel @danhoeflinger @julianmi please review
@rarutyun @reble @SergeyKopienko please look if you have time; I'd like to know if the new implementation is better or worse for understanding than the old one.