### PR TITLE
Replace instances of __invoke_if/__invoke_if_not (#725 part 1)

### DIFF
--- a/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
+++ b/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
@@ -65,7 +65,9 @@ __pattern_walk2_async(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _Fo
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
         ::std::forward<_ExecutionPolicy>(__exec), unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f}, __n,
         __buf1.all_view(), __buf2.all_view());
-    oneapi::dpl::__internal::__invoke_if(_IsSync(), [&__future]() { __future.wait(); });
+
+    if constexpr (_IsSync::value)
+        __future.wait();
 
     return __future.__make_future(__first2 + __n);
 }

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1459,8 +1459,10 @@ __remove_elements(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardI
                 __internal::__brick_copy_by_mask(
                     __first + __i, __first + __i + __len, __result + __initial, __mask + __i,
                     [](_ForwardIterator __x, _Tp* __z) {
-                        __internal::__invoke_if_else(::std::is_trivial<_Tp>(), [&]() { *__z = ::std::move(*__x); },
-                                                     [&]() { ::new (::std::addressof(*__z)) _Tp(::std::move(*__x)); });
+                        if constexpr (::std::is_trivial_v<_Tp>)
+                            *__z = ::std::move(*__x);
+                        else
+                            ::new (::std::addressof(*__z)) _Tp(::std::move(*__x));
                     },
                     __is_vector);
             },
@@ -2477,11 +2479,10 @@ __pattern_partial_sort_copy(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __
                                                   __i, __j, __d_first + (__i - __r), __is_vector);
                                           });
 
-            __internal::__invoke_if_not(::std::is_trivially_destructible<_T1>(), [&]() {
+            if constexpr (!::std::is_trivially_destructible_v<_T1>)
                 __par_backend::__parallel_for(
                     ::std::forward<_ExecutionPolicy>(__exec), __r + __n2, __r + __n1,
                     [__is_vector](_T1* __i, _T1* __j) { __brick_destroy(__i, __j, __is_vector); });
-            });
 
             return __d_first + __n2;
         }
@@ -2931,8 +2932,10 @@ __pattern_inplace_merge(_ExecutionPolicy&& __exec, _RandomAccessIterator __first
     _Tp* __r = __buf.get();
     __internal::__except_handler([&]() {
         auto __move_values = [](_RandomAccessIterator __x, _Tp* __z) {
-            __internal::__invoke_if_else(::std::is_trivial<_Tp>(), [&]() { *__z = ::std::move(*__x); },
-                                         [&]() { ::new (::std::addressof(*__z)) _Tp(::std::move(*__x)); });
+            if constexpr (::std::is_trivial_v<_Tp>)
+                *__z = ::std::move(*__x);
+            else
+                ::new (::std::addressof(*__z)) _Tp(::std::move(*__x));
         };
 
         auto __move_sequences = [](_RandomAccessIterator __first1, _RandomAccessIterator __last1, _Tp* __first2) {

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -99,7 +99,9 @@ __pattern_walk2(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardI
     auto __future_obj = oneapi::dpl::__par_backend_hetero::__parallel_for(
         ::std::forward<_ExecutionPolicy>(__exec), unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f}, __n,
         __buf1.all_view(), __buf2.all_view());
-    oneapi::dpl::__internal::__invoke_if(_IsSync(), [&__future_obj]() { __future_obj.wait(); });
+
+    if constexpr (_IsSync())
+        __future_obj.wait();
 
     return __first2 + __n;
 }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -626,12 +626,9 @@ struct __early_exit_find_or
                 typename ::std::conditional<_OrTagType::value, decltype(__init_index + __i * __shift),
                                             decltype(__found_local.load())>::type;
 
-            _IterSize __current_iter =  [__n_iter, __i](){
-                if constexpr (_BackwardTagType::value)
-                    return __n_iter - 1 - __i;
-                else
-                    return __i;
-            }();
+            _IterSize __current_iter = __i;
+            if constexpr (_BackwardTagType::value)
+                __current_iter = __n_iter - 1 - __i;
 
             _ShiftedIdxType __shifted_idx = __init_index + __current_iter * __shift;
             // TODO:[Performance] the issue with atomic load (in comparison with __shifted_idx for early exit)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -550,7 +550,7 @@ struct __global_scan_functor
             __out_acc[__item_idx] =
                 static_cast<typename __internal::__get_tuple_type<__in_type, __out_type>::__type>(__bin_op_result);
         }
-        __internal::__invoke_if_not(_Inclusive{}, [&]() {
+        if constexpr (!_Inclusive::value)
             //store an initial value to the output first position should be done as postprocess (for in-place scanning)
             if (__item_idx == 0)
             {
@@ -558,7 +558,6 @@ struct __global_scan_functor
                 __init_processing<_Tp> __use_init{};
                 __use_init(__init, __out_acc[__item_idx]);
             }
-        });
     }
 };
 
@@ -586,7 +585,8 @@ struct __scan
         __init_processing<_Tp> __use_init{};
 
         ::std::size_t __shift = 0;
-        __internal::__invoke_if_not(_Inclusive{}, [&]() { __shift = 1; });
+        if (!_Inclusive::value)
+            __shift = 1;
 
         ::std::size_t __adjusted_global_id = __local_id + __size_per_wg * __group_id;
         auto __adder = __local_acc[0];
@@ -668,7 +668,8 @@ struct __scan
         auto __use_init = __init_processing<_Tp>{};
 
         auto __shift = 0;
