### PR TITLE
Fix deprecated sycl::default_selector

### DIFF
--- a/documentation/library_guide/api_for_sycl_kernels/random.rst
+++ b/documentation/library_guide/api_for_sycl_kernels/random.rst
@@ -94,7 +94,7 @@ Random number generation is available for SYCL* device-side and host-side code. 
     #include <oneapi/dpl/random>
 
     int main() {
-        sycl::queue queue(sycl::default_selector{});
+        sycl::queue queue(sycl::default_selector_v);
 
         std::int64_t nsamples = 100;
         std::uint32_t seed = 777;

--- a/documentation/library_guide/api_for_sycl_kernels/random.rst
+++ b/documentation/library_guide/api_for_sycl_kernels/random.rst
@@ -94,7 +94,7 @@ Random number generation is available for SYCL* device-side and host-side code. 
     #include <oneapi/dpl/random>
 
     int main() {
-        sycl::queue queue(sycl::default_selector_v);
+        sycl::queue queue;
 
         std::int64_t nsamples = 100;
         std::uint32_t seed = 777;

--- a/examples/random/src/main.cpp
+++ b/examples/random/src/main.cpp
@@ -133,7 +133,7 @@ main()
         }
     };
 
-    sycl::queue queue(sycl::default_selector{}, async_handler);
+    sycl::queue queue(sycl::default_selector_v, async_handler);
 
     constexpr std::int64_t nsamples = 100;
     constexpr int vec_size = 4;

--- a/examples/random/src/main.cpp
+++ b/examples/random/src/main.cpp
@@ -133,7 +133,7 @@ main()
         }
     };
 
-    sycl::queue queue(sycl::default_selector_v, async_handler);
+    sycl::queue queue(async_handler);
 
     constexpr std::int64_t nsamples = 100;
     constexpr int vec_size = 4;

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -119,7 +119,13 @@ make_new_policy(_Policy&& __policy)
         oneapi::dpl::execution::make_fpga_policy(sycl::queue{default_selector});
 #    endif // ONEDPL_USE_PREDEFINED_POLICIES
 #else
-    auto default_selector = sycl::default_selector{};
+    auto default_selector =
+#   if _ONEDPL_LIBSYCL_VERSION >= 60000
+        sycl::default_selector_v;
+#   else
+        sycl::default_selector{};
+#   endif
+
     auto&& default_dpcpp_policy =
 #    if ONEDPL_USE_PREDEFINED_POLICIES
         oneapi::dpl::execution::dpcpp_default;

--- a/test/xpu_api/random/conformance_tests/minstd_rand_rand0_test.pass.cpp
+++ b/test/xpu_api/random/conformance_tests/minstd_rand_rand0_test.pass.cpp
@@ -50,7 +50,7 @@ int main() {
         }
     };
 
-    sycl::queue queue(exception_handler);
+    sycl::queue queue(TestUtils::default_selector, exception_handler);
 
     // Reference values
     uint_fast32_t minstd_rand0_ref_sample = 1043618065;

--- a/test/xpu_api/random/conformance_tests/minstd_rand_rand0_test.pass.cpp
+++ b/test/xpu_api/random/conformance_tests/minstd_rand_rand0_test.pass.cpp
@@ -50,7 +50,7 @@ int main() {
         }
     };
 
-    sycl::queue queue(sycl::default_selector{}, exception_handler);
+    sycl::queue queue(sycl::default_selector_v, exception_handler);
 
     // Reference values
     uint_fast32_t minstd_rand0_ref_sample = 1043618065;

--- a/test/xpu_api/random/conformance_tests/minstd_rand_rand0_test.pass.cpp
+++ b/test/xpu_api/random/conformance_tests/minstd_rand_rand0_test.pass.cpp
@@ -50,7 +50,7 @@ int main() {
         }
     };
 
-    sycl::queue queue(sycl::default_selector_v, exception_handler);
+    sycl::queue queue(exception_handler);
 
     // Reference values
     uint_fast32_t minstd_rand0_ref_sample = 1043618065;

