### PR TITLE
Replace instances of __invoke_if/__invoke_if_not in glue_memory_impl.h (#725 part 1)

### DIFF
--- a/include/oneapi/dpl/pstl/glue_memory_impl.h
+++ b/include/oneapi/dpl/pstl/glue_memory_impl.h
@@ -50,19 +50,19 @@ uninitialized_copy(_ExecutionPolicy&& __exec, _InputIterator __first, _InputIter
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(
             __exec);
 
-    return oneapi::dpl::__internal::__invoke_if_else(
-        ::std::integral_constant<bool, ::std::is_trivial<_ValueType1>::value&& ::std::is_trivial<_ValueType2>::value>(),
-        [&]() {
-            return oneapi::dpl::__internal::__pattern_walk2_brick(
-                ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
-                oneapi::dpl::__internal::__brick_copy<_DecayedExecutionPolicy>{}, __is_parallel);
-        },
-        [&]() {
-            return oneapi::dpl::__internal::__pattern_walk2(
-                ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
-                oneapi::dpl::__internal::__op_uninitialized_copy<_DecayedExecutionPolicy>{}, __is_vector,
-                __is_parallel);
-        });
+    if constexpr (::std::is_trivial_v<_ValueType1> && ::std::is_trivial_v<_ValueType2>)
+    {
+        return oneapi::dpl::__internal::__pattern_walk2_brick(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
+            oneapi::dpl::__internal::__brick_copy<_DecayedExecutionPolicy>{}, __is_parallel);
+    }
+    else
+    {
+        return oneapi::dpl::__internal::__pattern_walk2(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
+            oneapi::dpl::__internal::__op_uninitialized_copy<_DecayedExecutionPolicy>{}, __is_vector,
+            __is_parallel);
+    }
 }
 
 template <class _ExecutionPolicy, class _InputIterator, class _Size, class _ForwardIterator>
@@ -80,19 +80,19 @@ uninitialized_copy_n(_ExecutionPolicy&& __exec, _InputIterator __first, _Size __
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(
             __exec);
 
-    return oneapi::dpl::__internal::__invoke_if_else(
-        ::std::integral_constant<bool, ::std::is_trivial<_ValueType1>::value&& ::std::is_trivial<_ValueType2>::value>(),
-        [&]() {
-            return oneapi::dpl::__internal::__pattern_walk2_brick_n(
-                ::std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
-                oneapi::dpl::__internal::__brick_copy_n<_DecayedExecutionPolicy>{}, __is_parallel);
-        },
-        [&]() {
-            return oneapi::dpl::__internal::__pattern_walk2_n(
-                ::std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
-                oneapi::dpl::__internal::__op_uninitialized_copy<_DecayedExecutionPolicy>{}, __is_vector,
-                __is_parallel);
-        });
+    if constexpr (::std::is_trivial_v<_ValueType1> && ::std::is_trivial_v<_ValueType2>)
+    {
+        return oneapi::dpl::__internal::__pattern_walk2_brick_n(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
+            oneapi::dpl::__internal::__brick_copy_n<_DecayedExecutionPolicy>{}, __is_parallel);
+    }
+    else
+    {
+        return oneapi::dpl::__internal::__pattern_walk2_n(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
+            oneapi::dpl::__internal::__op_uninitialized_copy<_DecayedExecutionPolicy>{}, __is_vector,
+            __is_parallel);
+    }
 }
 
 // [uninitialized.move]
@@ -112,19 +112,19 @@ uninitialized_move(_ExecutionPolicy&& __exec, _InputIterator __first, _InputIter
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(
             __exec);
 
-    return oneapi::dpl::__internal::__invoke_if_else(
-        ::std::integral_constant<bool, ::std::is_trivial<_ValueType1>::value&& ::std::is_trivial<_ValueType2>::value>(),
-        [&]() {
-            return oneapi::dpl::__internal::__pattern_walk2_brick(
-                ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
-                oneapi::dpl::__internal::__brick_copy<_DecayedExecutionPolicy>{}, __is_parallel);
-        },
-        [&]() {
-            return oneapi::dpl::__internal::__pattern_walk2(
-                ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
-                oneapi::dpl::__internal::__op_uninitialized_move<_DecayedExecutionPolicy>{}, __is_vector,
-                __is_parallel);
-        });
+    if constexpr (::std::is_trivial_v<_ValueType1> && ::std::is_trivial_v<_ValueType2>)
+    {
+        return oneapi::dpl::__internal::__pattern_walk2_brick(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
+            oneapi::dpl::__internal::__brick_copy<_DecayedExecutionPolicy>{}, __is_parallel);
+    }
+    else
+    {
+        return oneapi::dpl::__internal::__pattern_walk2(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
+            oneapi::dpl::__internal::__op_uninitialized_move<_DecayedExecutionPolicy>{}, __is_vector,
+            __is_parallel);
+    }
 }
 
 template <class _ExecutionPolicy, class _InputIterator, class _Size, class _ForwardIterator>
@@ -142,19 +142,19 @@ uninitialized_move_n(_ExecutionPolicy&& __exec, _InputIterator __first, _Size __
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(
             __exec);
 
-    return oneapi::dpl::__internal::__invoke_if_else(
-        ::std::integral_constant<bool, ::std::is_trivial<_ValueType1>::value&& ::std::is_trivial<_ValueType2>::value>(),
-        [&]() {
-            return oneapi::dpl::__internal::__pattern_walk2_brick_n(
-                ::std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
-                oneapi::dpl::__internal::__brick_copy_n<_DecayedExecutionPolicy>{}, __is_parallel);
-        },
-        [&]() {
-            return oneapi::dpl::__internal::__pattern_walk2_n(
-                ::std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
-                oneapi::dpl::__internal::__op_uninitialized_move<_DecayedExecutionPolicy>{}, __is_vector,
-                __is_parallel);
-        });
+    if constexpr (::std::is_trivial_v<_ValueType1> && ::std::is_trivial_v<_ValueType2>)
+    {
+        return oneapi::dpl::__internal::__pattern_walk2_brick_n(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
+            oneapi::dpl::__internal::__brick_copy_n<_DecayedExecutionPolicy>{}, __is_parallel);
+    }
+    else
+    {
+        return oneapi::dpl::__internal::__pattern_walk2_n(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
+            oneapi::dpl::__internal::__op_uninitialized_move<_DecayedExecutionPolicy>{}, __is_vector,
+            __is_parallel);
+    }
 }
 
 // [uninitialized.fill]
@@ -171,20 +171,20 @@ uninitialized_fill(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Forward
     const auto __is_vector =
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
 
-    oneapi::dpl::__internal::__invoke_if_else(
-        ::std::is_arithmetic<_ValueType>(),
-        [&]() {
-            oneapi::dpl::__internal::__pattern_walk_brick(
-                ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
-                oneapi::dpl::__internal::__brick_fill<_ValueType, _DecayedExecutionPolicy>{_ValueType(__value)},
-                __is_parallel);
-        },
-        [&]() {
-            oneapi::dpl::__internal::__pattern_walk1(
-                ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
-                oneapi::dpl::__internal::__op_uninitialized_fill<_Tp, _DecayedExecutionPolicy>{__value}, __is_vector,
-                __is_parallel);
-        });
+    if constexpr (::std::is_arithmetic_v<_ValueType>)
+    {
+        oneapi::dpl::__internal::__pattern_walk_brick(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+            oneapi::dpl::__internal::__brick_fill<_ValueType, _DecayedExecutionPolicy>{_ValueType(__value)},
+            __is_parallel);
+    }
+    else
+    {
+        oneapi::dpl::__internal::__pattern_walk1(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+            oneapi::dpl::__internal::__op_uninitialized_fill<_Tp, _DecayedExecutionPolicy>{__value}, __is_vector,
+            __is_parallel);
+    }
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Tp>
@@ -199,20 +199,20 @@ uninitialized_fill_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size 
     const auto __is_vector =
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
 
-    return oneapi::dpl::__internal::__invoke_if_else(
-        ::std::is_arithmetic<_ValueType>(),
-        [&]() {
-            return oneapi::dpl::__internal::__pattern_walk_brick_n(
-                ::std::forward<_ExecutionPolicy>(__exec), __first, __n,
-                oneapi::dpl::__internal::__brick_fill_n<_ValueType, _DecayedExecutionPolicy>{_ValueType(__value)},
-                __is_parallel);
-        },
-        [&]() {
-            return oneapi::dpl::__internal::__pattern_walk1_n(
-                ::std::forward<_ExecutionPolicy>(__exec), __first, __n,
-                oneapi::dpl::__internal::__op_uninitialized_fill<_Tp, _DecayedExecutionPolicy>{__value}, __is_vector,
-                __is_parallel);
-        });
+    if constexpr (::std::is_arithmetic_v<_ValueType>)
+    {
+        return oneapi::dpl::__internal::__pattern_walk_brick_n(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __n,
+            oneapi::dpl::__internal::__brick_fill_n<_ValueType, _DecayedExecutionPolicy>{_ValueType(__value)},
+            __is_parallel);
+    }
+    else
+    {
+        return oneapi::dpl::__internal::__pattern_walk1_n(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __n,
+            oneapi::dpl::__internal::__op_uninitialized_fill<_Tp, _DecayedExecutionPolicy>{__value}, __is_vector,
+            __is_parallel);
+    }
 }
 
 // [specialized.destroy]
@@ -229,11 +229,12 @@ destroy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __
     const auto __is_vector =
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
 
-    oneapi::dpl::__internal::__invoke_if_not(::std::is_trivially_destructible<_ValueType>(), [&]() {
+    if constexpr (!::std::is_trivially_destructible_v<_ValueType>)
+    {
         oneapi::dpl::__internal::__pattern_walk1(::std::forward<_ExecutionPolicy>(__exec), __first, __last,
                                                  [](_ReferenceType __val) { __val.~_ValueType(); }, __is_vector,
                                                  __is_parallel);
-    });
+    }
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Size>
@@ -248,14 +249,16 @@ destroy_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n)
     const auto __is_vector =
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
 