-        __internal::__invoke_if_not(_Inclusive{}, [&]() { __shift = 1; });
+        if constexpr (!_Inclusive::value)
+            __shift = 1;
 
         auto __adjusted_global_id = __local_id + __size_per_wg * __group_id;
         auto __adder = __local_acc[0];
@@ -877,9 +878,10 @@ class __brick_set_op
                                      __res -
                                      __internal::__pstl_left_bound(__b, _Size2(0), _Size2(__res), __val_b, __comp);
 
-            bres = __internal::__invoke_if_else(_IsOpDifference(),
-                                                [&]() { return __count_a_left > __count_b; }, /*difference*/
-                                                [&]() { return __count_a_left <= __count_b; } /*intersection*/);
+            if constexpr (_IsOpDifference::value)
+                bres = __count_a_left > __count_b;   /*difference*/
+            else
+                bres = __count_a_left <= __count_b; /*intersection*/
         }
         __c[__idx_c] = bres; //store a mask
         return bres;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -584,9 +584,7 @@ struct __scan
         ::std::size_t __local_id = __item.get_local_id(0);
         __init_processing<_Tp> __use_init{};
 
-        ::std::size_t __shift = 0;
-        if (!_Inclusive::value)
-            __shift = 1;
+        constexpr ::std::size_t __shift = _Inclusive{} ? 0 : 1;
 
         ::std::size_t __adjusted_global_id = __local_id + __size_per_wg * __group_id;
         auto __adder = __local_acc[0];
@@ -667,9 +665,7 @@ struct __scan
         auto __local_id = __item.get_local_id(0);
         auto __use_init = __init_processing<_Tp>{};
 
-        auto __shift = 0;
-        if constexpr (!_Inclusive::value)
-            __shift = 1;
+        constexpr auto __shift = _Inclusive{} ? 0 : 1;
 
         auto __adjusted_global_id = __local_id + __size_per_wg * __group_id;
         auto __adder = __local_acc[0];

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -332,14 +332,15 @@ struct __get_sycl_range
         return buf;
     }
 
-    template <typename _Iter, typename _copy_direct_tag>
+    template <typename _Iter, typename _CopyDirectTag>
     buf_type<val_t<_Iter>>
-    copy_direct(_Iter __first, _Iter __last, _copy_direct_tag)
+    copy_direct(_Iter __first, _Iter __last, _CopyDirectTag)
     {
         //create a SYCL buffer and copy data [first, last) or create a empty SYCL buffer with size = (last - first)
-        return oneapi::dpl::__internal::__invoke_if_else(
-            _copy_direct_tag{}, [&]() { return sycl::buffer<val_t<_Iter>, 1>(__first, __last); },
-            [&]() { return sycl::buffer<val_t<_Iter>, 1>(__last - __first); });
+        if constexpr (_CopyDirectTag::value)
+            return sycl::buffer<val_t<_Iter>, 1>(__first, __last);
+        else
+            return sycl::buffer<val_t<_Iter>, 1>(__last - __first);
     }
 
     template <typename _F, typename _It, typename _DiffType>

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -906,9 +906,8 @@ class __merge_func
         else
         {
             __move_range()(_M_z_beg + _M_zs, _M_z_beg + _M_zs + __nx, _M_x_beg + _M_xs);
-            oneapi::dpl::__internal::__invoke_if_not(::std::is_trivially_destructible<_ValueType>(), [&]() {
+            if constexpr (!::std::is_trivially_destructible_v<_ValueType>)
                 __cleanup_range()(_M_z_beg + _M_zs, _M_z_beg + _M_zs + __nx);
-            });
         }
 
         _x_orig = !_x_orig;
@@ -924,9 +923,8 @@ class __merge_func
         else
         {
             __move_range()(_M_z_beg + _M_zs + __nx, _M_z_beg + _M_zs + __nx + __ny, _M_x_beg + _M_ys);
-            oneapi::dpl::__internal::__invoke_if_not(::std::is_trivially_destructible<_ValueType>(), [&]() {
+            if constexpr (!::std::is_trivially_destructible_v<_ValueType>)
                 __cleanup_range()(_M_z_beg + _M_zs + __nx, _M_z_beg + _M_zs + __nx + __ny);
-            });
         }
 
         _y_orig = !_y_orig;
@@ -961,10 +959,11 @@ class __merge_func
             _M_leaf_merge(_M_z_beg + _M_xs, _M_z_beg + _M_xe, _M_z_beg + _M_ys, _M_z_beg + _M_ye, _M_x_beg + _M_zs,
                           _M_comp, __move_value(), __move_value(), __move_range(), __move_range());
 
-            oneapi::dpl::__internal::__invoke_if_not(::std::is_trivially_destructible<_ValueType>(), [&]() {
+            if constexpr (!::std::is_trivially_destructible_v<_ValueType>)
+            {
                 __cleanup_range()(_M_z_beg + _M_xs, _M_z_beg + _M_xe);
                 __cleanup_range()(_M_z_beg + _M_ys, _M_z_beg + _M_ye);
-            });
+            }
         }
         return nullptr;
     }


### PR DESCRIPTION
Splitting #725 in to multiple PRs.

This PR replaces the internal helper functions oneapi::dpl::__internal::__invoke_if, oneapi::dpl::__internal::__invoke_if_not and oneapi::dpl::__internal::__invoke_if_else with if constexpr now that oneDPL is free to use C++17 constructs.