### PR TITLE
Avoid double type in tests of std::complex<T>

### DIFF
--- a/test/xpu_api/numerics/c.math/cmath.pass.cpp
+++ b/test/xpu_api/numerics/c.math/cmath.pass.cpp
@@ -88,17 +88,15 @@ void test_abs()
     static_assert((std::is_same<decltype(dpl::abs((short)0)), int>::value), "");
     static_assert((std::is_same<decltype(dpl::abs((unsigned char)0)), int>::value), "");
     static_assert((std::is_same<decltype(dpl::abs((char)0)), int>::value), "");
-    static_assert((std::is_same<decltype(dpl::abs(Ambiguous())), Ambiguous>::value), "");
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::abs(Ambiguous())), Ambiguous>::value), ""))
 
     static_assert(!has_abs<unsigned>::value, "");
     static_assert(!has_abs<unsigned long>::value, "");
     static_assert(!has_abs<unsigned long long>::value, "");
     static_assert(!has_abs<size_t>::value, "");
 
-    auto fnc = []() { static_assert((std::is_same<decltype(dpl::abs((double)0)), double>::value), ""); };
-    IF_DOUBLE_SUPPORT_L(fnc)
-    auto fnc1 = []() { static_assert((std::is_same<decltype(dpl::abs((long double)0)), long double>::value), ""); };
-    IF_LONG_DOUBLE_SUPPORT_L(fnc1)
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::abs((double)0)), double>::value), ""))
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::abs((long double)0)), long double>::value), ""))
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif
@@ -110,8 +108,7 @@ ONEDPL_TEST_DECLARE
 void test_ceil()
 {
     static_assert((std::is_same<decltype(dpl::ceil((float)0)), float>::value), "");
-    auto fnc = []()
-    {
+    IF_DOUBLE_SUPPORT(
         static_assert((std::is_same<decltype(dpl::ceil((bool)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::ceil((unsigned short)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::ceil((int)0)), double>::value), "");
@@ -120,21 +117,17 @@ void test_ceil()
         static_assert((std::is_same<decltype(dpl::ceil((unsigned long)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::ceil((long long)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::ceil((unsigned long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::ceil((double)0)), double>::value), "");
-    };
-    IF_DOUBLE_SUPPORT_L(fnc)
-    auto fnc1 = []() { static_assert((std::is_same<decltype(dpl::ceil((long double)0)), long double>::value), ""); };
-    IF_LONG_DOUBLE_SUPPORT_L(fnc1)
-    static_assert((std::is_same<decltype(dpl::ceil(Ambiguous())), Ambiguous>::value), "");
-    assert(dpl::ceil(0) == 0);
+        static_assert((std::is_same<decltype(dpl::ceil((double)0)), double>::value), ""))
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::ceil((long double)0)), long double>::value), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::ceil(Ambiguous())), Ambiguous>::value), "");
+                      assert(dpl::ceil(0) == 0))
 }
 
 ONEDPL_TEST_DECLARE
 void test_exp()
 {
     static_assert((std::is_same<decltype(dpl::exp((float)0)), float>::value), "");
-    auto fnc = []()
-    {
+    IF_DOUBLE_SUPPORT(
         static_assert((std::is_same<decltype(dpl::exp((bool)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::exp((unsigned short)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::exp((int)0)), double>::value), "");
@@ -143,21 +136,17 @@ void test_exp()
         static_assert((std::is_same<decltype(dpl::exp((unsigned long)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::exp((long long)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::exp((unsigned long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::exp((double)0)), double>::value), "");
-    };
-    IF_DOUBLE_SUPPORT_L(fnc)
-    auto fnc1 = []() { static_assert((std::is_same<decltype(dpl::exp((long double)0)), long double>::value), ""); };
-    IF_LONG_DOUBLE_SUPPORT_L(fnc1)
-    static_assert((std::is_same<decltype(dpl::exp(Ambiguous())), Ambiguous>::value), "");
-    assert(dpl::exp(0) == 1);
+        static_assert((std::is_same<decltype(dpl::exp((double)0)), double>::value), ""))
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::exp((long double)0)), long double>::value), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::exp(Ambiguous())), Ambiguous>::value), "");
+                      assert(dpl::exp(0) == 1))
 }
 
 ONEDPL_TEST_DECLARE
 void test_fabs()
 {
     static_assert((std::is_same<decltype(dpl::fabs((float)0)), float>::value), "");
-    auto fnc = []()
-    {
+    IF_DOUBLE_SUPPORT(
         static_assert((std::is_same<decltype(dpl::fabs((bool)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::fabs((unsigned short)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::fabs((int)0)), double>::value), "");
@@ -166,22 +155,17 @@ void test_fabs()
         static_assert((std::is_same<decltype(dpl::fabs((unsigned long)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::fabs((long long)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::fabs((unsigned long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fabs((double)0)), double>::value), "");
-    };
-    IF_DOUBLE_SUPPORT_L(fnc)
-    auto fnc1 = []()
-    { static_assert((std::is_same<decltype(dpl::fabs((long double)0)), long double>::value), ""); };
-    IF_LONG_DOUBLE_SUPPORT_L(fnc1)
-    static_assert((std::is_same<decltype(dpl::fabs(Ambiguous())), Ambiguous>::value), "");
-    assert(dpl::fabs(-1) == 1);
+        static_assert((std::is_same<decltype(dpl::fabs((double)0)), double>::value), ""))
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::fabs((long double)0)), long double>::value), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::fabs(Ambiguous())), Ambiguous>::value), "");
+                      assert(dpl::fabs(-1) == 1));
 }
 
 ONEDPL_TEST_DECLARE
 void test_floor()
 {
     static_assert((std::is_same<decltype(dpl::floor((float)0)), float>::value), "");
-    auto fnc = []()
-    {
+    IF_DOUBLE_SUPPORT(
         static_assert((std::is_same<decltype(dpl::floor((bool)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::floor((unsigned short)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::floor((int)0)), double>::value), "");
@@ -190,14 +174,10 @@ void test_floor()
         static_assert((std::is_same<decltype(dpl::floor((unsigned long)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::floor((long long)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::floor((unsigned long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::floor((double)0)), double>::value), "");
-    };
-    IF_DOUBLE_SUPPORT_L(fnc)
-    auto fnc1 = []()
-    { static_assert((std::is_same<decltype(dpl::floor((long double)0)), long double>::value), ""); };
-    IF_LONG_DOUBLE_SUPPORT_L(fnc1)
-    static_assert((std::is_same<decltype(dpl::floor(Ambiguous())), Ambiguous>::value), "");
-    assert(dpl::floor(1) == 1);
+        static_assert((std::is_same<decltype(dpl::floor((double)0)), double>::value), ""))
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::floor((long double)0)), long double>::value), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::floor(Ambiguous())), Ambiguous>::value), "");
+                      assert(dpl::floor(1) == 1))
 }
 
 ONEDPL_TEST_DECLARE
@@ -207,25 +187,19 @@ void test_isgreater()
 #error isgreater defined
 #endif
     static_assert((std::is_same<decltype(dpl::isgreater((float)0, (float)0)), bool>::value), "");
