### PR TITLE
Fix deprecated sycl::default_selector class

### DIFF
--- a/documentation/library_guide/api_for_sycl_kernels/random.rst
+++ b/documentation/library_guide/api_for_sycl_kernels/random.rst
@@ -94,7 +94,7 @@ Random number generation is available for SYCL* device-side and host-side code. 
     #include <oneapi/dpl/random>
 
     int main() {
-        sycl::queue queue(sycl::default_selector{});
+        sycl::queue queue(sycl::default_selector_v);
 
         std::int64_t nsamples = 100;
         std::uint32_t seed = 777;

--- a/examples/random/src/main.cpp
+++ b/examples/random/src/main.cpp
@@ -133,7 +133,7 @@ main()
         }
     };
 
-    sycl::queue queue(sycl::default_selector{}, async_handler);
+    sycl::queue queue(sycl::default_selector_v, async_handler);
 
     constexpr std::int64_t nsamples = 100;
     constexpr int vec_size = 4;

--- a/test/parallel_api/algorithm/alg.sorting/sort_by_key.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/sort_by_key.pass.cpp
@@ -73,7 +73,7 @@ int
 main()
 {
 #if TEST_DPCPP_BACKEND_PRESENT
-    sycl::queue q;
+    sycl::queue q = TestUtils::get_test_queue();
 #if _ONEDPL_DEBUG_SYCL
     std::cout << "    Device Name = " << q.get_device().get_info<sycl::info::device::name>().c_str() << "\n";
 #endif // _ONEDPL_DEBUG_SYCL

--- a/test/parallel_api/experimental/asynch.pass.cpp
+++ b/test/parallel_api/experimental/asynch.pass.cpp
@@ -120,7 +120,7 @@ template <sycl::usm::alloc alloc_type>
 void
 test_with_usm()
 {
-    sycl::queue q;
+    sycl::queue q = TestUtils::get_test_queue();
 
     constexpr int n = 1024;
     constexpr int n_small = 13;

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan.pass.cpp
@@ -78,7 +78,7 @@ int
 main()
 {
 #if TEST_DPCPP_BACKEND_PRESENT
-    sycl::queue q;
+    sycl::queue q = TestUtils::get_test_queue();
 #if _ONEDPL_DEBUG_SYCL
     std::cout << "    Device Name = " << q.get_device().get_info<sycl::info::device::name>().c_str() << "\n";
 #endif // _ONEDPL_DEBUG_SYCL

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment_perm_it.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment_perm_it.pass.cpp
@@ -174,7 +174,7 @@ int
 main(int argc, char* argv[])
 {
 #if TEST_DPCPP_BACKEND_PRESENT
-    sycl::queue q;
+    sycl::queue q = TestUtils::get_test_queue();
 #if _ONEDPL_DEBUG_SYCL
     std::cout << "    Device Name = " << q.get_device().get_info<sycl::info::device::name>().c_str() << "\n";
 #    endif // _ONEDPL_DEBUG_SYCL

--- a/test/parallel_api/numeric/numeric.ops/in_place_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/in_place_scan.pass.cpp
@@ -39,7 +39,7 @@ int main()
   std::vector<int> excl_input_host = v;  
   
   // Setup device inputs
-  sycl::queue syclQue;
+  sycl::queue syclQue = TestUtils::get_test_queue();
   int* incl_input_dev = sycl::malloc_device<int>(10, syclQue);
   int* excl_input_dev = sycl::malloc_device<int>(10, syclQue);  
 

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -121,7 +121,7 @@ template <sycl::usm::alloc alloc_type, typename KernelName, typename T>
 void
 test_with_usm()
 {
-    sycl::queue q;
+    sycl::queue q = TestUtils::get_test_queue();
 
     // Initialize data
     //T keys[n1] = { 1, 2, 3, 4, 1, 1, 3, 3, 1, 1, 3, 3, 0 };

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment_zip.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment_zip.pass.cpp
@@ -33,7 +33,7 @@ template <sycl::usm::alloc alloc_type>
 void
 test_with_usm()
 {
-    sycl::queue q;
+    sycl::queue q = TestUtils::get_test_queue();
 
     constexpr int n = 9;
 

--- a/test/support/test_complex.h
+++ b/test/support/test_complex.h
@@ -126,7 +126,7 @@ namespace TestUtils
 #if TEST_DPCPP_BACKEND_PRESENT
         try
         {
-            sycl::queue deviceQueue{TestUtils::default_selector};
+            sycl::queue deviceQueue = TestUtils::get_test_queue();
 
             const auto device = deviceQueue.get_device();
 

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -119,7 +119,12 @@ make_new_policy(_Policy&& __policy)
         oneapi::dpl::execution::make_fpga_policy(sycl::queue{default_selector});
 #    endif // ONEDPL_USE_PREDEFINED_POLICIES
 #else
-    auto default_selector = sycl::default_selector{};
+    auto default_selector =
+#    if _ONEDPL_LIBSYCL_VERSION >= 60000
+        sycl::default_selector_v;
+#    else
+        sycl::default_selector{};
+#    endif
     auto&& default_dpcpp_policy =
 #    if ONEDPL_USE_PREDEFINED_POLICIES
         oneapi::dpl::execution::dpcpp_default;

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy.pass.cpp
@@ -66,7 +66,7 @@ test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<input_iterator<const int*>, output_iterator<int*>>(deviceQueue);
     test<input_iterator<const int*>, input_iterator<int*>>(deviceQueue);
     test<input_iterator<const int*>, forward_iterator<int*>>(deviceQueue);

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy_backward.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy_backward.pass.cpp
@@ -67,7 +67,7 @@ test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<bidirectional_iterator<const int*>, bidirectional_iterator<int*>>(deviceQueue);
     test<bidirectional_iterator<const int*>, random_access_iterator<int*>>(deviceQueue);
     test<bidirectional_iterator<const int*>, int*>(deviceQueue);

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy_if.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy_if.pass.cpp
@@ -67,7 +67,7 @@ test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<input_iterator<const int*>, output_iterator<int*>>(deviceQueue);
     test<input_iterator<const int*>, input_iterator<int*>>(deviceQueue);
     test<input_iterator<const int*>, forward_iterator<int*>>(deviceQueue);

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy_n.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy_n.pass.cpp
@@ -66,7 +66,7 @@ test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<input_iterator<const int*>, output_iterator<int*>>(deviceQueue);
     test<input_iterator<const int*>, input_iterator<int*>>(deviceQueue);
     test<input_iterator<const int*>, forward_iterator<int*>>(deviceQueue);

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.fill/xpu_fill.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.fill/xpu_fill.pass.cpp
@@ -44,7 +44,7 @@ test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<forward_iterator<int*>>(deviceQueue);
     test<bidirectional_iterator<int*>>(deviceQueue);
     test<random_access_iterator<int*>>(deviceQueue);

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.fill/xpu_fill_n.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.fill/xpu_fill_n.pass.cpp
@@ -44,7 +44,7 @@ test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<forward_iterator<int*>>(deviceQueue);
     test<bidirectional_iterator<int*>>(deviceQueue);
     test<random_access_iterator<int*>>(deviceQueue);

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.generate/xpu_generate.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.generate/xpu_generate.pass.cpp
@@ -14,6 +14,7 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
@@ -51,7 +52,7 @@ test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<forward_iterator<int*>>(deviceQueue);
     test<bidirectional_iterator<int*>>(deviceQueue);
     test<random_access_iterator<int*>>(deviceQueue);

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.generate/xpu_generate_n.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.generate/xpu_generate_n.pass.cpp
@@ -14,6 +14,7 @@
 
 #include <oneapi/dpl/algorithm>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
@@ -51,7 +52,7 @@ test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<forward_iterator<int*>>(deviceQueue);
     test<bidirectional_iterator<int*>>(deviceQueue);
     test<random_access_iterator<int*>>(deviceQueue);

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.move/xpu_move.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.move/xpu_move.pass.cpp
@@ -66,7 +66,7 @@ test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<input_iterator<const int*>, output_iterator<int*>>(deviceQueue);
     test<input_iterator<const int*>, input_iterator<int*>>(deviceQueue);
     test<input_iterator<const int*>, forward_iterator<int*>>(deviceQueue);

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.move/xpu_move_backward.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.move/xpu_move_backward.pass.cpp
@@ -67,7 +67,7 @@ test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<bidirectional_iterator<const int*>, bidirectional_iterator<int*>>(deviceQueue);
     test<bidirectional_iterator<const int*>, random_access_iterator<int*>>(deviceQueue);
     test<bidirectional_iterator<const int*>, int*>(deviceQueue);

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.transform/xpu_binary_transform.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.transform/xpu_binary_transform.pass.cpp
@@ -15,6 +15,7 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
@@ -58,7 +59,7 @@ test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<input_iterator<const int*>, input_iterator<const int*>, output_iterator<int*>>(deviceQueue);
     test<input_iterator<const int*>, input_iterator<const int*>, input_iterator<int*>>(deviceQueue);
     test<input_iterator<const int*>, input_iterator<const int*>, forward_iterator<int*>>(deviceQueue);

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.transform/xpu_unary_transform.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.transform/xpu_unary_transform.pass.cpp
@@ -15,6 +15,7 @@
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
 
+#include "support/utils_sycl.h"
 #include "support/test_iterators.h"
 
 #include <cassert>
@@ -67,7 +68,7 @@ test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<input_iterator<const int*>, output_iterator<int*>>(deviceQueue);
     test<input_iterator<const int*>, input_iterator<int*>>(deviceQueue);
     test<input_iterator<const int*>, forward_iterator<int*>>(deviceQueue);

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.all_of/xpu_all_of.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.all_of/xpu_all_of.pass.cpp
@@ -63,7 +63,7 @@ kernel_test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     kernel_test(deviceQueue);
     return 0;
 }

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.any_of/xpu_any_of.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.any_of/xpu_any_of.pass.cpp
@@ -67,7 +67,7 @@ kernel_test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     kernel_test(deviceQueue);
     return 0;
 }

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.count/xpu_count.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.count/xpu_count.pass.cpp
@@ -43,7 +43,7 @@ kernel_test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     kernel_test(deviceQueue);
     return 0;
 }

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.count/xpu_count_if.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.count/xpu_count_if.pass.cpp
@@ -57,7 +57,7 @@ kernel_test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     kernel_test(deviceQueue);
     return 0;
 }

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.find/xpu_find.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.find/xpu_find.pass.cpp
@@ -45,7 +45,7 @@ test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<input_iterator<const int*>>(deviceQueue);
     test<forward_iterator<const int*>>(deviceQueue);
     test<bidirectional_iterator<const int*>>(deviceQueue);

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.find/xpu_find_if.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.find/xpu_find_if.pass.cpp
@@ -56,7 +56,7 @@ test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<input_iterator<const int*>>(deviceQueue);
     test<forward_iterator<const int*>>(deviceQueue);
     test<bidirectional_iterator<const int*>>(deviceQueue);

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.find/xpu_find_if_not.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.find/xpu_find_if_not.pass.cpp
@@ -55,7 +55,7 @@ test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<input_iterator<const int*>>(deviceQueue);
     test<forward_iterator<const int*>>(deviceQueue);
     test<bidirectional_iterator<const int*>>(deviceQueue);

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.foreach/xpu_for_each.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.foreach/xpu_for_each.pass.cpp
@@ -57,7 +57,7 @@ kernel_test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     kernel_test(deviceQueue);
     return 0;
 }

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.foreach/xpu_for_each_n.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.foreach/xpu_for_each_n.pass.cpp
@@ -105,7 +105,7 @@ test(sycl::queue& deviceQueue)
 int
 main(int, char**)
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     test(deviceQueue);
 
     return 0;

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.is_permutation/xpu_is_permutation.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.is_permutation/xpu_is_permutation.pass.cpp
@@ -89,7 +89,7 @@ kernel_test1(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     kernel_test1<forward_iterator<const int*>>(deviceQueue);
     kernel_test1<bidirectional_iterator<const int*>>(deviceQueue);
     kernel_test1<random_access_iterator<const int*>>(deviceQueue);

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.is_permutation/xpu_is_permutation_pred.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.is_permutation/xpu_is_permutation_pred.pass.cpp
@@ -86,7 +86,7 @@ kernel_test1(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     kernel_test1<forward_iterator<const int*>>(deviceQueue);
     kernel_test1<bidirectional_iterator<const int*>>(deviceQueue);
     kernel_test1<random_access_iterator<const int*>>(deviceQueue);

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.none_of/xpu_none_of.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.none_of/xpu_none_of.pass.cpp
@@ -69,7 +69,7 @@ kernel_test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     kernel_test(deviceQueue);
     return 0;
 }

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap.pass.cpp
@@ -70,7 +70,7 @@ test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<random_access_iterator<int*>>(deviceQueue);
     test<int*>(deviceQueue);
     test<random_access_iterator<float*>>(deviceQueue);

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap_comp.pass.cpp
@@ -72,7 +72,7 @@ test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<random_access_iterator<int*>>(deviceQueue);
     test<int*>(deviceQueue);
     test<random_access_iterator<float*>>(deviceQueue);

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap_until.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap_until.pass.cpp
@@ -60,7 +60,7 @@ test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<random_access_iterator<int*>>(deviceQueue);
     test<int*>(deviceQueue);
     test<random_access_iterator<float*>>(deviceQueue);

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap_until_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap_until_comp.pass.cpp
@@ -61,7 +61,7 @@ test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<random_access_iterator<int*>>(deviceQueue);
     test<int*>(deviceQueue);
     test<random_access_iterator<float*>>(deviceQueue);

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/make.heap/xpu_make_heap.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/make.heap/xpu_make_heap.pass.cpp
@@ -46,7 +46,7 @@ test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<random_access_iterator<int*>>(deviceQueue);
     test<int*>(deviceQueue);
     test<random_access_iterator<float*>>(deviceQueue);

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/make.heap/xpu_make_heap_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/make.heap/xpu_make_heap_comp.pass.cpp
@@ -47,7 +47,7 @@ test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<random_access_iterator<int*>>(deviceQueue);
     test<int*>(deviceQueue);
     test<random_access_iterator<float*>>(deviceQueue);

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/pop.heap/xpu_pop_heap.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/pop.heap/xpu_pop_heap.pass.cpp
@@ -63,7 +63,7 @@ test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<random_access_iterator<int*>>(deviceQueue);
     test<int*>(deviceQueue);
     return 0;

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/pop.heap/xpu_pop_heap_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/pop.heap/xpu_pop_heap_comp.pass.cpp
@@ -65,7 +65,7 @@ test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<random_access_iterator<int*>>(deviceQueue);
     test<int*>(deviceQueue);
     return 0;

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/push.heap/xpu_push_heap.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/push.heap/xpu_push_heap.pass.cpp
@@ -63,7 +63,7 @@ test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<random_access_iterator<int*>>(deviceQueue);
     test<int*>(deviceQueue);
     return 0;

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/push.heap/xpu_push_heap_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/push.heap/xpu_push_heap_comp.pass.cpp
@@ -64,7 +64,7 @@ test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<random_access_iterator<int*>>(deviceQueue);
     test<int*>(deviceQueue);
     return 0;

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted.pass.cpp
@@ -65,7 +65,7 @@ test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<forward_iterator<const int*>>(deviceQueue);
     test<bidirectional_iterator<const int*>>(deviceQueue);
     test<random_access_iterator<const int*>>(deviceQueue);

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted_comp.pass.cpp
@@ -66,7 +66,7 @@ test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<forward_iterator<const int*>>(deviceQueue);
     test<bidirectional_iterator<const int*>>(deviceQueue);
     test<random_access_iterator<const int*>>(deviceQueue);

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted_until.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted_until.pass.cpp
@@ -70,7 +70,7 @@ test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<forward_iterator<const int*>>(deviceQueue);
     test<bidirectional_iterator<const int*>>(deviceQueue);
     test<random_access_iterator<const int*>>(deviceQueue);

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted_until_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted_until_comp.pass.cpp
@@ -71,7 +71,7 @@ test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<forward_iterator<const int*>>(deviceQueue);
     test<bidirectional_iterator<const int*>>(deviceQueue);
     test<random_access_iterator<const int*>>(deviceQueue);

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort.copy/xpu_partial_sort_copy.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort.copy/xpu_partial_sort_copy.pass.cpp
@@ -56,7 +56,7 @@ test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<random_access_iterator<int*>>(deviceQueue);
     test<int*>(deviceQueue);
     return 0;

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort.copy/xpu_partial_sort_copy_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort.copy/xpu_partial_sort_copy_comp.pass.cpp
@@ -56,7 +56,7 @@ test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<random_access_iterator<int*>>(deviceQueue);
     test<int*>(deviceQueue);
     return 0;

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort/xpu_partial_sort.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort/xpu_partial_sort.pass.cpp
@@ -67,7 +67,7 @@ test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<random_access_iterator<int*>>(deviceQueue);
     test<int*>(deviceQueue);
     return 0;

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort/xpu_partial_sort_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort/xpu_partial_sort_comp.pass.cpp
@@ -67,7 +67,7 @@ test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<random_access_iterator<int*>>(deviceQueue);
     test<int*>(deviceQueue);
     return 0;

--- a/test/xpu_api/cmath/nearbyint/xpu_nearbyint.pass.cpp
+++ b/test/xpu_api/cmath/nearbyint/xpu_nearbyint.pass.cpp
@@ -40,7 +40,7 @@ test(Function fnc, const std::vector<ValueType>& args, const char* message)
 
     // Evaluate results in Kernel
     {
-        sycl::queue deviceQueue(TestUtils::async_handler);
+        sycl::queue deviceQueue = TestUtils::get_test_queue();
 
         if (!TestUtils::has_type_support<ValueType>(deviceQueue.get_device()))
         {

--- a/test/xpu_api/numerics/numeric.ops/accumulate/xpu_accumulate.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/accumulate/xpu_accumulate.pass.cpp
@@ -32,7 +32,7 @@ template <typename _T1, typename _T2> void ASSERT_EQUAL(_T1 &&X, _T2 &&Y) {
 }
 
 template <class Iter> void test() {
-  sycl::queue deviceQueue;
+  sycl::queue deviceQueue = TestUtils::get_test_queue();
   int input[6] = {1, 2, 3, 4, 5, 6};
   int output[7] = {};
   sycl::range<1> numOfItems1{6};

--- a/test/xpu_api/numerics/numeric.ops/accumulate/xpu_accumulate_op.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/accumulate/xpu_accumulate_op.pass.cpp
@@ -33,7 +33,7 @@ template <typename _T1, typename _T2> void ASSERT_EQUAL(_T1 &&X, _T2 &&Y) {
 }
 
 template <class Iter> void test() {
-  sycl::queue deviceQueue;
+  sycl::queue deviceQueue = TestUtils::get_test_queue();
   int input[6] = {1, 2, 3, 4, 5, 6};
   int output[8] = {};
   sycl::range<1> numOfItems1{6};

--- a/test/xpu_api/numerics/numeric.ops/inner.product/xpu_inner_product.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/inner.product/xpu_inner_product.pass.cpp
@@ -39,7 +39,7 @@ template <class Iter1, class Iter2>
 void
 test()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     int input1[6] = {1, 2, 3, 4, 5, 6};
     int input2[6] = {6, 5, 4, 3, 2, 1};
     int output[8] = {};

--- a/test/xpu_api/numerics/numeric.ops/inner.product/xpu_inner_product_comp.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/inner.product/xpu_inner_product_comp.pass.cpp
@@ -41,7 +41,7 @@ template <class Iter1, class Iter2>
 void
 test()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     int input1[6] = {1, 2, 3, 4, 5, 6};
     int input2[6] = {6, 5, 4, 3, 2, 1};
     int output[8] = {};

--- a/test/xpu_api/numerics/numeric.ops/numeric.iota/xpu_iota.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/numeric.iota/xpu_iota.pass.cpp
@@ -33,7 +33,7 @@ template <typename _T1, typename _T2> void ASSERT_EQUAL(_T1 &&X, _T2 &&Y) {
 }
 
 template <class InIter> void test() {
-  sycl::queue deviceQueue;
+  sycl::queue deviceQueue = TestUtils::get_test_queue();
   int output[5] = {1, 2, 3, 4, 5};
   sycl::range<1> numOfItems1{5};
 

--- a/test/xpu_api/numerics/numeric.ops/numeric.ops.gcd/xpu_gcd.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/numeric.ops.gcd/xpu_gcd.pass.cpp
@@ -105,7 +105,7 @@ do_test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
 
 // TODO: remove the macro guard once L0 backend fixes the issue
 #if defined(_WIN32)

--- a/test/xpu_api/numerics/numeric.ops/numeric.ops.lcm/xpu_lcm.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/numeric.ops.lcm/xpu_lcm.pass.cpp
@@ -112,7 +112,7 @@ do_test(sycl::queue& deviceQueue)
 int
 main()
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
 
 // TODO: remove the macro guard once L0 backend fixes the issue
 #if defined(_WIN32)

--- a/test/xpu_api/numerics/numeric.ops/partial.sum/xpu_partial_sum.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/partial.sum/xpu_partial_sum.pass.cpp
@@ -31,7 +31,7 @@ template <typename _T1, typename _T2> void ASSERT_EQUAL(_T1 &&X, _T2 &&Y) {
 }
 
 template <class InIter, class OutIter, class Test> void test() {
-  sycl::queue deviceQueue;
+  sycl::queue deviceQueue = TestUtils::get_test_queue();
   int input[5] = {1, 2, 3, 4, 5};
   int output[5] = {0};
   sycl::range<1> numOfItems1{5};

--- a/test/xpu_api/numerics/numeric.ops/partial.sum/xpu_partial_sum_op.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/partial.sum/xpu_partial_sum_op.pass.cpp
@@ -32,7 +32,7 @@ template <typename _T1, typename _T2> void ASSERT_EQUAL(_T1 &&X, _T2 &&Y) {
 }
 
 template <class InIter, class OutIter, class Test> void test() {
-  sycl::queue deviceQueue;
+  sycl::queue deviceQueue = TestUtils::get_test_queue();
   int input[5] = {1, 2, 3, 4, 5};
   int output[5] = {0};
   sycl::range<1> numOfItems1{5};

--- a/test/xpu_api/numerics/numeric.ops/reduce/xpu_reduce.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/reduce/xpu_reduce.pass.cpp
@@ -97,7 +97,7 @@ test(sycl::queue& deviceQueue)
 int
 main(int, char**)
 {
-    sycl::queue deviceQueue;
+    sycl::queue deviceQueue = TestUtils::get_test_queue();
     test(deviceQueue);
 
     return 0;

--- a/test/xpu_api/random/conformance_tests/minstd_rand_rand0_test.pass.cpp
+++ b/test/xpu_api/random/conformance_tests/minstd_rand_rand0_test.pass.cpp
@@ -38,19 +38,7 @@ int main() {
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 
-    // Catch asynchronous exceptions
-    auto exception_handler = [] (sycl::exception_list exceptions) {
-        for (std::exception_ptr const& e : exceptions) {
-            try {
-                std::rethrow_exception(e);
-            } catch(sycl::exception const& e) {
-                std::cout << "Caught asynchronous SYCL exception during generation:\n"
-                << e.what() << std::endl;
-            }
-        }
-    };
-
-    sycl::queue queue(sycl::default_selector{}, exception_handler);
+    sycl::queue queue = TestUtils::get_test_queue();
 
     // Reference values
     uint_fast32_t minstd_rand0_ref_sample = 1043618065;

--- a/test/xpu_api/random/conformance_tests/ranlux_24_48_base_test.pass.cpp
+++ b/test/xpu_api/random/conformance_tests/ranlux_24_48_base_test.pass.cpp
@@ -38,19 +38,7 @@ int main() {
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 
-    // Catch asynchronous exceptions
-    auto exception_handler = [] (sycl::exception_list exceptions) {
-        for (std::exception_ptr const& e : exceptions) {
-            try {
-                std::rethrow_exception(e);
-            } catch(sycl::exception const& e) {
-                std::cout << "Caught asynchronous SYCL exception during generation:\n"
-                << e.what() << std::endl;
-            }
-        }
-    };
-
-    sycl::queue queue(sycl::default_selector{}, exception_handler);
+    sycl::queue queue = TestUtils::get_test_queue();
 
     // Reference values
     uint_fast32_t ranlux24_base_ref_sample = 7937952;

--- a/test/xpu_api/random/conformance_tests/ranlux_24_48_test.pass.cpp
+++ b/test/xpu_api/random/conformance_tests/ranlux_24_48_test.pass.cpp
@@ -38,19 +38,7 @@ int main() {
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 
-    // Catch asynchronous exceptions
-    auto exception_handler = [] (sycl::exception_list exceptions) {
-        for (std::exception_ptr const& e : exceptions) {
-            try {
-                std::rethrow_exception(e);
-            } catch(sycl::exception const& e) {
-                std::cout << "Caught asynchronous SYCL exception during generation:\n"
-                << e.what() << std::endl;
-            }
-        }
-    };
-
-    sycl::queue queue(sycl::default_selector{}, exception_handler);
+    sycl::queue queue = TestUtils::get_test_queue();
 
     // Reference values
     uint_fast32_t ranlux24_ref_sample = 9901578;

--- a/test/xpu_api/random/device_tests/bernoulli_distribution_device_test.pass.cpp
+++ b/test/xpu_api/random/device_tests/bernoulli_distribution_device_test.pass.cpp
@@ -34,7 +34,8 @@ main()
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 
-    sycl::queue queue(exception_handler);
+    sycl::queue queue = TestUtils::get_test_queue();
+
     // Skip tests if DP is not supported
     if (TestUtils::has_type_support<double>(queue.get_device())) {
         int err = 0;

--- a/test/xpu_api/random/device_tests/cauchy_distribution_device_test.pass.cpp
+++ b/test/xpu_api/random/device_tests/cauchy_distribution_device_test.pass.cpp
@@ -34,7 +34,7 @@ main()
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 
-    sycl::queue queue(exception_handler);
+    sycl::queue queue = TestUtils::get_test_queue();
     int err = 0;
 
     // testing oneapi::dpl::cauchy_distribution<sycl::vec<float, 1>> oneapi::dpl::linear_congruential_engine

--- a/test/xpu_api/random/device_tests/common_for_device_tests.h
+++ b/test/xpu_api/random/device_tests/common_for_device_tests.h
@@ -30,17 +30,6 @@
 constexpr auto seed = 777;
 constexpr int N = 96;
 
-auto exception_handler = [] (sycl::exception_list exceptions) {
-    for (std::exception_ptr const& e : exceptions) {
-        try {
-            std::rethrow_exception(e);
-        } catch(sycl::exception const& e) {
-            std::cout << "Caught asynchronous SYCL exception during calculation:\n"
-            << e.what() << std::endl;
-        }
-    }
-};
-
 template <typename Fp>
 int comparison(Fp* r0, Fp* r1, std::uint32_t length) {
     Fp coeff;

--- a/test/xpu_api/random/device_tests/engine_device_test.pass.cpp
+++ b/test/xpu_api/random/device_tests/engine_device_test.pass.cpp
@@ -30,7 +30,7 @@ main()
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 
-    sycl::queue queue(exception_handler);
+    sycl::queue queue = TestUtils::get_test_queue();
     int err = 0;
 
     std::cout << "---------------------------------------------------" << std::endl;

--- a/test/xpu_api/random/device_tests/exponential_distribution_device_test.pass.cpp
+++ b/test/xpu_api/random/device_tests/exponential_distribution_device_test.pass.cpp
@@ -34,7 +34,7 @@ main()
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 
-    sycl::queue queue(exception_handler);
+    sycl::queue queue = TestUtils::get_test_queue();
     int err = 0;
 
     // testing oneapi::dpl::exponential_distribution<sycl::vec<float, 1>> oneapi::dpl::linear_congruential_engine

--- a/test/xpu_api/random/device_tests/extreme_value_distribution_device_test.pass.cpp
+++ b/test/xpu_api/random/device_tests/extreme_value_distribution_device_test.pass.cpp
@@ -34,7 +34,7 @@ main()
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 
-    sycl::queue queue(exception_handler);
+    sycl::queue queue = TestUtils::get_test_queue();
     int err = 0;
 
     // testing oneapi::dpl::extreme_value_distribution<sycl::vec<float, 1>> oneapi::dpl::linear_congruential_engine

--- a/test/xpu_api/random/device_tests/geometric_distribution_device_test.pass.cpp
+++ b/test/xpu_api/random/device_tests/geometric_distribution_device_test.pass.cpp
@@ -34,7 +34,7 @@ main()
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 
-    sycl::queue queue(exception_handler);
+    sycl::queue queue = TestUtils::get_test_queue();
     // Skip tests if DP is not supported
     if (TestUtils::has_type_support<double>(queue.get_device())) {
         int err = 0;

--- a/test/xpu_api/random/device_tests/lognormal_distribution_device_test.pass.cpp
+++ b/test/xpu_api/random/device_tests/lognormal_distribution_device_test.pass.cpp
@@ -34,7 +34,7 @@ main()
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 
-    sycl::queue queue(exception_handler);
+    sycl::queue queue = TestUtils::get_test_queue();
     int err = 0;
 
     // testing oneapi::dpl::lognormal_distribution<sycl::vec<float, 2>> oneapi::dpl::linear_congruential_engine

--- a/test/xpu_api/random/device_tests/normal_distribution_device_test.pass.cpp
+++ b/test/xpu_api/random/device_tests/normal_distribution_device_test.pass.cpp
@@ -34,7 +34,7 @@ main()
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 
-    sycl::queue queue(exception_handler);
+    sycl::queue queue = TestUtils::get_test_queue();
     int err = 0;
 
     // testing oneapi::dpl::normal_distribution<sycl::vec<float, 2>> oneapi::dpl::linear_congruential_engine

--- a/test/xpu_api/random/device_tests/uniform_int_distribution_device_test.pass.cpp
+++ b/test/xpu_api/random/device_tests/uniform_int_distribution_device_test.pass.cpp
@@ -34,7 +34,7 @@ main()
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 
-    sycl::queue queue(exception_handler);
+    sycl::queue queue = TestUtils::get_test_queue();
     // Skip tests if DP is not supported
     if (TestUtils::has_type_support<double>(queue.get_device())) {
         int err = 0;

--- a/test/xpu_api/random/device_tests/uniform_real_distribution_device_test.pass.cpp
+++ b/test/xpu_api/random/device_tests/uniform_real_distribution_device_test.pass.cpp
@@ -34,7 +34,7 @@ main()
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 
-    sycl::queue queue(exception_handler);
+    sycl::queue queue = TestUtils::get_test_queue();
     int err = 0;
 
     // testing oneapi::dpl::uniform_real_distribution<sycl::vec<float, 1>> oneapi::dpl::linear_congruential_engine

--- a/test/xpu_api/random/device_tests/weibull_distribution_device_test.pass.cpp
+++ b/test/xpu_api/random/device_tests/weibull_distribution_device_test.pass.cpp
@@ -34,7 +34,7 @@ main()
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 
-    sycl::queue queue(exception_handler);
+    sycl::queue queue = TestUtils::get_test_queue();
     int err = 0;
 
     // testing oneapi::dpl::weibull_distribution<sycl::vec<float, 1>> oneapi::dpl::linear_congruential_engine

--- a/test/xpu_api/random/interface_tests/distributions_methods.pass.cpp
+++ b/test/xpu_api/random/interface_tests/distributions_methods.pass.cpp
@@ -350,22 +350,7 @@ main()
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 
-    // Catch asynchronous exceptions
-    auto exception_handler = [](sycl::exception_list exceptions) {
-        for (std::exception_ptr const& e : exceptions)
-        {
-            try
-            {
-                std::rethrow_exception(e);
-            }
-            catch (sycl::exception const& e)
-            {
-                std::cout << "Caught asynchronous SYCL exception during generation:\n" << e.what() << std::endl;
-            }
-        }
-    };
-
-    sycl::queue queue(sycl::default_selector{}, exception_handler);
+    sycl::queue queue = TestUtils::get_test_queue();
     std::int32_t err = 0;
 
     // Skip tests if DP is not supported

--- a/test/xpu_api/random/interface_tests/engines_methods.pass.cpp
+++ b/test/xpu_api/random/interface_tests/engines_methods.pass.cpp
@@ -388,22 +388,8 @@ main()
 {
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
-    // Catch asynchronous exceptions
-    auto exception_handler = [](sycl::exception_list exceptions) {
-        for (std::exception_ptr const& e : exceptions)
-        {
-            try
-            {
-                std::rethrow_exception(e);
-            }
-            catch (sycl::exception const& e)
-            {
-                std::cout << "Caught asynchronous SYCL exception during generation:\n" << e.what() << std::endl;
-            }
-        }
-    };
 
-    sycl::queue queue(sycl::default_selector{}, exception_handler);
+    sycl::queue queue = TestUtils::get_test_queue();
     
     std::int32_t err = 0;
 

--- a/test/xpu_api/random/statistics_tests/bernoulli_distribution_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/bernoulli_distribution_test.pass.cpp
@@ -187,7 +187,7 @@ main()
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 
-    sycl::queue queue;
+    sycl::queue queue = TestUtils::get_test_queue();
     // Skip tests if DP is not supported
     if (TestUtils::has_type_support<double>(queue.get_device())) {
         constexpr int nsamples = 100;

--- a/test/xpu_api/random/statistics_tests/exponential_distribution_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/exponential_distribution_test.pass.cpp
@@ -185,7 +185,7 @@ main()
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 
-    sycl::queue queue;
+    sycl::queue queue = TestUtils::get_test_queue();
 
     constexpr int nsamples = 100;
     int err = 0;

--- a/test/xpu_api/random/statistics_tests/extreme_value_distribution_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/extreme_value_distribution_test.pass.cpp
@@ -185,7 +185,7 @@ main()
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 
-    sycl::queue queue;
+    sycl::queue queue = TestUtils::get_test_queue();
 
     constexpr int nsamples = 100;
     int err = 0;

--- a/test/xpu_api/random/statistics_tests/geometric_distribution_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/geometric_distribution_test.pass.cpp
@@ -188,7 +188,7 @@ main()
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 
-    sycl::queue queue;
+    sycl::queue queue = TestUtils::get_test_queue();
     // Skip tests if DP is not supported
     if (TestUtils::has_type_support<double>(queue.get_device())) {
         constexpr int nsamples = 100;

--- a/test/xpu_api/random/statistics_tests/lognormal_distribution_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/lognormal_distribution_test.pass.cpp
@@ -173,7 +173,7 @@ int main() {
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 
-    sycl::queue queue;
+    sycl::queue queue = TestUtils::get_test_queue();
 
     constexpr int nsamples = 100;
     int err = 0;

--- a/test/xpu_api/random/statistics_tests/normal_distribution_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/normal_distribution_test.pass.cpp
@@ -236,7 +236,7 @@ int main() {
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 
-    sycl::queue queue;
+    sycl::queue queue = TestUtils::get_test_queue();
 
     constexpr int nsamples = 100;
     int err = 0;

--- a/test/xpu_api/random/statistics_tests/uniform_int_distribution_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/uniform_int_distribution_test.pass.cpp
@@ -177,7 +177,7 @@ int main() {
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 
-    sycl::queue queue;
+    sycl::queue queue = TestUtils::get_test_queue();
     // Skip tests if DP is not supported
     if (TestUtils::has_type_support<double>(queue.get_device())) {
         constexpr int nsamples = 100;

--- a/test/xpu_api/random/statistics_tests/uniform_real_distribution_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/uniform_real_distribution_test.pass.cpp
@@ -172,7 +172,7 @@ int main() {
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 
-    sycl::queue queue;
+    sycl::queue queue = TestUtils::get_test_queue();
 
     constexpr int nsamples = 100;
     int err = 0;

--- a/test/xpu_api/random/statistics_tests/weibull_distribution_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/weibull_distribution_test.pass.cpp
@@ -186,7 +186,7 @@ main()
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 
-    sycl::queue queue;
+    sycl::queue queue = TestUtils::get_test_queue();
 
     constexpr int nsamples = 100;
     int err = 0;

--- a/test/xpu_api/random/template_tests/discard_block_std_template_test.pass.cpp
+++ b/test/xpu_api/random/template_tests/discard_block_std_template_test.pass.cpp
@@ -174,7 +174,7 @@ int main() {
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 
-    sycl::queue queue;
+    sycl::queue queue = TestUtils::get_test_queue();
     constexpr int nsamples = 100;
     int err = 0;
 

--- a/test/xpu_api/random/template_tests/linear_congruential_std_template_test.pass.cpp
+++ b/test/xpu_api/random/template_tests/linear_congruential_std_template_test.pass.cpp
@@ -195,7 +195,7 @@ int main() {
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 
-    sycl::queue queue;
+    sycl::queue queue = TestUtils::get_test_queue();
 
     constexpr int nsamples = 100;
     int err = 0;

--- a/test/xpu_api/random/template_tests/subtract_with_carry_std_template_test.pass.cpp
+++ b/test/xpu_api/random/template_tests/subtract_with_carry_std_template_test.pass.cpp
@@ -185,7 +185,7 @@ int main() {
 
 #if TEST_DPCPP_BACKEND_PRESENT && TEST_UNNAMED_LAMBDAS
 
-    sycl::queue queue;
+    sycl::queue queue = TestUtils::get_test_queue();
 
     constexpr int nsamples = 100;
     int err = 0;


### PR DESCRIPTION
In this PR we fix usage of ```sycl::default_selector``` deprecated class.
Instead of them we use ```sycl::default_selector_v``` function.
For additional info please see https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:device-selector
Also, now we use ```TestUtils::get_test_queue()``` to create ```sycl::queue``` in all tests.