### PR TITLE
Remove unused __invoke_if utils

### DIFF
--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -58,44 +58,6 @@ __except_handler(_Fp __f) -> decltype(__f())
     }
 }
 
-template <typename _Fp>
-void
-__invoke_if(::std::true_type, _Fp __f)
-{
-    __f();
-}
-
-template <typename _Fp>
-void __invoke_if(::std::false_type, _Fp)
-{
-}
-
-template <typename _Fp>
-void
-__invoke_if_not(::std::false_type, _Fp __f)
-{
-    __f();
-}
-
-template <typename _Fp>
-void __invoke_if_not(::std::true_type, _Fp)
-{
-}
-
-template <typename _F1, typename _F2>
-auto
-__invoke_if_else(::std::true_type, _F1 __f1, _F2) -> decltype(__f1())
-{
-    return __f1();
-}
-
-template <typename _F1, typename _F2>
-auto
-__invoke_if_else(::std::false_type, _F1, _F2 __f2) -> decltype(__f2())
-{
-    return __f2();
-}
-
 template <typename _Op>
 struct __invoke_unary_op
 {


### PR DESCRIPTION
After #746 and #747, these helper functions are no longer used.