### PR TITLE
Replace invoke_if with if constexpr

### DIFF
--- a/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
+++ b/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
@@ -65,7 +65,9 @@ __pattern_walk2_async(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _Fo
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
         ::std::forward<_ExecutionPolicy>(__exec), unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f}, __n,
         __buf1.all_view(), __buf2.all_view());
-    oneapi::dpl::__internal::__invoke_if(_IsSync(), [&__future]() { __future.wait(); });
+
+    if constexpr (_IsSync::value)
+        __future.wait();
 
     return __future.__make_future(__first2 + __n);
 }

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1460,7 +1460,7 @@ __remove_elements(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardI
                     __first + __i, __first + __i + __len, __result + __initial, __mask + __i,
                     [](_ForwardIterator __x, _Tp* __z) {
                         if constexpr (::std::is_trivial_v<_Tp>)
-                            __z = ::std::move(*__x);
+                            *__z = ::std::move(*__x);
                         else
                             ::new (::std::addressof(*__z)) _Tp(::std::move(*__x));
                     },

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1459,8 +1459,10 @@ __remove_elements(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardI
                 __internal::__brick_copy_by_mask(
                     __first + __i, __first + __i + __len, __result + __initial, __mask + __i,
                     [](_ForwardIterator __x, _Tp* __z) {
-                        __internal::__invoke_if_else(::std::is_trivial<_Tp>(), [&]() { *__z = ::std::move(*__x); },
-                                                     [&]() { ::new (::std::addressof(*__z)) _Tp(::std::move(*__x)); });
+                        if constexpr (::std::is_trivial_v<_Tp>)
+                            __z = ::std::move(*__x);
+                        else
+                            ::new (::std::addressof(*__z)) _Tp(::std::move(*__x));
                     },
                     __is_vector);
             },
@@ -2477,11 +2479,10 @@ __pattern_partial_sort_copy(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __
                                                   __i, __j, __d_first + (__i - __r), __is_vector);
                                           });
 
-            __internal::__invoke_if_not(::std::is_trivially_destructible<_T1>(), [&]() {
+            if constexpr (!::std::is_trivially_destructible_v<_T1>)
                 __par_backend::__parallel_for(
                     ::std::forward<_ExecutionPolicy>(__exec), __r + __n2, __r + __n1,
                     [__is_vector](_T1* __i, _T1* __j) { __brick_destroy(__i, __j, __is_vector); });
-            });
 
             return __d_first + __n2;
         }
