### PR TITLE
Check availability of parallel backends

### DIFF
--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -49,11 +49,27 @@
 #    define _ONEDPL_PREDEFINED_POLICIES 1
 #endif
 
-#if ONEDPL_USE_TBB_BACKEND || (!defined(ONEDPL_USE_TBB_BACKEND) && !ONEDPL_USE_OPENMP_BACKEND)
+// Check availability of parallel backends
+#if __has_include(<tbb/tbb.h>)
+#   define _ONEDPL_TBB_AVAILABLE 1
+#endif
+#if ONEDPL_USE_TBB_BACKEND && !_ONEDPL_TBB_AVAILABLE
+#   error "TBB backend is selected, but TBB is not found"
+#endif
+
+#if defined(_OPENMP)
+#   define _ONEDPL_OPENMP_AVAILABLE 1
+#endif
+#if ONEDPL_USE_OPENMP_BACKEND && !_ONEDPL_OPENMP_AVAILABLE
+#   error "OpenMP backend is selected, but OpenMP is not found"
+#endif
+
+// Select a parallel backend
+#if ONEDPL_USE_TBB_BACKEND || (!defined(ONEDPL_USE_TBB_BACKEND) && !ONEDPL_USE_OPENMP_BACKEND && _ONEDPL_TBB_AVAILABLE)
 #    define _ONEDPL_PAR_BACKEND_TBB 1
 #endif
 
-#if ONEDPL_USE_OPENMP_BACKEND || (!defined(ONEDPL_USE_OPENMP_BACKEND) && defined(_OPENMP))
+#if ONEDPL_USE_OPENMP_BACKEND || (!defined(ONEDPL_USE_OPENMP_BACKEND) && _ONEDPL_OPENMP_AVAILABLE)
 #    define _ONEDPL_PAR_BACKEND_OPENMP 1
 #endif
 

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -57,7 +57,7 @@
 #   error "TBB backend is selected, but TBB is not found"
 #endif
 
-#if defined(_OPENMP)
+#if defined(_OPENMP) && !defined(__SYCL_DEVICE_ONLY__)
 #   define _ONEDPL_OPENMP_AVAILABLE 1
 #endif
 #if ONEDPL_USE_OPENMP_BACKEND && !_ONEDPL_OPENMP_AVAILABLE

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -51,17 +51,17 @@
 
 // Check availability of parallel backends
 #if __has_include(<tbb/tbb.h>)
-#   define _ONEDPL_TBB_AVAILABLE 1
+#    define _ONEDPL_TBB_AVAILABLE 1
 #endif
 #if ONEDPL_USE_TBB_BACKEND && !_ONEDPL_TBB_AVAILABLE
-#   error "TBB backend is selected, but TBB is not found"
+#    error "TBB backend is selected, but TBB is not found"
 #endif
-
+// Check OpenMP availability only during host code compilation
 #if defined(_OPENMP) && !defined(__SYCL_DEVICE_ONLY__)
-#   define _ONEDPL_OPENMP_AVAILABLE 1
+#    define _ONEDPL_OPENMP_AVAILABLE 1
 #endif
 #if ONEDPL_USE_OPENMP_BACKEND && !_ONEDPL_OPENMP_AVAILABLE
-#   error "OpenMP backend is selected, but OpenMP is not found"
+#    error "OpenMP backend is selected, but OpenMP is not found"
 #endif
 
 // Select a parallel backend

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -55,7 +55,7 @@
 #if defined(_OPENMP) && __has_include(<omp.h>)
 #    define _ONEDPL_OPENMP_AVAILABLE 1
 #endif
-// Avoid throwing an error during compilation for a device
+// Avoid throwing an error during compilation for a device by checking __SYCL_DEVICE_ONLY__
 #if ONEDPL_USE_OPENMP_BACKEND && !_ONEDPL_OPENMP_AVAILABLE && !defined(__SYCL_DEVICE_ONLY__)
 #    error "Parallel execution policies with OpenMP* support are enabled, \
         but OpenMP* headers are not found or the compiler does not support OpenMP*"

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -54,29 +54,16 @@
 #    define _ONEDPL_TBB_AVAILABLE 1
 #endif
 #if ONEDPL_USE_TBB_BACKEND && !_ONEDPL_TBB_AVAILABLE