-    return oneapi::dpl::__internal::__invoke_if_else(
-        ::std::is_trivially_destructible<_ValueType>(),
-        [&]() { return oneapi::dpl::__internal::__pstl_next(__first, __n); },
-        [&]() {
-            return oneapi::dpl::__internal::__pattern_walk1_n(::std::forward<_ExecutionPolicy>(__exec), __first, __n,
-                                                              [](_ReferenceType __val) { __val.~_ValueType(); },
-                                                              __is_vector, __is_parallel);
-        });
+    if constexpr (::std::is_trivially_destructible_v<_ValueType>)
+    {
+        return oneapi::dpl::__internal::__pstl_next(__first, __n);
+    }
+    else
+    {
+        return oneapi::dpl::__internal::__pattern_walk1_n(::std::forward<_ExecutionPolicy>(__exec), __first, __n,
+                                                          [](_ReferenceType __val) { __val.~_ValueType(); },
+                                                          __is_vector, __is_parallel);
+    }
 }
 
 // [uninitialized.construct.default]
@@ -272,12 +275,13 @@ uninitialized_default_construct(_ExecutionPolicy&& __exec, _ForwardIterator __fi
     const auto __is_vector =
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
 
-    oneapi::dpl::__internal::__invoke_if_not(::std::is_trivial<_ValueType>(), [&]() {
+    if constexpr (!::std::is_trivial_v<_ValueType>)
+    {
         oneapi::dpl::__internal::__pattern_walk1(
             ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
             oneapi::dpl::__internal::__op_uninitialized_default_construct<_DecayedExecutionPolicy>{}, __is_vector,
             __is_parallel);
-    });
+    }
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Size>
@@ -292,14 +296,17 @@ uninitialized_default_construct_n(_ExecutionPolicy&& __exec, _ForwardIterator __
     const auto __is_vector =
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
 
-    return oneapi::dpl::__internal::__invoke_if_else(
-        ::std::is_trivial<_ValueType>(), [&]() { return oneapi::dpl::__internal::__pstl_next(__first, __n); },
-        [&]() {
-            return oneapi::dpl::__internal::__pattern_walk1_n(
-                ::std::forward<_ExecutionPolicy>(__exec), __first, __n,
-                oneapi::dpl::__internal::__op_uninitialized_default_construct<_DecayedExecutionPolicy>{}, __is_vector,
-                __is_parallel);
-        });
+    if constexpr (::std::is_trivial_v<_ValueType>)
+    {
+        return oneapi::dpl::__internal::__pstl_next(__first, __n);
+    }
+    else
+    {
+        return oneapi::dpl::__internal::__pattern_walk1_n(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __n,
+            oneapi::dpl::__internal::__op_uninitialized_default_construct<_DecayedExecutionPolicy>{}, __is_vector,
+            __is_parallel);
+    }
 }
 
 // [uninitialized.construct.value]
@@ -316,20 +323,20 @@ uninitialized_value_construct(_ExecutionPolicy&& __exec, _ForwardIterator __firs
     const auto __is_vector =
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
 
-    oneapi::dpl::__internal::__invoke_if_else(
-        ::std::is_trivial<_ValueType>(),
-        [&]() {
-            oneapi::dpl::__internal::__pattern_walk_brick(
-                ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
-                oneapi::dpl::__internal::__brick_fill<_ValueType, _DecayedExecutionPolicy>{_ValueType()},
-                __is_parallel);
-        },
-        [&]() {
-            oneapi::dpl::__internal::__pattern_walk1(
-                ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
-                oneapi::dpl::__internal::__op_uninitialized_value_construct<_DecayedExecutionPolicy>{}, __is_vector,
-                __is_parallel);
-        });
+    if constexpr (::std::is_trivial_v<_ValueType>)
+    {
+        oneapi::dpl::__internal::__pattern_walk_brick(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+            oneapi::dpl::__internal::__brick_fill<_ValueType, _DecayedExecutionPolicy>{_ValueType()},
+            __is_parallel);
+    }
+    else
+    {
+        oneapi::dpl::__internal::__pattern_walk1(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+            oneapi::dpl::__internal::__op_uninitialized_value_construct<_DecayedExecutionPolicy>{}, __is_vector,
+            __is_parallel);
+    }
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Size>
@@ -344,20 +351,20 @@ uninitialized_value_construct_n(_ExecutionPolicy&& __exec, _ForwardIterator __fi
     const auto __is_vector =
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
 
-    return oneapi::dpl::__internal::__invoke_if_else(
-        ::std::is_trivial<_ValueType>(),
-        [&]() {
-            return oneapi::dpl::__internal::__pattern_walk_brick_n(
-                ::std::forward<_ExecutionPolicy>(__exec), __first, __n,
-                oneapi::dpl::__internal::__brick_fill_n<_ValueType, _DecayedExecutionPolicy>{_ValueType()},
-                __is_parallel);
-        },
-        [&]() {
-            return oneapi::dpl::__internal::__pattern_walk1_n(
-                ::std::forward<_ExecutionPolicy>(__exec), __first, __n,
-                oneapi::dpl::__internal::__op_uninitialized_value_construct<_DecayedExecutionPolicy>{}, __is_vector,
-                __is_parallel);
-        });
+    if constexpr (::std::is_trivial_v<_ValueType>)
+    {
+        return oneapi::dpl::__internal::__pattern_walk_brick_n(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __n,
+            oneapi::dpl::__internal::__brick_fill_n<_ValueType, _DecayedExecutionPolicy>{_ValueType()},
+            __is_parallel);
+    }
+    else
+    {
+        return oneapi::dpl::__internal::__pattern_walk1_n(
+            ::std::forward<_ExecutionPolicy>(__exec), __first, __n,
+            oneapi::dpl::__internal::__op_uninitialized_value_construct<_DecayedExecutionPolicy>{}, __is_vector,
+            __is_parallel);
+    }
 }
 
 } // namespace dpl


### PR DESCRIPTION
Splitting https://github.com/oneapi-src/oneDPL/pull/725 in to multiple PRs.

This PR replaces the internal helper functions oneapi::dpl::__internal::__invoke_if, oneapi::dpl::__internal::__invoke_if_not and oneapi::dpl::__internal::__invoke_if_else with if constexpr now that oneDPL is free to use C++17 constructs.