### PR TITLE
Add C++17 requirement to installed oneDPL target

### DIFF
--- a/cmake/templates/oneDPLConfig.cmake.in
+++ b/cmake/templates/oneDPLConfig.cmake.in
@@ -22,6 +22,7 @@ if (EXISTS "${_onedpl_headers}")
 
         add_library(oneDPL INTERFACE IMPORTED)
         set_target_properties(oneDPL PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${_onedpl_headers}")
+        target_compile_features(oneDPL interface cxx_std_17)
 
         if (ONEDPL_PAR_BACKEND AND NOT ONEDPL_PAR_BACKEND MATCHES "^(tbb|openmp|serial)$")
             message(STATUS "oneDPL: ONEDPL_PAR_BACKEND=${ONEDPL_PAR_BACKEND} is requested, but not supported, available backends: tbb, openmp, serial")

--- a/cmake/templates/oneDPLConfig.cmake.in
+++ b/cmake/templates/oneDPLConfig.cmake.in
@@ -22,7 +22,7 @@ if (EXISTS "${_onedpl_headers}")
 
         add_library(oneDPL INTERFACE IMPORTED)
         set_target_properties(oneDPL PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${_onedpl_headers}")
-        target_compile_features(oneDPL interface cxx_std_17)
+        target_compile_features(oneDPL INTERFACE cxx_std_17)
 
         if (ONEDPL_PAR_BACKEND AND NOT ONEDPL_PAR_BACKEND MATCHES "^(tbb|openmp|serial)$")
             message(STATUS "oneDPL: ONEDPL_PAR_BACKEND=${ONEDPL_PAR_BACKEND} is requested, but not supported, available backends: tbb, openmp, serial")


### PR DESCRIPTION
Add the c++17 compile feature requirement to the oneDPL target so consumers also use c++17. This is still overridden by the CXX_STANDARD target property, so there still can be sharp edges for users.