-    auto fnc = []()
-    {
+    IF_DOUBLE_SUPPORT(
         static_assert((std::is_same<decltype(dpl::isgreater((float)0, (double)0)), bool>::value), "");
         static_assert((std::is_same<decltype(dpl::isgreater((double)0, (float)0)), bool>::value), "");
         static_assert((std::is_same<decltype(dpl::isgreater((double)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isgreater(0, (double)0)), bool>::value), "");
-    };
-    IF_DOUBLE_SUPPORT_L(fnc)
-    auto fnc1 = []()
-    {
+        static_assert((std::is_same<decltype(dpl::isgreater(0, (double)0)), bool>::value), ""))
+    IF_LONG_DOUBLE_SUPPORT(
         static_assert((std::is_same<decltype(dpl::isgreater((float)0, (long double)0)), bool>::value), "");
         static_assert((std::is_same<decltype(dpl::isgreater((double)0, (long double)0)), bool>::value), "");
         static_assert((std::is_same<decltype(dpl::isgreater((long double)0, (float)0)), bool>::value), "");
         static_assert((std::is_same<decltype(dpl::isgreater((long double)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isgreater((long double)0, (long double)0)), bool>::value), "");
-    };
-    IF_LONG_DOUBLE_SUPPORT_L(fnc1)
-    static_assert((std::is_same<decltype(dpl::isgreater(Ambiguous(), Ambiguous())), Ambiguous>::value), "");
-    assert(dpl::isgreater(-1.0, 0.F) == false);
+        static_assert((std::is_same<decltype(dpl::isgreater((long double)0, (long double)0)), bool>::value), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::isgreater(Ambiguous(), Ambiguous())), Ambiguous>::value), "");
+                      assert(dpl::isgreater(-1.0, 0.F) == false))
 }
 
 ONEDPL_TEST_DECLARE
@@ -235,25 +209,19 @@ void test_isgreaterequal()
 #error isgreaterequal defined
 #endif
     static_assert((std::is_same<decltype(dpl::isgreaterequal((float)0, (float)0)), bool>::value), "");
-    auto fnc = []()
-    {
+    IF_DOUBLE_SUPPORT(
         static_assert((std::is_same<decltype(dpl::isgreaterequal((float)0, (double)0)), bool>::value), "");
         static_assert((std::is_same<decltype(dpl::isgreaterequal((double)0, (float)0)), bool>::value), "");
         static_assert((std::is_same<decltype(dpl::isgreaterequal((double)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isgreaterequal(0, (double)0)), bool>::value), "");
-    };
-    IF_DOUBLE_SUPPORT_L(fnc)
-    auto fnc1 = []()
-    {
+        static_assert((std::is_same<decltype(dpl::isgreaterequal(0, (double)0)), bool>::value), ""))
+    IF_LONG_DOUBLE_SUPPORT(
         static_assert((std::is_same<decltype(dpl::isgreaterequal((float)0, (long double)0)), bool>::value), "");
         static_assert((std::is_same<decltype(dpl::isgreaterequal((double)0, (long double)0)), bool>::value), "");
         static_assert((std::is_same<decltype(dpl::isgreaterequal((long double)0, (float)0)), bool>::value), "");
         static_assert((std::is_same<decltype(dpl::isgreaterequal((long double)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isgreaterequal((long double)0, (long double)0)), bool>::value), "");
-    };
-    IF_LONG_DOUBLE_SUPPORT_L(fnc1)
-    static_assert((std::is_same<decltype(dpl::isgreaterequal(Ambiguous(), Ambiguous())), Ambiguous>::value), "");
-    assert(dpl::isgreaterequal(-1.0, 0.F) == false);
+        static_assert((std::is_same<decltype(dpl::isgreaterequal((long double)0, (long double)0)), bool>::value), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::isgreaterequal(Ambiguous(), Ambiguous())), Ambiguous>::value), "");
+                      assert(dpl::isgreaterequal(-1.0, 0.F) == false))
 }
 
 ONEDPL_TEST_DECLARE
@@ -286,9 +254,8 @@ void test_isinf()
     };
     IF_DOUBLE_SUPPORT_L(fnc)
 
-    auto fnc1 = []() { static_assert((std::is_same<decltype(dpl::isinf((long double)0)), bool>::value), ""); };
-    IF_LONG_DOUBLE_SUPPORT_L(fnc1)
-    assert(dpl::isinf(-1.0) == false);
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::isinf((long double)0)), bool>::value), ""))
+    IF_DOUBLE_SUPPORT(assert(dpl::isinf(-1.0) == false))
     assert(dpl::isinf(0) == false);
     assert(dpl::isinf(1) == false);
     assert(dpl::isinf(-1) == false);
@@ -307,25 +274,19 @@ void test_isless()
 #error isless defined
 #endif
     static_assert((std::is_same<decltype(dpl::isless((float)0, (float)0)), bool>::value), "");
-    auto fnc = []()
-    {
+    IF_DOUBLE_SUPPORT(
         static_assert((std::is_same<decltype(dpl::isless((float)0, (double)0)), bool>::value), "");
         static_assert((std::is_same<decltype(dpl::isless((double)0, (float)0)), bool>::value), "");
         static_assert((std::is_same<decltype(dpl::isless((double)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isless(0, (double)0)), bool>::value), "");
-    };
-    IF_DOUBLE_SUPPORT_L(fnc)
-    auto fnc1 = []()
-    {
+        static_assert((std::is_same<decltype(dpl::isless(0, (double)0)), bool>::value), ""))
+    IF_LONG_DOUBLE_SUPPORT(
         static_assert((std::is_same<decltype(dpl::isless((float)0, (long double)0)), bool>::value), "");
         static_assert((std::is_same<decltype(dpl::isless((double)0, (long double)0)), bool>::value), "");
         static_assert((std::is_same<decltype(dpl::isless((long double)0, (float)0)), bool>::value), "");
         static_assert((std::is_same<decltype(dpl::isless((long double)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isless((long double)0, (long double)0)), bool>::value), "");
-    };
-    IF_LONG_DOUBLE_SUPPORT_L(fnc1)
-    static_assert((std::is_same<decltype(dpl::isless(Ambiguous(), Ambiguous())), Ambiguous>::value), "");
-    assert(dpl::isless(-1.0, 0.F) == true);
+        static_assert((std::is_same<decltype(dpl::isless((long double)0, (long double)0)), bool>::value), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::isless(Ambiguous(), Ambiguous())), Ambiguous>::value), "");
+                      assert(dpl::isless(-1.0, 0.F) == true))
 }
 
 ONEDPL_TEST_DECLARE
@@ -335,25 +296,19 @@ void test_islessequal()
 #error islessequal defined
 #endif
     static_assert((std::is_same<decltype(dpl::islessequal((float)0, (float)0)), bool>::value), "");
-    auto fnc = []()
-    {
+    IF_DOUBLE_SUPPORT(
         static_assert((std::is_same<decltype(dpl::islessequal((float)0, (double)0)), bool>::value), "");
         static_assert((std::is_same<decltype(dpl::islessequal((double)0, (float)0)), bool>::value), "");
         static_assert((std::is_same<decltype(dpl::islessequal((double)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::islessequal(0, (double)0)), bool>::value), "");
-    };
-    IF_DOUBLE_SUPPORT_L(fnc)
-    auto fnc1 = []()
-    {
+        static_assert((std::is_same<decltype(dpl::islessequal(0, (double)0)), bool>::value), ""))
+    IF_LONG_DOUBLE_SUPPORT(
         static_assert((std::is_same<decltype(dpl::islessequal((float)0, (long double)0)), bool>::value), "");
         static_assert((std::is_same<decltype(dpl::islessequal((double)0, (long double)0)), bool>::value), "");
         static_assert((std::is_same<decltype(dpl::islessequal((long double)0, (float)0)), bool>::value), "");
         static_assert((std::is_same<decltype(dpl::islessequal((long double)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::islessequal((long double)0, (long double)0)), bool>::value), "");
-    };
-    IF_LONG_DOUBLE_SUPPORT_L(fnc1)
-    static_assert((std::is_same<decltype(dpl::islessequal(Ambiguous(), Ambiguous())), Ambiguous>::value), "");
-    assert(dpl::islessequal(-1.0, 0.F) == true);
+        static_assert((std::is_same<decltype(dpl::islessequal((long double)0, (long double)0)), bool>::value), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::islessequal(Ambiguous(), Ambiguous())), Ambiguous>::value), "");
+                      assert(dpl::islessequal(-1.0, 0.F) == true));
 }
 
 ONEDPL_TEST_DECLARE