@@ -2931,8 +2932,10 @@ __pattern_inplace_merge(_ExecutionPolicy&& __exec, _RandomAccessIterator __first
     _Tp* __r = __buf.get();
     __internal::__except_handler([&]() {
         auto __move_values = [](_RandomAccessIterator __x, _Tp* __z) {
-            __internal::__invoke_if_else(::std::is_trivial<_Tp>(), [&]() { *__z = ::std::move(*__x); },
-                                         [&]() { ::new (::std::addressof(*__z)) _Tp(::std::move(*__x)); });
+            if constexpr (::std::is_trivial_v<_Tp>)
+                *__z = ::std::move(*__x);
+            else
+                ::new (::std::addressof(*__z)) _Tp(::std::move(*__x));
         };
 
         auto __move_sequences = [](_RandomAccessIterator __first1, _RandomAccessIterator __last1, _Tp* __first2) {

--- a/include/oneapi/dpl/pstl/glue_memory_impl.h
+++ b/include/oneapi/dpl/pstl/glue_memory_impl.h
@@ -249,7 +249,7 @@ destroy_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n)
     const auto __is_vector =
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
 
-    if constexpr (::std::is_trivially_destructible_v<_ValueType>())
+    if constexpr (::std::is_trivially_destructible_v<_ValueType>)
     {
         return oneapi::dpl::__internal::__pstl_next(__first, __n);
     }

--- a/include/oneapi/dpl/pstl/glue_memory_impl.h
+++ b/include/oneapi/dpl/pstl/glue_memory_impl.h
@@ -50,19 +50,15 @@ uninitialized_copy(_ExecutionPolicy&& __exec, _InputIterator __first, _InputIter
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(
             __exec);
 
-    return oneapi::dpl::__internal::__invoke_if_else(
-        ::std::integral_constant<bool, ::std::is_trivial<_ValueType1>::value&& ::std::is_trivial<_ValueType2>::value>(),
-        [&]() {
-            return oneapi::dpl::__internal::__pattern_walk2_brick(
-                ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
-                oneapi::dpl::__internal::__brick_copy<_DecayedExecutionPolicy>{}, __is_parallel);
-        },
-        [&]() {
-            return oneapi::dpl::__internal::__pattern_walk2(
-                ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
-                oneapi::dpl::__internal::__op_uninitialized_copy<_DecayedExecutionPolicy>{}, __is_vector,
-                __is_parallel);
-        });
+    if constexpr (::std::is_trivial_v<_ValueType1> && ::std::is_trivial_v<_ValueType2>)
+        return oneapi::dpl::__internal::__pattern_walk2_brick(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
+            oneapi::dpl::__internal::__brick_copy<_DecayedExecutionPolicy>{}, __is_parallel);
+    else
+        return oneapi::dpl::__internal::__pattern_walk2(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
+            oneapi::dpl::__internal::__op_uninitialized_copy<_DecayedExecutionPolicy>{}, __is_vector,
+            __is_parallel);
 }
 
 template <class _ExecutionPolicy, class _InputIterator, class _Size, class _ForwardIterator>
@@ -80,19 +76,15 @@ uninitialized_copy_n(_ExecutionPolicy&& __exec, _InputIterator __first, _Size __
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(
             __exec);
 
-    return oneapi::dpl::__internal::__invoke_if_else(
-        ::std::integral_constant<bool, ::std::is_trivial<_ValueType1>::value&& ::std::is_trivial<_ValueType2>::value>(),
-        [&]() {
-            return oneapi::dpl::__internal::__pattern_walk2_brick_n(
-                ::std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
-                oneapi::dpl::__internal::__brick_copy_n<_DecayedExecutionPolicy>{}, __is_parallel);
-        },
-        [&]() {
-            return oneapi::dpl::__internal::__pattern_walk2_n(
-                ::std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
-                oneapi::dpl::__internal::__op_uninitialized_copy<_DecayedExecutionPolicy>{}, __is_vector,
-                __is_parallel);
-        });
+    if constexpr (::std::is_trivial_v<_ValueType1> && ::std::is_trivial_v<_ValueType2>)
+        return oneapi::dpl::__internal::__pattern_walk2_brick_n(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
+            oneapi::dpl::__internal::__brick_copy_n<_DecayedExecutionPolicy>{}, __is_parallel);
+    else
+        return oneapi::dpl::__internal::__pattern_walk2_n(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
+            oneapi::dpl::__internal::__op_uninitialized_copy<_DecayedExecutionPolicy>{}, __is_vector,
+            __is_parallel);
 }
 
 // [uninitialized.move]
@@ -112,19 +104,15 @@ uninitialized_move(_ExecutionPolicy&& __exec, _InputIterator __first, _InputIter
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(
             __exec);
 
-    return oneapi::dpl::__internal::__invoke_if_else(
-        ::std::integral_constant<bool, ::std::is_trivial<_ValueType1>::value&& ::std::is_trivial<_ValueType2>::value>(),
-        [&]() {
-            return oneapi::dpl::__internal::__pattern_walk2_brick(
-                ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
-                oneapi::dpl::__internal::__brick_copy<_DecayedExecutionPolicy>{}, __is_parallel);
-        },
-        [&]() {
-            return oneapi::dpl::__internal::__pattern_walk2(
-                ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
-                oneapi::dpl::__internal::__op_uninitialized_move<_DecayedExecutionPolicy>{}, __is_vector,
-                __is_parallel);
-        });
+    if constexpr (::std::is_trivial_v<_ValueType1> && ::std::is_trivial_v<_ValueType2>)
+        return oneapi::dpl::__internal::__pattern_walk2_brick(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
+            oneapi::dpl::__internal::__brick_copy<_DecayedExecutionPolicy>{}, __is_parallel);
+    else
+        return oneapi::dpl::__internal::__pattern_walk2(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
+            oneapi::dpl::__internal::__op_uninitialized_move<_DecayedExecutionPolicy>{}, __is_vector,
+            __is_parallel);
 }
 
 template <class _ExecutionPolicy, class _InputIterator, class _Size, class _ForwardIterator>
@@ -142,19 +130,15 @@ uninitialized_move_n(_ExecutionPolicy&& __exec, _InputIterator __first, _Size __
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(
             __exec);
 
-    return oneapi::dpl::__internal::__invoke_if_else(
-        ::std::integral_constant<bool, ::std::is_trivial<_ValueType1>::value&& ::std::is_trivial<_ValueType2>::value>(),
-        [&]() {
-            return oneapi::dpl::__internal::__pattern_walk2_brick_n(
-                ::std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
-                oneapi::dpl::__internal::__brick_copy_n<_DecayedExecutionPolicy>{}, __is_parallel);
-        },
-        [&]() {
-            return oneapi::dpl::__internal::__pattern_walk2_n(
-                ::std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
-                oneapi::dpl::__internal::__op_uninitialized_move<_DecayedExecutionPolicy>{}, __is_vector,
-                __is_parallel);
-        });
+    if constexpr (::std::is_trivial_v<_ValueType1> && ::std::is_trivial_v<_ValueType2>)
+        return oneapi::dpl::__internal::__pattern_walk2_brick_n(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
+            oneapi::dpl::__internal::__brick_copy_n<_DecayedExecutionPolicy>{}, __is_parallel);
+    else
+        return oneapi::dpl::__internal::__pattern_walk2_n(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
+            oneapi::dpl::__internal::__op_uninitialized_move<_DecayedExecutionPolicy>{}, __is_vector,
+            __is_parallel);
 }
 
 // [uninitialized.fill]
@@ -171,20 +155,16 @@ uninitialized_fill(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Forward
     const auto __is_vector =
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
 
-    oneapi::dpl::__internal::__invoke_if_else(
-        ::std::is_arithmetic<_ValueType>(),
-        [&]() {
-            oneapi::dpl::__internal::__pattern_walk_brick(
-                ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
-                oneapi::dpl::__internal::__brick_fill<_ValueType, _DecayedExecutionPolicy>{_ValueType(__value)},
-                __is_parallel);
-        },
-        [&]() {
-            oneapi::dpl::__internal::__pattern_walk1(
-                ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
-                oneapi::dpl::__internal::__op_uninitialized_fill<_Tp, _DecayedExecutionPolicy>{__value}, __is_vector,
-                __is_parallel);
-        });
+    if constexpr (::std::is_arithmetic_v<_ValueType>)
+        oneapi::dpl::__internal::__pattern_walk_brick(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+            oneapi::dpl::__internal::__brick_fill<_ValueType, _DecayedExecutionPolicy>{_ValueType(__value)},
+            __is_parallel);
+    else
+        oneapi::dpl::__internal::__pattern_walk1(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+            oneapi::dpl::__internal::__op_uninitialized_fill<_Tp, _DecayedExecutionPolicy>{__value}, __is_vector,
+            __is_parallel);
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Tp>
@@ -199,20 +179,16 @@ uninitialized_fill_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size 
     const auto __is_vector =
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
 
-    return oneapi::dpl::__internal::__invoke_if_else(
-        ::std::is_arithmetic<_ValueType>(),
-        [&]() {
-            return oneapi::dpl::__internal::__pattern_walk_brick_n(
-                ::std::forward<_ExecutionPolicy>(__exec), __first, __n,
-                oneapi::dpl::__internal::__brick_fill_n<_ValueType, _DecayedExecutionPolicy>{_ValueType(__value)},
-                __is_parallel);
-        },
-        [&]() {
-            return oneapi::dpl::__internal::__pattern_walk1_n(
-                ::std::forward<_ExecutionPolicy>(__exec), __first, __n,
-                oneapi::dpl::__internal::__op_uninitialized_fill<_Tp, _DecayedExecutionPolicy>{__value}, __is_vector,
-                __is_parallel);
-        });
+    if constexpr (::std::is_arithmetic_v<_ValueType>)
+        return oneapi::dpl::__internal::__pattern_walk_brick_n(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __n,
+            oneapi::dpl::__internal::__brick_fill_n<_ValueType, _DecayedExecutionPolicy>{_ValueType(__value)},
+            __is_parallel);
+    else
+        return oneapi::dpl::__internal::__pattern_walk1_n(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __n,
+            oneapi::dpl::__internal::__op_uninitialized_fill<_Tp, _DecayedExecutionPolicy>{__value}, __is_vector,
+            __is_parallel);
 }
 
 // [specialized.destroy]
@@ -229,11 +205,10 @@ destroy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __
     const auto __is_vector =
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
 
-    oneapi::dpl::__internal::__invoke_if_not(::std::is_trivially_destructible<_ValueType>(), [&]() {
+    if constexpr (!::std::is_trivially_destructible_v<_ValueType>)
         oneapi::dpl::__internal::__pattern_walk1(::std::forward<_ExecutionPolicy>(__exec), __first, __last,
                                                  [](_ReferenceType __val) { __val.~_ValueType(); }, __is_vector,
                                                  __is_parallel);
-    });
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Size>
@@ -248,14 +223,12 @@ destroy_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n)
     const auto __is_vector =
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
 
-    return oneapi::dpl::__internal::__invoke_if_else(
-        ::std::is_trivially_destructible<_ValueType>(),
-        [&]() { return oneapi::dpl::__internal::__pstl_next(__first, __n); },
-        [&]() {
-            return oneapi::dpl::__internal::__pattern_walk1_n(::std::forward<_ExecutionPolicy>(__exec), __first, __n,
-                                                              [](_ReferenceType __val) { __val.~_ValueType(); },
-                                                              __is_vector, __is_parallel);
-        });
+    if constexpr (::std::is_trivially_destructible_v<_ValueType>())
+        return oneapi::dpl::__internal::__pstl_next(__first, __n);
+    else
+        return oneapi::dpl::__internal::__pattern_walk1_n(::std::forward<_ExecutionPolicy>(__exec), __first, __n,
+                                                          [](_ReferenceType __val) { __val.~_ValueType(); },
+                                                          __is_vector, __is_parallel);
 }
 
 // [uninitialized.construct.default]
@@ -272,12 +245,11 @@ uninitialized_default_construct(_ExecutionPolicy&& __exec, _ForwardIterator __fi
     const auto __is_vector =
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
 
-    oneapi::dpl::__internal::__invoke_if_not(::std::is_trivial<_ValueType>(), [&]() {
+    if constexpr (!::std::is_trivial_v<_ValueType>)
         oneapi::dpl::__internal::__pattern_walk1(
             ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
             oneapi::dpl::__internal::__op_uninitialized_default_construct<_DecayedExecutionPolicy>{}, __is_vector,
             __is_parallel);
-    });
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Size>
@@ -292,14 +264,13 @@ uninitialized_default_construct_n(_ExecutionPolicy&& __exec, _ForwardIterator __
     const auto __is_vector =
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
 
-    return oneapi::dpl::__internal::__invoke_if_else(
-        ::std::is_trivial<_ValueType>(), [&]() { return oneapi::dpl::__internal::__pstl_next(__first, __n); },
-        [&]() {
-            return oneapi::dpl::__internal::__pattern_walk1_n(
-                ::std::forward<_ExecutionPolicy>(__exec), __first, __n,
-                oneapi::dpl::__internal::__op_uninitialized_default_construct<_DecayedExecutionPolicy>{}, __is_vector,
-                __is_parallel);
-        });
+    if constexpr (::std::is_trivial_v<_ValueType>)
+        return oneapi::dpl::__internal::__pstl_next(__first, __n);
+    else
+        return oneapi::dpl::__internal::__pattern_walk1_n(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __n,
+            oneapi::dpl::__internal::__op_uninitialized_default_construct<_DecayedExecutionPolicy>{}, __is_vector,
+            __is_parallel);
 }
 
 // [uninitialized.construct.value]
@@ -316,20 +287,16 @@ uninitialized_value_construct(_ExecutionPolicy&& __exec, _ForwardIterator __firs
     const auto __is_vector =
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
 
-    oneapi::dpl::__internal::__invoke_if_else(
-        ::std::is_trivial<_ValueType>(),
-        [&]() {
-            oneapi::dpl::__internal::__pattern_walk_brick(
-                ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
-                oneapi::dpl::__internal::__brick_fill<_ValueType, _DecayedExecutionPolicy>{_ValueType()},
-                __is_parallel);
-        },
-        [&]() {
-            oneapi::dpl::__internal::__pattern_walk1(
-                ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
-                oneapi::dpl::__internal::__op_uninitialized_value_construct<_DecayedExecutionPolicy>{}, __is_vector,
-                __is_parallel);
-        });
+    if constexpr (::std::is_trivial_v<_ValueType>)
+        oneapi::dpl::__internal::__pattern_walk_brick(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+            oneapi::dpl::__internal::__brick_fill<_ValueType, _DecayedExecutionPolicy>{_ValueType()},
+            __is_parallel);
+    else
+        oneapi::dpl::__internal::__pattern_walk1(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+            oneapi::dpl::__internal::__op_uninitialized_value_construct<_DecayedExecutionPolicy>{}, __is_vector,
+            __is_parallel);
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Size>
@@ -344,20 +311,16 @@ uninitialized_value_construct_n(_ExecutionPolicy&& __exec, _ForwardIterator __fi
     const auto __is_vector =
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
 
-    return oneapi::dpl::__internal::__invoke_if_else(
-        ::std::is_trivial<_ValueType>(),
-        [&]() {
-            return oneapi::dpl::__internal::__pattern_walk_brick_n(
-                ::std::forward<_ExecutionPolicy>(__exec), __first, __n,
-                oneapi::dpl::__internal::__brick_fill_n<_ValueType, _DecayedExecutionPolicy>{_ValueType()},
-                __is_parallel);
-        },
-        [&]() {
-            return oneapi::dpl::__internal::__pattern_walk1_n(
-                ::std::forward<_ExecutionPolicy>(__exec), __first, __n,
-                oneapi::dpl::__internal::__op_uninitialized_value_construct<_DecayedExecutionPolicy>{}, __is_vector,
-                __is_parallel);
-        });
+    if constexpr (::std::is_trivial_v<_ValueType>)
+        return oneapi::dpl::__internal::__pattern_walk_brick_n(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __n,
+            oneapi::dpl::__internal::__brick_fill_n<_ValueType, _DecayedExecutionPolicy>{_ValueType()},
+            __is_parallel);
+    else
+        return oneapi::dpl::__internal::__pattern_walk1_n(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __n,
+            oneapi::dpl::__internal::__op_uninitialized_value_construct<_DecayedExecutionPolicy>{}, __is_vector,
+            __is_parallel);
 }
 
 } // namespace dpl

--- a/include/oneapi/dpl/pstl/glue_memory_impl.h
+++ b/include/oneapi/dpl/pstl/glue_memory_impl.h
@@ -51,14 +51,18 @@ uninitialized_copy(_ExecutionPolicy&& __exec, _InputIterator __first, _InputIter
             __exec);
 
     if constexpr (::std::is_trivial_v<_ValueType1> && ::std::is_trivial_v<_ValueType2>)
+    {
         return oneapi::dpl::__internal::__pattern_walk2_brick(
             ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
             oneapi::dpl::__internal::__brick_copy<_DecayedExecutionPolicy>{}, __is_parallel);
+    }
     else
+    {
         return oneapi::dpl::__internal::__pattern_walk2(
             ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
             oneapi::dpl::__internal::__op_uninitialized_copy<_DecayedExecutionPolicy>{}, __is_vector,
             __is_parallel);
+    }
 }
 
 template <class _ExecutionPolicy, class _InputIterator, class _Size, class _ForwardIterator>
@@ -77,14 +81,18 @@ uninitialized_copy_n(_ExecutionPolicy&& __exec, _InputIterator __first, _Size __
             __exec);
 
     if constexpr (::std::is_trivial_v<_ValueType1> && ::std::is_trivial_v<_ValueType2>)
+    {
         return oneapi::dpl::__internal::__pattern_walk2_brick_n(
             ::std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
             oneapi::dpl::__internal::__brick_copy_n<_DecayedExecutionPolicy>{}, __is_parallel);
+    }
     else
+    {
         return oneapi::dpl::__internal::__pattern_walk2_n(
             ::std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
             oneapi::dpl::__internal::__op_uninitialized_copy<_DecayedExecutionPolicy>{}, __is_vector,
             __is_parallel);
+    }
 }
 
 // [uninitialized.move]
