### PR TITLE
Required to use <sycl/sycl.hpp> instead of <cl/sycl.hpp>

### DIFF
--- a/documentation/library_guide/api_for_sycl_kernels/random.rst
+++ b/documentation/library_guide/api_for_sycl_kernels/random.rst
@@ -90,7 +90,7 @@ Random number generation is available for SYCL* device-side and host-side code. 
 
     #include <iostream>
     #include <vector>
-    #include <CL/sycl.hpp>
+    #include <sycl/sycl.hpp>
     #include <oneapi/dpl/random>
 
     int main() {

--- a/documentation/library_guide/api_for_sycl_kernels/tested_standard_cpp_api.rst
+++ b/documentation/library_guide/api_for_sycl_kernels/tested_standard_cpp_api.rst
@@ -14,7 +14,7 @@ Below is an example code that shows how to use ``oneapi::dpl::swap`` in SYCL dev
 
 .. code:: cpp
 
-  #include <CL/sycl.hpp>
+  #include <sycl/sycl.hpp>
   #include <oneapi/dpl/utility>
   #include <iostream>
   constexpr sycl::access::mode sycl_read_write = sycl::access::mode::read_write;

--- a/documentation/library_guide/parallel_api/async_api.rst
+++ b/documentation/library_guide/parallel_api/async_api.rst
@@ -52,7 +52,7 @@ Example of Async API Usage
 
     #include <oneapi/dpl/execution>
     #include <oneapi/dpl/async>
-    #include <CL/sycl.hpp>
+    #include <sycl/sycl.hpp>
     
     int main() {
         using namespace oneapi;

--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -40,7 +40,7 @@ To use the functions, add ``#include <oneapi/dpl/iterator>`` to your code. For e
   #include <oneapi/dpl/execution>
   #include <oneapi/dpl/algorithm>
   #include <oneapi/dpl/iterator>
-  #include <CL/sycl.hpp>
+  #include <sycl/sycl.hpp>
   int main(){
     sycl::buffer<int> buf { 1000 };
     auto buf_begin = oneapi::dpl::begin(buf);
@@ -65,7 +65,7 @@ the buffer were created for the same queue. For example:
 
   #include <oneapi/dpl/execution>
   #include <oneapi/dpl/algorithm>
-  #include <CL/sycl.hpp>
+  #include <sycl/sycl.hpp>
   int main(){
     sycl::queue q;
     const int n = 1000;
@@ -83,7 +83,7 @@ Alternatively, use ``std::vector`` with a USM allocator. For example:
 
   #include <oneapi/dpl/execution>
   #include <oneapi/dpl/algorithm>
-  #include <CL/sycl.hpp>
+  #include <sycl/sycl.hpp>
   int main(){
     const int n = 1000;
     auto policy = oneapi::dpl::execution::dpcpp_default;

--- a/examples/gamma_correction/src/main.cpp
+++ b/examples/gamma_correction/src/main.cpp
@@ -10,7 +10,7 @@
 #include <oneapi/dpl/iterator>
 
 #if !BUILD_FOR_HOST
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #endif
 #include <iomanip>
 #include <iostream>

--- a/examples/histogram/src/main.cpp
+++ b/examples/histogram/src/main.cpp
@@ -9,7 +9,7 @@
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/numeric>
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 #include <random>
 

--- a/examples/random/src/main.cpp
+++ b/examples/random/src/main.cpp
@@ -16,7 +16,7 @@
 // oneDPL headers should be included before standard headers
 #include <oneapi/dpl/random>
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 #include <vector>
 

--- a/examples/stable_sort_by_key/src/main.cpp
+++ b/examples/stable_sort_by_key/src/main.cpp
@@ -9,7 +9,7 @@
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/iterator>
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <iostream>
 
 int main() {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -21,8 +21,11 @@
 #ifndef _ONEDPL_sycl_defs_H
 #define _ONEDPL_sycl_defs_H
 
-#include <CL/sycl.hpp>
-
+#if __has_include(<sycl/sycl.hpp>)
+#    include <sycl/sycl.hpp>
+#else
+#    include <CL/sycl.hpp>
+#endif
 #include <memory>
 
 // Combine SYCL runtime library version

--- a/test/general/dpl_namespace.pass.cpp
+++ b/test/general/dpl_namespace.pass.cpp
@@ -23,10 +23,6 @@
 #include <iostream>
 #include <tuple>
 
-#if TEST_DPCPP_BACKEND_PRESENT
-#    include THE_SYCL_HPP
-#endif
-
 int main()
 {
 #if TEST_DPCPP_BACKEND_PRESENT

--- a/test/general/dpl_namespace.pass.cpp
+++ b/test/general/dpl_namespace.pass.cpp
@@ -24,7 +24,7 @@
 #include <tuple>
 
 #if TEST_DPCPP_BACKEND_PRESENT
-#   include <CL/sycl.hpp>
+#    include THE_SYCL_HPP
 #endif
 
 int main()

--- a/test/general/interface_check.pass.cpp
+++ b/test/general/interface_check.pass.cpp
@@ -26,10 +26,6 @@
 #include <vector>
 #include "support/test_config.h"
 
-#if TEST_DPCPP_BACKEND_PRESENT
-#include THE_SYCL_HPP
-#endif
-
 template <typename Policy, typename NewName>
 struct rebind_policy { using type = Policy; };
 

--- a/test/general/interface_check.pass.cpp
+++ b/test/general/interface_check.pass.cpp
@@ -27,7 +27,7 @@
 #include "support/test_config.h"
 
 #if TEST_DPCPP_BACKEND_PRESENT
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 #endif
 
 template <typename Policy, typename NewName>

--- a/test/general/lambda_naming.pass.cpp
+++ b/test/general/lambda_naming.pass.cpp
@@ -23,7 +23,7 @@
 #include "support/utils.h"
 
 #if TEST_DPCPP_BACKEND_PRESENT
-#    include <CL/sycl.hpp>
+#    include THE_SYCL_HPP
 #endif
 
 using namespace TestUtils;

--- a/test/general/lambda_naming.pass.cpp
+++ b/test/general/lambda_naming.pass.cpp
@@ -22,10 +22,6 @@
 
 #include "support/utils.h"
 
-#if TEST_DPCPP_BACKEND_PRESENT
-#    include THE_SYCL_HPP
-#endif
-
 using namespace TestUtils;
 
 // This is the simple test for compilation only, to check if lambda naming works correctly

--- a/test/general/test_policies.pass.cpp
+++ b/test/general/test_policies.pass.cpp
@@ -25,8 +25,6 @@
 
 #if TEST_DPCPP_BACKEND_PRESENT
 
-#include THE_SYCL_HPP
-
 template<typename Policy>
 void test_policy_instance(const Policy& policy)
 {

--- a/test/general/test_policies.pass.cpp
+++ b/test/general/test_policies.pass.cpp
@@ -25,7 +25,7 @@
 
 #if TEST_DPCPP_BACKEND_PRESENT
 
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 template<typename Policy>
 void test_policy_instance(const Policy& policy)

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
@@ -22,7 +22,7 @@
 #include "support/binary_search_utils.h"
 
 #if TEST_DPCPP_BACKEND_PRESENT
-#    include <CL/sycl.hpp>
+#    include THE_SYCL_HPP
 
 using namespace oneapi::dpl::execution;
 #endif

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
@@ -22,8 +22,6 @@
 #include "support/binary_search_utils.h"
 
 #if TEST_DPCPP_BACKEND_PRESENT
-#    include THE_SYCL_HPP
-
 using namespace oneapi::dpl::execution;
 #endif
 using namespace TestUtils;

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
@@ -21,10 +21,6 @@
 #include "support/utils.h"
 #include "support/binary_search_utils.h"
 
-#if TEST_DPCPP_BACKEND_PRESENT
-#    include THE_SYCL_HPP
-#endif
-
 #include <cmath>
 
 #if TEST_DPCPP_BACKEND_PRESENT

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
@@ -22,7 +22,7 @@
 #include "support/binary_search_utils.h"
 
 #if TEST_DPCPP_BACKEND_PRESENT
-#    include <CL/sycl.hpp>
+#    include THE_SYCL_HPP
 #endif
 
 #include <cmath>

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
@@ -22,7 +22,7 @@
 #include "support/binary_search_utils.h"
 
 #if TEST_DPCPP_BACKEND_PRESENT
-#    include <CL/sycl.hpp>
+#    include THE_SYCL_HPP
 
 using namespace oneapi::dpl::execution;
 #endif

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
@@ -22,8 +22,6 @@
 #include "support/binary_search_utils.h"
 
 #if TEST_DPCPP_BACKEND_PRESENT
-#    include THE_SYCL_HPP
-
 using namespace oneapi::dpl::execution;
 #endif
 using namespace TestUtils;

--- a/test/parallel_api/experimental/asynch-scan.pass.cpp
+++ b/test/parallel_api/experimental/asynch-scan.pass.cpp
@@ -20,7 +20,7 @@
 
 #if TEST_DPCPP_BACKEND_PRESENT
 #   include "oneapi/dpl/async"
-#   include <CL/sycl.hpp>
+#   include THE_SYCL_HPP
 #endif
 
 #include <iostream>

--- a/test/parallel_api/experimental/asynch-scan.pass.cpp
+++ b/test/parallel_api/experimental/asynch-scan.pass.cpp
@@ -20,7 +20,6 @@
 
 #if TEST_DPCPP_BACKEND_PRESENT
 #   include "oneapi/dpl/async"
-#   include THE_SYCL_HPP
 #endif
 
 #include <iostream>

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -23,7 +23,6 @@
 
 
 #if TEST_DPCPP_BACKEND_PRESENT
-#include THE_SYCL_HPP
 
 using namespace oneapi::dpl::execution;
 #endif

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -23,7 +23,7 @@
 
 
 #if TEST_DPCPP_BACKEND_PRESENT
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 using namespace oneapi::dpl::execution;
 #endif

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -17,13 +17,13 @@
 #include "oneapi/dpl/algorithm"
 #include "oneapi/dpl/numeric"
 #include "oneapi/dpl/iterator"
+#include "oneapi/dpl/complex"
 
 #include "support/test_config.h"
 #include "support/utils.h"
 
 #include <iostream>
 #include <iomanip>
-#include <oneapi/dpl/complex>
 
 template<typename _T1, typename _T2>
 void ASSERT_EQUAL(_T1&& X, _T2&& Y) {

--- a/test/support/test_iterators.h
+++ b/test/support/test_iterators.h
@@ -19,6 +19,8 @@
 #include <iterator>
 #include <cstddef>
 
+#include "utils.h"
+
 #define DELETE_FUNCTION = delete
 
 template <class It>

--- a/test/support/test_iterators.h
+++ b/test/support/test_iterators.h
@@ -19,8 +19,6 @@
 #include <iterator>
 #include <cstddef>
 
-#include "utils.h"
-
 #define DELETE_FUNCTION = delete
 
 template <class It>

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -42,6 +42,12 @@
 #    include "utils_sycl.h"
 #endif
 
+#if __has_include(<sycl/sycl.hpp>)
+#    define THE_SYCL_HPP <sycl/sycl.hpp>
+#else
+#    define THE_SYCL_HPP <CL/sycl.hpp>
+#endif
+
 namespace TestUtils
 {
 

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -42,12 +42,6 @@
 #    include "utils_sycl.h"
 #endif
 
-#if __has_include(<sycl/sycl.hpp>)
-#    define THE_SYCL_HPP <sycl/sycl.hpp>
-#else
-#    define THE_SYCL_HPP <CL/sycl.hpp>
-#endif
-
 namespace TestUtils
 {
 

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy.pass.cpp
@@ -18,7 +18,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 template <typename _T1, typename _T2>
 void

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy.pass.cpp
@@ -14,10 +14,11 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 template <typename _T1, typename _T2>
 void

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy.pass.cpp
@@ -14,6 +14,7 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy.pass.cpp
@@ -14,7 +14,6 @@
 
 #include <oneapi/dpl/algorithm>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy_backward.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy_backward.pass.cpp
@@ -18,7 +18,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 template <typename _T1, typename _T2>
 void

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy_backward.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy_backward.pass.cpp
@@ -14,10 +14,11 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 template <typename _T1, typename _T2>
 void

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy_backward.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy_backward.pass.cpp
@@ -14,6 +14,7 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy_backward.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy_backward.pass.cpp
@@ -14,7 +14,6 @@
 
 #include <oneapi/dpl/algorithm>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy_if.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy_if.pass.cpp
@@ -14,6 +14,7 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy_if.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy_if.pass.cpp
@@ -14,7 +14,6 @@
 
 #include <oneapi/dpl/algorithm>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy_if.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy_if.pass.cpp
@@ -14,10 +14,11 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 struct Pred
 {

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy_if.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy_if.pass.cpp
@@ -18,7 +18,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 struct Pred
 {

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy_n.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy_n.pass.cpp
@@ -14,10 +14,11 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 template <class Iter1, class Iter2>
 class KernelTest;

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy_n.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy_n.pass.cpp
@@ -14,6 +14,7 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy_n.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy_n.pass.cpp
@@ -14,7 +14,6 @@
 
 #include <oneapi/dpl/algorithm>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy_n.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy_n.pass.cpp
@@ -18,7 +18,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 template <class Iter1, class Iter2>
 class KernelTest;

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.fill/xpu_fill.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.fill/xpu_fill.pass.cpp
@@ -14,10 +14,11 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 template <class Iter>
 void

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.fill/xpu_fill.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.fill/xpu_fill.pass.cpp
@@ -14,6 +14,7 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.fill/xpu_fill.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.fill/xpu_fill.pass.cpp
@@ -18,7 +18,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 template <class Iter>
 void

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.fill/xpu_fill.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.fill/xpu_fill.pass.cpp
@@ -14,7 +14,6 @@
 
 #include <oneapi/dpl/algorithm>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.fill/xpu_fill_n.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.fill/xpu_fill_n.pass.cpp
@@ -14,10 +14,11 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 template <class Iter>
 void

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.fill/xpu_fill_n.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.fill/xpu_fill_n.pass.cpp
@@ -14,6 +14,7 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.fill/xpu_fill_n.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.fill/xpu_fill_n.pass.cpp
@@ -18,7 +18,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 template <class Iter>
 void

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.fill/xpu_fill_n.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.fill/xpu_fill_n.pass.cpp
@@ -14,7 +14,6 @@
 
 #include <oneapi/dpl/algorithm>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.move/xpu_move.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.move/xpu_move.pass.cpp
@@ -18,7 +18,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 template <typename _T1, typename _T2>
 void

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.move/xpu_move.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.move/xpu_move.pass.cpp
@@ -14,10 +14,11 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 template <typename _T1, typename _T2>
 void

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.move/xpu_move.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.move/xpu_move.pass.cpp
@@ -14,6 +14,7 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.move/xpu_move.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.move/xpu_move.pass.cpp
@@ -14,7 +14,6 @@
 
 #include <oneapi/dpl/algorithm>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.move/xpu_move_backward.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.move/xpu_move_backward.pass.cpp
@@ -18,7 +18,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 template <typename _T1, typename _T2>
 void

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.move/xpu_move_backward.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.move/xpu_move_backward.pass.cpp
@@ -14,10 +14,11 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 template <typename _T1, typename _T2>
 void

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.move/xpu_move_backward.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.move/xpu_move_backward.pass.cpp
@@ -14,6 +14,7 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.move/xpu_move_backward.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.move/xpu_move_backward.pass.cpp
@@ -14,7 +14,6 @@
 
 #include <oneapi/dpl/algorithm>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.all_of/xpu_all_of.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.all_of/xpu_all_of.pass.cpp
@@ -18,7 +18,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 using oneapi::dpl::all_of;
 

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.all_of/xpu_all_of.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.all_of/xpu_all_of.pass.cpp
@@ -14,6 +14,7 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.all_of/xpu_all_of.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.all_of/xpu_all_of.pass.cpp
@@ -14,7 +14,6 @@
 
 #include <oneapi/dpl/algorithm>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.all_of/xpu_all_of.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.all_of/xpu_all_of.pass.cpp
@@ -14,10 +14,11 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 using oneapi::dpl::all_of;
 

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.any_of/xpu_any_of.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.any_of/xpu_any_of.pass.cpp
@@ -18,7 +18,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 using oneapi::dpl::any_of;
 

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.any_of/xpu_any_of.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.any_of/xpu_any_of.pass.cpp
@@ -14,10 +14,11 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 using oneapi::dpl::any_of;
 

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.any_of/xpu_any_of.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.any_of/xpu_any_of.pass.cpp
@@ -14,6 +14,7 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.any_of/xpu_any_of.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.any_of/xpu_any_of.pass.cpp
@@ -14,7 +14,6 @@
 
 #include <oneapi/dpl/algorithm>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.count/xpu_count.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.count/xpu_count.pass.cpp
@@ -14,6 +14,7 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.count/xpu_count.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.count/xpu_count.pass.cpp
@@ -14,7 +14,6 @@
 
 #include <oneapi/dpl/algorithm>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.count/xpu_count.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.count/xpu_count.pass.cpp
@@ -18,7 +18,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 void
 kernel_test(sycl::queue& deviceQueue)

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.count/xpu_count.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.count/xpu_count.pass.cpp
@@ -14,10 +14,11 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 void
 kernel_test(sycl::queue& deviceQueue)

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.count/xpu_count_if.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.count/xpu_count_if.pass.cpp
@@ -14,10 +14,11 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 struct eq
 {

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.count/xpu_count_if.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.count/xpu_count_if.pass.cpp
@@ -14,6 +14,7 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.count/xpu_count_if.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.count/xpu_count_if.pass.cpp
@@ -14,7 +14,6 @@
 
 #include <oneapi/dpl/algorithm>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.count/xpu_count_if.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.count/xpu_count_if.pass.cpp
@@ -18,7 +18,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 struct eq
 {

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.find/xpu_find.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.find/xpu_find.pass.cpp
@@ -14,10 +14,11 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 template <class Iter>
 void

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.find/xpu_find.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.find/xpu_find.pass.cpp
@@ -14,6 +14,7 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.find/xpu_find.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.find/xpu_find.pass.cpp
@@ -18,7 +18,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 template <class Iter>
 void

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.find/xpu_find.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.find/xpu_find.pass.cpp
@@ -14,7 +14,6 @@
 
 #include <oneapi/dpl/algorithm>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.find/xpu_find_if.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.find/xpu_find_if.pass.cpp
@@ -14,10 +14,11 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 struct eq
 {

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.find/xpu_find_if.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.find/xpu_find_if.pass.cpp
@@ -14,6 +14,7 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.find/xpu_find_if.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.find/xpu_find_if.pass.cpp
@@ -14,7 +14,6 @@
 
 #include <oneapi/dpl/algorithm>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.find/xpu_find_if.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.find/xpu_find_if.pass.cpp
@@ -18,7 +18,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 struct eq
 {

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.find/xpu_find_if_not.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.find/xpu_find_if_not.pass.cpp
@@ -18,7 +18,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 struct ne
 {

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.find/xpu_find_if_not.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.find/xpu_find_if_not.pass.cpp
@@ -14,6 +14,7 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.find/xpu_find_if_not.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.find/xpu_find_if_not.pass.cpp
@@ -14,7 +14,6 @@
 
 #include <oneapi/dpl/algorithm>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.find/xpu_find_if_not.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.find/xpu_find_if_not.pass.cpp
@@ -14,10 +14,11 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 struct ne
 {

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.foreach/xpu_for_each.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.foreach/xpu_for_each.pass.cpp
@@ -14,10 +14,11 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 struct for_each_test
 {

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.foreach/xpu_for_each.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.foreach/xpu_for_each.pass.cpp
@@ -18,7 +18,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 struct for_each_test
 {

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.foreach/xpu_for_each.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.foreach/xpu_for_each.pass.cpp
@@ -14,6 +14,7 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.foreach/xpu_for_each.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.foreach/xpu_for_each.pass.cpp
@@ -14,7 +14,6 @@
 
 #include <oneapi/dpl/algorithm>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.foreach/xpu_for_each_n.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.foreach/xpu_for_each_n.pass.cpp
@@ -15,7 +15,6 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.foreach/xpu_for_each_n.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.foreach/xpu_for_each_n.pass.cpp
@@ -19,7 +19,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 template <typename _T1, typename _T2>
 void

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.foreach/xpu_for_each_n.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.foreach/xpu_for_each_n.pass.cpp
@@ -15,6 +15,7 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.foreach/xpu_for_each_n.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.foreach/xpu_for_each_n.pass.cpp
@@ -15,10 +15,11 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 template <typename _T1, typename _T2>
 void

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.is_permutation/xpu_is_permutation.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.is_permutation/xpu_is_permutation.pass.cpp
@@ -18,7 +18,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 template <class Iter1>
 void

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.is_permutation/xpu_is_permutation.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.is_permutation/xpu_is_permutation.pass.cpp
@@ -14,6 +14,7 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.is_permutation/xpu_is_permutation.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.is_permutation/xpu_is_permutation.pass.cpp
@@ -14,7 +14,6 @@
 
 #include <oneapi/dpl/algorithm>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.is_permutation/xpu_is_permutation.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.is_permutation/xpu_is_permutation.pass.cpp
@@ -14,10 +14,11 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 template <class Iter1>
 void

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.is_permutation/xpu_is_permutation_pred.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.is_permutation/xpu_is_permutation_pred.pass.cpp
@@ -18,7 +18,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 struct S
 {

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.is_permutation/xpu_is_permutation_pred.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.is_permutation/xpu_is_permutation_pred.pass.cpp
@@ -14,10 +14,11 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 struct S
 {

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.is_permutation/xpu_is_permutation_pred.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.is_permutation/xpu_is_permutation_pred.pass.cpp
@@ -14,6 +14,7 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.is_permutation/xpu_is_permutation_pred.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.is_permutation/xpu_is_permutation_pred.pass.cpp
@@ -14,7 +14,6 @@
 
 #include <oneapi/dpl/algorithm>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.none_of/xpu_none_of.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.none_of/xpu_none_of.pass.cpp
@@ -14,10 +14,11 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 using oneapi::dpl::none_of;
 

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.none_of/xpu_none_of.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.none_of/xpu_none_of.pass.cpp
@@ -18,7 +18,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 using oneapi::dpl::none_of;
 

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.none_of/xpu_none_of.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.none_of/xpu_none_of.pass.cpp
@@ -14,6 +14,7 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.none_of/xpu_none_of.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.none_of/xpu_none_of.pass.cpp
@@ -14,7 +14,6 @@
 
 #include <oneapi/dpl/algorithm>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap.pass.cpp
@@ -18,7 +18,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 template <class Iter1>
 void

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap.pass.cpp
@@ -14,6 +14,7 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap.pass.cpp
@@ -14,7 +14,6 @@
 
 #include <oneapi/dpl/algorithm>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap.pass.cpp
@@ -14,10 +14,11 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 template <class Iter1>
 void

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap_comp.pass.cpp
@@ -15,7 +15,6 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap_comp.pass.cpp
@@ -19,7 +19,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 template <class Iter1>
 void

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap_comp.pass.cpp
@@ -15,6 +15,7 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap_comp.pass.cpp
@@ -15,10 +15,11 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 template <class Iter1>
 void

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap_until.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap_until.pass.cpp
@@ -18,7 +18,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 template <class Iter1>
 void

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap_until.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap_until.pass.cpp
@@ -14,6 +14,7 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap_until.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap_until.pass.cpp
@@ -14,7 +14,6 @@
 
 #include <oneapi/dpl/algorithm>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap_until.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap_until.pass.cpp
@@ -14,10 +14,11 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 template <class Iter1>
 void

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap_until_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap_until_comp.pass.cpp
@@ -15,7 +15,6 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap_until_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap_until_comp.pass.cpp
@@ -19,7 +19,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 template <class Iter1>
 void

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap_until_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap_until_comp.pass.cpp
@@ -15,6 +15,7 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap_until_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap_until_comp.pass.cpp
@@ -15,10 +15,11 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 template <class Iter1>
 void

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/make.heap/xpu_make_heap.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/make.heap/xpu_make_heap.pass.cpp
@@ -14,10 +14,11 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 template <class Iter>
 void

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/make.heap/xpu_make_heap.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/make.heap/xpu_make_heap.pass.cpp
@@ -14,6 +14,7 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/make.heap/xpu_make_heap.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/make.heap/xpu_make_heap.pass.cpp
@@ -18,7 +18,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 template <class Iter>
 void

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/make.heap/xpu_make_heap.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/make.heap/xpu_make_heap.pass.cpp
@@ -14,7 +14,6 @@
 
 #include <oneapi/dpl/algorithm>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/make.heap/xpu_make_heap_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/make.heap/xpu_make_heap_comp.pass.cpp
@@ -15,10 +15,11 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 template <class Iter>
 void

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/make.heap/xpu_make_heap_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/make.heap/xpu_make_heap_comp.pass.cpp
@@ -15,7 +15,6 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/make.heap/xpu_make_heap_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/make.heap/xpu_make_heap_comp.pass.cpp
@@ -15,6 +15,7 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/make.heap/xpu_make_heap_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/make.heap/xpu_make_heap_comp.pass.cpp
@@ -19,7 +19,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 template <class Iter>
 void

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/pop.heap/xpu_pop_heap.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/pop.heap/xpu_pop_heap.pass.cpp
@@ -14,10 +14,11 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 template <class Iter>
 void

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/pop.heap/xpu_pop_heap.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/pop.heap/xpu_pop_heap.pass.cpp
@@ -14,6 +14,7 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/pop.heap/xpu_pop_heap.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/pop.heap/xpu_pop_heap.pass.cpp
@@ -18,7 +18,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 template <class Iter>
 void

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/pop.heap/xpu_pop_heap.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/pop.heap/xpu_pop_heap.pass.cpp
@@ -14,7 +14,6 @@
 
 #include <oneapi/dpl/algorithm>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/pop.heap/xpu_pop_heap_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/pop.heap/xpu_pop_heap_comp.pass.cpp
@@ -15,10 +15,11 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 template <class Iter>
 void

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/pop.heap/xpu_pop_heap_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/pop.heap/xpu_pop_heap_comp.pass.cpp
@@ -15,7 +15,6 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/pop.heap/xpu_pop_heap_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/pop.heap/xpu_pop_heap_comp.pass.cpp
@@ -15,6 +15,7 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/pop.heap/xpu_pop_heap_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/pop.heap/xpu_pop_heap_comp.pass.cpp
@@ -19,7 +19,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 template <class Iter>
 void

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/push.heap/xpu_push_heap.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/push.heap/xpu_push_heap.pass.cpp
@@ -14,10 +14,11 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 template <class Iter>
 void

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/push.heap/xpu_push_heap.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/push.heap/xpu_push_heap.pass.cpp
@@ -14,6 +14,7 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/push.heap/xpu_push_heap.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/push.heap/xpu_push_heap.pass.cpp
@@ -18,7 +18,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 template <class Iter>
 void

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/push.heap/xpu_push_heap.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/push.heap/xpu_push_heap.pass.cpp
@@ -14,7 +14,6 @@
 
 #include <oneapi/dpl/algorithm>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/push.heap/xpu_push_heap_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/push.heap/xpu_push_heap_comp.pass.cpp
@@ -15,10 +15,11 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 template <class Iter>
 void

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/push.heap/xpu_push_heap_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/push.heap/xpu_push_heap_comp.pass.cpp
@@ -15,7 +15,6 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/push.heap/xpu_push_heap_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/push.heap/xpu_push_heap_comp.pass.cpp
@@ -15,6 +15,7 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/push.heap/xpu_push_heap_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/push.heap/xpu_push_heap_comp.pass.cpp
@@ -19,7 +19,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 template <class Iter>
 void

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted.pass.cpp
@@ -14,10 +14,11 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 template <class Iter>
 void

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted.pass.cpp
@@ -14,6 +14,7 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted.pass.cpp
@@ -18,7 +18,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 template <class Iter>
 void

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted.pass.cpp
@@ -14,7 +14,6 @@
 
 #include <oneapi/dpl/algorithm>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted_comp.pass.cpp
@@ -15,10 +15,11 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 template <class Iter>
 void

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted_comp.pass.cpp
@@ -15,7 +15,6 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted_comp.pass.cpp
@@ -15,6 +15,7 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted_comp.pass.cpp
@@ -19,7 +19,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 template <class Iter>
 void

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted_until.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted_until.pass.cpp
@@ -14,10 +14,11 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 template <class Iter>
 void

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted_until.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted_until.pass.cpp
@@ -14,6 +14,7 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted_until.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted_until.pass.cpp
@@ -18,7 +18,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 template <class Iter>
 void

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted_until.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted_until.pass.cpp
@@ -14,7 +14,6 @@
 
 #include <oneapi/dpl/algorithm>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted_until_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted_until_comp.pass.cpp
@@ -15,10 +15,11 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 template <class Iter>
 void

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted_until_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted_until_comp.pass.cpp
@@ -15,7 +15,6 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted_until_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted_until_comp.pass.cpp
@@ -15,6 +15,7 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted_until_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted_until_comp.pass.cpp
@@ -19,7 +19,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 template <class Iter>
 void

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort.copy/xpu_partial_sort_copy.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort.copy/xpu_partial_sort_copy.pass.cpp
@@ -15,10 +15,11 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 template <class Iter>
 void

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort.copy/xpu_partial_sort_copy.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort.copy/xpu_partial_sort_copy.pass.cpp
@@ -15,7 +15,6 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort.copy/xpu_partial_sort_copy.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort.copy/xpu_partial_sort_copy.pass.cpp
@@ -15,6 +15,7 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort.copy/xpu_partial_sort_copy.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort.copy/xpu_partial_sort_copy.pass.cpp
@@ -19,7 +19,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 template <class Iter>
 void

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort.copy/xpu_partial_sort_copy_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort.copy/xpu_partial_sort_copy_comp.pass.cpp
@@ -15,10 +15,11 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 template <class Iter>
 void

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort.copy/xpu_partial_sort_copy_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort.copy/xpu_partial_sort_copy_comp.pass.cpp
@@ -15,7 +15,6 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort.copy/xpu_partial_sort_copy_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort.copy/xpu_partial_sort_copy_comp.pass.cpp
@@ -15,6 +15,7 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort.copy/xpu_partial_sort_copy_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort.copy/xpu_partial_sort_copy_comp.pass.cpp
@@ -19,7 +19,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 template <class Iter>
 void

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort/xpu_partial_sort.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort/xpu_partial_sort.pass.cpp
@@ -15,10 +15,11 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 template <class Iter>
 void

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort/xpu_partial_sort.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort/xpu_partial_sort.pass.cpp
@@ -15,7 +15,6 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort/xpu_partial_sort.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort/xpu_partial_sort.pass.cpp
@@ -15,6 +15,7 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort/xpu_partial_sort.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort/xpu_partial_sort.pass.cpp
@@ -19,7 +19,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 template <class Iter>
 void

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort/xpu_partial_sort_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort/xpu_partial_sort_comp.pass.cpp
@@ -15,10 +15,11 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 template <class Iter>
 void

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort/xpu_partial_sort_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort/xpu_partial_sort_comp.pass.cpp
@@ -15,7 +15,6 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort/xpu_partial_sort_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort/xpu_partial_sort_comp.pass.cpp
@@ -15,6 +15,7 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort/xpu_partial_sort_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort/xpu_partial_sort_comp.pass.cpp
@@ -19,7 +19,6 @@
 #include "support/test_iterators.h"
 
 #include <cassert>
-#include THE_SYCL_HPP
 
 template <class Iter>
 void

--- a/test/xpu_api/cmath/nearbyint/xpu_nearbyint.pass.cpp
+++ b/test/xpu_api/cmath/nearbyint/xpu_nearbyint.pass.cpp
@@ -23,7 +23,6 @@
 #include <vector>
 
 #if TEST_DPCPP_BACKEND_PRESENT
-#include THE_SYCL_HPP
 
 constexpr sycl::access::mode sycl_read = sycl::access::mode::read;
 constexpr sycl::access::mode sycl_write = sycl::access::mode::write;

--- a/test/xpu_api/cmath/nearbyint/xpu_nearbyint.pass.cpp
+++ b/test/xpu_api/cmath/nearbyint/xpu_nearbyint.pass.cpp
@@ -23,7 +23,7 @@
 #include <vector>
 
 #if TEST_DPCPP_BACKEND_PRESENT
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 
 constexpr sycl::access::mode sycl_read = sycl::access::mode::read;
 constexpr sycl::access::mode sycl_write = sycl::access::mode::write;

--- a/test/xpu_api/functional/test_functional.cpp
+++ b/test/xpu_api/functional/test_functional.cpp
@@ -21,10 +21,12 @@
 
 #include <oneapi/dpl/functional>
 
+#include "support/utils.h"
+
 #include <iostream>
 
 #ifndef ONEDPL_STANDARD_POLICIES_ONLY
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 #else
 #include <vector>
 #endif

--- a/test/xpu_api/functional/test_functional.cpp
+++ b/test/xpu_api/functional/test_functional.cpp
@@ -26,9 +26,13 @@
 #include <iostream>
 
 #ifndef ONEDPL_STANDARD_POLICIES_ONLY
-#include THE_SYCL_HPP
+#    if __has_include(<sycl/sycl.hpp>)
+#        include <sycl/sycl.hpp>
+#    else
+#        include <CL/sycl.hpp>
+#    endif
 #else
-#include <vector>
+#    include <vector>
 #endif
 
 template<typename Iterator, typename T>

--- a/test/xpu_api/functional/test_functional.cpp
+++ b/test/xpu_api/functional/test_functional.cpp
@@ -21,8 +21,6 @@
 
 #include <oneapi/dpl/functional>
 
-#include "support/utils.h"
-
 #include <iostream>
 
 #ifndef ONEDPL_STANDARD_POLICIES_ONLY

--- a/test/xpu_api/numerics/numeric.ops/accumulate/xpu_accumulate.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/accumulate/xpu_accumulate.pass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-
 #include <oneapi/dpl/numeric>
+
+#include <iostream>
 
 #include "support/utils_sycl.h"
 #include "support/test_iterators.h"

--- a/test/xpu_api/numerics/numeric.ops/accumulate/xpu_accumulate.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/accumulate/xpu_accumulate.pass.cpp
@@ -17,6 +17,7 @@
 
 #include <oneapi/dpl/numeric>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 constexpr sycl::access::mode sycl_read = sycl::access::mode::read;

--- a/test/xpu_api/numerics/numeric.ops/accumulate/xpu_accumulate.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/accumulate/xpu_accumulate.pass.cpp
@@ -17,7 +17,6 @@
 
 #include <oneapi/dpl/numeric>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 constexpr sycl::access::mode sycl_read = sycl::access::mode::read;

--- a/test/xpu_api/numerics/numeric.ops/accumulate/xpu_accumulate.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/accumulate/xpu_accumulate.pass.cpp
@@ -20,8 +20,6 @@
 #include "support/utils.h"
 #include "support/test_iterators.h"
 
-#include THE_SYCL_HPP
-
 constexpr sycl::access::mode sycl_read = sycl::access::mode::read;
 constexpr sycl::access::mode sycl_write = sycl::access::mode::write;
 

--- a/test/xpu_api/numerics/numeric.ops/accumulate/xpu_accumulate.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/accumulate/xpu_accumulate.pass.cpp
@@ -15,10 +15,12 @@
 
 #include <iostream>
 
-#include <CL/sycl.hpp>
 #include <oneapi/dpl/numeric>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
+
+#include THE_SYCL_HPP
 
 constexpr sycl::access::mode sycl_read = sycl::access::mode::read;
 constexpr sycl::access::mode sycl_write = sycl::access::mode::write;

--- a/test/xpu_api/numerics/numeric.ops/accumulate/xpu_accumulate_op.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/accumulate/xpu_accumulate_op.pass.cpp
@@ -21,8 +21,6 @@
 #include "support/utils.h"
 #include "support/test_iterators.h"
 
-#include THE_SYCL_HPP
-
 constexpr sycl::access::mode sycl_read = sycl::access::mode::read;
 constexpr sycl::access::mode sycl_write = sycl::access::mode::write;
 

--- a/test/xpu_api/numerics/numeric.ops/accumulate/xpu_accumulate_op.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/accumulate/xpu_accumulate_op.pass.cpp
@@ -18,7 +18,6 @@
 #include <oneapi/dpl/functional>
 #include <oneapi/dpl/numeric>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 constexpr sycl::access::mode sycl_read = sycl::access::mode::read;

--- a/test/xpu_api/numerics/numeric.ops/accumulate/xpu_accumulate_op.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/accumulate/xpu_accumulate_op.pass.cpp
@@ -18,6 +18,7 @@
 #include <oneapi/dpl/functional>
 #include <oneapi/dpl/numeric>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 constexpr sycl::access::mode sycl_read = sycl::access::mode::read;

--- a/test/xpu_api/numerics/numeric.ops/accumulate/xpu_accumulate_op.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/accumulate/xpu_accumulate_op.pass.cpp
@@ -13,10 +13,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
-
 #include <oneapi/dpl/functional>
 #include <oneapi/dpl/numeric>
+
+#include <iostream>
 
 #include "support/utils_sycl.h"
 #include "support/test_iterators.h"

--- a/test/xpu_api/numerics/numeric.ops/accumulate/xpu_accumulate_op.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/accumulate/xpu_accumulate_op.pass.cpp
@@ -15,11 +15,13 @@
 
 #include <iostream>
 
-#include <CL/sycl.hpp>
 #include <oneapi/dpl/functional>
 #include <oneapi/dpl/numeric>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
+
+#include THE_SYCL_HPP
 
 constexpr sycl::access::mode sycl_read = sycl::access::mode::read;
 constexpr sycl::access::mode sycl_write = sycl::access::mode::write;

--- a/test/xpu_api/numerics/numeric.ops/inner.product/xpu_inner_product.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/inner.product/xpu_inner_product.pass.cpp
@@ -17,6 +17,8 @@
 #include <oneapi/dpl/numeric>
 
 #include <iostream>
+
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 constexpr sycl::access::mode sycl_read = sycl::access::mode::read;

--- a/test/xpu_api/numerics/numeric.ops/inner.product/xpu_inner_product.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/inner.product/xpu_inner_product.pass.cpp
@@ -21,8 +21,6 @@
 #include "support/utils.h"
 #include "support/test_iterators.h"
 
-#include THE_SYCL_HPP
-
 constexpr sycl::access::mode sycl_read = sycl::access::mode::read;
 constexpr sycl::access::mode sycl_write = sycl::access::mode::write;
 

--- a/test/xpu_api/numerics/numeric.ops/inner.product/xpu_inner_product.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/inner.product/xpu_inner_product.pass.cpp
@@ -17,7 +17,6 @@
 #include <oneapi/dpl/numeric>
 
 #include <iostream>
-
 #include "support/test_iterators.h"
 
 constexpr sycl::access::mode sycl_read = sycl::access::mode::read;

--- a/test/xpu_api/numerics/numeric.ops/inner.product/xpu_inner_product.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/inner.product/xpu_inner_product.pass.cpp
@@ -18,7 +18,6 @@
 
 #include <iostream>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 constexpr sycl::access::mode sycl_read = sycl::access::mode::read;

--- a/test/xpu_api/numerics/numeric.ops/inner.product/xpu_inner_product.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/inner.product/xpu_inner_product.pass.cpp
@@ -16,9 +16,12 @@
 
 #include <oneapi/dpl/numeric>
 
-#include <CL/sycl.hpp>
 #include <iostream>
+
+#include "support/utils.h"
 #include "support/test_iterators.h"
+
+#include THE_SYCL_HPP
 
 constexpr sycl::access::mode sycl_read = sycl::access::mode::read;
 constexpr sycl::access::mode sycl_write = sycl::access::mode::write;

--- a/test/xpu_api/numerics/numeric.ops/inner.product/xpu_inner_product_comp.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/inner.product/xpu_inner_product_comp.pass.cpp
@@ -19,7 +19,6 @@
 #include <oneapi/dpl/numeric>
 
 #include <iostream>
-
 #include "support/test_iterators.h"
 
 constexpr sycl::access::mode sycl_read = sycl::access::mode::read;

--- a/test/xpu_api/numerics/numeric.ops/inner.product/xpu_inner_product_comp.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/inner.product/xpu_inner_product_comp.pass.cpp
@@ -20,7 +20,6 @@
 
 #include <iostream>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 constexpr sycl::access::mode sycl_read = sycl::access::mode::read;

--- a/test/xpu_api/numerics/numeric.ops/inner.product/xpu_inner_product_comp.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/inner.product/xpu_inner_product_comp.pass.cpp
@@ -19,6 +19,8 @@
 #include <oneapi/dpl/numeric>
 
 #include <iostream>
+
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 constexpr sycl::access::mode sycl_read = sycl::access::mode::read;

--- a/test/xpu_api/numerics/numeric.ops/inner.product/xpu_inner_product_comp.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/inner.product/xpu_inner_product_comp.pass.cpp
@@ -18,9 +18,12 @@
 #include <oneapi/dpl/iterator>
 #include <oneapi/dpl/numeric>
 
-#include <CL/sycl.hpp>
 #include <iostream>
+
+#include "support/utils.h"
 #include "support/test_iterators.h"
+
+#include THE_SYCL_HPP
 
 constexpr sycl::access::mode sycl_read = sycl::access::mode::read;
 constexpr sycl::access::mode sycl_write = sycl::access::mode::write;

--- a/test/xpu_api/numerics/numeric.ops/inner.product/xpu_inner_product_comp.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/inner.product/xpu_inner_product_comp.pass.cpp
@@ -23,8 +23,6 @@
 #include "support/utils.h"
 #include "support/test_iterators.h"
 
-#include THE_SYCL_HPP
-
 constexpr sycl::access::mode sycl_read = sycl::access::mode::read;
 constexpr sycl::access::mode sycl_write = sycl::access::mode::write;
 

--- a/test/xpu_api/numerics/numeric.ops/numeric.iota/xpu_iota.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/numeric.iota/xpu_iota.pass.cpp
@@ -17,7 +17,6 @@
 #include <iostream>
 #include <oneapi/dpl/numeric>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 constexpr sycl::access::mode sycl_read = sycl::access::mode::read;

--- a/test/xpu_api/numerics/numeric.ops/numeric.iota/xpu_iota.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/numeric.iota/xpu_iota.pass.cpp
@@ -14,11 +14,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <CL/sycl.hpp>
 #include <iostream>
 #include <oneapi/dpl/numeric>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
+
+#include THE_SYCL_HPP
 
 constexpr sycl::access::mode sycl_read = sycl::access::mode::read;
 constexpr sycl::access::mode sycl_write = sycl::access::mode::write;

--- a/test/xpu_api/numerics/numeric.ops/numeric.iota/xpu_iota.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/numeric.iota/xpu_iota.pass.cpp
@@ -20,8 +20,6 @@
 #include "support/utils.h"
 #include "support/test_iterators.h"
 
-#include THE_SYCL_HPP
-
 constexpr sycl::access::mode sycl_read = sycl::access::mode::read;
 constexpr sycl::access::mode sycl_write = sycl::access::mode::write;
 

--- a/test/xpu_api/numerics/numeric.ops/numeric.iota/xpu_iota.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/numeric.iota/xpu_iota.pass.cpp
@@ -14,8 +14,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
 #include <oneapi/dpl/numeric>
+
+#include <iostream>
 
 #include "support/utils_sycl.h"
 #include "support/test_iterators.h"

--- a/test/xpu_api/numerics/numeric.ops/numeric.iota/xpu_iota.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/numeric.iota/xpu_iota.pass.cpp
@@ -17,6 +17,7 @@
 #include <iostream>
 #include <oneapi/dpl/numeric>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 constexpr sycl::access::mode sycl_read = sycl::access::mode::read;

--- a/test/xpu_api/numerics/numeric.ops/numeric.ops.gcd/xpu_gcd.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/numeric.ops.gcd/xpu_gcd.pass.cpp
@@ -20,7 +20,8 @@
 
 #include <cassert>
 #include <iostream>
-#include <CL/sycl.hpp>
+
+#include THE_SYCL_HPP
 
 constexpr sycl::access::mode sycl_read = sycl::access::mode::read;
 constexpr sycl::access::mode sycl_write = sycl::access::mode::write;

--- a/test/xpu_api/numerics/numeric.ops/numeric.ops.gcd/xpu_gcd.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/numeric.ops.gcd/xpu_gcd.pass.cpp
@@ -21,8 +21,6 @@
 #include <cassert>
 #include <iostream>
 
-#include THE_SYCL_HPP
-
 constexpr sycl::access::mode sycl_read = sycl::access::mode::read;
 constexpr sycl::access::mode sycl_write = sycl::access::mode::write;
 

--- a/test/xpu_api/numerics/numeric.ops/numeric.ops.lcm/xpu_lcm.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/numeric.ops.lcm/xpu_lcm.pass.cpp
@@ -20,7 +20,8 @@
 
 #include <cassert>
 #include <iostream>
-#include <CL/sycl.hpp>
+
+#include THE_SYCL_HPP
 
 constexpr sycl::access::mode sycl_read = sycl::access::mode::read;
 constexpr sycl::access::mode sycl_write = sycl::access::mode::write;

--- a/test/xpu_api/numerics/numeric.ops/numeric.ops.lcm/xpu_lcm.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/numeric.ops.lcm/xpu_lcm.pass.cpp
@@ -21,8 +21,6 @@
 #include <cassert>
 #include <iostream>
 
-#include THE_SYCL_HPP
-
 constexpr sycl::access::mode sycl_read = sycl::access::mode::read;
 constexpr sycl::access::mode sycl_write = sycl::access::mode::write;
 

--- a/test/xpu_api/numerics/numeric.ops/partial.sum/xpu_partial_sum.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/partial.sum/xpu_partial_sum.pass.cpp
@@ -17,7 +17,6 @@
 #include <iostream>
 #include <oneapi/dpl/numeric>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 constexpr sycl::access::mode sycl_read = sycl::access::mode::read;

--- a/test/xpu_api/numerics/numeric.ops/partial.sum/xpu_partial_sum.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/partial.sum/xpu_partial_sum.pass.cpp
@@ -14,11 +14,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <CL/sycl.hpp>
 #include <iostream>
 #include <oneapi/dpl/numeric>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
+
+#include THE_SYCL_HPP
 
 constexpr sycl::access::mode sycl_read = sycl::access::mode::read;
 constexpr sycl::access::mode sycl_write = sycl::access::mode::write;

--- a/test/xpu_api/numerics/numeric.ops/partial.sum/xpu_partial_sum.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/partial.sum/xpu_partial_sum.pass.cpp
@@ -20,8 +20,6 @@
 #include "support/utils.h"
 #include "support/test_iterators.h"
 
-#include THE_SYCL_HPP
-
 constexpr sycl::access::mode sycl_read = sycl::access::mode::read;
 constexpr sycl::access::mode sycl_write = sycl::access::mode::write;
 

--- a/test/xpu_api/numerics/numeric.ops/partial.sum/xpu_partial_sum.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/partial.sum/xpu_partial_sum.pass.cpp
@@ -14,8 +14,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
 #include <oneapi/dpl/numeric>
+
+#include <iostream>
 
 #include "support/utils_sycl.h"
 #include "support/test_iterators.h"

--- a/test/xpu_api/numerics/numeric.ops/partial.sum/xpu_partial_sum.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/partial.sum/xpu_partial_sum.pass.cpp
@@ -17,6 +17,7 @@
 #include <iostream>
 #include <oneapi/dpl/numeric>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 constexpr sycl::access::mode sycl_read = sycl::access::mode::read;

--- a/test/xpu_api/numerics/numeric.ops/partial.sum/xpu_partial_sum_op.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/partial.sum/xpu_partial_sum_op.pass.cpp
@@ -21,8 +21,6 @@
 #include "support/utils.h"
 #include "support/test_iterators.h"
 
-#include THE_SYCL_HPP
-
 constexpr sycl::access::mode sycl_read = sycl::access::mode::read;
 constexpr sycl::access::mode sycl_write = sycl::access::mode::write;
 

--- a/test/xpu_api/numerics/numeric.ops/partial.sum/xpu_partial_sum_op.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/partial.sum/xpu_partial_sum_op.pass.cpp
@@ -14,12 +14,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <CL/sycl.hpp>
 #include <iostream>
 #include <oneapi/dpl/functional>
 #include <oneapi/dpl/numeric>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
+
+#include THE_SYCL_HPP
 
 constexpr sycl::access::mode sycl_read = sycl::access::mode::read;
 constexpr sycl::access::mode sycl_write = sycl::access::mode::write;

--- a/test/xpu_api/numerics/numeric.ops/partial.sum/xpu_partial_sum_op.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/partial.sum/xpu_partial_sum_op.pass.cpp
@@ -14,9 +14,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <iostream>
 #include <oneapi/dpl/functional>
 #include <oneapi/dpl/numeric>
+
+#include <iostream>
 
 #include "support/utils_sycl.h"
 #include "support/test_iterators.h"

--- a/test/xpu_api/numerics/numeric.ops/partial.sum/xpu_partial_sum_op.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/partial.sum/xpu_partial_sum_op.pass.cpp
@@ -18,7 +18,6 @@
 #include <oneapi/dpl/functional>
 #include <oneapi/dpl/numeric>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 constexpr sycl::access::mode sycl_read = sycl::access::mode::read;

--- a/test/xpu_api/numerics/numeric.ops/partial.sum/xpu_partial_sum_op.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/partial.sum/xpu_partial_sum_op.pass.cpp
@@ -18,6 +18,7 @@
 #include <oneapi/dpl/functional>
 #include <oneapi/dpl/numeric>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 constexpr sycl::access::mode sycl_read = sycl::access::mode::read;

--- a/test/xpu_api/numerics/numeric.ops/reduce/xpu_reduce.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/reduce/xpu_reduce.pass.cpp
@@ -17,7 +17,6 @@
 #include <oneapi/dpl/numeric>
 #include <cassert>
 
-#include "support/utils.h"
 #include "support/test_iterators.h"
 
 template <class T>

--- a/test/xpu_api/numerics/numeric.ops/reduce/xpu_reduce.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/reduce/xpu_reduce.pass.cpp
@@ -20,8 +20,6 @@
 #include "support/utils.h"
 #include "support/test_iterators.h"
 
-#include THE_SYCL_HPP
-
 template <class T>
 class KernelTest;
 

--- a/test/xpu_api/numerics/numeric.ops/reduce/xpu_reduce.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/reduce/xpu_reduce.pass.cpp
@@ -16,9 +16,11 @@
 
 #include <oneapi/dpl/numeric>
 #include <cassert>
-#include <CL/sycl.hpp>
 
+#include "support/utils.h"
 #include "support/test_iterators.h"
+
+#include THE_SYCL_HPP
 
 template <class T>
 class KernelTest;

--- a/test/xpu_api/numerics/numeric.ops/reduce/xpu_reduce.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/reduce/xpu_reduce.pass.cpp
@@ -17,6 +17,7 @@
 #include <oneapi/dpl/numeric>
 #include <cassert>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 template <class T>

--- a/test/xpu_api/random/conformance_tests/common_for_conformance_tests.hpp
+++ b/test/xpu_api/random/conformance_tests/common_for_conformance_tests.hpp
@@ -25,8 +25,6 @@
 
 #include "support/utils.h"
 
-#include THE_SYCL_HPP
-
 constexpr auto REF_SAMPLE_ID = 9999;
 
 template<class Engine, int NGenSamples, int NElemsInResultType>

--- a/test/xpu_api/random/conformance_tests/common_for_conformance_tests.hpp
+++ b/test/xpu_api/random/conformance_tests/common_for_conformance_tests.hpp
@@ -21,8 +21,11 @@
 #define DPSTD_RANDOM_CONFORMANCE_TESTS_COMMON
 
 #include <vector>
-#include <CL/sycl.hpp>
 #include <random>
+
+#include "support/utils.h"
+
+#include THE_SYCL_HPP
 
 constexpr auto REF_SAMPLE_ID = 9999;
 

--- a/test/xpu_api/random/device_tests/common_for_device_tests.h
+++ b/test/xpu_api/random/device_tests/common_for_device_tests.h
@@ -27,8 +27,6 @@
 
 #include "support/utils.h"
 
-#include THE_SYCL_HPP
-
 constexpr auto seed = 777;
 constexpr int N = 96;
 

--- a/test/xpu_api/random/device_tests/common_for_device_tests.h
+++ b/test/xpu_api/random/device_tests/common_for_device_tests.h
@@ -20,11 +20,14 @@
 #ifndef _ONEDPL_RANDOM_DEVICE_TESTS_COMMON
 #define _ONEDPL_RANDOM_DEVICE_TESTS_COMMON
 
-#include <CL/sycl.hpp>
 #include <oneapi/dpl/random>
 #include <limits>
 #include <iostream>
 #include <iomanip>
+
+#include "support/utils.h"
+
+#include THE_SYCL_HPP
 
 constexpr auto seed = 777;
 constexpr int N = 96;

--- a/test/xpu_api/random/interface_tests/distributions_methods.pass.cpp
+++ b/test/xpu_api/random/interface_tests/distributions_methods.pass.cpp
@@ -23,8 +23,11 @@
 #include <iostream>
 #include <cmath>
 #include <vector>
-#include <CL/sycl.hpp>
 #include <oneapi/dpl/random>
+
+#include "support/utils.h"
+
+#include THE_SYCL_HPP
 
 constexpr auto SEED = 777;
 constexpr auto N_GEN = 960;

--- a/test/xpu_api/random/interface_tests/distributions_methods.pass.cpp
+++ b/test/xpu_api/random/interface_tests/distributions_methods.pass.cpp
@@ -25,8 +25,6 @@
 #include <vector>
 #include <oneapi/dpl/random>
 
-#include "support/utils.h"
-
 constexpr auto SEED = 777;
 constexpr auto N_GEN = 960;
 

--- a/test/xpu_api/random/interface_tests/distributions_methods.pass.cpp
+++ b/test/xpu_api/random/interface_tests/distributions_methods.pass.cpp
@@ -27,8 +27,6 @@
 
 #include "support/utils.h"
 
-#include THE_SYCL_HPP
-
 constexpr auto SEED = 777;
 constexpr auto N_GEN = 960;
 

--- a/test/xpu_api/random/interface_tests/engines_methods.pass.cpp
+++ b/test/xpu_api/random/interface_tests/engines_methods.pass.cpp
@@ -24,8 +24,6 @@
 #    include <vector>
 #    include <oneapi/dpl/random>
 
-#    include "support/utils.h"
-
 constexpr auto SEED = 777;
 constexpr auto N_GEN = 960;
 constexpr auto MINSTD_A = 48271;

--- a/test/xpu_api/random/interface_tests/engines_methods.pass.cpp
+++ b/test/xpu_api/random/interface_tests/engines_methods.pass.cpp
@@ -26,8 +26,6 @@
 
 #    include "support/utils.h"
 
-#    include THE_SYCL_HPP
-
 constexpr auto SEED = 777;
 constexpr auto N_GEN = 960;
 constexpr auto MINSTD_A = 48271;

--- a/test/xpu_api/random/interface_tests/engines_methods.pass.cpp
+++ b/test/xpu_api/random/interface_tests/engines_methods.pass.cpp
@@ -22,8 +22,11 @@
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 #    include <iostream>
 #    include <vector>
-#    include <CL/sycl.hpp>
 #    include <oneapi/dpl/random>
+
+#    include "support/utils.h"
+
+#    include THE_SYCL_HPP
 
 constexpr auto SEED = 777;
 constexpr auto N_GEN = 960;

--- a/test/xpu_api/random/statistics_tests/bernoulli_distribution_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/bernoulli_distribution_test.pass.cpp
@@ -21,7 +21,7 @@
 #include <iostream>
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 #include <limits>
 #include <oneapi/dpl/random>
 #include <math.h>

--- a/test/xpu_api/random/statistics_tests/bernoulli_distribution_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/bernoulli_distribution_test.pass.cpp
@@ -21,7 +21,6 @@
 #include <iostream>
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
-#include THE_SYCL_HPP
 #include <limits>
 #include <oneapi/dpl/random>
 #include <math.h>

--- a/test/xpu_api/random/statistics_tests/exponential_distribution_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/exponential_distribution_test.pass.cpp
@@ -21,7 +21,7 @@
 #include <iostream>
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 #include <random>
 #include <limits>
 #include <oneapi/dpl/random>

--- a/test/xpu_api/random/statistics_tests/exponential_distribution_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/exponential_distribution_test.pass.cpp
@@ -21,7 +21,6 @@
 #include <iostream>
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
-#include THE_SYCL_HPP
 #include <random>
 #include <limits>
 #include <oneapi/dpl/random>

--- a/test/xpu_api/random/statistics_tests/extreme_value_distribution_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/extreme_value_distribution_test.pass.cpp
@@ -21,7 +21,7 @@
 #include <iostream>
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 #include <random>
 #include <limits>
 #include <oneapi/dpl/random>

--- a/test/xpu_api/random/statistics_tests/extreme_value_distribution_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/extreme_value_distribution_test.pass.cpp
@@ -21,7 +21,6 @@
 #include <iostream>
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
-#include THE_SYCL_HPP
 #include <random>
 #include <limits>
 #include <oneapi/dpl/random>

--- a/test/xpu_api/random/statistics_tests/geometric_distribution_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/geometric_distribution_test.pass.cpp
@@ -21,7 +21,7 @@
 #include <iostream>
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 #include <limits>
 #include <oneapi/dpl/random>
 #include <math.h>

--- a/test/xpu_api/random/statistics_tests/geometric_distribution_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/geometric_distribution_test.pass.cpp
@@ -21,7 +21,6 @@
 #include <iostream>
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
-#include THE_SYCL_HPP
 #include <limits>
 #include <oneapi/dpl/random>
 #include <math.h>

--- a/test/xpu_api/random/statistics_tests/lognormal_distribution_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/lognormal_distribution_test.pass.cpp
@@ -21,7 +21,7 @@
 #include <iostream>
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 #include <random>
 #include <limits>
 #include <oneapi/dpl/random>

--- a/test/xpu_api/random/statistics_tests/lognormal_distribution_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/lognormal_distribution_test.pass.cpp
@@ -21,7 +21,6 @@
 #include <iostream>
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
-#include THE_SYCL_HPP
 #include <random>
 #include <limits>
 #include <oneapi/dpl/random>

--- a/test/xpu_api/random/statistics_tests/normal_distribution_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/normal_distribution_test.pass.cpp
@@ -21,7 +21,7 @@
 #include <iostream>
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 #include <random>
 #include <limits>
 #include <oneapi/dpl/random>

--- a/test/xpu_api/random/statistics_tests/normal_distribution_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/normal_distribution_test.pass.cpp
@@ -21,7 +21,6 @@
 #include <iostream>
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
-#include THE_SYCL_HPP
 #include <random>
 #include <limits>
 #include <oneapi/dpl/random>

--- a/test/xpu_api/random/statistics_tests/uniform_int_distribution_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/uniform_int_distribution_test.pass.cpp
@@ -22,7 +22,6 @@
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 #include <vector>
-#include THE_SYCL_HPP
 #include <random>
 #include <oneapi/dpl/random>
 #include "statistics_common.h"

--- a/test/xpu_api/random/statistics_tests/uniform_int_distribution_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/uniform_int_distribution_test.pass.cpp
@@ -22,7 +22,7 @@
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 #include <vector>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 #include <random>
 #include <oneapi/dpl/random>
 #include "statistics_common.h"

--- a/test/xpu_api/random/statistics_tests/uniform_real_distribution_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/uniform_real_distribution_test.pass.cpp
@@ -22,7 +22,6 @@
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 #include <vector>
-#include THE_SYCL_HPP
 #include <random>
 #include <oneapi/dpl/random>
 #include "statistics_common.h"

--- a/test/xpu_api/random/statistics_tests/uniform_real_distribution_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/uniform_real_distribution_test.pass.cpp
@@ -22,7 +22,7 @@
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 #include <vector>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 #include <random>
 #include <oneapi/dpl/random>
 #include "statistics_common.h"

--- a/test/xpu_api/random/statistics_tests/weibull_distribution_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/weibull_distribution_test.pass.cpp
@@ -21,7 +21,7 @@
 #include <iostream>
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 #include <random>
 #include <limits>
 #include <oneapi/dpl/random>

--- a/test/xpu_api/random/statistics_tests/weibull_distribution_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/weibull_distribution_test.pass.cpp
@@ -21,7 +21,6 @@
 #include <iostream>
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
-#include THE_SYCL_HPP
 #include <random>
 #include <limits>
 #include <oneapi/dpl/random>

--- a/test/xpu_api/random/template_tests/discard_block_std_template_test.pass.cpp
+++ b/test/xpu_api/random/template_tests/discard_block_std_template_test.pass.cpp
@@ -22,7 +22,6 @@
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 #include <vector>
-#include THE_SYCL_HPP
 #include <random>
 #include <oneapi/dpl/random>
 

--- a/test/xpu_api/random/template_tests/discard_block_std_template_test.pass.cpp
+++ b/test/xpu_api/random/template_tests/discard_block_std_template_test.pass.cpp
@@ -22,7 +22,7 @@
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 #include <vector>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 #include <random>
 #include <oneapi/dpl/random>
 

--- a/test/xpu_api/random/template_tests/linear_congruential_std_template_test.pass.cpp
+++ b/test/xpu_api/random/template_tests/linear_congruential_std_template_test.pass.cpp
@@ -22,7 +22,6 @@
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 #include <vector>
-#include THE_SYCL_HPP
 #include <random>
 #include <oneapi/dpl/random>
 

--- a/test/xpu_api/random/template_tests/linear_congruential_std_template_test.pass.cpp
+++ b/test/xpu_api/random/template_tests/linear_congruential_std_template_test.pass.cpp
@@ -22,7 +22,7 @@
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 #include <vector>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 #include <random>
 #include <oneapi/dpl/random>
 

--- a/test/xpu_api/random/template_tests/subtract_with_carry_std_template_test.pass.cpp
+++ b/test/xpu_api/random/template_tests/subtract_with_carry_std_template_test.pass.cpp
@@ -22,7 +22,6 @@
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 #include <vector>
-#include THE_SYCL_HPP
 #include <random>
 #include <oneapi/dpl/random>
 

--- a/test/xpu_api/random/template_tests/subtract_with_carry_std_template_test.pass.cpp
+++ b/test/xpu_api/random/template_tests/subtract_with_carry_std_template_test.pass.cpp
@@ -22,7 +22,7 @@
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 #include <vector>
-#include <CL/sycl.hpp>
+#include THE_SYCL_HPP
 #include <random>
 #include <oneapi/dpl/random>
 


### PR DESCRIPTION
In this PR we started usage of ```<sycl/sycl.hpp>```  instead of ```<cl/sycl.hpp>``` header file.
Previous implementation of this task were in https://github.com/oneapi-src/oneDPL/pull/643

The Intel LLVM compiler modification were made in this PR: https://github.com/intel/llvm/pull/6407