### PR TITLE
Fix buffer size calculation in algorithm_impl_hetero.h v2

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1677,7 +1677,8 @@ __pattern_hetero_set_op(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _ForwardIterator2>();
     auto __buf2 = __keep2(__first2, __last2);
 
-    auto __keep3 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _OutputIterator>();
+    auto __keep3 =
+        oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _OutputIterator>(__n1);
     auto __buf3 = __keep3(__result, __result + __n1);
 
     auto __result_size =

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -848,7 +848,7 @@ __pattern_scan_copy(_ExecutionPolicy&& __exec, _Iterator1 __first, _Iterator1 __
     auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
     auto __buf1 = __keep1(__first, __last);
     auto __keep2 =
-        oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _IteratorOrTuple>();
+        oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _IteratorOrTuple>(__n);
     auto __buf2 = __keep2(__output_first, __output_first + __n);
 
     auto __res = __par_backend_hetero::__parallel_transform_scan(
@@ -868,7 +868,7 @@ __pattern_scan_copy(_ExecutionPolicy&& __exec, _Iterator1 __first, _Iterator1 __
         // global scan
         __copy_by_mask_op);
 
-    return ::std::make_pair(__output_first + __n, __res.get());
+    return ::std::make_pair(__output_first + __keep2.size(), __res.get());
 }
 
 template <typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2, typename _Predicate>

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1132,17 +1132,23 @@ __pattern_merge(_ExecutionPolicy&& __exec, _Iterator1 __first1, _Iterator1 __las
 
     //To consider the direct copying pattern call in case just one of sequences is empty.
     if (__n1 == 0)
+    {
         oneapi::dpl::__internal::__pattern_walk2_brick(
             oneapi::dpl::__par_backend_hetero::make_wrapped_policy<copy_back_wrapper>(
                 ::std::forward<_ExecutionPolicy>(__exec)),
             __first2, __last2, __d_first, oneapi::dpl::__internal::__brick_copy<_ExecutionPolicy>{},
             ::std::true_type());
+        return __d_first + __n;
+    }
     else if (__n2 == 0)
+    {
         oneapi::dpl::__internal::__pattern_walk2_brick(
             oneapi::dpl::__par_backend_hetero::make_wrapped_policy<copy_back_wrapper2>(
                 ::std::forward<_ExecutionPolicy>(__exec)),
             __first1, __last1, __d_first, oneapi::dpl::__internal::__brick_copy<_ExecutionPolicy>{},
             ::std::true_type());
+        return __d_first + __n;
+    }
     else
     {
         auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
@@ -1150,14 +1156,15 @@ __pattern_merge(_ExecutionPolicy&& __exec, _Iterator1 __first1, _Iterator1 __las
         auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator2>();
         auto __buf2 = __keep2(__first2, __last2);
 
-        auto __keep3 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _Iterator3>();
+        auto __keep3 =
+            oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _Iterator3>(__n);
         auto __buf3 = __keep3(__d_first, __d_first + __n);
 
         __par_backend_hetero::__parallel_merge(::std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(),
                                                __buf2.all_view(), __buf3.all_view(), __comp)
             .wait();
+        return __d_first + __keep3.size();
     }
-    return __d_first + __n;
 }
 //------------------------------------------------------------------------
 // inplace_merge

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -93,7 +93,7 @@ __pattern_walk2(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardI
     auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__acc_mode1, _ForwardIterator1>();
     auto __buf1 = __keep1(__first1, __last1);
 
-    auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__acc_mode2, _ForwardIterator2>();
+    auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__acc_mode2, _ForwardIterator2>(__n);
     auto __buf2 = __keep2(__first2, __first2 + __n);
 
     auto __future_obj = oneapi::dpl::__par_backend_hetero::__parallel_for(
@@ -103,7 +103,7 @@ __pattern_walk2(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardI
     if constexpr (_IsSync())
         __future_obj.wait();
 
-    return __first2 + __n;
+    return __first2 + __keep2.size();
 }
 
 template <typename _ExecutionPolicy, typename _ForwardIterator1, typename _Size, typename _ForwardIterator2,


### PR DESCRIPTION
In this PR we fix case for remove_copy algorithm and other when output buffer size is less then source buffer size.
In this case we had assertion at [include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h](https://github.com/oneapi-src/oneDPL/blob/main/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h), line 493:
```
assert(__offset + __n <= __size);
```

Example for reproduce this assert:
```
    dpct::device_ext& dev_ct1 = dpct::get_current_device();
    sycl::queue& q_ct1 = dev_ct1.default_queue(); // device iterator
    const int N = 6;
    int A[N] = {-2, 0, -1, 0, 1, 2};
    int B[N - 2];
    int ans[N - 2] = {-2, -1, 1, 2};
    dpct::device_vector<int> V(A, A + N);
    dpct::device_vector<int> result(B, B + N - 2);

    oneapi::dpl::remove_copy(oneapi::dpl::execution::make_device_policy(q_ct1), V.begin(), V.end(), result.begin(), 0);

```
In this example the size of output buffer ```result``` is less then the size of source buffer ```V``` and we have failed statement in assert.
But there are no requirements for this algorithm about output buffer size at [cppreference](https://en.cppreference.com/w/cpp/algorithm/remove_copy).

This issue was introduced in PR [Fix assert in reduce_by_segment_impl #573](https://github.com/oneapi-src/oneDPL/pull/573)