### PR TITLE
Fix deprecated sycl::access::target::local enum value usage

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -317,8 +317,7 @@ __parallel_transform_reduce(_ExecutionPolicy&& __exec, _Up __u, _LRp __brick_lea
 
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...); //get an access to data under SYCL buffer
             auto __temp_acc = __temp.template get_access<access_mode::read_write>(__cgh);
-            __dpl_sycl::__local_accessor<_Tp, access_mode::read_write> __temp_local(sycl::range<1>(__work_group_size),
-                                                                                    __cgh);
+            __dpl_sycl::__local_accessor<_Tp> __temp_local(sycl::range<1>(__work_group_size), __cgh);
 #if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
             __cgh.use_kernel_bundle(__kernel.get_kernel_bundle());
 #endif
@@ -448,7 +447,7 @@ struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name
         auto __submit_event = __exec.queue().submit([&](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rng1, __rng2); //get an access to data under SYCL buffer
             auto __wg_sums_acc = __wg_sums.template get_access<access_mode::discard_write>(__cgh);
-            __dpl_sycl::__local_accessor<_Type, access_mode::discard_read_write> __local_acc(__wgroup_size, __cgh);
+            __dpl_sycl::__local_accessor<_Type> __local_acc(__wgroup_size, __cgh);
 #if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
             __cgh.use_kernel_bundle(__kernel_1.get_kernel_bundle());
 #endif
@@ -469,7 +468,7 @@ struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name
             __submit_event = __exec.queue().submit([&](sycl::handler& __cgh) {
                 __cgh.depends_on(__submit_event);
                 auto __wg_sums_acc = __wg_sums.template get_access<access_mode::read_write>(__cgh);
-                __dpl_sycl::__local_accessor<_Type, access_mode::discard_read_write> __local_acc(__wgroup_size, __cgh);
+                __dpl_sycl::__local_accessor<_Type> __local_acc(__wgroup_size, __cgh);
 #if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
                 __cgh.use_kernel_bundle(__kernel_2.get_kernel_bundle());
 #endif
@@ -705,7 +704,7 @@ __parallel_find_or(_ExecutionPolicy&& __exec, _Brick __f, _BrickTag __brick_tag,
             auto __temp_acc = __temp.template get_access<access_mode::read_write>(__cgh);
 
             // create local accessor to connect atomic with
-            __dpl_sycl::__local_accessor<_AtomicType, access_mode::read_write> __temp_local(1, __cgh);
+            __dpl_sycl::__local_accessor<_AtomicType> __temp_local(1, __cgh);
 #if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
             __cgh.use_kernel_bundle(__kernel.get_kernel_bundle());
 #endif

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -317,8 +317,8 @@ __parallel_transform_reduce(_ExecutionPolicy&& __exec, _Up __u, _LRp __brick_lea
 
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...); //get an access to data under SYCL buffer
             auto __temp_acc = __temp.template get_access<access_mode::read_write>(__cgh);
-            sycl::accessor<_Tp, 1, access_mode::read_write, __dpl_sycl::__target::local> __temp_local(
-                sycl::range<1>(__work_group_size), __cgh);
+            __dpl_sycl::__local_accessor<_Tp, access_mode::read_write> __temp_local(sycl::range<1>(__work_group_size),
+                                                                                    __cgh);
 #if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
             __cgh.use_kernel_bundle(__kernel.get_kernel_bundle());
 #endif
@@ -448,8 +448,7 @@ struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name
         auto __submit_event = __exec.queue().submit([&](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rng1, __rng2); //get an access to data under SYCL buffer
             auto __wg_sums_acc = __wg_sums.template get_access<access_mode::discard_write>(__cgh);
-            sycl::accessor<_Type, 1, access_mode::discard_read_write, __dpl_sycl::__target::local> __local_acc(
-                __wgroup_size, __cgh);
+            __dpl_sycl::__local_accessor<_Type, access_mode::discard_read_write> __local_acc(__wgroup_size, __cgh);
 #if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
             __cgh.use_kernel_bundle(__kernel_1.get_kernel_bundle());
 #endif
@@ -470,8 +469,7 @@ struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name
             __submit_event = __exec.queue().submit([&](sycl::handler& __cgh) {
                 __cgh.depends_on(__submit_event);
                 auto __wg_sums_acc = __wg_sums.template get_access<access_mode::read_write>(__cgh);
-                sycl::accessor<_Type, 1, access_mode::discard_read_write, __dpl_sycl::__target::local> __local_acc(
-                    __wgroup_size, __cgh);
+                __dpl_sycl::__local_accessor<_Type, access_mode::discard_read_write> __local_acc(__wgroup_size, __cgh);
 #if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
                 __cgh.use_kernel_bundle(__kernel_2.get_kernel_bundle());
 #endif
@@ -707,7 +705,7 @@ __parallel_find_or(_ExecutionPolicy&& __exec, _Brick __f, _BrickTag __brick_tag,
             auto __temp_acc = __temp.template get_access<access_mode::read_write>(__cgh);
 
             // create local accessor to connect atomic with
-            sycl::accessor<_AtomicType, 1, access_mode::read_write, __dpl_sycl::__target::local> __temp_local(1, __cgh);
+            __dpl_sycl::__local_accessor<_AtomicType, access_mode::read_write> __temp_local(1, __cgh);
 #if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
             __cgh.use_kernel_bundle(__kernel.get_kernel_bundle());
 #endif

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -175,7 +175,7 @@ __radix_sort_count_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments, :
         oneapi::dpl::__ranges::__require_access(__hdl, __val_rng,
                                                 __count_rng); //get an access to data under SYCL buffer
         // an accessor per work-group with value counters from each work-item
-        auto __count_lacc = __dpl_sycl::__local_accessor<_CountT, access_mode::read_write>(__block_size * __radix_states, __hdl);
+        auto __count_lacc = __dpl_sycl::__local_accessor<_CountT>(__block_size * __radix_states, __hdl);
 #if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
         __hdl.use_kernel_bundle(__kernel.get_kernel_bundle());
 #endif
@@ -313,7 +313,7 @@ template <typename _OffsetT>
 struct __peer_prefix_helper<_OffsetT, __peer_prefix_algo::atomic_fetch_or>
 {
     using _AtomicT = __dpl_sycl::__atomic_ref<::std::uint32_t, sycl::access::address_space::local_space>;
-    using _TempStorageT = __dpl_sycl::__local_accessor<::std::uint32_t, sycl::access::mode::read_write>;
+    using _TempStorageT = __dpl_sycl::__local_accessor<::std::uint32_t>;
 
     sycl::sub_group __sgroup;
     ::std::uint32_t __self_lidx;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -175,8 +175,7 @@ __radix_sort_count_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments, :
         oneapi::dpl::__ranges::__require_access(__hdl, __val_rng,
                                                 __count_rng); //get an access to data under SYCL buffer
         // an accessor per work-group with value counters from each work-item
-        auto __count_lacc = sycl::accessor<_CountT, 1, access_mode::read_write, __dpl_sycl::__target::local>(
-            __block_size * __radix_states, __hdl);
+        auto __count_lacc = __dpl_sycl::__local_accessor<_CountT, access_mode::read_write>(__block_size * __radix_states, __hdl);
 #if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
         __hdl.use_kernel_bundle(__kernel.get_kernel_bundle());
 #endif
@@ -314,8 +313,7 @@ template <typename _OffsetT>
 struct __peer_prefix_helper<_OffsetT, __peer_prefix_algo::atomic_fetch_or>
 {
     using _AtomicT = __dpl_sycl::__atomic_ref<::std::uint32_t, sycl::access::address_space::local_space>;
-    using _TempStorageT =
-        sycl::accessor<::std::uint32_t, 1, sycl::access::mode::read_write, sycl::access::target::local>;
+    using _TempStorageT = __dpl_sycl::__local_accessor<::std::uint32_t, sycl::access::mode::read_write>;
 
     sycl::sub_group __sgroup;
     ::std::uint32_t __self_lidx;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -239,9 +239,7 @@ using __local_accessor =
 #if _ONEDPL_LIBSYCL_VERSION >= 60000
     sycl::local_accessor<DataT, Dimensions>;
 #else
-    sycl::accessor<DataT, Dimensions,
-                   ::std::is_const_v<DataT> ? sycl::access::mode::read : sycl::access::mode::read_write,
-                   __dpl_sycl::__target::local>;
+    sycl::accessor<DataT, Dimensions, sycl::access::mode::read_write, __dpl_sycl::__target::local>;
 #endif
 
 } // namespace __dpl_sycl

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -233,12 +233,12 @@ struct __atomic_ref : sycl::atomic<_AtomicType, _Space>
 };
 #endif // _ONEDPL_SYCL2023_ATOMIC_REF_PRESENT
 
-template <typename DataT, sycl::access::mode AccessMode, int Dimensions = 1>
+template <typename DataT, int Dimensions = 1>
 using __local_accessor =
 #if _ONEDPL_LIBSYCL_VERSION >= 60000
     sycl::local_accessor<DataT, Dimensions>;
 #else
-    sycl::accessor<DataT, Dimensions, AccessMode, __dpl_sycl::__target::local>;
+    sycl::accessor<DataT, Dimensions, sycl::access::mode::read_write, __dpl_sycl::__target::local>;
 #endif
 
 } // namespace __dpl_sycl

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -27,6 +27,7 @@
 #    include <CL/sycl.hpp>
 #endif
 #include <memory>
+#include <type_traits>
 
 // Combine SYCL runtime library version
 #if defined(__LIBSYCL_MAJOR_VERSION) && defined(__LIBSYCL_MINOR_VERSION) && defined(__LIBSYCL_PATCH_VERSION)
@@ -238,7 +239,9 @@ using __local_accessor =
 #if _ONEDPL_LIBSYCL_VERSION >= 60000
     sycl::local_accessor<DataT, Dimensions>;
 #else
-    sycl::accessor<DataT, Dimensions, sycl::access::mode::read_write, __dpl_sycl::__target::local>;
+    sycl::accessor<DataT, Dimensions,
+                   ::std::is_const_v<DataT> ? sycl::access::mode::read : sycl::access::mode::read_write,
+                   __dpl_sycl::__target::local>;
 #endif
 
 } // namespace __dpl_sycl

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -233,6 +233,14 @@ struct __atomic_ref : sycl::atomic<_AtomicType, _Space>
 };
 #endif // _ONEDPL_SYCL2023_ATOMIC_REF_PRESENT
 
+template <typename DataT, sycl::access::mode AccessMode, int Dimensions = 1>
+using __local_accessor =
+#if _ONEDPL_LIBSYCL_VERSION >= 60000
+    sycl::local_accessor<DataT, Dimensions>;
+#else
+    sycl::accessor<DataT, Dimensions, AccessMode, __dpl_sycl::__target::local>;
+#endif
+
 } // namespace __dpl_sycl
 
 #endif /* _ONEDPL_sycl_defs_H */

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -80,36 +80,6 @@ inline constexpr _Tp __known_identity =
     __known_identity_for_plus<_BinaryOp, _Tp>::value; //for plus only
 #endif //_ONEDPL_LIBSYCL_VERSION >= 50200
 
-// a way to get value_type from both accessors and USM that is needed for transform_init
-template <typename _Unknown>
-struct __accessor_traits_impl
-{
-};
-
-template <typename _T, int _Dim, sycl::access::mode _AccMode, __dpl_sycl::__target _AccTarget,
-          sycl::access::placeholder _Placeholder>
-struct __accessor_traits_impl<sycl::accessor<_T, _Dim, _AccMode, _AccTarget, _Placeholder>>
-{
-    using value_type = typename sycl::accessor<_T, _Dim, _AccMode, _AccTarget, _Placeholder>::value_type;
-};
-
-#if _ONEDPL_LIBSYCL_VERSION >= 60000
-template <typename _T, int _Dim>
-struct __accessor_traits_impl<sycl::local_accessor<_T, _Dim>>
-{
-    using value_type = typename sycl::local_accessor<_T, _Dim>::value_type;
-};
-#endif // _ONEDPL_LIBSYCL_VERSION >= 60000
-
-template <typename _RawArrayValueType>
-struct __accessor_traits_impl<_RawArrayValueType*>
-{
-    using value_type = _RawArrayValueType;
-};
-
-template <typename _Unknown>
-using __accessor_traits = __accessor_traits_impl<typename ::std::decay<_Unknown>::type>;
-
 template <typename _ExecutionPolicy, typename _F>
 struct walk_n
 {
@@ -225,12 +195,11 @@ struct transform_init
     operator()(const _NDItemId __item, _Size __n, ::std::size_t __iters_per_work_item, ::std::size_t __global_id,
                ::std::size_t __global_offset, _AccLocal& __local_mem, const _Acc&... __acc) const
     {
-        using _Tp = typename __accessor_traits<_AccLocal>::value_type;
         ::std::size_t __adjusted_global_id = __global_offset + __iters_per_work_item * __global_id;
         _Size __adjusted_n = __global_offset + __n;
         if (__adjusted_global_id < __adjusted_n)
         {
-            _Tp __res = __unary_op(__adjusted_global_id, __acc...);
+            auto __res = __unary_op(__adjusted_global_id, __acc...);
             // Add neighbour to the current __local_mem
             for (::std::size_t __i = 1; __i < __iters_per_work_item; ++__i)
             {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -93,6 +93,14 @@ struct __accessor_traits_impl<sycl::accessor<_T, _Dim, _AccMode, _AccTarget, _Pl
     using value_type = typename sycl::accessor<_T, _Dim, _AccMode, _AccTarget, _Placeholder>::value_type;
 };
 
+#if _ONEDPL_LIBSYCL_VERSION >= 60000
+template <typename _T, int _Dim>
+struct __accessor_traits_impl<sycl::local_accessor<_T, _Dim>>
+{
+    using value_type = typename sycl::local_accessor<_T, _Dim>::value_type;
+};
+#endif // _ONEDPL_LIBSYCL_VERSION >= 60000
+
 template <typename _RawArrayValueType>
 struct __accessor_traits_impl<_RawArrayValueType*>
 {


### PR DESCRIPTION
In this PR we fix deprecated sycl::access::target::local enum value usage:
```
enum class target {
  // ...
  local __SYCL2020_DEPRECATED("use `local_accessor` instead") = 2016,
  // ...
};
```
Instead this enum value we start using of ```sycl::local_accessor``` class.

For additional information about class ```sycl::local_accessor``` please see
https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_interface_for_local_accessors