### PR TITLE
CI: make oneTBB available when testing on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,9 +213,11 @@ jobs:
       - name: Install Intel® oneAPI DPC++/C++ Compiler
         if: matrix.cxx_compiler == 'dpcpp' || matrix.cxx_compiler == 'icx'
         shell: cmd
-        run: |
+        ### powershell cmnd in the following run termal is to set the tbb path in cl.cfg file" #####
+        run: | 
           call %CONDA%/condabin/conda.bat activate base
           conda install -c intel dpcpp_win-64
+          powershell -command "(Get-Content %CONDA_PREFIX%\Library\lib\cl.cfg) -replace 'CL_CONFIG_TBB_DLL_PATH =', 'CL_CONFIG_TBB_DLL_PATH = %CONDA_PREFIX%\Library\bin' | Out-File -encoding ASCII %CONDA_PREFIX%\Library\lib\cl.cfg"
       - name: Run testing
         shell: cmd
         run: |
@@ -239,7 +241,6 @@ jobs:
           set CPATH=%CONDA_PREFIX%\include
           set TBB_DLL_PATH=%CONDA_PREFIX%\Library\bin
           set CL_CONFIG_TBB_DLL_PATH=%CONDA_PREFIX%\Library\bin
-          powershell -command "(Get-Content %CONDA_PREFIX%\Library\lib\cl.cfg) -replace 'CL_CONFIG_TBB_DLL_PATH =', 'CL_CONFIG_TBB_DLL_PATH = %CONDA_PREFIX%\Library\bin' | Out-File -encoding ASCII %CONDA_PREFIX%\Library\lib\cl.cfg"
           reg add HKLM\SOFTWARE\khronos\OpenCL\Vendors /v intelocl64.dll /t REG_DWORD /d 00000000
           cmake -G "Ninja" %toolchain_option% -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DONEDPL_BACKEND=${{ matrix.backend }} -DONEDPL_DEVICE_TYPE=${{ matrix.device_type }} ..
           ninja -j 2 -v %ninja_targets%

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,19 +210,14 @@ jobs:
         run: |
           call %CONDA%/condabin/conda.bat activate base
           conda install -c intel tbb-devel
-          cd tbb-devel
-          dir
+          dir tbb-devel
       - name: Install Intel® oneAPI DPC++/C++ Compiler
         if: matrix.cxx_compiler == 'dpcpp' || matrix.cxx_compiler == 'icx'
         shell: cmd
         run: |
           call %CONDA%/condabin/conda.bat activate base
           conda install -c intel dpcpp_win-64
-      - name: check the files
-        shell: cmd
-        run: |
-          cd dpcpp_win-64
-          dir
+          dir dpcpp_win-64
       - name: Run testing
         shell: cmd
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,6 @@ jobs:
           set PATH=%CONDA_PREFIX%\Library\lib;%PATH%
           set CPATH=%CONDA_PREFIX%\include
           set TBB_DLL_PATH=%CONDA_PREFIX%\Library\bin
-          set CL_CONFIG_TBB_DLL_PATH=%CONDA_PREFIX%\Library\bin
           powershell -command "(Get-Content %CONDA_PREFIX%\Library\lib\cl.cfg) -replace 'CL_CONFIG_TBB_DLL_PATH =', 'CL_CONFIG_TBB_DLL_PATH = %CONDA_PREFIX%\Library\bin' | Out-File -encoding ASCII %CONDA_PREFIX%\Library\lib\cl.cfg"
           reg add HKLM\SOFTWARE\khronos\OpenCL\Vendors /v intelocl64.dll /t REG_DWORD /d 00000000
           cmake -G "Ninja" %toolchain_option% -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DONEDPL_BACKEND=${{ matrix.backend }} -DONEDPL_DEVICE_TYPE=${{ matrix.device_type }} ..

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,11 +213,9 @@ jobs:
       - name: Install Intel® oneAPI DPC++/C++ Compiler
         if: matrix.cxx_compiler == 'dpcpp' || matrix.cxx_compiler == 'icx'
         shell: cmd
-        ### powershell cmnd in the following run termal is to set the tbb path in cl.cfg file" #####
         run: | 
           call %CONDA%/condabin/conda.bat activate base
           conda install -c intel dpcpp_win-64
-          powershell -command "(Get-Content %CONDA_PREFIX%\Library\lib\cl.cfg) -replace 'CL_CONFIG_TBB_DLL_PATH =', 'CL_CONFIG_TBB_DLL_PATH = %CONDA_PREFIX%\Library\bin' | Out-File -encoding ASCII %CONDA_PREFIX%\Library\lib\cl.cfg"
       - name: Run testing
         shell: cmd
         run: |
@@ -241,6 +239,7 @@ jobs:
           set CPATH=%CONDA_PREFIX%\include
           set TBB_DLL_PATH=%CONDA_PREFIX%\Library\bin
           set CL_CONFIG_TBB_DLL_PATH=%CONDA_PREFIX%\Library\bin