-#    error "TBB backend is selected, but TBB is not found"
-#endif
-// Check OpenMP availability only during host code compilation
-#if !defined(__SYCL_DEVICE_ONLY__)
-#    if defined(_OPENMP)
-#        define _ONEDPL_OPENMP_AVAILABLE 1
-#    endif
-#    if ONEDPL_USE_OPENMP_BACKEND && !_ONEDPL_OPENMP_AVAILABLE
-#        error "OpenMP backend is selected, but OpenMP is not found"
-#    endif
-#endif //no __SYCL_DEVICE_ONLY__
-
-// Select a parallel backend
-#if ONEDPL_USE_TBB_BACKEND || (!defined(ONEDPL_USE_TBB_BACKEND) && !ONEDPL_USE_OPENMP_BACKEND && _ONEDPL_TBB_AVAILABLE)
-#    define _ONEDPL_PAR_BACKEND_TBB 1
+#    error "Parallel execution policies with oneTBB or Intel(R) TBB support are enabled, but the library is not found"
 #endif
 
-#if ONEDPL_USE_OPENMP_BACKEND || (!defined(ONEDPL_USE_OPENMP_BACKEND) && _ONEDPL_OPENMP_AVAILABLE)
-#    define _ONEDPL_PAR_BACKEND_OPENMP 1
+#if defined(_OPENMP) && __has_include(<omp.h>)
+#    define _ONEDPL_OPENMP_AVAILABLE 1
 #endif
-
-#if !_ONEDPL_PAR_BACKEND_TBB && !_ONEDPL_PAR_BACKEND_OPENMP
-#    define _ONEDPL_PAR_BACKEND_SERIAL 1
+// Avoid throwing an error during compilation for a device
+#if ONEDPL_USE_OPENMP_BACKEND && !_ONEDPL_OPENMP_AVAILABLE && !defined(__SYCL_DEVICE_ONLY__)
+#    error "Parallel execution policies with OpenMP* support are enabled, \
+        but OpenMP* headers are not found or the compiler does not support OpenMP*"
 #endif
 
 // Check the user-defined macro for warnings

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -57,12 +57,14 @@
 #    error "TBB backend is selected, but TBB is not found"
 #endif
 // Check OpenMP availability only during host code compilation
-#if defined(_OPENMP) && !defined(__SYCL_DEVICE_ONLY__)
-#    define _ONEDPL_OPENMP_AVAILABLE 1
-#endif
-#if ONEDPL_USE_OPENMP_BACKEND && !_ONEDPL_OPENMP_AVAILABLE
-#    error "OpenMP backend is selected, but OpenMP is not found"
-#endif
+#if !defined(__SYCL_DEVICE_ONLY__)
+#    if defined(_OPENMP)
+#        define _ONEDPL_OPENMP_AVAILABLE 1
+#    endif
+#    if ONEDPL_USE_OPENMP_BACKEND && !_ONEDPL_OPENMP_AVAILABLE
+#        error "OpenMP backend is selected, but OpenMP is not found"
+#    endif
+#endif //no __SYCL_DEVICE_ONLY__
 
 // Select a parallel backend
 #if ONEDPL_USE_TBB_BACKEND || (!defined(ONEDPL_USE_TBB_BACKEND) && !ONEDPL_USE_OPENMP_BACKEND && _ONEDPL_TBB_AVAILABLE)

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -62,7 +62,7 @@
         but OpenMP headers are not found or the compiler does not support OpenMP"
 #endif
 
-#if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) &&                                           \
+#if (defined(SYCL_LANGUAGE_VERSION) || defined(CL_SYCL_LANGUAGE_VERSION)) && \
     (__has_include(<sycl/sycl.hpp>) || __has_include(<CL/sycl.hpp>))
 #    define _ONEDPL_SYCL_AVAILABLE 1
 #endif

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -62,7 +62,7 @@
         but OpenMP headers are not found or the compiler does not support OpenMP"
 #endif
 
-#if (defined(SYCL_LANGUAGE_VERSION) || defined(CL_SYCL_LANGUAGE_VERSION)) && \
+#if (defined(SYCL_LANGUAGE_VERSION) || defined(CL_SYCL_LANGUAGE_VERSION)) &&                                           \
     (__has_include(<sycl/sycl.hpp>) || __has_include(<CL/sycl.hpp>))
 #    define _ONEDPL_SYCL_AVAILABLE 1
 #endif

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -55,7 +55,8 @@
 #if defined(_OPENMP) && __has_include(<omp.h>)
 #    define _ONEDPL_OPENMP_AVAILABLE 1
 #endif
