### PR TITLE
Fix warning in transform_binary.pass.cpp

### DIFF
--- a/test/parallel_api/algorithm/alg.modifying.operations/transform_binary.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/transform_binary.pass.cpp
@@ -49,7 +49,7 @@ check_and_reset(InputIterator1 first1, InputIterator1 last1, InputIterator2 firs
         Out actual = *out_first;
         if (::std::is_floating_point<Out>::value)
         {
-            EXPECT_TRUE((expected > actual ? expected - actual : actual - expected) < 1e-7,
+            EXPECT_TRUE((expected > actual ? expected - actual : actual - expected) < Out(1e-7),
                         "wrong value in output sequence");
         }
         else


### PR DESCRIPTION
In this PR we fix warning in test transform_binary.pass.cpp :
```
/oneDPL/test/parallel_api/algorithm/alg.modifying.operations/transform_binary.pass.cpp:52:85: warning: floating-point comparison is always true; constant cannot be represented exactly in type 'float' [-Wliteral-range]
            EXPECT_TRUE((expected > actual ? expected - actual : actual - expected) < 1e-7,
                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~
/oneDPL/test/support/utils.h:59:67: note: expanded from macro 'EXPECT_TRUE'
#define EXPECT_TRUE(condition, message) ::TestUtils::expect(true, condition, __FILE__, __LINE__, message)
                                                                  ^~~~~~~~~
/oneDPL/test/parallel_api/algorithm/alg.modifying.operations/transform_binary.pass.cpp:74:9: note: in instantiation of function template specialization 'check_and_reset<__gnu_cxx::__normal_iterator<float *, std::vector<float>>, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, __gnu_cxx::__normal_iterator<float *, std::vector<float>>>' requested here
        check_and_reset(first1, last1, first2, out_first);
        ^
/oneDPL/test/support/iterator_utils.h:260:9: note: in instantiation of function template specialization 'test_one_policy<float, float, float>::operator()<const oneapi::dpl::execution::sequenced_policy &, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, TheOperation<float, float, float>>' requested here
        op(::std::forward<Rest>(rest)...);
        ^
/oneDPL/test/support/iterator_utils.h:411:9: note: in instantiation of function template specialization 'TestUtils::invoke_if_<std::integral_constant<bool, false>, std::integral_constant<bool, false>>::operator()<test_one_policy<float, float, float>, const oneapi::dpl::execution::sequenced_policy &, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, TheOperation<float, float, float> &>' requested here
        invoke_if<InputIterator1>()(
        ^
/oneDPL/test/support/iterator_utils.h:542:9: note: in instantiation of function template specialization 'TestUtils::iterator_invoker<std::random_access_iterator_tag, std::integral_constant<bool, false>>::operator()<const oneapi::dpl::execution::sequenced_policy &, test_one_policy<float, float, float>, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, TheOperation<float, float, float> &>' requested here
        iterator_invoker<::std::random_access_iterator_tag, IsReverse>()(::std::forward<Rest>(rest)...);
        ^
/oneDPL/test/support/iterator_utils.h:558:9: note: in instantiation of function template specialization 'TestUtils::reverse_invoker<std::integral_constant<bool, false>>::operator()<const oneapi::dpl::execution::sequenced_policy &, test_one_policy<float, float, float> &, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, TheOperation<float, float, float> &>' requested here
        reverse_invoker</* IsReverse = */ ::std::false_type>()(::std::forward<Rest>(rest)...);
        ^
/oneDPL/test/support/utils_invoke.h:54:9: note: in instantiation of function template specialization 'TestUtils::invoke_on_all_iterator_types::operator()<const oneapi::dpl::execution::sequenced_policy &, test_one_policy<float, float, float> &, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, TheOperation<float, float, float> &>' requested here
        invoke_on_all_iterator_types()(seq,       op, ::std::forward<T>(rest)...);
        ^
/oneDPL/test/support/utils_invoke.h:165:9: note: in instantiation of function template specialization 'TestUtils::invoke_on_all_host_policies::operator()<test_one_policy<float, float, float>, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, TheOperation<float, float, float> &>' requested here
        invoke_on_all_host_policies()(op, ::std::forward<T>(rest)...);
        ^
/oneDPL/test/parallel_api/algorithm/alg.modifying.operations/transform_binary.pass.cpp:89:9: note: in instantiation of function template specialization 'TestUtils::invoke_on_all_policies<0>::operator()<test_one_policy<float, float, float>, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, __gnu_cxx::__normal_iterator<float *, std::vector<float>>, TheOperation<float, float, float> &>' requested here
        invoke_on_all_policies<0>()(test_one_policy<In1, In2, Out>(), in1.begin(), in1.end(), in2.begin(), in2.end(),
        ^
/oneDPL/test/parallel_api/algorithm/alg.modifying.operations/transform_binary.pass.cpp:115:5: note: in instantiation of function template specialization 'test<float, float, float, TheOperation<float, float, float>>' requested here
    test<float32_t, float32_t, float32_t>(TheOperation<float32_t, float32_t, float32_t>(1.5));
    ^
```