@@ -105,14 +113,18 @@ uninitialized_move(_ExecutionPolicy&& __exec, _InputIterator __first, _InputIter
             __exec);
 
     if constexpr (::std::is_trivial_v<_ValueType1> && ::std::is_trivial_v<_ValueType2>)
+    {
         return oneapi::dpl::__internal::__pattern_walk2_brick(
             ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
             oneapi::dpl::__internal::__brick_copy<_DecayedExecutionPolicy>{}, __is_parallel);
+    }
     else
+    {
         return oneapi::dpl::__internal::__pattern_walk2(
             ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
             oneapi::dpl::__internal::__op_uninitialized_move<_DecayedExecutionPolicy>{}, __is_vector,
             __is_parallel);
+    }
 }
 
 template <class _ExecutionPolicy, class _InputIterator, class _Size, class _ForwardIterator>
@@ -131,14 +143,18 @@ uninitialized_move_n(_ExecutionPolicy&& __exec, _InputIterator __first, _Size __
             __exec);
 
     if constexpr (::std::is_trivial_v<_ValueType1> && ::std::is_trivial_v<_ValueType2>)
+    {
         return oneapi::dpl::__internal::__pattern_walk2_brick_n(
             ::std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
             oneapi::dpl::__internal::__brick_copy_n<_DecayedExecutionPolicy>{}, __is_parallel);
+    }
     else