+          powershell -command "(Get-Content %CONDA_PREFIX%\Library\lib\cl.cfg) -replace 'CL_CONFIG_TBB_DLL_PATH =', 'CL_CONFIG_TBB_DLL_PATH = %CONDA_PREFIX%\Library\bin' | Out-File -encoding ASCII %CONDA_PREFIX%\Library\lib\cl.cfg"
           reg add HKLM\SOFTWARE\khronos\OpenCL\Vendors /v intelocl64.dll /t REG_DWORD /d 00000000
           cmake -G "Ninja" %toolchain_option% -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DONEDPL_BACKEND=${{ matrix.backend }} -DONEDPL_DEVICE_TYPE=${{ matrix.device_type }} ..
           ninja -j 2 -v %ninja_targets%

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,9 @@ jobs:
         run: |
           call %CONDA%/condabin/conda.bat activate base
           conda install -c intel dpcpp_win-64
+      - name: check the files
+        shell: cmd
+        run: |
           cd dpcpp_win-64
           dir
       - name: Run testing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,19 +185,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: windows-2019
+          - os: windows-2022
             cxx_compiler: dpcpp
             std: 17
             build_type: release
             backend: tbb
             device_type: HOST
-          - os: windows-2019
+          - os: windows-2022
             cxx_compiler: cl
             std: 17
             build_type: release
             backend: tbb
             device_type: HOST
-          - os: windows-2019
+          - os: windows-2022
             cxx_compiler: dpcpp
             std: 17
             build_type: release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,19 +185,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: windows-2022
+          - os: windows-2019
             cxx_compiler: dpcpp
             std: 17
             build_type: release
             backend: tbb
             device_type: HOST
-          - os: windows-2022
+          - os: windows-2019
             cxx_compiler: cl
             std: 17
             build_type: release
             backend: tbb
             device_type: HOST
-          - os: windows-2022
+          - os: windows-2019
             cxx_compiler: dpcpp
             std: 17
             build_type: release
@@ -239,6 +239,7 @@ jobs:
           set CPATH=%CONDA_PREFIX%\include
           set TBB_DLL_PATH=%CONDA_PREFIX%\Library\bin
           set CL_CONFIG_TBB_DLL_PATH=%CONDA_PREFIX%\Library\bin
+          powershell -command "(Get-Content %CONDA_PREFIX%\Library\lib\cl.cfg) -replace 'CL_CONFIG_TBB_DLL_PATH =', 'CL_CONFIG_TBB_DLL_PATH = %CONDA_PREFIX%\Library\bin' | Out-File -encoding ASCII %CONDA_PREFIX%\Library\lib\cl.cfg"
           reg add HKLM\SOFTWARE\khronos\OpenCL\Vendors /v intelocl64.dll /t REG_DWORD /d 00000000
           cmake -G "Ninja" %toolchain_option% -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DONEDPL_BACKEND=${{ matrix.backend }} -DONEDPL_DEVICE_TYPE=${{ matrix.device_type }} ..
           ninja -j 2 -v %ninja_targets%

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,7 +238,9 @@ jobs:
           set PATH=%CONDA_PREFIX%\Library\lib;%PATH%
           set CPATH=%CONDA_PREFIX%\include
           set TBB_DLL_PATH=%CONDA_PREFIX%\Library\bin
-          powershell -command "(Get-Content %CONDA_PREFIX%\Library\lib\cl.cfg) -replace 'CL_CONFIG_TBB_DLL_PATH =', 'CL_CONFIG_TBB_DLL_PATH = %CONDA_PREFIX%\Library\bin' | Out-File -encoding ASCII %CONDA_PREFIX%\Library\lib\cl.cfg"
+          if "${{ matrix.cxx_compiler }}" == "dpcpp" ( 
+             powershell -command "(Get-Content %CONDA_PREFIX%\Library\lib\cl.cfg) -replace 'CL_CONFIG_TBB_DLL_PATH =', 'CL_CONFIG_TBB_DLL_PATH = %CONDA_PREFIX%\Library\bin' | Out-File -encoding ASCII %CONDA_PREFIX%\Library\lib\cl.cfg"
+          )
           reg add HKLM\SOFTWARE\khronos\OpenCL\Vendors /v intelocl64.dll /t REG_DWORD /d 00000000
           cmake -G "Ninja" %toolchain_option% -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DONEDPL_BACKEND=${{ matrix.backend }} -DONEDPL_DEVICE_TYPE=${{ matrix.device_type }} ..
           ninja -j 2 -v %ninja_targets%

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,7 +216,6 @@ jobs:
         run: |
           call %CONDA%/condabin/conda.bat activate base
           conda install -c intel dpcpp_win-64
