### PR TITLE
Fix buffer size calculation in algorithm_impl_hetero.h

### DIFF
--- a/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
+++ b/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
@@ -31,7 +31,7 @@ template <typename _ExecutionPolicy, typename _ForwardIterator, typename _Functi
 auto
 __pattern_walk1_async(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Function __f)
 {
-    auto __n = __last - __first;
+    const auto __n = __last - __first;
     assert(__n > 0);
 
     auto __keep =
@@ -53,7 +53,7 @@ auto
 __pattern_walk2_async(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
                       _ForwardIterator2 __first2, _Function __f)
 {
-    auto __n = __last1 - __first1;
+    const auto __n = __last1 - __first1;
     assert(__n > 0);
 
     auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__acc_mode1, _ForwardIterator1>();
@@ -78,7 +78,7 @@ auto
 __pattern_walk3_async(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
                       _ForwardIterator2 __first2, _ForwardIterator3 __first3, _Function __f)
 {
-    auto __n = __last1 - __first1;
+    const auto __n = __last1 - __first1;
     assert(__n > 0);
 
     auto __keep1 =
@@ -128,7 +128,7 @@ __pattern_transform_reduce_async(_ExecutionPolicy&& __exec, _RandomAccessIterato
     using _RepackedTp = __par_backend_hetero::__repacked_tuple_t<_Tp>;
     using _NoOpFunctor = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;
 
-    auto __n = __last1 - __first1;
+    const auto __n = __last1 - __first1;
     auto __keep1 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _RandomAccessIterator1>();
     auto __buf1 = __keep1(__first1, __last1);
@@ -215,7 +215,7 @@ __pattern_transform_scan_base_async(_ExecutionPolicy&& __exec, _Iterator1 __firs
     _NoAssign __no_assign_op;
     _NoOpFunctor __get_data_op;
 
-    auto __n = __last - __first;
+    const auto __n = __last - __first;
     auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
     auto __buf1 = __keep1(__first, __last);
     auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _Iterator2>();

--- a/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
+++ b/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
@@ -60,7 +60,7 @@ __pattern_walk2_async(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _Fo
     auto __buf1 = __keep1(__first1, __last1);
 
     auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__acc_mode2, _ForwardIterator2>();
-    auto __buf2 = __keep2.create_holder(__first2, __n);
+    auto __buf2 = __keep2(__first2, __n);
 
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
         ::std::forward<_ExecutionPolicy>(__exec), unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f}, __n,
@@ -86,10 +86,10 @@ __pattern_walk3_async(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _Fo
     auto __buf1 = __keep1(__first1, __last1);
     auto __keep2 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _ForwardIterator2>();
-    auto __buf2 = __keep2.create_holder(__first2, __n);
+    auto __buf2 = __keep2(__first2, __n);
     auto __keep3 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _ForwardIterator3>();
-    auto __buf3 = __keep3.create_holder(__first3, __n);
+    auto __buf3 = __keep3(__first3, __n);
 
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
         ::std::forward<_ExecutionPolicy>(__exec), unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f}, __n,
@@ -134,7 +134,7 @@ __pattern_transform_reduce_async(_ExecutionPolicy&& __exec, _RandomAccessIterato
     auto __buf1 = __keep1(__first1, __last1);
     auto __keep2 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _RandomAccessIterator2>();
-    auto __buf2 = __keep2.create_holder(__first2, __n);
+    auto __buf2 = __keep2(__first2, __n);
 
     auto __res = oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp>(
         ::std::forward<_ExecutionPolicy>(__exec),
@@ -219,7 +219,7 @@ __pattern_transform_scan_base_async(_ExecutionPolicy&& __exec, _Iterator1 __firs
     auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
     auto __buf1 = __keep1(__first, __last);
     auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _Iterator2>();
-    auto __buf2 = __keep2.create_holder(__result, __n);
+    auto __buf2 = __keep2(__result, __n);
 
     auto __res = oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(
         ::std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(), __buf2.all_view(), __binary_op, __init,

--- a/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
+++ b/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
@@ -60,7 +60,7 @@ __pattern_walk2_async(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _Fo
     auto __buf1 = __keep1(__first1, __last1);
 
     auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__acc_mode2, _ForwardIterator2>();
-    auto __buf2 = __keep2(__first2, __first2 + __n);
+    auto __buf2 = __keep2.keep_with_size(__first2, __n);
 
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
         ::std::forward<_ExecutionPolicy>(__exec), unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f}, __n,
@@ -86,10 +86,10 @@ __pattern_walk3_async(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _Fo
     auto __buf1 = __keep1(__first1, __last1);
     auto __keep2 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _ForwardIterator2>();
-    auto __buf2 = __keep2(__first2, __first2 + __n);
+    auto __buf2 = __keep2.keep_with_size(__first2, __n);
     auto __keep3 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _ForwardIterator3>();
-    auto __buf3 = __keep3(__first3, __first3 + __n);
+    auto __buf3 = __keep3.keep_with_size(__first3, __n);
 
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
         ::std::forward<_ExecutionPolicy>(__exec), unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f}, __n,
@@ -134,7 +134,7 @@ __pattern_transform_reduce_async(_ExecutionPolicy&& __exec, _RandomAccessIterato
     auto __buf1 = __keep1(__first1, __last1);
     auto __keep2 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _RandomAccessIterator2>();
-    auto __buf2 = __keep2(__first2, __first2 + __n);
+    auto __buf2 = __keep2.keep_with_size(__first2, __n);
 
     auto __res = oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp>(
         ::std::forward<_ExecutionPolicy>(__exec),
@@ -219,7 +219,7 @@ __pattern_transform_scan_base_async(_ExecutionPolicy&& __exec, _Iterator1 __firs
     auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
     auto __buf1 = __keep1(__first, __last);
     auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _Iterator2>();
-    auto __buf2 = __keep2(__result, __result + __n);
+    auto __buf2 = __keep2.keep_with_size(__result, __n);
 
     auto __res = oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(
         ::std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(), __buf2.all_view(), __binary_op, __init,

--- a/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
+++ b/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
@@ -69,7 +69,7 @@ __pattern_walk2_async(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _Fo
     if constexpr (_IsSync::value)
         __future.wait();
 
-    return __future.__make_future(__first2 + __n);
+    return __future.__make_future(__first2 + __buf2.get_size());
 }
 
 template <typename _ExecutionPolicy, typename _ForwardIterator1, typename _ForwardIterator2, typename _ForwardIterator3,
@@ -95,7 +95,7 @@ __pattern_walk3_async(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _Fo
         ::std::forward<_ExecutionPolicy>(__exec), unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f}, __n,
         __buf1.all_view(), __buf2.all_view(), __buf3.all_view());
 
-    return __future.__make_future(__first3 + __n);
+    return __future.__make_future(__first3 + __buf3.get_size());
 }
 
 template <typename _ExecutionPolicy, typename _ForwardIterator1, typename _ForwardIterator2, typename _Brick,
@@ -233,7 +233,7 @@ __pattern_transform_scan_base_async(_ExecutionPolicy&& __exec, _Iterator1 __firs
             __binary_op, _NoOpFunctor{}, __no_assign_op, __assign_op, __get_data_op},
         // global scan
         unseq_backend::__global_scan_functor<_Inclusive, _BinaryOperation, _InitType>{__binary_op, __init});
-    return __res.__make_future(__result + __n);
+    return __res.__make_future(__result + __buf2.get_size());
 }
 
 template <typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2, typename _UnaryOperation, typename _Type,

--- a/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
+++ b/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
@@ -31,7 +31,7 @@ template <typename _ExecutionPolicy, typename _ForwardIterator, typename _Functi
 auto
 __pattern_walk1_async(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Function __f)
 {
-    const auto __n = __last - __first;
+    auto __n = __last - __first;
     assert(__n > 0);
 
     auto __keep =
@@ -53,7 +53,7 @@ auto
 __pattern_walk2_async(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
                       _ForwardIterator2 __first2, _Function __f)
 {
-    const auto __n = __last1 - __first1;
+    auto __n = __last1 - __first1;
     assert(__n > 0);
 
     auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__acc_mode1, _ForwardIterator1>();
@@ -78,7 +78,7 @@ auto
 __pattern_walk3_async(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
                       _ForwardIterator2 __first2, _ForwardIterator3 __first3, _Function __f)
 {
-    const auto __n = __last1 - __first1;
+    auto __n = __last1 - __first1;
     assert(__n > 0);
 
     auto __keep1 =
@@ -128,7 +128,7 @@ __pattern_transform_reduce_async(_ExecutionPolicy&& __exec, _RandomAccessIterato
     using _RepackedTp = __par_backend_hetero::__repacked_tuple_t<_Tp>;
     using _NoOpFunctor = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;
 
-    const auto __n = __last1 - __first1;
+    auto __n = __last1 - __first1;
     auto __keep1 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _RandomAccessIterator1>();
     auto __buf1 = __keep1(__first1, __last1);
@@ -215,7 +215,7 @@ __pattern_transform_scan_base_async(_ExecutionPolicy&& __exec, _Iterator1 __firs
     _NoAssign __no_assign_op;
     _NoOpFunctor __get_data_op;
 
-    const auto __n = __last - __first;
+    auto __n = __last - __first;
     auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
     auto __buf1 = __keep1(__first, __last);
     auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _Iterator2>();

--- a/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
+++ b/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
@@ -60,7 +60,7 @@ __pattern_walk2_async(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _Fo
     auto __buf1 = __keep1(__first1, __last1);
 
     auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__acc_mode2, _ForwardIterator2>();
-    auto __buf2 = __keep2.keep_with_size(__first2, __n);
+    auto __buf2 = __keep2.create_holder(__first2, __n);
 
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
         ::std::forward<_ExecutionPolicy>(__exec), unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f}, __n,
@@ -86,10 +86,10 @@ __pattern_walk3_async(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _Fo
     auto __buf1 = __keep1(__first1, __last1);
     auto __keep2 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _ForwardIterator2>();
-    auto __buf2 = __keep2.keep_with_size(__first2, __n);
+    auto __buf2 = __keep2.create_holder(__first2, __n);
     auto __keep3 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _ForwardIterator3>();
-    auto __buf3 = __keep3.keep_with_size(__first3, __n);
+    auto __buf3 = __keep3.create_holder(__first3, __n);
 
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
         ::std::forward<_ExecutionPolicy>(__exec), unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f}, __n,
@@ -134,7 +134,7 @@ __pattern_transform_reduce_async(_ExecutionPolicy&& __exec, _RandomAccessIterato
     auto __buf1 = __keep1(__first1, __last1);
     auto __keep2 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _RandomAccessIterator2>();
-    auto __buf2 = __keep2.keep_with_size(__first2, __n);
+    auto __buf2 = __keep2.create_holder(__first2, __n);
 
     auto __res = oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp>(
         ::std::forward<_ExecutionPolicy>(__exec),
@@ -219,7 +219,7 @@ __pattern_transform_scan_base_async(_ExecutionPolicy&& __exec, _Iterator1 __firs
     auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
     auto __buf1 = __keep1(__first, __last);
     auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _Iterator2>();
-    auto __buf2 = __keep2.keep_with_size(__result, __n);
+    auto __buf2 = __keep2.create_holder(__result, __n);
 
     auto __res = oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(
         ::std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(), __buf2.all_view(), __binary_op, __init,

--- a/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
+++ b/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
@@ -69,7 +69,7 @@ __pattern_walk2_async(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _Fo
     if constexpr (_IsSync::value)
         __future.wait();
 
-    return __future.__make_future(__first2 + __buf2.get_size());
+    return __future.__make_future(__first2 + __buf2.size());
 }
 
 template <typename _ExecutionPolicy, typename _ForwardIterator1, typename _ForwardIterator2, typename _ForwardIterator3,
@@ -95,7 +95,7 @@ __pattern_walk3_async(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _Fo
         ::std::forward<_ExecutionPolicy>(__exec), unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f}, __n,
         __buf1.all_view(), __buf2.all_view(), __buf3.all_view());
 
-    return __future.__make_future(__first3 + __buf3.get_size());
+    return __future.__make_future(__first3 + __buf3.size());
 }
 
 template <typename _ExecutionPolicy, typename _ForwardIterator1, typename _ForwardIterator2, typename _Brick,
@@ -233,7 +233,7 @@ __pattern_transform_scan_base_async(_ExecutionPolicy&& __exec, _Iterator1 __firs
             __binary_op, _NoOpFunctor{}, __no_assign_op, __assign_op, __get_data_op},
         // global scan
         unseq_backend::__global_scan_functor<_Inclusive, _BinaryOperation, _InitType>{__binary_op, __init});
-    return __res.__make_future(__result + __buf2.get_size());
+    return __res.__make_future(__result + __buf2.size());
 }
 
 template <typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2, typename _UnaryOperation, typename _Type,

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -126,7 +126,7 @@ lower_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, Inpu
     auto value_buf = keep_values(value_start, value_end);
 
     auto keep_result = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read_write, OutputIterator>();
-    auto result_buf = keep_result(result, result + value_size);
+    auto result_buf = keep_result.keep_with_size(result, value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
     __bknd::__parallel_for(::std::forward<Policy>(policy),
                            custom_brick<StrictWeakOrdering, decltype(size), lower_bound>{comp, size}, value_size,
@@ -156,7 +156,7 @@ upper_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, Inpu
     auto value_buf = keep_values(value_start, value_end);
 
     auto keep_result = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read_write, OutputIterator>();
-    auto result_buf = keep_result(result, result + value_size);
+    auto result_buf = keep_result.keep_with_size(result, value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
     __bknd::__parallel_for(::std::forward<Policy>(policy),
                            custom_brick<StrictWeakOrdering, decltype(size), upper_bound>{comp, size}, value_size,
@@ -186,7 +186,7 @@ binary_search_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, In
     auto value_buf = keep_values(value_start, value_end);
 
     auto keep_result = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read_write, OutputIterator>();
-    auto result_buf = keep_result(result, result + value_size);
+    auto result_buf = keep_result.keep_with_size(result, value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
     __bknd::__parallel_for(::std::forward<Policy>(policy),
                            custom_brick<StrictWeakOrdering, decltype(size), binary_search>{comp, size}, value_size,

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -132,7 +132,7 @@ lower_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, Inpu
                            custom_brick<StrictWeakOrdering, decltype(size), lower_bound>{comp, size}, value_size,
                            zip_vw)
         .wait();
-    return result + value_size;
+    return result + result_buf.get_size();
 }
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
@@ -162,7 +162,7 @@ upper_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, Inpu
                            custom_brick<StrictWeakOrdering, decltype(size), upper_bound>{comp, size}, value_size,
                            zip_vw)
         .wait();
-    return result + value_size;
+    return result + result_buf.get_size();
 }
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
@@ -192,7 +192,7 @@ binary_search_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, In
                            custom_brick<StrictWeakOrdering, decltype(size), binary_search>{comp, size}, value_size,
                            zip_vw)
         .wait();
-    return result + value_size;
+    return result + result_buf.get_size();
 }
 
 #endif

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -132,7 +132,7 @@ lower_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, Inpu
                            custom_brick<StrictWeakOrdering, decltype(size), lower_bound>{comp, size}, value_size,
                            zip_vw)
         .wait();
-    return result + result_buf.get_size();
+    return result + result_buf.size();
 }
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
@@ -162,7 +162,7 @@ upper_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, Inpu
                            custom_brick<StrictWeakOrdering, decltype(size), upper_bound>{comp, size}, value_size,
                            zip_vw)
         .wait();
-    return result + result_buf.get_size();
+    return result + result_buf.size();
 }
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
@@ -192,7 +192,7 @@ binary_search_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, In
                            custom_brick<StrictWeakOrdering, decltype(size), binary_search>{comp, size}, value_size,
                            zip_vw)
         .wait();
-    return result + result_buf.get_size();
+    return result + result_buf.size();
 }
 
 #endif

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -126,7 +126,7 @@ lower_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, Inpu
     auto value_buf = keep_values(value_start, value_end);
 
     auto keep_result = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read_write, OutputIterator>();
-    auto result_buf = keep_result.create_holder(result, value_size);
+    auto result_buf = keep_result(result, value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
     __bknd::__parallel_for(::std::forward<Policy>(policy),
                            custom_brick<StrictWeakOrdering, decltype(size), lower_bound>{comp, size}, value_size,
@@ -156,7 +156,7 @@ upper_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, Inpu
     auto value_buf = keep_values(value_start, value_end);
 
     auto keep_result = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read_write, OutputIterator>();
-    auto result_buf = keep_result.create_holder(result, value_size);
+    auto result_buf = keep_result(result, value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
     __bknd::__parallel_for(::std::forward<Policy>(policy),
                            custom_brick<StrictWeakOrdering, decltype(size), upper_bound>{comp, size}, value_size,
@@ -186,7 +186,7 @@ binary_search_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, In
     auto value_buf = keep_values(value_start, value_end);
 
     auto keep_result = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read_write, OutputIterator>();
-    auto result_buf = keep_result.create_holder(result, value_size);
+    auto result_buf = keep_result(result, value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
     __bknd::__parallel_for(::std::forward<Policy>(policy),
                            custom_brick<StrictWeakOrdering, decltype(size), binary_search>{comp, size}, value_size,

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -126,7 +126,7 @@ lower_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, Inpu
     auto value_buf = keep_values(value_start, value_end);
 
     auto keep_result = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read_write, OutputIterator>();
-    auto result_buf = keep_result.keep_with_size(result, value_size);
+    auto result_buf = keep_result.create_holder(result, value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
     __bknd::__parallel_for(::std::forward<Policy>(policy),
                            custom_brick<StrictWeakOrdering, decltype(size), lower_bound>{comp, size}, value_size,
@@ -156,7 +156,7 @@ upper_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, Inpu
     auto value_buf = keep_values(value_start, value_end);
 
     auto keep_result = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read_write, OutputIterator>();
-    auto result_buf = keep_result.keep_with_size(result, value_size);
+    auto result_buf = keep_result.create_holder(result, value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
     __bknd::__parallel_for(::std::forward<Policy>(policy),
                            custom_brick<StrictWeakOrdering, decltype(size), upper_bound>{comp, size}, value_size,
@@ -186,7 +186,7 @@ binary_search_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, In
     auto value_buf = keep_values(value_start, value_end);
 
     auto keep_result = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read_write, OutputIterator>();
-    auto result_buf = keep_result.keep_with_size(result, value_size);
+    auto result_buf = keep_result.create_holder(result, value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
     __bknd::__parallel_for(::std::forward<Policy>(policy),
                            custom_brick<StrictWeakOrdering, decltype(size), binary_search>{comp, size}, value_size,

--- a/include/oneapi/dpl/internal/reduce_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/reduce_by_segment_impl.h
@@ -168,11 +168,11 @@ reduce_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIterator1 la
     auto keep_keys = __ranges::__get_sycl_range<__bknd::access_mode::read, InputIterator1>();
     auto key_buf = keep_keys(first1, last1);
     auto keep_values = __ranges::__get_sycl_range<__bknd::access_mode::read, InputIterator2>();
-    auto value_buf = keep_values(first2, first2 + n);
+    auto value_buf = keep_values.keep_with_size(first2, n);
     auto keep_key_outputs = __ranges::__get_sycl_range<__bknd::access_mode::write, OutputIterator1>();
-    auto key_output_buf = keep_key_outputs(result1, result1 + n);
+    auto key_output_buf = keep_key_outputs.keep_with_size(result1, n);
     auto keep_value_outputs = __ranges::__get_sycl_range<__bknd::access_mode::write, OutputIterator2>();
-    auto value_output_buf = keep_value_outputs(result2, result2 + n);
+    auto value_output_buf = keep_value_outputs.keep_with_size(result2, n);
 
     // number of unique keys
     const CountType N = oneapi::dpl::experimental::ranges::reduce_by_segment(

--- a/include/oneapi/dpl/internal/reduce_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/reduce_by_segment_impl.h
@@ -175,7 +175,7 @@ reduce_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIterator1 la
     auto value_output_buf = keep_value_outputs(result2, result2 + n);
 
     // number of unique keys
-    CountType N = oneapi::dpl::experimental::ranges::reduce_by_segment(
+    const CountType N = oneapi::dpl::experimental::ranges::reduce_by_segment(
         ::std::forward<Policy>(policy), key_buf.all_view(), value_buf.all_view(), key_output_buf.all_view(),
         value_output_buf.all_view(), binary_pred, binary_op);
     return ::std::make_pair(result1 + N, result2 + N);

--- a/include/oneapi/dpl/internal/reduce_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/reduce_by_segment_impl.h
@@ -168,11 +168,11 @@ reduce_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIterator1 la
     auto keep_keys = __ranges::__get_sycl_range<__bknd::access_mode::read, InputIterator1>();
     auto key_buf = keep_keys(first1, last1);
     auto keep_values = __ranges::__get_sycl_range<__bknd::access_mode::read, InputIterator2>();
-    auto value_buf = keep_values.create_holder(first2, n);
+    auto value_buf = keep_values(first2, n);
     auto keep_key_outputs = __ranges::__get_sycl_range<__bknd::access_mode::write, OutputIterator1>();
-    auto key_output_buf = keep_key_outputs.create_holder(result1, n);
+    auto key_output_buf = keep_key_outputs(result1, n);
     auto keep_value_outputs = __ranges::__get_sycl_range<__bknd::access_mode::write, OutputIterator2>();
-    auto value_output_buf = keep_value_outputs.create_holder(result2, n);
+    auto value_output_buf = keep_value_outputs(result2, n);
 
     // number of unique keys
     const CountType N = oneapi::dpl::experimental::ranges::reduce_by_segment(

--- a/include/oneapi/dpl/internal/reduce_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/reduce_by_segment_impl.h
@@ -168,11 +168,11 @@ reduce_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIterator1 la
     auto keep_keys = __ranges::__get_sycl_range<__bknd::access_mode::read, InputIterator1>();
     auto key_buf = keep_keys(first1, last1);
     auto keep_values = __ranges::__get_sycl_range<__bknd::access_mode::read, InputIterator2>();
-    auto value_buf = keep_values.keep_with_size(first2, n);
+    auto value_buf = keep_values.create_holder(first2, n);
     auto keep_key_outputs = __ranges::__get_sycl_range<__bknd::access_mode::write, OutputIterator1>();
-    auto key_output_buf = keep_key_outputs.keep_with_size(result1, n);
+    auto key_output_buf = keep_key_outputs.create_holder(result1, n);
     auto keep_value_outputs = __ranges::__get_sycl_range<__bknd::access_mode::write, OutputIterator2>();
-    auto value_output_buf = keep_value_outputs.keep_with_size(result2, n);
+    auto value_output_buf = keep_value_outputs.create_holder(result2, n);
 
     // number of unique keys
     const CountType N = oneapi::dpl::experimental::ranges::reduce_by_segment(

--- a/include/oneapi/dpl/internal/reduce_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/reduce_by_segment_impl.h
@@ -175,7 +175,7 @@ reduce_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIterator1 la
     auto value_output_buf = keep_value_outputs(result2, n);
 
     // number of unique keys
-    const CountType N = oneapi::dpl::experimental::ranges::reduce_by_segment(
+    CountType N = oneapi::dpl::experimental::ranges::reduce_by_segment(
         ::std::forward<Policy>(policy), key_buf.all_view(), value_buf.all_view(), key_output_buf.all_view(),
         value_output_buf.all_view(), binary_pred, binary_op);
     return ::std::make_pair(result1 + N, result2 + N);

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -43,7 +43,7 @@ oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, v
 __pattern_walk1(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Function __f,
                 /*vector=*/::std::true_type, /*parallel=*/::std::true_type)
 {
-    const auto __n = __last - __first;
+    auto __n = __last - __first;
     if (__n <= 0)
         return;
 
@@ -86,7 +86,7 @@ oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, _
 __pattern_walk2(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
                 _ForwardIterator2 __first2, _Function __f, /*vector=*/::std::true_type, /*parallel=*/::std::true_type)
 {
-    const auto __n = __last1 - __first1;
+    auto __n = __last1 - __first1;
     if (__n <= 0)
         return __first2;
 
@@ -143,7 +143,7 @@ __pattern_walk3(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardI
                 _ForwardIterator2 __first2, _ForwardIterator3 __first3, _Function __f, /*vector=*/::std::true_type,
                 /*parallel=*/::std::true_type)
 {
-    const auto __n = __last1 - __first1;
+    auto __n = __last1 - __first1;
     if (__n <= 0)
         return __first3;
 
@@ -833,9 +833,7 @@ __pattern_scan_copy(_ExecutionPolicy&& __exec, _Iterator1 __first, _Iterator1 __
     using _InitType = unseq_backend::__no_init_value<_It1DifferenceType>;
     using _DataAcc = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;
 
-    const auto __n = __last - __first;
-
-    if (__n == 0)
+    if (__first == __last)
         return ::std::make_pair(__output_first, _It1DifferenceType{0});
 
     _Assigner __assign_op;
@@ -844,6 +842,7 @@ __pattern_scan_copy(_ExecutionPolicy&& __exec, _Iterator1 __first, _Iterator1 __
     _MaskAssigner __add_mask_op;
 
     // temporary buffer to store boolean mask
+    auto __n = __last - __first;
     oneapi::dpl::__par_backend_hetero::__internal::__buffer<_ExecutionPolicy, int32_t> __mask_buf(__exec, __n);
 
     auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
@@ -1125,9 +1124,9 @@ __pattern_merge(_ExecutionPolicy&& __exec, _Iterator1 __first1, _Iterator1 __las
                 _Iterator2 __last2, _Iterator3 __d_first, _Compare __comp, /*vector=*/::std::true_type,
                 /*parallel=*/::std::true_type)
 {
-    const auto __n1 = __last1 - __first1;
-    const auto __n2 = __last2 - __first2;
-    const auto __n = __n1 + __n2;
+    auto __n1 = __last1 - __first1;
+    auto __n2 = __last2 - __first2;
+    auto __n = __n1 + __n2;
     if (__n == 0)
         return __d_first;
 
@@ -1181,7 +1180,7 @@ __pattern_inplace_merge(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator 
 
     assert(__first < __middle && __middle < __last);
 
-    const auto __n = __last - __first;
+    auto __n = __last - __first;
     oneapi::dpl::__par_backend_hetero::__internal::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec, __n);
     auto __copy_first = __buf.get();
     auto __copy_last = __copy_first + __n;
@@ -1241,18 +1240,17 @@ oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, _
 __pattern_stable_partition(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, _UnaryPredicate __pred,
                            /*vector*/ ::std::true_type, /*parallel*/ ::std::true_type)
 {
-    const auto __n = __last - __first;
-
-    if (__n == 0)
+    if (__last == __first)
         return __last;
-
-    if (__n < 2)
+    else if (__last - __first < 2)
         return __pattern_any_of(::std::forward<_ExecutionPolicy>(__exec), __first, __last, __pred, ::std::true_type(),
                                 ::std::true_type())
                    ? __last
                    : __first;
 
     using _ValueType = typename ::std::iterator_traits<_Iterator>::value_type;
+
+    auto __n = __last - __first;
 
     oneapi::dpl::__par_backend_hetero::__internal::__buffer<_ExecutionPolicy, _ValueType> __true_buf(__exec, __n);
     oneapi::dpl::__par_backend_hetero::__internal::__buffer<_ExecutionPolicy, _ValueType> __false_buf(__exec, __n);
@@ -1333,7 +1331,7 @@ __pattern_lexicographical_compare(_ExecutionPolicy&& __exec, _Iterator1 __first1
         return __a * __is_mismatched + __b * !__is_mismatched;
     };
 
-    const auto __shared_size = ::std::min(__last1 - __first1, (_Iterator1DifferenceType)(__last2 - __first2));
+    auto __shared_size = ::std::min(__last1 - __first1, (_Iterator1DifferenceType)(__last2 - __first2));
 
     auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
     auto __buf1 = __keep1(__first1, __shared_size);
@@ -1441,8 +1439,8 @@ __pattern_partial_sort_copy(_ExecutionPolicy&& __exec, _InIterator __first, _InI
 {
     using _ValueType = typename ::std::iterator_traits<_InIterator>::value_type;
 
-    const auto __in_size = __last - __first;
-    const auto __out_size = __out_last - __out_first;
+    auto __in_size = __last - __first;
+    auto __out_size = __out_last - __out_first;
 
     if (__in_size == 0 || __out_size == 0)
         return __out_first;
@@ -1541,7 +1539,7 @@ oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, _
 __pattern_reverse_copy(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __last,
                        _ForwardIterator __result, /*vector=*/::std::true_type, /*parallel=*/::std::true_type)
 {
-    const auto __n = __last - __first;
+    auto __n = __last - __first;
     if (__n <= 0)
         return __result;
 
@@ -1578,7 +1576,7 @@ oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, _
 __pattern_rotate(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __new_first, _Iterator __last,
                  /*vector=*/::std::true_type, /*parallel=*/::std::true_type)
 {
-    const auto __n = __last - __first;
+    auto __n = __last - __first;
     if (__n <= 0)
         return __first;
 
@@ -1616,7 +1614,7 @@ __pattern_rotate_copy(_ExecutionPolicy&& __exec, _BidirectionalIterator __first,
                       _BidirectionalIterator __last, _ForwardIterator __result, /*vector=*/::std::true_type,
                       /*parallel=*/::std::true_type)
 {
-    const auto __n = __last - __first;
+    auto __n = __last - __first;
     if (__n <= 0)
         return __result;
 
@@ -1951,7 +1949,7 @@ __pattern_shift_left(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __l
                      /*is_parallel=*/::std::true_type)
 {
     //If (n > 0 && n < m), returns first + (m - n). Otherwise, if n  > 0, returns first. Otherwise, returns last.
-    const auto __size = __last - __first;
+    auto __size = __last - __first;
     if (__n <= 0)
         return __last;
     if (__n >= __size)
@@ -1972,7 +1970,7 @@ __pattern_shift_right(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __
                       /*is_parallel=*/::std::true_type)
 {
     //If (n > 0 && n < m), returns first + n. Otherwise, if n  > 0, returns last. Otherwise, returns first.
-    const auto __size = __last - __first;
+    auto __size = __last - __first;
     if (__n <= 0)
         return __first;
     if (__n >= __size)

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -43,7 +43,7 @@ oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, v
 __pattern_walk1(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Function __f,
                 /*vector=*/::std::true_type, /*parallel=*/::std::true_type)
 {
-    auto __n = __last - __first;
+    const auto __n = __last - __first;
     if (__n <= 0)
         return;
 
@@ -86,7 +86,7 @@ oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, _
 __pattern_walk2(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
                 _ForwardIterator2 __first2, _Function __f, /*vector=*/::std::true_type, /*parallel=*/::std::true_type)
 {
-    auto __n = __last1 - __first1;
+    const auto __n = __last1 - __first1;
     if (__n <= 0)
         return __first2;
 
@@ -143,7 +143,7 @@ __pattern_walk3(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardI
                 _ForwardIterator2 __first2, _ForwardIterator3 __first3, _Function __f, /*vector=*/::std::true_type,
                 /*parallel=*/::std::true_type)
 {
-    auto __n = __last1 - __first1;
+    const auto __n = __last1 - __first1;
     if (__n <= 0)
         return __first3;
 
@@ -833,7 +833,9 @@ __pattern_scan_copy(_ExecutionPolicy&& __exec, _Iterator1 __first, _Iterator1 __
     using _InitType = unseq_backend::__no_init_value<_It1DifferenceType>;
     using _DataAcc = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;
 
-    if (__first == __last)
+    const auto __n = __last - __first;
+
+    if (__n == 0)
         return ::std::make_pair(__output_first, _It1DifferenceType{0});
 
     _Assigner __assign_op;
@@ -842,7 +844,6 @@ __pattern_scan_copy(_ExecutionPolicy&& __exec, _Iterator1 __first, _Iterator1 __
     _MaskAssigner __add_mask_op;
 
     // temporary buffer to store boolean mask
-    auto __n = __last - __first;
     oneapi::dpl::__par_backend_hetero::__internal::__buffer<_ExecutionPolicy, int32_t> __mask_buf(__exec, __n);
 
     auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
@@ -1124,9 +1125,9 @@ __pattern_merge(_ExecutionPolicy&& __exec, _Iterator1 __first1, _Iterator1 __las
                 _Iterator2 __last2, _Iterator3 __d_first, _Compare __comp, /*vector=*/::std::true_type,
                 /*parallel=*/::std::true_type)
 {
-    auto __n1 = __last1 - __first1;
-    auto __n2 = __last2 - __first2;
-    auto __n = __n1 + __n2;
+    const auto __n1 = __last1 - __first1;
+    const auto __n2 = __last2 - __first2;
+    const auto __n = __n1 + __n2;
     if (__n == 0)
         return __d_first;
 
@@ -1174,7 +1175,7 @@ __pattern_inplace_merge(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator 
 
     assert(__first < __middle && __middle < __last);
 
-    auto __n = __last - __first;
+    const auto __n = __last - __first;
     oneapi::dpl::__par_backend_hetero::__internal::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec, __n);
     auto __copy_first = __buf.get();
     auto __copy_last = __copy_first + __n;
@@ -1234,17 +1235,18 @@ oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, _
 __pattern_stable_partition(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, _UnaryPredicate __pred,
                            /*vector*/ ::std::true_type, /*parallel*/ ::std::true_type)
 {
-    if (__last == __first)
+    const auto __n = __last - __first;
+
+    if (__n == 0)
         return __last;
-    else if (__last - __first < 2)
+
+    if (__n < 2)
         return __pattern_any_of(::std::forward<_ExecutionPolicy>(__exec), __first, __last, __pred, ::std::true_type(),
                                 ::std::true_type())
                    ? __last
                    : __first;
 
     using _ValueType = typename ::std::iterator_traits<_Iterator>::value_type;
-
-    auto __n = __last - __first;
 
     oneapi::dpl::__par_backend_hetero::__internal::__buffer<_ExecutionPolicy, _ValueType> __true_buf(__exec, __n);
     oneapi::dpl::__par_backend_hetero::__internal::__buffer<_ExecutionPolicy, _ValueType> __false_buf(__exec, __n);
@@ -1325,7 +1327,7 @@ __pattern_lexicographical_compare(_ExecutionPolicy&& __exec, _Iterator1 __first1
         return __a * __is_mismatched + __b * !__is_mismatched;
     };
 
-    auto __shared_size = ::std::min(__last1 - __first1, (_Iterator1DifferenceType)(__last2 - __first2));
+    const auto __shared_size = ::std::min(__last1 - __first1, (_Iterator1DifferenceType)(__last2 - __first2));
 
     auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
     auto __buf1 = __keep1(__first1, __first1 + __shared_size);
@@ -1433,8 +1435,8 @@ __pattern_partial_sort_copy(_ExecutionPolicy&& __exec, _InIterator __first, _InI
 {
     using _ValueType = typename ::std::iterator_traits<_InIterator>::value_type;
 
-    auto __in_size = __last - __first;
-    auto __out_size = __out_last - __out_first;
+    const auto __in_size = __last - __first;
+    const auto __out_size = __out_last - __out_first;
 
     if (__in_size == 0 || __out_size == 0)
         return __out_first;
@@ -1533,7 +1535,7 @@ oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, _
 __pattern_reverse_copy(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __last,
                        _ForwardIterator __result, /*vector=*/::std::true_type, /*parallel=*/::std::true_type)
 {
-    auto __n = __last - __first;
+    const auto __n = __last - __first;
     if (__n <= 0)
         return __result;
 
@@ -1570,7 +1572,7 @@ oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, _
 __pattern_rotate(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __new_first, _Iterator __last,
                  /*vector=*/::std::true_type, /*parallel=*/::std::true_type)
 {
-    auto __n = __last - __first;
+    const auto __n = __last - __first;
     if (__n <= 0)
         return __first;
 
@@ -1608,7 +1610,7 @@ __pattern_rotate_copy(_ExecutionPolicy&& __exec, _BidirectionalIterator __first,
                       _BidirectionalIterator __last, _ForwardIterator __result, /*vector=*/::std::true_type,
                       /*parallel=*/::std::true_type)
 {
-    auto __n = __last - __first;
+    const auto __n = __last - __first;
     if (__n <= 0)
         return __result;
 
@@ -1943,7 +1945,7 @@ __pattern_shift_left(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __l
                      /*is_parallel=*/::std::true_type)
 {
     //If (n > 0 && n < m), returns first + (m - n). Otherwise, if n  > 0, returns first. Otherwise, returns last.
-    auto __size = __last - __first;
+    const auto __size = __last - __first;
     if (__n <= 0)
         return __last;
     if (__n >= __size)
@@ -1964,7 +1966,7 @@ __pattern_shift_right(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __
                       /*is_parallel=*/::std::true_type)
 {
     //If (n > 0 && n < m), returns first + n. Otherwise, if n  > 0, returns last. Otherwise, returns first.
-    auto __size = __last - __first;
+    const auto __size = __last - __first;
     if (__n <= 0)
         return __first;
     if (__n >= __size)

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1701,7 +1701,7 @@ __pattern_hetero_set_op(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _
             __copy_by_mask_op)
             .get();
 
-    return __result + __buf3.size();
+    return __result + __result_size;
 }
 
 template <typename _ExecutionPolicy, typename _ForwardIterator1, typename _ForwardIterator2, typename _OutputIterator,

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -103,7 +103,7 @@ __pattern_walk2(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardI
     if constexpr (_IsSync())
         __future_obj.wait();
 
-    return __first2 + __buf2.get_size();
+    return __first2 + __buf2.size();
 }
 
 template <typename _ExecutionPolicy, typename _ForwardIterator1, typename _Size, typename _ForwardIterator2,
@@ -162,7 +162,7 @@ __pattern_walk3(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardI
                                                       __buf1.all_view(), __buf2.all_view(), __buf3.all_view())
         .wait();
 
-    return __first3 + __buf3.get_size();
+    return __first3 + __buf3.size();
 }
 
 //------------------------------------------------------------------------
@@ -869,7 +869,7 @@ __pattern_scan_copy(_ExecutionPolicy&& __exec, _Iterator1 __first, _Iterator1 __
         // global scan
         __copy_by_mask_op);
 
-    return ::std::make_pair(__output_first + __buf2.get_size(), __res.get());
+    return ::std::make_pair(__output_first + __buf2.size(), __res.get());
 }
 
 template <typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2, typename _Predicate>
@@ -1163,7 +1163,7 @@ __pattern_merge(_ExecutionPolicy&& __exec, _Iterator1 __first1, _Iterator1 __las
         __par_backend_hetero::__parallel_merge(::std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(),
                                                __buf2.all_view(), __buf3.all_view(), __comp)
             .wait();
-        return __d_first + __buf3.get_size();
+        return __d_first + __buf3.size();
     }
 }
 //------------------------------------------------------------------------
@@ -1558,7 +1558,7 @@ __pattern_reverse_copy(_ExecutionPolicy&& __exec, _BidirectionalIterator __first
         __n, __buf1.all_view(), __buf2.all_view())
         .wait();
 
-    return __result + __buf2.get_size();
+    return __result + __buf2.size();
 }
 
 //------------------------------------------------------------------------
@@ -1637,7 +1637,7 @@ __pattern_rotate_copy(_ExecutionPolicy&& __exec, _BidirectionalIterator __first,
         __n, __buf1.all_view(), __buf2.all_view())
         .wait();
 
-    return __result + __buf2.get_size();
+    return __result + __buf2.size();
 }
 
 template <typename _ExecutionPolicy, typename _ForwardIterator1, typename _ForwardIterator2, typename _OutputIterator,
@@ -1702,7 +1702,7 @@ __pattern_hetero_set_op(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _
             __copy_by_mask_op)
             .get();
 
-    return __result + __buf3.get_size();
+    return __result + __buf3.size();
 }
 
 template <typename _ExecutionPolicy, typename _ForwardIterator1, typename _ForwardIterator2, typename _OutputIterator,

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -75,25 +75,6 @@ __pattern_walk1_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n
 // walk2
 //------------------------------------------------------------------------
 
-struct get_buffer_size
-{
-    template <typename _ForwardIterator, typename _Size>
-    typename ::std::enable_if<is_hetero_iterator<_ForwardIterator>::value, _Size>::type
-    operator()(_ForwardIterator _it, _Size _n)
-    {
-        decltype(_n) size = __dpl_sycl::__get_buffer_size(_it.get_buffer());
-        size = ::std::min(size, _n);
-        return size;
-    }
-
-    template <typename _ForwardIterator, typename _Size>
-    typename ::std::enable_if<!is_hetero_iterator<_ForwardIterator>::value, _Size>::type
-    operator()(_ForwardIterator /*_it*/, _Size _n)
-    {
-        return _n;
-    }
-};
-
 // TODO: A tag _IsSync is used for provide a patterns call pipeline, where the last one should be synchronous
 // Probably it should be re-designed by a pipeline approach, when a pattern returns some sync obejects
 // and ones are combined into a "pipeline" (probably like Range pipeline)

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -94,7 +94,7 @@ __pattern_walk2(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardI
     auto __buf1 = __keep1(__first1, __last1);
 
     auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__acc_mode2, _ForwardIterator2>();
-    auto __buf2 = __keep2.create_holder(__first2, __n);
+    auto __buf2 = __keep2(__first2, __n);
 
     auto __future_obj = oneapi::dpl::__par_backend_hetero::__parallel_for(
         ::std::forward<_ExecutionPolicy>(__exec), unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f}, __n,
@@ -152,10 +152,10 @@ __pattern_walk3(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardI
     auto __buf1 = __keep1(__first1, __last1);
     auto __keep2 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _ForwardIterator2>();
-    auto __buf2 = __keep2.create_holder(__first2, __n);
+    auto __buf2 = __keep2(__first2, __n);
     auto __keep3 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _ForwardIterator3>();
-    auto __buf3 = __keep3.create_holder(__first3, __n);
+    auto __buf3 = __keep3(__first3, __n);
 
     oneapi::dpl::__par_backend_hetero::__parallel_for(::std::forward<_ExecutionPolicy>(__exec),
                                                       unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f}, __n,
@@ -850,7 +850,7 @@ __pattern_scan_copy(_ExecutionPolicy&& __exec, _Iterator1 __first, _Iterator1 __
     auto __buf1 = __keep1(__first, __last);
     auto __keep2 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _IteratorOrTuple>();
-    auto __buf2 = __keep2.create_holder(__output_first, __n);
+    auto __buf2 = __keep2(__output_first, __n);
 
     auto __res = __par_backend_hetero::__parallel_transform_scan(
         ::std::forward<_ExecutionPolicy>(__exec),
@@ -1158,7 +1158,7 @@ __pattern_merge(_ExecutionPolicy&& __exec, _Iterator1 __first1, _Iterator1 __las
         auto __buf2 = __keep2(__first2, __last2);
 
         auto __keep3 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _Iterator3>();
-        auto __buf3 = __keep3.create_holder(__d_first, __n);
+        auto __buf3 = __keep3(__d_first, __n);
 
         __par_backend_hetero::__parallel_merge(::std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(),
                                                __buf2.all_view(), __buf3.all_view(), __comp)
@@ -1336,10 +1336,10 @@ __pattern_lexicographical_compare(_ExecutionPolicy&& __exec, _Iterator1 __first1
     const auto __shared_size = ::std::min(__last1 - __first1, (_Iterator1DifferenceType)(__last2 - __first2));
 
     auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
-    auto __buf1 = __keep1.create_holder(__first1, __shared_size);
+    auto __buf1 = __keep1(__first1, __shared_size);
 
     auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator2>();
-    auto __buf2 = __keep2.create_holder(__first2, __shared_size);
+    auto __buf2 = __keep2(__first2, __shared_size);
 
     auto __ret_idx =
         oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_ReduceValueType>(
@@ -1550,7 +1550,7 @@ __pattern_reverse_copy(_ExecutionPolicy&& __exec, _BidirectionalIterator __first
     auto __buf1 = __keep1(__first, __last);
     auto __keep2 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _ForwardIterator>();
-    auto __buf2 = __keep2.create_holder(__result, __n);
+    auto __buf2 = __keep2(__result, __n);
 
     oneapi::dpl::__par_backend_hetero::__parallel_for(
         ::std::forward<_ExecutionPolicy>(__exec),
@@ -1626,7 +1626,7 @@ __pattern_rotate_copy(_ExecutionPolicy&& __exec, _BidirectionalIterator __first,
     auto __buf1 = __keep1(__first, __last);
     auto __keep2 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _ForwardIterator>();
-    auto __buf2 = __keep2.create_holder(__result, __n);
+    auto __buf2 = __keep2(__result, __n);
 
     const auto __shift = __new_first - __first;
 
@@ -1680,7 +1680,7 @@ __pattern_hetero_set_op(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _
     auto __buf2 = __keep2(__first2, __last2);
 
     auto __keep3 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _OutputIterator>();
-    auto __buf3 = __keep3.create_holder(__result, __n1);
+    auto __buf3 = __keep3(__result, __n1);
 
     auto __result_size =
         __par_backend_hetero::__parallel_transform_scan(

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1520,7 +1520,7 @@ oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, v
 __pattern_reverse(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, /*vector=*/::std::true_type,
                   /*parallel=*/::std::true_type)
 {
-    const auto __n = __last - __first;
+    auto __n = __last - __first;
     if (__n <= 0)
         return;
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -94,7 +94,7 @@ __pattern_walk2(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardI
     auto __buf1 = __keep1(__first1, __last1);
 
     auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__acc_mode2, _ForwardIterator2>();
-    auto __buf2 = __keep2.keep_with_size(__first2, __n);
+    auto __buf2 = __keep2.create_holder(__first2, __n);
 
     auto __future_obj = oneapi::dpl::__par_backend_hetero::__parallel_for(
         ::std::forward<_ExecutionPolicy>(__exec), unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f}, __n,
@@ -152,10 +152,10 @@ __pattern_walk3(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardI
     auto __buf1 = __keep1(__first1, __last1);
     auto __keep2 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _ForwardIterator2>();
-    auto __buf2 = __keep2.keep_with_size(__first2, __n);
+    auto __buf2 = __keep2.create_holder(__first2, __n);
     auto __keep3 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _ForwardIterator3>();
-    auto __buf3 = __keep3.keep_with_size(__first3, __n);
+    auto __buf3 = __keep3.create_holder(__first3, __n);
 
     oneapi::dpl::__par_backend_hetero::__parallel_for(::std::forward<_ExecutionPolicy>(__exec),
                                                       unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f}, __n,
@@ -850,7 +850,7 @@ __pattern_scan_copy(_ExecutionPolicy&& __exec, _Iterator1 __first, _Iterator1 __
     auto __buf1 = __keep1(__first, __last);
     auto __keep2 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _IteratorOrTuple>();
-    auto __buf2 = __keep2.keep_with_size(__output_first, __n);
+    auto __buf2 = __keep2.create_holder(__output_first, __n);
 
     auto __res = __par_backend_hetero::__parallel_transform_scan(
         ::std::forward<_ExecutionPolicy>(__exec),
@@ -1158,7 +1158,7 @@ __pattern_merge(_ExecutionPolicy&& __exec, _Iterator1 __first1, _Iterator1 __las
         auto __buf2 = __keep2(__first2, __last2);
 
         auto __keep3 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _Iterator3>();
-        auto __buf3 = __keep3.keep_with_size(__d_first, __n);
+        auto __buf3 = __keep3.create_holder(__d_first, __n);
 
         __par_backend_hetero::__parallel_merge(::std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(),
                                                __buf2.all_view(), __buf3.all_view(), __comp)
@@ -1336,10 +1336,10 @@ __pattern_lexicographical_compare(_ExecutionPolicy&& __exec, _Iterator1 __first1
     const auto __shared_size = ::std::min(__last1 - __first1, (_Iterator1DifferenceType)(__last2 - __first2));
 
     auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
-    auto __buf1 = __keep1.keep_with_size(__first1, __shared_size);
+    auto __buf1 = __keep1.create_holder(__first1, __shared_size);
 
     auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator2>();
-    auto __buf2 = __keep2.keep_with_size(__first2, __shared_size);
+    auto __buf2 = __keep2.create_holder(__first2, __shared_size);
 
     auto __ret_idx =
         oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_ReduceValueType>(
@@ -1550,7 +1550,7 @@ __pattern_reverse_copy(_ExecutionPolicy&& __exec, _BidirectionalIterator __first
     auto __buf1 = __keep1(__first, __last);
     auto __keep2 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _ForwardIterator>();
-    auto __buf2 = __keep2.keep_with_size(__result, __n);
+    auto __buf2 = __keep2.create_holder(__result, __n);
 
     oneapi::dpl::__par_backend_hetero::__parallel_for(
         ::std::forward<_ExecutionPolicy>(__exec),
@@ -1626,7 +1626,7 @@ __pattern_rotate_copy(_ExecutionPolicy&& __exec, _BidirectionalIterator __first,
     auto __buf1 = __keep1(__first, __last);
     auto __keep2 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _ForwardIterator>();
-    auto __buf2 = __keep2.keep_with_size(__result, __n);
+    auto __buf2 = __keep2.create_holder(__result, __n);
 
     const auto __shift = __new_first - __first;
 
@@ -1680,7 +1680,7 @@ __pattern_hetero_set_op(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _
     auto __buf2 = __keep2(__first2, __last2);
 
     auto __keep3 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _OutputIterator>();
-    auto __buf3 = __keep3.keep_with_size(__result, __n1);
+    auto __buf3 = __keep3.create_holder(__result, __n1);
 
     auto __result_size =
         __par_backend_hetero::__parallel_transform_scan(

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -94,7 +94,7 @@ __pattern_walk2(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardI
     auto __buf1 = __keep1(__first1, __last1);
 
     auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__acc_mode2, _ForwardIterator2>();
-    auto __buf2 = __keep2(__first2, __first2 + get_buffer_size()(__first2, __n));
+    auto __buf2 = __keep2.keep_with_size(__first2, __n);
 
     auto __future_obj = oneapi::dpl::__par_backend_hetero::__parallel_for(
         ::std::forward<_ExecutionPolicy>(__exec), unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f}, __n,
@@ -152,10 +152,10 @@ __pattern_walk3(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardI
     auto __buf1 = __keep1(__first1, __last1);
     auto __keep2 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _ForwardIterator2>();
-    auto __buf2 = __keep2(__first2, __first2 + get_buffer_size()(__first2, __n));
+    auto __buf2 = __keep2.keep_with_size(__first2, __n);
     auto __keep3 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _ForwardIterator3>();
-    auto __buf3 = __keep3(__first3, __first3 + get_buffer_size()(__first3, __n));
+    auto __buf3 = __keep3.keep_with_size(__first3, __n);
 
     oneapi::dpl::__par_backend_hetero::__parallel_for(::std::forward<_ExecutionPolicy>(__exec),
                                                       unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f}, __n,
@@ -850,7 +850,7 @@ __pattern_scan_copy(_ExecutionPolicy&& __exec, _Iterator1 __first, _Iterator1 __
     auto __buf1 = __keep1(__first, __last);
     auto __keep2 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _IteratorOrTuple>();
-    auto __buf2 = __keep2(__output_first, __output_first + get_buffer_size()(__output_first, __n));
+    auto __buf2 = __keep2.keep_with_size(__output_first, __n);
 
     auto __res = __par_backend_hetero::__parallel_transform_scan(
         ::std::forward<_ExecutionPolicy>(__exec),
@@ -1152,7 +1152,7 @@ __pattern_merge(_ExecutionPolicy&& __exec, _Iterator1 __first1, _Iterator1 __las
         auto __buf2 = __keep2(__first2, __last2);
 
         auto __keep3 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _Iterator3>();
-        auto __buf3 = __keep3(__d_first, __d_first + get_buffer_size()(__d_first, __n));
+        auto __buf3 = __keep3.keep_with_size(__d_first, __n);
 
         __par_backend_hetero::__parallel_merge(::std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(),
                                                __buf2.all_view(), __buf3.all_view(), __comp)
@@ -1330,10 +1330,10 @@ __pattern_lexicographical_compare(_ExecutionPolicy&& __exec, _Iterator1 __first1
     const auto __shared_size = ::std::min(__last1 - __first1, (_Iterator1DifferenceType)(__last2 - __first2));
 
     auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
-    auto __buf1 = __keep1(__first1, __first1 + __shared_size);
+    auto __buf1 = __keep1.keep_with_size(__first1, __shared_size);
 
     auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator2>();
-    auto __buf2 = __keep2(__first2, __first2 + __shared_size);
+    auto __buf2 = __keep2.keep_with_size(__first2, __shared_size);
 
     auto __ret_idx =
         oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_ReduceValueType>(
@@ -1544,7 +1544,7 @@ __pattern_reverse_copy(_ExecutionPolicy&& __exec, _BidirectionalIterator __first
     auto __buf1 = __keep1(__first, __last);
     auto __keep2 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _ForwardIterator>();
-    auto __buf2 = __keep2(__result, __result + get_buffer_size()(__result, __n));
+    auto __buf2 = __keep2.keep_with_size(__result, __n);
 
     oneapi::dpl::__par_backend_hetero::__parallel_for(
         ::std::forward<_ExecutionPolicy>(__exec),
@@ -1620,7 +1620,7 @@ __pattern_rotate_copy(_ExecutionPolicy&& __exec, _BidirectionalIterator __first,
     auto __buf1 = __keep1(__first, __last);
     auto __keep2 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _ForwardIterator>();
-    auto __buf2 = __keep2(__result, __result + get_buffer_size()(__result, __n));
+    auto __buf2 = __keep2.keep_with_size(__result, __n);
 
     const auto __shift = __new_first - __first;
 
@@ -1674,7 +1674,7 @@ __pattern_hetero_set_op(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _
     auto __buf2 = __keep2(__first2, __last2);
 
     auto __keep3 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _OutputIterator>();
-    auto __buf3 = __keep3(__result, __result + __n1);
+    auto __buf3 = __keep3.keep_with_size(__result, __n1);
 
     auto __result_size =
         __par_backend_hetero::__parallel_transform_scan(

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1551,7 +1551,6 @@ __pattern_reverse_copy(_ExecutionPolicy&& __exec, _BidirectionalIterator __first
     auto __keep2 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _ForwardIterator>();
     auto __buf2 = __keep2(__result, __n);
-
     oneapi::dpl::__par_backend_hetero::__parallel_for(
         ::std::forward<_ExecutionPolicy>(__exec),
         unseq_backend::__reverse_copy<typename ::std::iterator_traits<_BidirectionalIterator>::difference_type>{__n},

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -389,6 +389,7 @@ struct __get_sycl_range
         return oneapi::dpl::__ranges::make_zip_view(::std::get<_Ip>(tmp).all_view()...);
     }
 
+  private:
     struct holder_size_evaluator
     {
         //specialization for zip iterators

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -262,9 +262,7 @@ struct __holder_base
 
     size_type __src_size;
 
-    __holder_base(size_type _size) : __src_size(_size)
-    {
-    }
+    __holder_base(size_type _size) : __src_size(_size) {}
 
     size_type
     size() const
@@ -278,11 +276,7 @@ struct __range_holder : __holder_base
 {
     _R __r;
 
-    __range_holder(_R _r, __holder_base::size_type _size)
-        : __holder_base(_size),
-        __r(_r)
-    {
-    }
+    __range_holder(_R _r, __holder_base::size_type _size) : __holder_base(_size), __r(_r) {}
 
     constexpr _R
     all_view() const
@@ -321,11 +315,7 @@ struct __buffer_holder : __holder_base
 {
     buf_type<_T> __buf;
 
-    __buffer_holder(buf_type<_T> buf, __holder_base::size_type _size)
-        : __holder_base(_size),
-        __buf(buf)
-    {
-    }
+    __buffer_holder(buf_type<_T> buf, __holder_base::size_type _size) : __holder_base(_size), __buf(buf) {}
 
     constexpr oneapi::dpl::__ranges::all_view<_T, AccMode>
     all_view() const
@@ -409,7 +399,8 @@ struct __get_sycl_range
         }
 
         //specialization for permutation_iterator using sycl_iterator as source
-        template <typename _Size, typename _It, typename _Map, typename ::std::enable_if<is_hetero_it<_It>::value, int>::type = 0>
+        template <typename _Size, typename _It, typename _Map,
+                  typename ::std::enable_if<is_hetero_it<_It>::value, int>::type = 0>
         _Size
         operator()(oneapi::dpl::permutation_iterator<_It, _Map> _it, _Size _n)
         {
@@ -419,7 +410,8 @@ struct __get_sycl_range
         // TODO Add specialization for general case, e.g., permutation_iterator using host
         // or another fancy iterator.
         //specialization for permutation_iterator using USM pointer as source
-        template <typename _Size, typename _It, typename _Map, typename ::std::enable_if<!is_hetero_it<_It>::value, int>::type = 0>
+        template <typename _Size, typename _It, typename _Map,
+                  typename ::std::enable_if<!is_hetero_it<_It>::value, int>::type = 0>
         _Size
         operator()(oneapi::dpl::permutation_iterator<_It, _Map> _it, _Size _n)
         {
@@ -580,8 +572,7 @@ struct __get_sycl_range
     {
         assert(__first < __last);
         return __range_holder<oneapi::dpl::__ranges::guard_view<_Iter>>(
-            oneapi::dpl::__ranges::guard_view<_Iter>{__first, __last - __first},
-            __last - __first);
+            oneapi::dpl::__ranges::guard_view<_Iter>{__first, __last - __first}, __last - __first);
     }
 
     //specialization for hetero iterator

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -635,7 +635,7 @@ struct __get_sycl_range
     //common specialization for call with (<Iterator, Size>)
     template <typename _Iter, typename _Size>
     auto
-    create_holder(_Iter __first, _Size __n)
+    operator()(_Iter __first, _Size __n)
     {
         return this->operator()(__first, __first + holder_size_evaluator()(__first, __n));
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -390,7 +390,7 @@ struct __get_sycl_range
     }
 
   private:
-    struct holder_size_evaluator
+    struct holder_size
     {
         //specialization for zip iterators
         template <typename _Size, typename... Iters>
@@ -636,9 +636,9 @@ struct __get_sycl_range
     template <typename _Iter, typename _Size>
     auto
     operator()(_Iter __first, _Size __n, typename ::std::enable_if<::std::is_integral_v<_Size>, void>::type* = nullptr)
-        -> decltype(this->operator()(__first, __first + holder_size_evaluator()(__first, __n)))
+        -> decltype(this->operator()(__first, __first + holder_size()(__first, __n)))
     {
-        return this->operator()(__first, __first + holder_size_evaluator()(__first, __n));
+        return this->operator()(__first, __first + holder_size()(__first, __n));
     }
 };
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -267,7 +267,7 @@ struct __holder_base
     }
 
     size_type
-    get_size() const
+    size() const
     {
         return __src_size;
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -389,7 +389,7 @@ struct __get_sycl_range
         return oneapi::dpl::__ranges::make_zip_view(::std::get<_Ip>(tmp).all_view()...);
     }
 
-    struct buffer_size_extractor
+    struct holder_size_evaluator
     {
         //specialization for zip iterators
         template <typename _Size, typename... Iters>
@@ -636,7 +636,7 @@ struct __get_sycl_range
     auto
     keep_with_size(_Iter __first, _Size __n)
     {
-        return this->operator()(__first, __first + buffer_size_extractor()(__first, __n));
+        return this->operator()(__first, __first + holder_size_evaluator()(__first, __n));
     }
 };
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -635,7 +635,8 @@ struct __get_sycl_range
     //common specialization for call with (<Iterator, Size>)
     template <typename _Iter, typename _Size>
     auto
-    operator()(_Iter __first, _Size __n)
+    operator()(_Iter __first, _Size __n, typename ::std::enable_if<::std::is_integral_v<_Size>, void>::type* = nullptr)
+        -> decltype(this->operator()(__first, __first + holder_size_evaluator()(__first, __n)))
     {
         return this->operator()(__first, __first + holder_size_evaluator()(__first, __n));
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -634,7 +634,7 @@ struct __get_sycl_range
     //common specialization for call with (<Iterator, Size>)
     template <typename _Iter, typename _Size>
     auto
-    keep_with_size(_Iter __first, _Size __n)
+    create_holder(_Iter __first, _Size __n)
     {
         return this->operator()(__first, __first + holder_size_evaluator()(__first, __n));
     }

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -57,7 +57,7 @@ __pattern_transform_reduce(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __f
     auto __buf1 = __keep1(__first1, __last1);
     auto __keep2 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _RandomAccessIterator2>();
-    auto __buf2 = __keep2(__first2, __first2 + __n);
+    auto __buf2 = __keep2.keep_with_buf_size(__first2, __n);
 
     auto __res =
         oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp>(
@@ -135,7 +135,7 @@ __pattern_transform_scan_base(_ExecutionPolicy&& __exec, _Iterator1 __first, _It
     auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
     auto __buf1 = __keep1(__first, __last);
     auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _Iterator2>();
-    auto __buf2 = __keep2(__result, __result + __n);
+    auto __buf2 = __keep2.keep_with_size(__result, __n);
 
     oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(
         ::std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(), __buf2.all_view(), __binary_op, __init,

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -51,7 +51,7 @@ __pattern_transform_reduce(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __f
     using _RepackedTp = __par_backend_hetero::__repacked_tuple_t<_Tp>;
     using _NoOpFunctor = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;
 
-    auto __n = __last1 - __first1;
+    const auto __n = __last1 - __first1;
     auto __keep1 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _RandomAccessIterator1>();
     auto __buf1 = __keep1(__first1, __last1);
@@ -131,7 +131,7 @@ __pattern_transform_scan_base(_ExecutionPolicy&& __exec, _Iterator1 __first, _It
     _NoAssign __no_assign_op;
     _NoOpFunctor __get_data_op;
 
-    auto __n = __last - __first;
+    const auto __n = __last - __first;
     auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
     auto __buf1 = __keep1(__first, __last);
     auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _Iterator2>();

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -57,7 +57,7 @@ __pattern_transform_reduce(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __f
     auto __buf1 = __keep1(__first1, __last1);
     auto __keep2 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _RandomAccessIterator2>();
-    auto __buf2 = __keep2.keep_with_buf_size(__first2, __n);
+    auto __buf2 = __keep2.create_holder(__first2, __n);
 
     auto __res =
         oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp>(
@@ -135,7 +135,7 @@ __pattern_transform_scan_base(_ExecutionPolicy&& __exec, _Iterator1 __first, _It
     auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
     auto __buf1 = __keep1(__first, __last);
     auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _Iterator2>();
-    auto __buf2 = __keep2.keep_with_size(__result, __n);
+    auto __buf2 = __keep2.create_holder(__result, __n);
 
     oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(
         ::std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(), __buf2.all_view(), __binary_op, __init,

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -57,7 +57,7 @@ __pattern_transform_reduce(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __f
     auto __buf1 = __keep1(__first1, __last1);
     auto __keep2 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _RandomAccessIterator2>();
-    auto __buf2 = __keep2.create_holder(__first2, __n);
+    auto __buf2 = __keep2(__first2, __n);
 
     auto __res =
         oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp>(
@@ -135,7 +135,7 @@ __pattern_transform_scan_base(_ExecutionPolicy&& __exec, _Iterator1 __first, _It
     auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
     auto __buf1 = __keep1(__first, __last);
     auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _Iterator2>();
-    auto __buf2 = __keep2.create_holder(__result, __n);
+    auto __buf2 = __keep2(__result, __n);
 
     oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(
         ::std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(), __buf2.all_view(), __binary_op, __init,

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -51,7 +51,7 @@ __pattern_transform_reduce(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __f
     using _RepackedTp = __par_backend_hetero::__repacked_tuple_t<_Tp>;
     using _NoOpFunctor = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;
 
-    const auto __n = __last1 - __first1;
+    auto __n = __last1 - __first1;
     auto __keep1 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _RandomAccessIterator1>();
     auto __buf1 = __keep1(__first1, __last1);
@@ -131,7 +131,7 @@ __pattern_transform_scan_base(_ExecutionPolicy&& __exec, _Iterator1 __first, _It
     _NoAssign __no_assign_op;
     _NoOpFunctor __get_data_op;
 
-    const auto __n = __last - __first;
+    auto __n = __last - __first;
     auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
     auto __buf1 = __keep1(__first, __last);
     auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _Iterator2>();

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -151,7 +151,7 @@ __pattern_transform_scan_base(_ExecutionPolicy&& __exec, _Iterator1 __first, _It
         unseq_backend::__global_scan_functor<_Inclusive, _BinaryOperation, _InitType>{__binary_op, __init})
         .wait();
 
-    return __result + __buf2.get_size();
+    return __result + __buf2.size();
 }
 
 template <typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2, typename _UnaryOperation, typename _Type,

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -151,7 +151,7 @@ __pattern_transform_scan_base(_ExecutionPolicy&& __exec, _Iterator1 __first, _It
         unseq_backend::__global_scan_functor<_Inclusive, _BinaryOperation, _InitType>{__binary_op, __init})
         .wait();
 
-    return __result + __n;
+    return __result + __buf2.get_size();
 }
 
 template <typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2, typename _UnaryOperation, typename _Type,


### PR DESCRIPTION
In this PR we fix case for remove_copy algorithm and other when output buffer size is less then source buffer size.
In this case we had assertion at [include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h](https://github.com/oneapi-src/oneDPL/blob/main/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h), line 493:
```
assert(__offset + __n <= __size);
```

Example for reproduce this assert:
```
    dpct::device_ext& dev_ct1 = dpct::get_current_device();
    sycl::queue& q_ct1 = dev_ct1.default_queue(); // device iterator
    const int N = 6;
    int A[N] = {-2, 0, -1, 0, 1, 2};
    int B[N - 2];
    int ans[N - 2] = {-2, -1, 1, 2};
    dpct::device_vector<int> V(A, A + N);
    dpct::device_vector<int> result(B, B + N - 2);

    oneapi::dpl::remove_copy(oneapi::dpl::execution::make_device_policy(q_ct1), V.begin(), V.end(), result.begin(), 0);

```
In this example the size of output buffer ```result``` is less then the size of source buffer ```V``` and we have failed statement in assert.
But there are no requirements for this algorithm about output buffer size at [cppreference](https://en.cppreference.com/w/cpp/algorithm/remove_copy).

This issue was introduced in PR [Fix assert in reduce_by_segment_impl #573](https://github.com/oneapi-src/oneDPL/pull/573)