-// Avoid throwing an error during compilation for a device by checking __SYCL_DEVICE_ONLY__
+// During compilation for a device _OPENMP may not be set, so avoid throwing an error if
+// __SYCL_DEVICE_ONLY__ found
 #if ONEDPL_USE_OPENMP_BACKEND && !_ONEDPL_OPENMP_AVAILABLE && !defined(__SYCL_DEVICE_ONLY__)
 #    error "Parallel execution policies with OpenMP* support are enabled, \
         but OpenMP headers are not found or the compiler does not support OpenMP"

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -64,7 +64,7 @@
 
 #if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) &&                                           \
     (__has_include(<sycl/sycl.hpp>) || __has_include(<CL/sycl.hpp>))
-#   define _ONEDPL_SYCL_AVAILABLE 1
+#    define _ONEDPL_SYCL_AVAILABLE 1
 #endif
 #if ONEDPL_USE_DPCPP_BACKEND && !_ONEDPL_SYCL_AVAILABLE
 #    error "Device execution policies are enabled, \

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -58,7 +58,7 @@
 // Avoid throwing an error during compilation for a device by checking __SYCL_DEVICE_ONLY__
 #if ONEDPL_USE_OPENMP_BACKEND && !_ONEDPL_OPENMP_AVAILABLE && !defined(__SYCL_DEVICE_ONLY__)
 #    error "Parallel execution policies with OpenMP* support are enabled, \
-        but OpenMP* headers are not found or the compiler does not support OpenMP*"
+        but OpenMP headers are not found or the compiler does not support OpenMP"
 #endif
 
 #if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) &&                                           \
@@ -67,7 +67,7 @@
 #endif
 #if ONEDPL_USE_DPCPP_BACKEND && !_ONEDPL_SYCL_AVAILABLE
 #    error "Device execution policies are enabled, \
-        but SYCL* headers are not found or the compiler does not support SYCL*"
+        but SYCL* headers are not found or the compiler does not support SYCL"
 #endif
 
 // Check the user-defined macro for warnings

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -27,11 +27,6 @@
 #define ONEDPL_VERSION_MINOR 3
 #define ONEDPL_VERSION_PATCH 0
 
-#if defined(ONEDPL_USE_DPCPP_BACKEND)
-#    undef _ONEDPL_BACKEND_SYCL
-#    define _ONEDPL_BACKEND_SYCL ONEDPL_USE_DPCPP_BACKEND
-#endif
-
 #if defined(ONEDPL_FPGA_DEVICE)
 #    undef _ONEDPL_FPGA_DEVICE
 #    define _ONEDPL_FPGA_DEVICE ONEDPL_FPGA_DEVICE
@@ -64,6 +59,15 @@
 #if ONEDPL_USE_OPENMP_BACKEND && !_ONEDPL_OPENMP_AVAILABLE && !defined(__SYCL_DEVICE_ONLY__)
 #    error "Parallel execution policies with OpenMP* support are enabled, \
         but OpenMP* headers are not found or the compiler does not support OpenMP*"
+#endif
+
+#if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) &&                                           \
+    (__has_include(<sycl/sycl.hpp>) || __has_include(<CL/sycl.hpp>))
+#   define _ONEDPL_SYCL_AVAILABLE 1
+#endif
+#if ONEDPL_USE_DPCPP_BACKEND && !_ONEDPL_SYCL_AVAILABLE
+#    error "Device execution policies are enabled, \
+        but SYCL* headers are not found or the compiler does not support SYCL*"
 #endif
 
 // Check the user-defined macro for warnings
@@ -245,15 +249,8 @@
 #define _ONEDPL_HAS_NUMERIC_SERIAL_IMPL                                                                                \
     (__GLIBCXX__ && (_GLIBCXX_RELEASE < 9 || (_GLIBCXX_RELEASE == 9 && __GLIBCXX__ < 20200312)))
 
-// Check the user-defined macro for parallel policies
-// define _ONEDPL_BACKEND_SYCL 1 when we compile with the Compiler that supports SYCL
-#if !defined(_ONEDPL_BACKEND_SYCL)
-#    if ((defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) &&                                      \
-         (__has_include(<sycl/sycl.hpp>) || __has_include(<CL/sycl.hpp>)))
-#        define _ONEDPL_BACKEND_SYCL 1
-#    else
-#        define _ONEDPL_BACKEND_SYCL 0
-#    endif // CL_SYCL_LANGUAGE_VERSION
+#if ONEDPL_USE_DPCPP_BACKEND || (!defined(ONEDPL_USE_DPCPP_BACKEND) && _ONEDPL_SYCL_AVAILABLE)
+#    define _ONEDPL_BACKEND_SYCL 1
 #endif
 
 // if SYCL policy switch on then let's switch hetero policy macro on