-          set CL_CONFIG_TBB_DLL_PATH=%CONDA_PREFIX%\Library\bin
       - name: Run testing
         shell: cmd
         run: |
@@ -239,6 +238,7 @@ jobs:
           set PATH=%CONDA_PREFIX%\Library\lib;%PATH%
           set CPATH=%CONDA_PREFIX%\include
           set TBB_DLL_PATH=%CONDA_PREFIX%\Library\bin
+          set CL_CONFIG_TBB_DLL_PATH=%CONDA_PREFIX%\Library\bin
           reg add HKLM\SOFTWARE\khronos\OpenCL\Vendors /v intelocl64.dll /t REG_DWORD /d 00000000
           cmake -G "Ninja" %toolchain_option% -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DONEDPL_BACKEND=${{ matrix.backend }} -DONEDPL_DEVICE_TYPE=${{ matrix.device_type }} ..
           ninja -j 2 -v %ninja_targets%

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,7 @@ jobs:
           if "${{ matrix.cxx_compiler }}" == "dpcpp" (
             powershell $output = dpcpp --version; Write-Host ::warning::Compiler: $output
             set toolchain_option=-DCMAKE_TOOLCHAIN_FILE=../cmake/windows-dpcpp-toolchain.cmake
+            powershell -command "(Get-Content %CONDA_PREFIX%\Library\lib\cl.cfg) -replace 'CL_CONFIG_TBB_DLL_PATH =', 'CL_CONFIG_TBB_DLL_PATH = %CONDA_PREFIX%\Library\bin' | Out-File -encoding ASCII %CONDA_PREFIX%\Library\lib\cl.cfg"
           )
           mkdir build && cd build
           call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
@@ -238,9 +239,6 @@ jobs:
           set PATH=%CONDA_PREFIX%\Library\lib;%PATH%
           set CPATH=%CONDA_PREFIX%\include
           set TBB_DLL_PATH=%CONDA_PREFIX%\Library\bin
-          if "${{ matrix.cxx_compiler }}" == "dpcpp" ( 
-             powershell -command "(Get-Content %CONDA_PREFIX%\Library\lib\cl.cfg) -replace 'CL_CONFIG_TBB_DLL_PATH =', 'CL_CONFIG_TBB_DLL_PATH = %CONDA_PREFIX%\Library\bin' | Out-File -encoding ASCII %CONDA_PREFIX%\Library\lib\cl.cfg"
-          )
           reg add HKLM\SOFTWARE\khronos\OpenCL\Vendors /v intelocl64.dll /t REG_DWORD /d 00000000
           cmake -G "Ninja" %toolchain_option% -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DONEDPL_BACKEND=${{ matrix.backend }} -DONEDPL_DEVICE_TYPE=${{ matrix.device_type }} ..
           ninja -j 2 -v %ninja_targets%

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,14 +210,12 @@ jobs:
         run: |
           call %CONDA%/condabin/conda.bat activate base
           conda install -c intel tbb-devel
-          dir tbb-devel
       - name: Install Intel® oneAPI DPC++/C++ Compiler
         if: matrix.cxx_compiler == 'dpcpp' || matrix.cxx_compiler == 'icx'
         shell: cmd
         run: |
           call %CONDA%/condabin/conda.bat activate base
           conda install -c intel dpcpp_win-64
-          dir dpcpp_win-64
       - name: Run testing
         shell: cmd
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,6 +216,7 @@ jobs:
         run: |
           call %CONDA%/condabin/conda.bat activate base
           conda install -c intel dpcpp_win-64
+          set CL_CONFIG_TBB_DLL_PATH=%CONDA_PREFIX%\Library\bin
       - name: Run testing
         shell: cmd
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,12 +210,16 @@ jobs:
         run: |
           call %CONDA%/condabin/conda.bat activate base
           conda install -c intel tbb-devel
+          cd tbb-devel
+          dir
       - name: Install Intel® oneAPI DPC++/C++ Compiler
         if: matrix.cxx_compiler == 'dpcpp' || matrix.cxx_compiler == 'icx'
         shell: cmd
         run: |
           call %CONDA%/condabin/conda.bat activate base
           conda install -c intel dpcpp_win-64
+          cd dpcpp_win-64
+          dir
       - name: Run testing
         shell: cmd
         run: |


### PR DESCRIPTION
cl.cfg is modified to specify installation location of Intel® oneAPI Threading Building Blocks according to the note from https://www.intel.com/content/www/us/en/developer/articles/release-notes/intel-oneapi-dpc-c-compiler-release-notes-2022.html:

> However, in other scenarios, OpenCL CPU RT will fail to load TBB since there is no TBB registry key installed and the TBB file in the configuration file is not set by default.... At the bottom of the file, there is a field named “CL_CONFIG_TBB_DLL_PATH,” to which you can add your TBB DLL path. For example: CL_CONFIG_TBB_DLL_PATH = c:\your_TBB_install_path