+    {
         return oneapi::dpl::__internal::__pattern_walk2_n(
             ::std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
             oneapi::dpl::__internal::__op_uninitialized_move<_DecayedExecutionPolicy>{}, __is_vector,
             __is_parallel);
+    }
 }
 
 // [uninitialized.fill]
@@ -156,15 +172,19 @@ uninitialized_fill(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Forward
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
 
     if constexpr (::std::is_arithmetic_v<_ValueType>)
+    {
         oneapi::dpl::__internal::__pattern_walk_brick(
             ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
             oneapi::dpl::__internal::__brick_fill<_ValueType, _DecayedExecutionPolicy>{_ValueType(__value)},
             __is_parallel);
+    }
     else
+    {
         oneapi::dpl::__internal::__pattern_walk1(
             ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
             oneapi::dpl::__internal::__op_uninitialized_fill<_Tp, _DecayedExecutionPolicy>{__value}, __is_vector,
             __is_parallel);
+    }
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Tp>
@@ -180,15 +200,19 @@ uninitialized_fill_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size 
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
 
     if constexpr (::std::is_arithmetic_v<_ValueType>)
+    {
         return oneapi::dpl::__internal::__pattern_walk_brick_n(
             ::std::forward<_ExecutionPolicy>(__exec), __first, __n,
             oneapi::dpl::__internal::__brick_fill_n<_ValueType, _DecayedExecutionPolicy>{_ValueType(__value)},
             __is_parallel);
+    }
     else
+    {
         return oneapi::dpl::__internal::__pattern_walk1_n(
             ::std::forward<_ExecutionPolicy>(__exec), __first, __n,
             oneapi::dpl::__internal::__op_uninitialized_fill<_Tp, _DecayedExecutionPolicy>{__value}, __is_vector,
             __is_parallel);
+    }
 }
 
 // [specialized.destroy]