--- a/include/oneapi/dpl/pstl/parallel_backend.h
+++ b/include/oneapi/dpl/pstl/parallel_backend.h
@@ -15,6 +15,20 @@
 #ifndef _ONEDPL_PARALLEL_BACKEND_H
 #define _ONEDPL_PARALLEL_BACKEND_H
 #include "onedpl_config.h"
+
+// Select a parallel backend
+#if ONEDPL_USE_TBB_BACKEND || (!defined(ONEDPL_USE_TBB_BACKEND) && !ONEDPL_USE_OPENMP_BACKEND && _ONEDPL_TBB_AVAILABLE)
+#    define _ONEDPL_PAR_BACKEND_TBB 1
+#endif
+
+#if ONEDPL_USE_OPENMP_BACKEND || (!defined(ONEDPL_USE_OPENMP_BACKEND) && _ONEDPL_OPENMP_AVAILABLE)
+#    define _ONEDPL_PAR_BACKEND_OPENMP 1
+#endif
+
+#if !_ONEDPL_PAR_BACKEND_TBB && !_ONEDPL_PAR_BACKEND_OPENMP
+#    define _ONEDPL_PAR_BACKEND_SERIAL 1
+#endif
+
 #if _ONEDPL_BACKEND_SYCL
 #    include "hetero/dpcpp/parallel_backend_sycl.h"
 #    if _ONEDPL_FPGA_DEVICE

--- a/include/oneapi/dpl/pstl/parallel_backend.h
+++ b/include/oneapi/dpl/pstl/parallel_backend.h
@@ -19,13 +19,12 @@
 // Select a parallel backend
 #if ONEDPL_USE_TBB_BACKEND || (!defined(ONEDPL_USE_TBB_BACKEND) && !ONEDPL_USE_OPENMP_BACKEND && _ONEDPL_TBB_AVAILABLE)
 #    define _ONEDPL_PAR_BACKEND_TBB 1
-#endif
-
-#if ONEDPL_USE_OPENMP_BACKEND || (!defined(ONEDPL_USE_OPENMP_BACKEND) && _ONEDPL_OPENMP_AVAILABLE)
+#    include "parallel_backend_tbb.h"
+#elif ONEDPL_USE_OPENMP_BACKEND || (!defined(ONEDPL_USE_OPENMP_BACKEND) && _ONEDPL_OPENMP_AVAILABLE)
+#    include "parallel_backend_omp.h"
 #    define _ONEDPL_PAR_BACKEND_OPENMP 1
-#endif
-
-#if !_ONEDPL_PAR_BACKEND_TBB && !_ONEDPL_PAR_BACKEND_OPENMP
+#else
+#    include "parallel_backend_serial.h"
 #    define _ONEDPL_PAR_BACKEND_SERIAL 1
 #endif
 
@@ -36,35 +35,21 @@
 #    endif
 #endif
 
+namespace oneapi
+{
+namespace dpl
+{
+namespace __par_backend =
 #if _ONEDPL_PAR_BACKEND_TBB
-#    include "parallel_backend_tbb.h"
-namespace oneapi
-{
-namespace dpl
-{
-namespace __par_backend = __tbb_backend;
-}
-} // namespace oneapi
+__tbb_backend;
 #elif _ONEDPL_PAR_BACKEND_OPENMP
-#    include "parallel_backend_omp.h"
-namespace oneapi
-{
-namespace dpl
-{
-namespace __par_backend = __omp_backend;
-}
-} // namespace oneapi
+__omp_backend;
 #elif _ONEDPL_PAR_BACKEND_SERIAL
-#    include "parallel_backend_serial.h"
-namespace oneapi
-{
-namespace dpl
-{
-namespace __par_backend = __serial_backend;
-}
-} // namespace oneapi
+__serial_backend;
 #else
 _PSTL_PRAGMA_MESSAGE("Parallel backend was not specified");
 #endif
+}
+} // namespace oneapi
 
 #endif // _ONEDPL_PARALLEL_BACKEND_H

--- a/include/oneapi/dpl/pstl/parallel_backend.h
+++ b/include/oneapi/dpl/pstl/parallel_backend.h
@@ -41,15 +41,15 @@ namespace dpl
 {
 namespace __par_backend =
 #if _ONEDPL_PAR_BACKEND_TBB
-__tbb_backend;
+    __tbb_backend;
 #elif _ONEDPL_PAR_BACKEND_OPENMP
-__omp_backend;
+    __omp_backend;
 #elif _ONEDPL_PAR_BACKEND_SERIAL
-__serial_backend;
+    __serial_backend;
 #else
-_PSTL_PRAGMA_MESSAGE("Parallel backend was not specified");
+    _PSTL_PRAGMA_MESSAGE("Parallel backend was not specified");
 #endif
-}
+} // namespace dpl
 } // namespace oneapi
 
 #endif // _ONEDPL_PARALLEL_BACKEND_H

