### PR TITLE
Improve the SYCL backend utility functions

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -681,9 +681,6 @@ __parallel_radix_sort(_ExecutionPolicy&& __exec, _Range&& __in_rng)
             __iteration_event = __parallel_radix_sort_iteration<__radix_bits, __is_ascending, /*even=*/false>::submit(
                 ::std::forward<_ExecutionPolicy>(__exec), __segments, __radix_iter,
                 __out_rng, ::std::forward<_Range>(__in_rng), __tmp_buf, __iteration_event);
-
-        // TODO: since reassign to __iteration_event does not work, we have to make explicit wait on the event
-        explicit_wait_if<::std::is_pointer<decltype(__in_rng.begin())>::value>{}(__iteration_event);
     }
 
     return __future(__iteration_event, __tmp_buf, __out_buffer_holder.get_buffer());

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -59,7 +59,7 @@ using __enable_if_t = typename ::std::enable_if<__flag, _T>::type;
 template <typename _Dst, typename _Src>
 __enable_if_t<
     sizeof(_Dst) == sizeof(_Src) && ::std::is_trivially_copyable_v<_Dst> && ::std::is_trivially_copyable_v<_Src>, _Dst>
-__dpl_bit_cast(const _Src& __src)
+__dpl_bit_cast(const _Src& __src) noexcept
 {
 #if SYCL_LANGUAGE_VERSION >= 2020
     return sycl::bit_cast<_Dst>(__src);
@@ -77,7 +77,7 @@ __dpl_bit_cast(const _Src& __src)
 // The max power of 2 not exceeding the given value, same as C++20 std::bit_floor
 template <typename _T>
 __enable_if_t<::std::is_integral<_T>::value && ::std::is_unsigned<_T>::value, _T>
-__dpl_bit_floor(_T __x)
+__dpl_bit_floor(_T __x) noexcept
 {
     if (__x == 0) return 0;
 #if SYCL_LANGUAGE_VERSION >= 2020

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -114,34 +114,6 @@ zip(T... args)
     return oneapi::dpl::zip_iterator<T...>(args...);
 }
 
-// function to explicitly wait for an event in case a compile-time condition is met
-template <bool flag>
-struct explicit_wait_if
-{
-    template <typename _ExecutionPolicy>
-    void
-    operator()(_ExecutionPolicy&&){};
-
-    void operator()(sycl::event){};
-};
-
-template <>
-struct explicit_wait_if<true>
-{
-    template <typename _ExecutionPolicy>
-    void
-    operator()(_ExecutionPolicy&& __exec)
-    {
-        __exec.queue().wait_and_throw();
-    };
-
-    void
-    operator()(sycl::event __event)
-    {
-        __event.wait_and_throw();
-    }
-};
-
 // function is needed to wrap kernel name into another policy class
 template <template <typename> class _NewKernelName, typename _Policy,
           oneapi::dpl::__internal::__enable_if_device_execution_policy<_Policy, int> = 0>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -466,7 +466,7 @@ class __future : private std::tuple<_Args...>
 
     template <typename _T>
     constexpr auto
-    __possibly_wait_and_get_value(sycl::buffer<_T>& __buf)
+    __wait_and_get_value(sycl::buffer<_T>& __buf)
     {
         //according to a contract, returned value is one-element sycl::buffer
         return __buf.template get_access<access_mode::read>()[0];
@@ -474,7 +474,7 @@ class __future : private std::tuple<_Args...>
 
     template <typename _T>
     constexpr auto
-    __possibly_wait_and_get_value(_T& __val)
+    __wait_and_get_value(_T& __val)
     {
         wait();
         return __val;
@@ -504,7 +504,7 @@ public:
         if constexpr (sizeof...(_Args) > 0)
         {
             auto& __val = std::get<0>(*this);
-            return __possibly_wait_and_get_value(__val);
+            return __wait_and_get_value(__val);
         }
         else
             wait();


### PR DESCRIPTION
`__dpl_bit_cast`, `__dpl_bit_floor`, `__ceiling_div` moved from the radix sort implementation to the general SYCL utilities and improved/fixed (including the fix for compilation errors in C++20 mode).

`explicit_wait_if` and its sole use in radix sort are removed; it seems to be a workaround for some issues 2+ years back (in the code since GitLab times), and it is not used anywhere else. If someone remembers what it is about please comment how to check if it is still needed.

The implementation of `__future` is simplified a bit via combining condition-dependent waits and getting the value into a single overloaded routine. It's less orthogonal but these utilities are not used anywhere else, so I do not see much value in orthogonality which is not really used.