@@ -206,9 +230,11 @@ destroy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
 
     if constexpr (!::std::is_trivially_destructible_v<_ValueType>)
+    {
         oneapi::dpl::__internal::__pattern_walk1(::std::forward<_ExecutionPolicy>(__exec), __first, __last,
                                                  [](_ReferenceType __val) { __val.~_ValueType(); }, __is_vector,
                                                  __is_parallel);
+    }
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Size>
@@ -224,11 +250,15 @@ destroy_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n)
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
 
     if constexpr (::std::is_trivially_destructible_v<_ValueType>())
+    {
         return oneapi::dpl::__internal::__pstl_next(__first, __n);
+    }
     else
+    {
         return oneapi::dpl::__internal::__pattern_walk1_n(::std::forward<_ExecutionPolicy>(__exec), __first, __n,
                                                           [](_ReferenceType __val) { __val.~_ValueType(); },
                                                           __is_vector, __is_parallel);
+    }
 }
 
 // [uninitialized.construct.default]
@@ -246,10 +276,12 @@ uninitialized_default_construct(_ExecutionPolicy&& __exec, _ForwardIterator __fi
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
 
     if constexpr (!::std::is_trivial_v<_ValueType>)
+    {
         oneapi::dpl::__internal::__pattern_walk1(
             ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
             oneapi::dpl::__internal::__op_uninitialized_default_construct<_DecayedExecutionPolicy>{}, __is_vector,
             __is_parallel);
+    }
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Size>
@@ -265,12 +297,16 @@ uninitialized_default_construct_n(_ExecutionPolicy&& __exec, _ForwardIterator __
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
 
     if constexpr (::std::is_trivial_v<_ValueType>)
+    {
         return oneapi::dpl::__internal::__pstl_next(__first, __n);
+    }
     else
+    {
         return oneapi::dpl::__internal::__pattern_walk1_n(
             ::std::forward<_ExecutionPolicy>(__exec), __first, __n,
             oneapi::dpl::__internal::__op_uninitialized_default_construct<_DecayedExecutionPolicy>{}, __is_vector,
             __is_parallel);
+    }
 }
 
 // [uninitialized.construct.value]
@@ -288,15 +324,19 @@ uninitialized_value_construct(_ExecutionPolicy&& __exec, _ForwardIterator __firs
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
 
     if constexpr (::std::is_trivial_v<_ValueType>)
+    {
         oneapi::dpl::__internal::__pattern_walk_brick(
             ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
             oneapi::dpl::__internal::__brick_fill<_ValueType, _DecayedExecutionPolicy>{_ValueType()},
             __is_parallel);
+    }
     else
+    {
         oneapi::dpl::__internal::__pattern_walk1(
             ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
             oneapi::dpl::__internal::__op_uninitialized_value_construct<_DecayedExecutionPolicy>{}, __is_vector,
             __is_parallel);
+    }
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Size>
@@ -312,15 +352,19 @@ uninitialized_value_construct_n(_ExecutionPolicy&& __exec, _ForwardIterator __fi
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
 
     if constexpr (::std::is_trivial_v<_ValueType>)
+    {
         return oneapi::dpl::__internal::__pattern_walk_brick_n(
             ::std::forward<_ExecutionPolicy>(__exec), __first, __n,
             oneapi::dpl::__internal::__brick_fill_n<_ValueType, _DecayedExecutionPolicy>{_ValueType()},
             __is_parallel);
+    }
     else
+    {
         return oneapi::dpl::__internal::__pattern_walk1_n(
             ::std::forward<_ExecutionPolicy>(__exec), __first, __n,
             oneapi::dpl::__internal::__op_uninitialized_value_construct<_DecayedExecutionPolicy>{}, __is_vector,
             __is_parallel);
+    }
 }
 
 } // namespace dpl

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -99,7 +99,9 @@ __pattern_walk2(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardI
     auto __future_obj = oneapi::dpl::__par_backend_hetero::__parallel_for(
         ::std::forward<_ExecutionPolicy>(__exec), unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f}, __n,
         __buf1.all_view(), __buf2.all_view());
-    oneapi::dpl::__internal::__invoke_if(_IsSync(), [&__future_obj]() { __future_obj.wait(); });
+
+    if constexpr (_IsSync())
+        __future_obj.wait();
 
     return __first2 + __n;
 }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -628,24 +628,27 @@ struct __early_exit_find_or
             using _ShiftedIdxType =
                 typename ::std::conditional<_OrTagType::value, decltype(__init_index + __i * __shift),
                                             decltype(__found_local.load())>::type;