@@ -385,9 +340,8 @@ void test_isnan()
     IF_DOUBLE_SUPPORT_L(fnc)
 
     static_assert((std::is_same<decltype(dpl::isnan(0)), bool>::value), "");
-    auto fnc1 = []() { static_assert((std::is_same<decltype(dpl::isnan((long double)0)), bool>::value), ""); };
-    IF_LONG_DOUBLE_SUPPORT_L(fnc1)
-    assert(dpl::isnan(-1.0) == false);
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::isnan((long double)0)), bool>::value), ""))
+    IF_DOUBLE_SUPPORT(assert(dpl::isnan(-1.0) == false))
     assert(dpl::isnan(0) == false);
     assert(dpl::isnan(1) == false);
     assert(dpl::isnan(-1) == false);
@@ -406,25 +360,19 @@ void test_isunordered()
 #error isunordered defined
 #endif
     static_assert((std::is_same<decltype(dpl::isunordered((float)0, (float)0)), bool>::value), "");
-    auto fnc = []()
-    {
+    IF_DOUBLE_SUPPORT(
         static_assert((std::is_same<decltype(dpl::isunordered((float)0, (double)0)), bool>::value), "");
         static_assert((std::is_same<decltype(dpl::isunordered((double)0, (float)0)), bool>::value), "");
         static_assert((std::is_same<decltype(dpl::isunordered((double)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isunordered(0, (double)0)), bool>::value), "");
-    };
-    IF_DOUBLE_SUPPORT_L(fnc)
-    auto fnc1 = []()
-    {
+        static_assert((std::is_same<decltype(dpl::isunordered(0, (double)0)), bool>::value), ""))
+    IF_LONG_DOUBLE_SUPPORT(
         static_assert((std::is_same<decltype(dpl::isunordered((float)0, (long double)0)), bool>::value), "");
         static_assert((std::is_same<decltype(dpl::isunordered((double)0, (long double)0)), bool>::value), "");
         static_assert((std::is_same<decltype(dpl::isunordered((long double)0, (float)0)), bool>::value), "");
         static_assert((std::is_same<decltype(dpl::isunordered((long double)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isunordered((long double)0, (long double)0)), bool>::value), "");
-    };
-    IF_LONG_DOUBLE_SUPPORT_L(fnc1)
-    static_assert((std::is_same<decltype(dpl::isunordered(Ambiguous(), Ambiguous())), Ambiguous>::value), "");
-    assert(dpl::isunordered(-1.0, 0.F) == false);
+        static_assert((std::is_same<decltype(dpl::isunordered((long double)0, (long double)0)), bool>::value), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::isunordered(Ambiguous(), Ambiguous())), Ambiguous>::value), "");
+                      assert(dpl::isunordered(-1.0, 0.F) == false));
 }
 
 ONEDPL_TEST_DECLARE
@@ -433,29 +381,23 @@ void test_copysign()
     static_assert((std::is_same<decltype(dpl::copysign((float)0, (float)0)), float>::value), "");
     static_assert((std::is_same<decltype(dpl::copysign((float)0, (unsigned int)0)), double>::value), "");
     static_assert((std::is_same<decltype(dpl::copysignf(0,0)), float>::value), "");