--- a/include/oneapi/dpl/pstl/parallel_backend.h
+++ b/include/oneapi/dpl/pstl/parallel_backend.h
@@ -18,8 +18,8 @@
 
 // Select a parallel backend
 #if ONEDPL_USE_TBB_BACKEND || (!defined(ONEDPL_USE_TBB_BACKEND) && !ONEDPL_USE_OPENMP_BACKEND && _ONEDPL_TBB_AVAILABLE)
-#    define _ONEDPL_PAR_BACKEND_TBB 1
 #    include "parallel_backend_tbb.h"
+#    define _ONEDPL_PAR_BACKEND_TBB 1
 #elif ONEDPL_USE_OPENMP_BACKEND || (!defined(ONEDPL_USE_OPENMP_BACKEND) && _ONEDPL_OPENMP_AVAILABLE)
 #    include "parallel_backend_omp.h"
 #    define _ONEDPL_PAR_BACKEND_OPENMP 1

--- a/include/oneapi/dpl/pstl/parallel_backend.h
+++ b/include/oneapi/dpl/pstl/parallel_backend.h
@@ -39,13 +39,12 @@ namespace oneapi
 {
 namespace dpl
 {
-namespace __par_backend =
 #if _ONEDPL_PAR_BACKEND_TBB
-    __tbb_backend;
+    namespace __par_backend = __tbb_backend;
 #elif _ONEDPL_PAR_BACKEND_OPENMP
-    __omp_backend;
+    namespace __par_backend = __omp_backend;
 #elif _ONEDPL_PAR_BACKEND_SERIAL
-    __serial_backend;
+    namespace __par_backend = __serial_backend;
 #else
 #    error "Parallel backend was not specified"
 #endif

--- a/include/oneapi/dpl/pstl/parallel_backend.h
+++ b/include/oneapi/dpl/pstl/parallel_backend.h
@@ -47,7 +47,7 @@ namespace __par_backend =
 #elif _ONEDPL_PAR_BACKEND_SERIAL
     __serial_backend;
 #else
-    _PSTL_PRAGMA_MESSAGE("Parallel backend was not specified");
+#   error "Parallel backend was not specified"
 #endif
 } // namespace dpl
 } // namespace oneapi

--- a/include/oneapi/dpl/pstl/parallel_backend.h
+++ b/include/oneapi/dpl/pstl/parallel_backend.h
@@ -47,7 +47,7 @@ namespace __par_backend =
 #elif _ONEDPL_PAR_BACKEND_SERIAL
     __serial_backend;
 #else
-#   error "Parallel backend was not specified"
+#    error "Parallel backend was not specified"
 #endif
 } // namespace dpl
 } // namespace oneapi

--- a/include/oneapi/dpl/pstl/parallel_backend.h
+++ b/include/oneapi/dpl/pstl/parallel_backend.h
@@ -40,11 +40,11 @@ namespace oneapi
 namespace dpl
 {
 #if _ONEDPL_PAR_BACKEND_TBB
-    namespace __par_backend = __tbb_backend;
+namespace __par_backend = __tbb_backend;
 #elif _ONEDPL_PAR_BACKEND_OPENMP
-    namespace __par_backend = __omp_backend;
+namespace __par_backend = __omp_backend;
 #elif _ONEDPL_PAR_BACKEND_SERIAL
-    namespace __par_backend = __serial_backend;
+namespace __par_backend = __serial_backend;
 #else
 #    error "Parallel backend was not specified"
 #endif


### PR DESCRIPTION
The PR has the following intention:

- Separate logic of finding available parallel backends from logic of their selection.
- Stop compilation if a user selected a not available backend.

Additional changes:
 - Availability of OpenMP backend now is verified by both compiler support (via `_OPENMP` support as before) and heaving `<omp.h>` header. Having compiler support indicated by `_OPENMP` is not enough, because the headers may be missing. They, for example, are provided separately on Ubuntu 20.04 as a part of `libomp-dev` package.
 - Availability of SYCL backend now is also verified by both compiler (as before) support and having `sycl.hpp` header. 

The PR was inspired by PR #524 and by this [discussion](https://github.com/oneapi-src/oneDPL/pull/524#discussion_r831326254).