-            _IterSize __current_iter = oneapi::dpl::__internal::__invoke_if_else(
-                _BackwardTagType{}, [__n_iter, __i]() { return __n_iter - 1 - __i; }, [__i]() { return __i; });
+
+            _IterSize __current_iter =  [__n_iter, __i](){ 
+                if constexpr (_BackwardTagType::value)
+                    return __n_iter - 1 - __i;
+                else
+                    return __i;
+            }();
 
             _ShiftedIdxType __shifted_idx = __init_index + __current_iter * __shift;
             // TODO:[Performance] the issue with atomic load (in comparison with __shifted_idx for early exit)
             // should be investigated later, with other HW
             if (__shifted_idx < __n && __pred(__shifted_idx, __rngs...))
             {
-                oneapi::dpl::__internal::__invoke_if_else(
-                    _OrTagType{}, [&__found_local]() { __found_local.store(1); },
-                    [&__found_local, &__comp, &__shifted_idx]() {
-                        for (auto __old = __found_local.load(); __comp(__shifted_idx, __old);
-                             __old = __found_local.load())
-                        {
-                            __found_local.compare_exchange_strong(__old, __shifted_idx);
-                        }
-                    });
-                return;
+                if constexpr (_OrTagType::value)
+                    __found_local.store(1);
+                else
+                    for (auto __old = __found_local.load(); __comp(__shifted_idx, __old);
+                         __old = __found_local.load())
+                    {
+                        __found_local.compare_exchange_strong(__old, __shifted_idx);
+                    }
             }
         }
     }