-    auto fnc = []()
-    {
+    IF_DOUBLE_SUPPORT(
         static_assert((std::is_same<decltype(dpl::copysign((bool)0, (float)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::copysign((unsigned short)0, (double)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::copysign((double)0, (long)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::copysign((int)0, (unsigned long long)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::copysign((double)0, (double)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::copysign((float)0, (double)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::copysign((int)0, (int)0)), double>::value), "");
-    };
-    IF_DOUBLE_SUPPORT_L(fnc)
-    auto fnc1 = []()
-    {
+        static_assert((std::is_same<decltype(dpl::copysign((int)0, (int)0)), double>::value), ""))
+    IF_LONG_DOUBLE_SUPPORT(
         static_assert((std::is_same<decltype(dpl::copysign((int)0, (long double)0)), long double>::value), "");
         static_assert((std::is_same<decltype(dpl::copysign((long double)0, (unsigned long)0)), long double>::value), "");
         static_assert((std::is_same<decltype(dpl::copysign((int)0, (long long)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::copysign((long double)0, (long double)0)), long double>::value), "");
         static_assert((std::is_same<decltype(dpl::copysign((float)0, (long double)0)), long double>::value), "");
-        static_assert((std::is_same<decltype(dpl::copysign((double)0, (long double)0)), long double>::value), "");
-    };
-    IF_LONG_DOUBLE_SUPPORT_L(fnc1)
-    static_assert((std::is_same<decltype(dpl::copysign(Ambiguous(), Ambiguous())), Ambiguous>::value), "");
-    assert(dpl::copysign(1,1) == 1);
+        static_assert((std::is_same<decltype(dpl::copysign((double)0, (long double)0)), long double>::value), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::copysign(Ambiguous(), Ambiguous())), Ambiguous>::value), "");
+                      assert(dpl::copysign(1,1) == 1))
 }
 
 ONEDPL_TEST_DECLARE
@@ -464,8 +406,7 @@ void test_fmax()
     static_assert((std::is_same<decltype(dpl::fmax((float)0, (float)0)), float>::value), "");
     static_assert((std::is_same<decltype(dpl::fmax((float)0, (unsigned int)0)), double>::value), "");
     static_assert((std::is_same<decltype(dpl::fmaxf(0,0)), float>::value), "");
-    auto fnc = []()
-    {
+    IF_DOUBLE_SUPPORT(
         static_assert((std::is_same<decltype(dpl::fmax((bool)0, (float)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::fmax((unsigned short)0, (double)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::fmax((int)0, (long long)0)), double>::value), "");
@@ -473,20 +414,15 @@ void test_fmax()
         static_assert((std::is_same<decltype(dpl::fmax((double)0, (long)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::fmax((double)0, (double)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::fmax((float)0, (double)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmax((int)0, (int)0)), double>::value), "");
-    };
-    IF_DOUBLE_SUPPORT_L(fnc)
-    auto fnc1 = []()
-    {
+        static_assert((std::is_same<decltype(dpl::fmax((int)0, (int)0)), double>::value), ""))
+    IF_LONG_DOUBLE_SUPPORT(
         static_assert((std::is_same<decltype(dpl::fmax((int)0, (long double)0)), long double>::value), "");
         static_assert((std::is_same<decltype(dpl::fmax((long double)0, (unsigned long)0)), long double>::value), "");
         static_assert((std::is_same<decltype(dpl::fmax((long double)0, (long double)0)), long double>::value), "");
         static_assert((std::is_same<decltype(dpl::fmax((float)0, (long double)0)), long double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmax((double)0, (long double)0)), long double>::value), "");
-    };
-    IF_LONG_DOUBLE_SUPPORT_L(fnc1)
-    static_assert((std::is_same<decltype(dpl::fmax(Ambiguous(), Ambiguous())), Ambiguous>::value), "");
-    assert(dpl::fmax(1,0) == 1);
+        static_assert((std::is_same<decltype(dpl::fmax((double)0, (long double)0)), long double>::value), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::fmax(Ambiguous(), Ambiguous())), Ambiguous>::value), "");
+                      assert(dpl::fmax(1,0) == 1))
 }
 
 ONEDPL_TEST_DECLARE
@@ -494,8 +430,7 @@ void test_fmin()
 {
     static_assert((std::is_same<decltype(dpl::fmin((float)0, (float)0)), float>::value), "");
     static_assert((std::is_same<decltype(dpl::fminf(0, 0)), float>::value), "");
-    auto fnc = []()
-    {
+    IF_DOUBLE_SUPPORT(
         static_assert((std::is_same<decltype(dpl::fmin((bool)0, (float)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::fmin((unsigned short)0, (double)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::fmin((float)0, (unsigned int)0)), double>::value), "");
@@ -503,28 +438,22 @@ void test_fmin()
         static_assert((std::is_same<decltype(dpl::fmin((int)0, (unsigned long long)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::fmin((double)0, (double)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::fmin((float)0, (double)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmin((int)0, (int)0)), double>::value), "");
-    };
-    IF_DOUBLE_SUPPORT_L(fnc)
-    auto fnc1 = []()
-    {
+        static_assert((std::is_same<decltype(dpl::fmin((int)0, (int)0)), double>::value), ""))
+    IF_LONG_DOUBLE_SUPPORT(
         static_assert((std::is_same<decltype(dpl::fmin((int)0, (long double)0)), long double>::value), "");
         static_assert((std::is_same<decltype(dpl::fmin((long double)0, (unsigned long)0)), long double>::value), "");
         static_assert((std::is_same<decltype(dpl::fmin((int)0, (long long)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::fmin((long double)0, (long double)0)), long double>::value), "");
         static_assert((std::is_same<decltype(dpl::fmin((float)0, (long double)0)), long double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmin((double)0, (long double)0)), long double>::value), "");
-    };
-    IF_LONG_DOUBLE_SUPPORT_L(fnc1)
-    static_assert((std::is_same<decltype(dpl::fmin(Ambiguous(), Ambiguous())), Ambiguous>::value), "");
-    assert(dpl::fmin(1,0) == 0);
+        static_assert((std::is_same<decltype(dpl::fmin((double)0, (long double)0)), long double>::value), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::fmin(Ambiguous(), Ambiguous())), Ambiguous>::value), "");
+                      assert(dpl::fmin(1,0) == 0))
 }
 
 ONEDPL_TEST_DECLARE
 void test_nan()
 {
-    auto fnc = []() { static_assert((std::is_same<decltype(dpl::nan("")), double>::value), ""); };
-    IF_DOUBLE_SUPPORT_L(fnc)
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::nan("")), double>::value), ""))
     static_assert((std::is_same<decltype(dpl::nanf("")), float>::value), "");
 }
 
@@ -533,8 +462,7 @@ void test_round()
 {
     static_assert((std::is_same<decltype(dpl::round((float)0)), float>::value), "");
     static_assert((std::is_same<decltype(dpl::roundf(0)), float>::value), "");
-    auto fnc = []()
-    {
+    IF_DOUBLE_SUPPORT(
         static_assert((std::is_same<decltype(dpl::round((bool)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::round((unsigned short)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::round((int)0)), double>::value), "");
@@ -542,17 +470,12 @@ void test_round()
         static_assert((std::is_same<decltype(dpl::round((long)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::round((unsigned long)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::round((unsigned long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::round((double)0)), double>::value), "");
-    };
-    IF_DOUBLE_SUPPORT_L(fnc)
-    auto fnc1 = []()
-    {
+        static_assert((std::is_same<decltype(dpl::round((double)0)), double>::value), ""))
+    IF_LONG_DOUBLE_SUPPORT(
         static_assert((std::is_same<decltype(dpl::round((long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::round((long double)0)), long double>::value), "");
-    };
-    IF_LONG_DOUBLE_SUPPORT_L(fnc1)
-    static_assert((std::is_same<decltype(dpl::round(Ambiguous())), Ambiguous>::value), "");
-    assert(dpl::round(1) == 1);
+        static_assert((std::is_same<decltype(dpl::round((long double)0)), long double>::value), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::round(Ambiguous())), Ambiguous>::value), "");
+                      assert(dpl::round(1) == 1))
 }
 
 ONEDPL_TEST_DECLARE
@@ -560,8 +483,7 @@ void test_trunc()
 {
     static_assert((std::is_same<decltype(dpl::trunc((float)0)), float>::value), "");
     static_assert((std::is_same<decltype(dpl::truncf(0)), float>::value), "");
-    auto fnc = []()
-    {
+    IF_DOUBLE_SUPPORT(
         static_assert((std::is_same<decltype(dpl::trunc((bool)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::trunc((unsigned short)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::trunc((int)0)), double>::value), "");
@@ -570,14 +492,10 @@ void test_trunc()
         static_assert((std::is_same<decltype(dpl::trunc((unsigned long)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::trunc((long long)0)), double>::value), "");
         static_assert((std::is_same<decltype(dpl::trunc((unsigned long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::trunc((double)0)), double>::value), "");
-    };
-    IF_DOUBLE_SUPPORT_L(fnc)
-    auto fnc1 = []()
-    { static_assert((std::is_same<decltype(dpl::trunc((long double)0)), long double>::value), ""); };
-    IF_LONG_DOUBLE_SUPPORT_L(fnc1)
-    static_assert((std::is_same<decltype(dpl::trunc(Ambiguous())), Ambiguous>::value), "");
-    assert(dpl::trunc(1) == 1);
+        static_assert((std::is_same<decltype(dpl::trunc((double)0)), double>::value), ""))
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::trunc((long double)0)), long double>::value), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::trunc(Ambiguous())), Ambiguous>::value), "");
+                      assert(dpl::trunc(1) == 1))
 }
 
 ONEDPL_TEST_NUM_MAIN

--- a/test/xpu_api/numerics/complex.number/cases.h
+++ b/test/xpu_api/numerics/complex.number/cases.h
@@ -234,7 +234,7 @@ template <typename T>
 constexpr auto __tol = std::numeric_limits<T>::epsilon() * 1e5;
 
 template <typename X, typename Y>
-typename std::enable_if<!std::numeric_limits<X>::is_integer, void>::type
+typename std::enable_if<!std::numeric_limits<X>::is_integer || !std::numeric_limits<Y>::is_integer, void>::type
 is_about(X x, Y y, const X eps = __tol<X>)
 {
     assert(std::fabs(x - y) <= eps);

--- a/test/xpu_api/numerics/complex.number/cases.h
+++ b/test/xpu_api/numerics/complex.number/cases.h
@@ -233,9 +233,9 @@ classify(double x)
 template <typename T>
 constexpr auto __tol = std::numeric_limits<T>::epsilon() * 1e5;
 
-template <typename T>
+template <typename T, typename Y>
 typename std::enable_if<!std::numeric_limits<T>::is_integer, void>::type
-is_about(T x, T y, const T eps = __tol<T>)
+is_about(T x, Y y, const T eps = __tol<T>)
 {
     assert(std::fabs(x - y) <= eps);
 }

--- a/test/xpu_api/numerics/complex.number/cases.h
+++ b/test/xpu_api/numerics/complex.number/cases.h
@@ -233,9 +233,9 @@ classify(double x)
 template <typename T>
 constexpr auto __tol = std::numeric_limits<T>::epsilon() * 1e5;
 
-template <typename T, typename Y>
-typename std::enable_if<!std::numeric_limits<T>::is_integer, void>::type
-is_about(T x, Y y, const T eps = __tol<T>)
+template <typename X, typename Y>
+typename std::enable_if<!std::numeric_limits<X>::is_integer, void>::type
+is_about(X x, Y y, const X eps = __tol<X>)
 {
     assert(std::fabs(x - y) <= eps);
 }

--- a/test/xpu_api/numerics/complex.number/cmplx.over/arg.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/arg.pass.cpp
@@ -48,9 +48,9 @@ ONEDPL_TEST_NUM_MAIN
     test<float>();
     IF_DOUBLE_SUPPORT(test<double>())
     IF_LONG_DOUBLE_SUPPORT(test<long double>())
-    test<int>();
-    test<unsigned>();
-    test<long long>();
+    IF_DOUBLE_SUPPORT(test<int>();
+                      test<unsigned>();
+                      test<long long>());
 
   return 0;
 }

--- a/test/xpu_api/numerics/complex.number/cmplx.over/norm.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/norm.pass.cpp
@@ -46,9 +46,9 @@ ONEDPL_TEST_NUM_MAIN
     test<float>();
     IF_DOUBLE_SUPPORT(test<double>())
     IF_LONG_DOUBLE_SUPPORT(test<long double>())
-    test<int>();
-    test<unsigned>();
-    test<long long>();
+    IF_DOUBLE_SUPPORT(test<int>();
+                      test<unsigned>();
+                      test<long long>());
 
   return 0;
 }

--- a/test/xpu_api/numerics/complex.number/cmplx.over/pow.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/pow.pass.cpp
@@ -26,90 +26,80 @@
 
 #include "../cases.h"
 
-struct PromoteFloat
-{
-    static float promote(float);
-};
+template <class T>
+double
+promote(T, typename std::enable_if<std::is_integral<T>::value>::type* = 0);
 
-struct PromoteDouble : PromoteFloat
-{
-    template <class T>
-    static double
-    promote(T, typename std::enable_if<std::is_integral<T>::value>::type* = 0);
+float promote(float);
+double promote(double);
+long double promote(long double);
 
-    static double
-    promote(double);
-};
-
-struct PromoteLongDouble : PromoteDouble
-{
-    static long double promote(long double);
-};
-
-template <class TPromote, class T, class U>
+template <class T, class U>
 void
 test(T x, const dpl::complex<U>& y)
 {
-    typedef decltype(TPromote::promote(x) + TPromote::promote(dpl::real(y))) V;
+    typedef decltype(promote(x) + promote(dpl::real(y))) V;
     static_assert((std::is_same<decltype(dpl::pow(x, y)), dpl::complex<V> >::value), "");
     is_about(dpl::pow(x, y), dpl::pow(dpl::complex<V>(x, 0), dpl::complex<V>(y)));
 }
 
-template <class TPromote, class T, class U>
+template <class T, class U>
 void
 test(const dpl::complex<T>& x, U y)
 {
-    typedef decltype(TPromote::promote(dpl::real(x)) + TPromote::promote(y)) V;
+    typedef decltype(promote(dpl::real(x)) + promote(y)) V;
     static_assert((std::is_same<decltype(dpl::pow(x, y)), dpl::complex<V> >::value), "");
     is_about(dpl::pow(x, y), dpl::pow(dpl::complex<V>(x), dpl::complex<V>(y, 0)));
 }
 
-template <class TPromote, class T, class U>
+template <class T, class U>
 void
 test(const dpl::complex<T>& x, const dpl::complex<U>& y)
 {
-    typedef decltype(TPromote::promote(dpl::real(x)) + TPromote::promote(dpl::real(y))) V;
+    typedef decltype(promote(dpl::real(x)) + promote(dpl::real(y))) V;
     static_assert((std::is_same<decltype(dpl::pow(x, y)), dpl::complex<V> >::value), "");
     assert(dpl::pow(x, y) == dpl::pow(dpl::complex<V>(x), dpl::complex<V>(y)));
 }
 
-template <class TPromote, class T, class U>
+template <class T, class U>
 void
 test(typename std::enable_if<std::is_integral<T>::value>::type* = 0, typename std::enable_if<!std::is_integral<U>::value>::type* = 0)
 {
-    test<TPromote>(T(3), dpl::complex<U>(4, 5));
-    test<TPromote>(dpl::complex<U>(3, 4), T(5));
+    test(T(3), dpl::complex<U>(4, 5));
+    test(dpl::complex<U>(3, 4), T(5));
 }
 
-template <class TPromote, class T, class U>
+template <class T, class U>
 void
 test(typename std::enable_if<!std::is_integral<T>::value>::type* = 0, typename std::enable_if<!std::is_integral<U>::value>::type* = 0)
 {
-    test<TPromote>(T(3), dpl::complex<U>(4, 5));
-    test<TPromote>(dpl::complex<T>(3, 4), U(5));
-    test<TPromote>(dpl::complex<T>(3, 4), dpl::complex<U>(5, 6));
+    test(T(3), dpl::complex<U>(4, 5));
+    test(dpl::complex<T>(3, 4), U(5));
+    test(dpl::complex<T>(3, 4), dpl::complex<U>(5, 6));
 }
 
 ONEDPL_TEST_NUM_MAIN
 {
+    IF_DOUBLE_SUPPORT(
 #if !_PSTL_GLIBCXX_TEST_COMPLEX_POW_BROKEN
-    test<int, float, PromoteFloat>();
+                      test<int, float>();
 #endif // !_PSTL_GLIBCXX_TEST_COMPLEX_POW_BROKEN
-    test<PromoteFloat, unsigned, float>();
-    test<PromoteFloat, long long, float>();
 
-    IF_DOUBLE_SUPPORT(test<PromoteDouble, int, double>();
-                      test<PromoteDouble, unsigned, double>();
-                      test<PromoteDouble, long long, double>();
-                      test<PromoteDouble, float, double>();
-                      test<PromoteDouble, double, float>())
+                      test<unsigned, float>();
+                      test<long long, float>();
 
-    IF_LONG_DOUBLE_SUPPORT(test<PromoteLongDouble, unsigned, long double>();
-                           test<PromoteLongDouble, long long, long double>();
-                           test<PromoteLongDouble, float, long double>();
-                           test<PromoteLongDouble, double, long double>();
-                           test<PromoteLongDouble, long double, float>();
-                           test<PromoteLongDouble, long double, double>())
+                      test<int, double>();
+                      test<unsigned, double>();
+                      test<long long, double>();
+                      test<float, double>();
+                      test<double, float>())
+
+    IF_LONG_DOUBLE_SUPPORT(test<unsigned, long double>();
+                           test<long long, long double>();
+                           test<float, long double>();
+                           test<double, long double>();
+                           test<long double, float>();
+                           test<long double, double>())
 
   return 0;
 }

--- a/test/xpu_api/numerics/complex.number/complex.member.ops/assignment_complex.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.member.ops/assignment_complex.pass.cpp
@@ -20,14 +20,14 @@ test()
     dpl::complex<T> c;
     assert(c.real() == 0);
     assert(c.imag() == 0);
-    dpl::complex<T> c2(1.5, 2.5);
+    dpl::complex<T> c2(1.5f, 2.5f);
     c = c2;
-    assert(c.real() == 1.5);
-    assert(c.imag() == 2.5);
-    dpl::complex<X> c3(3.5, -4.5);
+    assert(c.real() == 1.5f);
+    assert(c.imag() == 2.5f);
+    dpl::complex<X> c3(3.5f, -4.5f);
     c = c3;
-    assert(c.real() == 3.5);
-    assert(c.imag() == -4.5);
+    assert(c.real() == 3.5f);
+    assert(c.imag() == -4.5f);
 }
 
 ONEDPL_TEST_NUM_MAIN

--- a/test/xpu_api/numerics/complex.number/complex.member.ops/assignment_scalar.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.member.ops/assignment_scalar.pass.cpp
@@ -19,11 +19,11 @@ test()
     dpl::complex<T> c;
     assert(c.real() == 0);
     assert(c.imag() == 0);
-    c = 1.5;
-    assert(c.real() == 1.5);
+    c = 1.5f;
+    assert(c.real() == 1.5f);
     assert(c.imag() == 0);
-    c = -1.5;
-    assert(c.real() == -1.5);
+    c = -1.5f;
+    assert(c.real() == -1.5f);
     assert(c.imag() == 0);
 }
 

--- a/test/xpu_api/numerics/complex.number/complex.member.ops/divide_equal_complex.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.member.ops/divide_equal_complex.pass.cpp
@@ -17,16 +17,16 @@ template <class T>
 void
 test()
 {
-    dpl::complex<T> c(-4, 7.5);
-    const dpl::complex<T> c2(1.5, 2.5);
-    assert(c.real() == -4);
-    assert(c.imag() == 7.5);
+    dpl::complex<T> c(-4, 7.5f);
+    const dpl::complex<T> c2(1.5f, 2.5f);
+    assert(c.real() == -4.f);
+    assert(c.imag() == 7.5f);
     c /= c2;
-    is_about(c.real(), T(1.5));
-    is_about(c.imag(), T(2.5));
+    is_about(c.real(), 1.5f);
+    is_about(c.imag(), 2.5f);
     c /= c2;
-    is_about(c.real(), T(1.0));
-    is_about(c.imag(), T(0.0));
+    is_about(c.real(), 1.f);
+    is_about(c.imag(), 0);
 
     dpl::complex<T> c3;
 
@@ -34,15 +34,15 @@ test()
     c3 = c;
     dpl::complex<int> ic (1,1);
     c3 /= ic;
-    is_about(c3.real(), T( 0.5));
-    is_about(c3.imag(), T(-0.5));
+    is_about(c3.real(),  0.5f);
+    is_about(c3.imag(), -0.5f);
 #endif // !_PSTL_GLIBCXX_TEST_COMPLEX_DIV_EQ_BROKEN
 
     c3 = c;
-    dpl::complex<float> fc (1,1);
+    dpl::complex<float> fc (1.f, 1.f);
     c3 /= fc;
-    is_about(c3.real(), T( 0.5));
-    is_about(c3.imag(), T(-0.5));
+    is_about(c3.real(),  0.5f);
+    is_about(c3.imag(), -0.5f);
 }
 
 ONEDPL_TEST_NUM_MAIN

--- a/test/xpu_api/numerics/complex.number/complex.member.ops/divide_equal_complex.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.member.ops/divide_equal_complex.pass.cpp
@@ -19,13 +19,13 @@ test()
 {
     dpl::complex<T> c(-4, 7.5f);
     const dpl::complex<T> c2(1.5f, 2.5f);
-    assert(c.real() == -4.f);
+    assert(c.real() == -4);
     assert(c.imag() == 7.5f);
     c /= c2;
     is_about(c.real(), 1.5f);
     is_about(c.imag(), 2.5f);
     c /= c2;
-    is_about(c.real(), 1.f);
+    is_about(c.real(), 1);
     is_about(c.imag(), 0);
 
     dpl::complex<T> c3;
@@ -39,7 +39,7 @@ test()
 #endif // !_PSTL_GLIBCXX_TEST_COMPLEX_DIV_EQ_BROKEN
 
     c3 = c;
-    dpl::complex<float> fc (1.f, 1.f);
+    dpl::complex<float> fc (1,1);
     c3 /= fc;
     is_about(c3.real(),  0.5f);
     is_about(c3.imag(), -0.5f);

--- a/test/xpu_api/numerics/complex.number/complex.member.ops/minus_equal_complex.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.member.ops/minus_equal_complex.pass.cpp
@@ -38,7 +38,7 @@ test()
 #endif // !_PSTL_GLIBCXX_TEST_COMPLEX_MINUS_EQ_BROKEN
 
     c3 = c;
-    dpl::complex<float> fc (1.f, 1.f);
+    dpl::complex<float> fc (1,1);
     c3 -= fc;
     assert(c3.real() == -4.f);
     assert(c3.imag() == -6.f);

--- a/test/xpu_api/numerics/complex.number/complex.member.ops/minus_equal_complex.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.member.ops/minus_equal_complex.pass.cpp
@@ -17,15 +17,15 @@ void
 test()
 {
     dpl::complex<T> c;
-    const dpl::complex<T> c2(1.5, 2.5);
+    const dpl::complex<T> c2(1.5f, 2.5f);
     assert(c.real() == 0);
     assert(c.imag() == 0);
     c -= c2;
-    assert(c.real() == -1.5);
-    assert(c.imag() == -2.5);
+    assert(c.real() == -1.5f);
+    assert(c.imag() == -2.5f);
     c -= c2;
-    assert(c.real() == -3);
-    assert(c.imag() == -5);
+    assert(c.real() == -3.f);
+    assert(c.imag() == -5.f);
 
     dpl::complex<T> c3;
 
@@ -33,15 +33,15 @@ test()
     c3 = c;
     dpl::complex<int> ic (1,1);
     c3 -= ic;
-    assert(c3.real() == -4);
-    assert(c3.imag() == -6);
+    assert(c3.real() == -4.f);
+    assert(c3.imag() == -6.f);
 #endif // !_PSTL_GLIBCXX_TEST_COMPLEX_MINUS_EQ_BROKEN
 
     c3 = c;
-    dpl::complex<float> fc (1,1);
+    dpl::complex<float> fc (1.f, 1.f);
     c3 -= fc;
-    assert(c3.real() == -4);
-    assert(c3.imag() == -6);
+    assert(c3.real() == -4.f);
+    assert(c3.imag() == -6.f);
 }
 
 ONEDPL_TEST_NUM_MAIN

--- a/test/xpu_api/numerics/complex.number/complex.member.ops/minus_equal_complex.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.member.ops/minus_equal_complex.pass.cpp
@@ -24,8 +24,8 @@ test()
     assert(c.real() == -1.5f);
     assert(c.imag() == -2.5f);
     c -= c2;
-    assert(c.real() == -3.f);
-    assert(c.imag() == -5.f);
+    assert(c.real() == -3);
+    assert(c.imag() == -5);
 
     dpl::complex<T> c3;
 
@@ -33,15 +33,15 @@ test()
     c3 = c;
     dpl::complex<int> ic (1,1);
     c3 -= ic;
-    assert(c3.real() == -4.f);
-    assert(c3.imag() == -6.f);
+    assert(c3.real() == -4);
+    assert(c3.imag() == -6);
 #endif // !_PSTL_GLIBCXX_TEST_COMPLEX_MINUS_EQ_BROKEN
 
     c3 = c;
     dpl::complex<float> fc (1,1);
     c3 -= fc;
-    assert(c3.real() == -4.f);
-    assert(c3.imag() == -6.f);
+    assert(c3.real() == -4);
+    assert(c3.imag() == -6);
 }
 
 ONEDPL_TEST_NUM_MAIN

--- a/test/xpu_api/numerics/complex.number/complex.member.ops/minus_equal_scalar.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.member.ops/minus_equal_scalar.pass.cpp
@@ -19,14 +19,14 @@ test()
     dpl::complex<T> c;
     assert(c.real() == 0);
     assert(c.imag() == 0);
-    c -= 1.5;
-    assert(c.real() == -1.5);
+    c -= 1.5f;
+    assert(c.real() == -1.5f);
     assert(c.imag() == 0);
-    c -= 1.5;
-    assert(c.real() == -3);
+    c -= 1.5f;
+    assert(c.real() == -3.f);
     assert(c.imag() == 0);
-    c -= -1.5;
-    assert(c.real() == -1.5);
+    c -= -1.5f;
+    assert(c.real() == -1.5f);
     assert(c.imag() == 0);
 }
 

--- a/test/xpu_api/numerics/complex.number/complex.member.ops/minus_equal_scalar.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.member.ops/minus_equal_scalar.pass.cpp
@@ -23,7 +23,7 @@ test()
     assert(c.real() == -1.5f);
     assert(c.imag() == 0);
     c -= 1.5f;
-    assert(c.real() == -3.f);
+    assert(c.real() == -3);
     assert(c.imag() == 0);
     c -= -1.5f;
     assert(c.real() == -1.5f);

--- a/test/xpu_api/numerics/complex.number/complex.member.ops/plus_equal_complex.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.member.ops/plus_equal_complex.pass.cpp
@@ -17,15 +17,15 @@ void
 test()
 {
     dpl::complex<T> c;
-    const dpl::complex<T> c2(1.5, 2.5);
+    const dpl::complex<T> c2(1.5f, 2.5f);
     assert(c.real() == 0);
     assert(c.imag() == 0);
     c += c2;
-    assert(c.real() == 1.5);
-    assert(c.imag() == 2.5);
+    assert(c.real() == 1.5f);
+    assert(c.imag() == 2.5f);
     c += c2;
-    assert(c.real() == 3);
-    assert(c.imag() == 5);
+    assert(c.real() == 3.f);
+    assert(c.imag() == 5.f);
 
     dpl::complex<T> c3;
 
@@ -33,15 +33,15 @@ test()
     c3 = c;
     dpl::complex<int> ic (1,1);
     c3 += ic;
-    assert(c3.real() == 4);
-    assert(c3.imag() == 6);
+    assert(c3.real() == 4.f);
+    assert(c3.imag() == 6.f);
 #endif // !_PSTL_GLIBCXX_TEST_COMPLEX_PLUS_EQ_BROKEN
 
     c3 = c;
-    dpl::complex<float> fc (1,1);
+    dpl::complex<float> fc (1.f, 1.f);
     c3 += fc;
-    assert(c3.real() == 4);
-    assert(c3.imag() == 6);
+    assert(c3.real() == 4.f);
+    assert(c3.imag() == 6.f);
 }
 
 ONEDPL_TEST_NUM_MAIN

--- a/test/xpu_api/numerics/complex.number/complex.member.ops/plus_equal_complex.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.member.ops/plus_equal_complex.pass.cpp
@@ -24,8 +24,8 @@ test()
     assert(c.real() == 1.5f);
     assert(c.imag() == 2.5f);
     c += c2;
-    assert(c.real() == 3.f);
-    assert(c.imag() == 5.f);
+    assert(c.real() == 3);
+    assert(c.imag() == 5);
 
     dpl::complex<T> c3;
 
@@ -33,15 +33,15 @@ test()
     c3 = c;
     dpl::complex<int> ic (1,1);
     c3 += ic;
-    assert(c3.real() == 4.f);
-    assert(c3.imag() == 6.f);
+    assert(c3.real() == 4);
+    assert(c3.imag() == 6);
 #endif // !_PSTL_GLIBCXX_TEST_COMPLEX_PLUS_EQ_BROKEN
 
     c3 = c;
-    dpl::complex<float> fc (1.f, 1.f);
+    dpl::complex<float> fc (1,1);
     c3 += fc;
-    assert(c3.real() == 4.f);
-    assert(c3.imag() == 6.f);
+    assert(c3.real() == 4);
+    assert(c3.imag() == 6);
 }
 
 ONEDPL_TEST_NUM_MAIN

--- a/test/xpu_api/numerics/complex.number/complex.member.ops/plus_equal_scalar.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.member.ops/plus_equal_scalar.pass.cpp
@@ -20,13 +20,13 @@ test()
     assert(c.real() == 0);
     assert(c.imag() == 0);
     c += 1.5;
-    assert(c.real() == 1.5);
+    assert(c.real() == 1.5f);
     assert(c.imag() == 0);
     c += 1.5;
     assert(c.real() == 3);
     assert(c.imag() == 0);
     c += -1.5;
-    assert(c.real() == 1.5);
+    assert(c.real() == 1.5f);
     assert(c.imag() == 0);
 }
 

--- a/test/xpu_api/numerics/complex.number/complex.member.ops/times_equal_complex.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.member.ops/times_equal_complex.pass.cpp
@@ -17,15 +17,15 @@ void
 test()
 {
     dpl::complex<T> c(1);
-    const dpl::complex<T> c2(1.5, 2.5);
+    const dpl::complex<T> c2(1.5f, 2.5f);
     assert(c.real() == 1);
     assert(c.imag() == 0);
     c *= c2;
-    assert(c.real() == 1.5);
-    assert(c.imag() == 2.5);
+    assert(c.real() == 1.5f);
+    assert(c.imag() == 2.5f);
     c *= c2;
     assert(c.real() == -4);
-    assert(c.imag() == 7.5);
+    assert(c.imag() == 7.5f);
 
     dpl::complex<T> c3;
 
@@ -33,15 +33,15 @@ test()
     c3 = c;
     dpl::complex<int> ic (1,1);
     c3 *= ic;
-    assert(c3.real() == -11.5);
-    assert(c3.imag() ==   3.5);
+    assert(c3.real() == -11.5f);
+    assert(c3.imag() ==   3.5f);
 #endif // !_PSTL_GLIBCXX_TEST_COMPLEX_TIMES_EQ_BROKEN
 
     c3 = c;
     dpl::complex<float> fc (1,1);
     c3 *= fc;
-    assert(c3.real() == -11.5);
-    assert(c3.imag() ==   3.5);
+    assert(c3.real() == -11.5f);
+    assert(c3.imag() ==   3.5f);
 }
 
 ONEDPL_TEST_NUM_MAIN

--- a/test/xpu_api/numerics/complex.number/complex.member.ops/times_equal_scalar.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.member.ops/times_equal_scalar.pass.cpp
@@ -20,17 +20,17 @@ test()
     assert(c.real() == 1);
     assert(c.imag() == 0);
     c *= 1.5;
-    assert(c.real() == 1.5);
+    assert(c.real() == 1.5f);
     assert(c.imag() == 0);
-    c *= 1.5;
-    assert(c.real() == 2.25);
+    c *= 1.5f;
+    assert(c.real() == 2.25f);
     assert(c.imag() == 0);
-    c *= -1.5;
-    assert(c.real() == -3.375);
+    c *= -1.5f;
+    assert(c.real() == -3.375f);
     assert(c.imag() == 0);
     c.imag(2);
-    c *= 1.5;
-    assert(c.real() == -5.0625);
+    c *= 1.5f;
+    assert(c.real() == -5.0625f);
     assert(c.imag() == 3);
 }
 

--- a/test/xpu_api/numerics/complex.number/complex.member.ops/times_equal_scalar.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.member.ops/times_equal_scalar.pass.cpp
@@ -19,7 +19,7 @@ test()
     dpl::complex<T> c(1);
     assert(c.real() == 1);
     assert(c.imag() == 0);
-    c *= 1.5;
+    c *= 1.5f;
     assert(c.real() == 1.5f);
     assert(c.imag() == 0);
     c *= 1.5f;

--- a/test/xpu_api/numerics/complex.number/complex.members/real_imag.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.members/real_imag.pass.cpp
@@ -35,18 +35,18 @@ test()
     dpl::complex<T> c;
     assert(c.real() == 0);
     assert(c.imag() == 0);
-    c.real(3.5);
-    assert(c.real() == 3.5);
+    c.real(3.5f);
+    assert(c.real() == 3.5f);
     assert(c.imag() == 0);
-    c.imag(4.5);
-    assert(c.real() == 3.5);
-    assert(c.imag() == 4.5);
-    c.real(-4.5);
-    assert(c.real() == -4.5);
-    assert(c.imag() == 4.5);
-    c.imag(-5.5);
-    assert(c.real() == -4.5);
-    assert(c.imag() == -5.5);
+    c.imag(4.5f);
+    assert(c.real() == 3.5f);
+    assert(c.imag() == 4.5f);
+    c.real(-4.5f);
+    assert(c.real() == -4.5f);
+    assert(c.imag() == 4.5f);
+    c.imag(-5.5f);
+    assert(c.real() == -4.5f);
+    assert(c.imag() == -5.5f);
 
     test_constexpr<T> ();
 }

--- a/test/xpu_api/numerics/complex.number/complex.ops/complex_divide_complex.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.ops/complex_divide_complex.pass.cpp
@@ -27,9 +27,9 @@ template <class T>
 void
 test()
 {
-    dpl::complex<T> lhs(-4.0, 7.5);
-    dpl::complex<T> rhs(1.5, 2.5);
-    dpl::complex<T>   x(1.5, 2.5);
+    dpl::complex<T> lhs(-4.0f, 7.5f);
+    dpl::complex<T> rhs(1.5f, 2.5f);
+    dpl::complex<T>   x(1.5f, 2.5f);
     test(lhs, rhs, x);
 }
 

--- a/test/xpu_api/numerics/complex.number/complex.ops/scalar_divide_complex.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.ops/scalar_divide_complex.pass.cpp
@@ -26,9 +26,9 @@ template <class T>
 void
 test()
 {
-    T lhs(-8.5);
-    dpl::complex<T> rhs(1.5, 2.5);
-    dpl::complex<T>   x(-1.5, 2.5);
+    T lhs(-8.5f);
+    dpl::complex<T> rhs(1.5f, 2.5f);
+    dpl::complex<T>   x(-1.5f, 2.5f);
     test(lhs, rhs, x);
 }
 

--- a/test/xpu_api/numerics/complex.number/complex.ops/unary_minus.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.ops/unary_minus.pass.cpp
@@ -18,12 +18,12 @@ template <class T>
 void
 test()
 {
-    dpl::complex<T> z(1.5, 2.5);
-    assert(z.real() == 1.5);
-    assert(z.imag() == 2.5);
+    dpl::complex<T> z(1.5f, 2.5f);
+    assert(z.real() == 1.5f);
+    assert(z.imag() == 2.5f);
     dpl::complex<T> c = -z;
-    assert(c.real() == -1.5);
-    assert(c.imag() == -2.5);
+    assert(c.real() == -1.5f);
+    assert(c.imag() == -2.5f);
 }
 
 ONEDPL_TEST_NUM_MAIN

--- a/test/xpu_api/numerics/complex.number/complex.ops/unary_plus.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.ops/unary_plus.pass.cpp
@@ -18,12 +18,12 @@ template <class T>
 void
 test()
 {
-    dpl::complex<T> z(1.5, 2.5);
-    assert(z.real() == 1.5);
-    assert(z.imag() == 2.5);
+    dpl::complex<T> z(1.5f, 2.5f);
+    assert(z.real() == 1.5f);
+    assert(z.imag() == 2.5f);
     dpl::complex<T> c = +z;
-    assert(c.real() == 1.5);
-    assert(c.imag() == 2.5);
+    assert(c.real() == 1.5f);
+    assert(c.imag() == 2.5f);
 }
 
 ONEDPL_TEST_NUM_MAIN

--- a/test/xpu_api/numerics/complex.number/complex.special/double_float_explicit.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.special/double_float_explicit.pass.cpp
@@ -19,14 +19,14 @@
 ONEDPL_TEST_NUM_MAIN
 {
     {
-    const dpl::complex<float> cd(2.5, 3.5);
+    const dpl::complex<float> cd(2.5f, 3.5f);
     dpl::complex<double> cf(cd);
     assert(cf.real() == cd.real());
     assert(cf.imag() == cd.imag());
     }
 
     {
-    constexpr dpl::complex<float> cd(2.5, 3.5);
+    constexpr dpl::complex<float> cd(2.5f, 3.5f);
     constexpr dpl::complex<double> cf(cd);
     STD_COMPLEX_TESTS_STATIC_ASSERT(cf.real() == cd.real(), "");
     STD_COMPLEX_TESTS_STATIC_ASSERT(cf.imag() == cd.imag(), "");

--- a/test/xpu_api/numerics/complex.number/complex.special/double_float_explicit.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.special/double_float_explicit.pass.cpp
@@ -18,19 +18,15 @@
 
 ONEDPL_TEST_NUM_MAIN
 {
-    {
-    const dpl::complex<float> cd(2.5f, 3.5f);
-    dpl::complex<double> cf(cd);
-    assert(cf.real() == cd.real());
-    assert(cf.imag() == cd.imag());
-    }
+    IF_DOUBLE_SUPPORT(const dpl::complex<float> cd(2.5f, 3.5f);
+                      dpl::complex<double> cf(cd);
+                      assert(cf.real() == cd.real());
+                      assert(cf.imag() == cd.imag()))
 
-    {
-    constexpr dpl::complex<float> cd(2.5f, 3.5f);
-    constexpr dpl::complex<double> cf(cd);
-    STD_COMPLEX_TESTS_STATIC_ASSERT(cf.real() == cd.real(), "");
-    STD_COMPLEX_TESTS_STATIC_ASSERT(cf.imag() == cd.imag(), "");
-    }
+    IF_DOUBLE_SUPPORT(constexpr dpl::complex<float> cd(2.5f, 3.5f);
+                      constexpr dpl::complex<double> cf(cd);
+                      STD_COMPLEX_TESTS_STATIC_ASSERT(cf.real() == cd.real(), "");
+                      STD_COMPLEX_TESTS_STATIC_ASSERT(cf.imag() == cd.imag(), ""))
 
   return 0;
 }

--- a/test/xpu_api/numerics/complex.number/complex.transcendentals/pow_scalar_complex.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.transcendentals/pow_scalar_complex.pass.cpp
@@ -24,7 +24,7 @@ test(const T& a, const dpl::complex<T>& b, dpl::complex<T> x)
 {
     dpl::complex<T> c = dpl::pow(a, b);
     is_about(dpl::real(c), dpl::real(x));
-    assert(std::abs(dpl::imag(c)) < 1.e-6f);
+    assert(std::abs(dpl::imag(c)) < T(1.e-6));
 }
 
 template <class T>

--- a/test/xpu_api/numerics/complex.number/complex.transcendentals/pow_scalar_complex.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.transcendentals/pow_scalar_complex.pass.cpp
@@ -24,7 +24,7 @@ test(const T& a, const dpl::complex<T>& b, dpl::complex<T> x)
 {
     dpl::complex<T> c = dpl::pow(a, b);
     is_about(dpl::real(c), dpl::real(x));
-    assert(std::abs(dpl::imag(c)) < 1.e-6);
+    assert(std::abs(dpl::imag(c)) < 1.e-6f);
 }
 
 template <class T>

--- a/test/xpu_api/numerics/complex.number/complex.transcendentals/sqrt.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.transcendentals/sqrt.pass.cpp
@@ -24,7 +24,7 @@ test(const dpl::complex<T>& c, dpl::complex<T> x)
 {
     dpl::complex<T> a = dpl::sqrt(c);
     is_about(dpl::real(a), dpl::real(x));
-    assert(std::abs(dpl::imag(c)) < 1.e-6);
+    assert(std::abs(dpl::imag(c)) < T(1.e-6));
 }
 
 template <class T>

--- a/test/xpu_api/numerics/complex.number/complex.value.ops/imag1.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.value.ops/imag1.pass.cpp
@@ -18,8 +18,8 @@ template <class T>
 void
 test()
 {
-    dpl::complex<T> z(1.5, 2.5);
-    assert(dpl::imag(z) == 2.5);
+    dpl::complex<T> z(1.5f, 2.5f);
+    assert(dpl::imag(z) == 2.5f);
 }
 
 ONEDPL_TEST_NUM_MAIN

--- a/test/xpu_api/numerics/complex.number/complex.value.ops/real1.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.value.ops/real1.pass.cpp
@@ -18,8 +18,8 @@ template <class T>
 void
 test()
 {
-    dpl::complex<T> z(1.5, 2.5);
-    assert(dpl::real(z) == 1.5);
+    dpl::complex<T> z(1.5f, 2.5f);
+    assert(dpl::real(z) == 1.5f);
 }
 
 ONEDPL_TEST_NUM_MAIN


### PR DESCRIPTION
In this PR we fix the following problem:
- avoid runtime-error (exception) when we run tests of ```::std::complex<T>``` on device without ```double``` type support.

To fox this problem in tests we change usage of constants like ```1.5``` and etc. which has ```double``` type:
- we change ```1.5``` -> ```1.5f``` and etc.
- some peace's of tests moved under ```IF_DOUBLE_SUPPORT``` condition check.