--- a/test/xpu_api/random/conformance_tests/ranlux_24_48_base_test.pass.cpp
+++ b/test/xpu_api/random/conformance_tests/ranlux_24_48_base_test.pass.cpp
@@ -50,7 +50,7 @@ int main() {
         }
     };
 
-    sycl::queue queue(sycl::default_selector{}, exception_handler);
+    sycl::queue queue(sycl::default_selector_v, exception_handler);
 
     // Reference values
     uint_fast32_t ranlux24_base_ref_sample = 7937952;

--- a/test/xpu_api/random/conformance_tests/ranlux_24_48_base_test.pass.cpp
+++ b/test/xpu_api/random/conformance_tests/ranlux_24_48_base_test.pass.cpp
@@ -50,7 +50,7 @@ int main() {
         }
     };
 
-    sycl::queue queue(sycl::default_selector_v, exception_handler);
+    sycl::queue queue(exception_handler);
 
     // Reference values
     uint_fast32_t ranlux24_base_ref_sample = 7937952;

--- a/test/xpu_api/random/conformance_tests/ranlux_24_48_test.pass.cpp
+++ b/test/xpu_api/random/conformance_tests/ranlux_24_48_test.pass.cpp
@@ -50,7 +50,7 @@ int main() {
         }
     };
 
-    sycl::queue queue(sycl::default_selector{}, exception_handler);
+    sycl::queue queue(sycl::default_selector_v, exception_handler);
 
     // Reference values
     uint_fast32_t ranlux24_ref_sample = 9901578;

--- a/test/xpu_api/random/conformance_tests/ranlux_24_48_test.pass.cpp
+++ b/test/xpu_api/random/conformance_tests/ranlux_24_48_test.pass.cpp
@@ -50,7 +50,7 @@ int main() {
         }
     };
 
-    sycl::queue queue(sycl::default_selector_v, exception_handler);
+    sycl::queue queue(exception_handler);
 
     // Reference values
     uint_fast32_t ranlux24_ref_sample = 9901578;

--- a/test/xpu_api/random/interface_tests/distributions_methods.pass.cpp
+++ b/test/xpu_api/random/interface_tests/distributions_methods.pass.cpp
@@ -365,7 +365,7 @@ main()
         }
     };
 
-    sycl::queue queue(sycl::default_selector{}, exception_handler);
+    sycl::queue queue(sycl::default_selector_v, exception_handler);
     std::int32_t err = 0;
 
     // Skip tests if DP is not supported

--- a/test/xpu_api/random/interface_tests/distributions_methods.pass.cpp
+++ b/test/xpu_api/random/interface_tests/distributions_methods.pass.cpp
@@ -365,7 +365,7 @@ main()
         }
     };
 
-    sycl::queue queue(sycl::default_selector_v, exception_handler);
+    sycl::queue queue(exception_handler);
     std::int32_t err = 0;
 
     // Skip tests if DP is not supported

--- a/test/xpu_api/random/interface_tests/engines_methods.pass.cpp
+++ b/test/xpu_api/random/interface_tests/engines_methods.pass.cpp
@@ -403,7 +403,7 @@ main()
         }
     };
 
-    sycl::queue queue(sycl::default_selector{}, exception_handler);
+    sycl::queue queue(sycl::default_selector_v, exception_handler);
     
     std::int32_t err = 0;
 

--- a/test/xpu_api/random/interface_tests/engines_methods.pass.cpp
+++ b/test/xpu_api/random/interface_tests/engines_methods.pass.cpp
@@ -403,7 +403,7 @@ main()
         }
     };
 
-    sycl::queue queue(sycl::default_selector_v, exception_handler);
+    sycl::queue queue(exception_handler);
     
     std::int32_t err = 0;
 


### PR DESCRIPTION
In this PR we fix usage of deprecated ```sycl::default_selector``` in oneDPL: instead of them we should use ```sycl::default_selector_v```.

For additional info about ```sycl::default_selector_v``` please see https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:device-selector