@@ -671,7 +674,7 @@ __parallel_find_or(_ExecutionPolicy&& __exec, _Brick __f, _BrickTag __brick_tag,
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<__find_or_kernel, _CustomName, _Brick,
                                                                                _Ranges...>;
 
-    auto __or_tag_check = ::std::is_same<_BrickTag, __parallel_or_tag>{};
+    constexpr bool __or_tag_check = ::std::is_same_v<_BrickTag, __parallel_or_tag>;
     auto __rng_n = oneapi::dpl::__ranges::__get_first_range_size(__rngs...);
     assert(__rng_n > 0);
 
@@ -738,24 +741,24 @@ __parallel_find_or(_ExecutionPolicy&& __exec, _Brick __f, _BrickTag __brick_tag,
                     // Set local atomic value to global atomic
                     if (__local_idx == 0 && __comp(__found_local.load(), __found.load()))
                     {
-                        oneapi::dpl::__internal::__invoke_if_else(
-                            __or_tag_check, [&__found]() { __found.store(1); },
-                            [&__found_local, &__found, &__comp]() {
-                                for (auto __old = __found.load(); __comp(__found_local.load(), __old);
-                                     __old = __found.load())
-                                {
-                                    __found.compare_exchange_strong(__old, __found_local.load());
-                                }
-                            });
+                        if constexpr (__or_tag_check)
+                            __found.store(1);
+                        else
+                            for (auto __old = __found.load(); __comp(__found_local.load(), __old);
+                                 __old = __found.load())
+                            {
+                                __found.compare_exchange_strong(__old, __found_local.load());
+                            }
                     }
                 });
         });
         //The end of the scope  -  a point of synchronization (on temporary sycl buffer destruction)
     }
 
-    return oneapi::dpl::__internal::__invoke_if_else(
-        __or_tag_check, [&__result]() { return __result; },
-        [&__result, &__rng_n, &__init_value]() { return __result != __init_value ? __result : __rng_n; });
+    if constexpr (__or_tag_check)
+        return __result;
+    else
+        return __result != __init_value ? __result : __rng_n;
 }
 
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -644,11 +644,13 @@ struct __early_exit_find_or
                 if constexpr (_OrTagType::value)
                     __found_local.store(1);
                 else
+                {
                     for (auto __old = __found_local.load(); __comp(__shifted_idx, __old);
                          __old = __found_local.load())
                     {
                         __found_local.compare_exchange_strong(__old, __shifted_idx);
                     }
+                }
             }
         }
     }
@@ -744,11 +746,13 @@ __parallel_find_or(_ExecutionPolicy&& __exec, _Brick __f, _BrickTag __brick_tag,
                         if constexpr (__or_tag_check)
                             __found.store(1);
                         else
+                        {
                             for (auto __old = __found.load(); __comp(__found_local.load(), __old);
                                  __old = __found.load())
                             {
                                 __found.compare_exchange_strong(__old, __found_local.load());
                             }
+                        }
                     }
                 });
         });

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -902,7 +902,7 @@ class __brick_set_op
                                      __internal::__pstl_left_bound(__b, _Size2(0), _Size2(__res), __val_b, __comp);
 
             if constexpr (_IsOpDifference::value)
-                bres = _count_a_left > __count_b;   /*difference*/
+                bres = __count_a_left > __count_b;   /*difference*/
             else
                 bres = __count_a_left <= __count_b; /*intersection*/
         }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -334,10 +334,10 @@ struct __get_sycl_range
 
     template <typename _Iter, typename _CopyDirectTag>
     buf_type<val_t<_Iter>>
-    copy_direct(_Iter __first, _Iter __last, _CopyDirectTag __copy_direct_tag)
+    copy_direct(_Iter __first, _Iter __last, _CopyDirectTag)
     {
         //create a SYCL buffer and copy data [first, last) or create a empty SYCL buffer with size = (last - first)
-        if constexpr (__copy_direct_tag::value)
+        if constexpr (_CopyDirectTag::value)
             return sycl::buffer<val_t<_Iter>, 1>(__first, __last);
         else
             return sycl::buffer<val_t<_Iter>, 1>(__last - __first);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -332,14 +332,15 @@ struct __get_sycl_range
         return buf;
     }
 
-    template <typename _Iter, typename _copy_direct_tag>
+    template <typename _Iter, typename _CopyDirectTag>
     buf_type<val_t<_Iter>>
-    copy_direct(_Iter __first, _Iter __last, _copy_direct_tag)
+    copy_direct(_Iter __first, _Iter __last, _CopyDirectTag __copy_direct_tag)
     {
         //create a SYCL buffer and copy data [first, last) or create a empty SYCL buffer with size = (last - first)
-        return oneapi::dpl::__internal::__invoke_if_else(
-            _copy_direct_tag{}, [&]() { return sycl::buffer<val_t<_Iter>, 1>(__first, __last); },
-            [&]() { return sycl::buffer<val_t<_Iter>, 1>(__last - __first); });
+        if constexpr (__copy_direct_tag::value)
+            return sycl::buffer<val_t<_Iter>, 1>(__first, __last);
+        else
+            return sycl::buffer<val_t<_Iter>, 1>(__last - __first);
     }
 
     template <typename _F, typename _It, typename _DiffType>

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -906,9 +906,8 @@ class __merge_func
         else
         {
             __move_range()(_M_z_beg + _M_zs, _M_z_beg + _M_zs + __nx, _M_x_beg + _M_xs);
-            oneapi::dpl::__internal::__invoke_if_not(::std::is_trivially_destructible<_ValueType>(), [&]() {
+            if constexpr (!::std::is_trivially_destructible_v<_ValueType>)
                 __cleanup_range()(_M_z_beg + _M_zs, _M_z_beg + _M_zs + __nx);
-            });
         }
 
         _x_orig = !_x_orig;
@@ -924,9 +923,8 @@ class __merge_func
         else
         {
             __move_range()(_M_z_beg + _M_zs + __nx, _M_z_beg + _M_zs + __nx + __ny, _M_x_beg + _M_ys);
-            oneapi::dpl::__internal::__invoke_if_not(::std::is_trivially_destructible<_ValueType>(), [&]() {
+            if constexpr (!::std::is_trivially_destructible_v<_ValueType>)
                 __cleanup_range()(_M_z_beg + _M_zs + __nx, _M_z_beg + _M_zs + __nx + __ny);
-            });
         }
 
         _y_orig = !_y_orig;
@@ -961,10 +959,11 @@ class __merge_func
             _M_leaf_merge(_M_z_beg + _M_xs, _M_z_beg + _M_xe, _M_z_beg + _M_ys, _M_z_beg + _M_ye, _M_x_beg + _M_zs,
                           _M_comp, __move_value(), __move_value(), __move_range(), __move_range());
 
-            oneapi::dpl::__internal::__invoke_if_not(::std::is_trivially_destructible<_ValueType>(), [&]() {
+            if constexpr (!::std::is_trivially_destructible_v<_ValueType>)
+            {
                 __cleanup_range()(_M_z_beg + _M_xs, _M_z_beg + _M_xe);
                 __cleanup_range()(_M_z_beg + _M_ys, _M_z_beg + _M_ye);
-            });
+            }
         }
         return nullptr;
     }

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -58,44 +58,6 @@ __except_handler(_Fp __f) -> decltype(__f())
     }
 }
 
-template <typename _Fp>
-void
-__invoke_if(::std::true_type, _Fp __f)
-{
-    __f();
-}
-
-template <typename _Fp>
-void __invoke_if(::std::false_type, _Fp)
-{
-}
-
-template <typename _Fp>
-void
-__invoke_if_not(::std::false_type, _Fp __f)
-{
-    __f();
-}
-
-template <typename _Fp>
-void __invoke_if_not(::std::true_type, _Fp)
-{
-}
-
-template <typename _F1, typename _F2>
-auto
-__invoke_if_else(::std::true_type, _F1 __f1, _F2) -> decltype(__f1())
-{
-    return __f1();
-}
-
-template <typename _F1, typename _F2>
-auto
-__invoke_if_else(::std::false_type, _F1, _F2 __f2) -> decltype(__f2())
-{
-    return __f2();
-}
-
 template <typename _Op>
 struct __invoke_unary_op
 {


### PR DESCRIPTION
This PR replaces the internal helper functions `oneapi::dpl::__internal::__invoke_if`, `oneapi::dpl::__internal::__invoke_if_not` and `oneapi::dpl::__internal::__invoke_if_else` with `if constexpr` now that oneDPL is free to use C++17 constructs.