### PR TITLE
Fix buffer size calculation in algorithm_impl_hetero.h for hetero iterator

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -489,7 +489,7 @@ struct __get_sycl_range
 
         const auto __offset = __first - oneapi::dpl::begin(__first.get_buffer());
         const auto __size = __dpl_sycl::__get_buffer_size(__first.get_buffer());
-        const auto __n = ::std::min(__last - __first, decltype(__last - __first)(__size));
+        const auto __n = ::std::min(decltype(__size)(__last - __first), __size);
         assert(__offset + __n <= __size);
 
         return __range_holder<oneapi::dpl::__ranges::all_view<value_type, AccMode>>{

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -488,8 +488,8 @@ struct __get_sycl_range
         using value_type = val_t<_Iter>;
 
         const auto __offset = __first - oneapi::dpl::begin(__first.get_buffer());
-        const auto __n = __last - __first;
         const auto __size = __dpl_sycl::__get_buffer_size(__first.get_buffer());
+        const auto __n = ::std::min(__last - __first, __size);
         assert(__offset + __n <= __size);
 
         return __range_holder<oneapi::dpl::__ranges::all_view<value_type, AccMode>>{

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -489,7 +489,7 @@ struct __get_sycl_range
 
         const auto __offset = __first - oneapi::dpl::begin(__first.get_buffer());
         const auto __size = __dpl_sycl::__get_buffer_size(__first.get_buffer());
-        const auto __n = ::std::min(__last - __first, __size);
+        const auto __n = ::std::min(__last - __first, decltype(__last - __first)(__size));
         assert(__offset + __n <= __size);
 
         return __range_holder<oneapi::dpl::__ranges::all_view<value_type, AccMode>>{


### PR DESCRIPTION
In this PR we fix case for remove_copy algorithm and other when output buffer size is less then source buffer size.
In this case we had assertion at [include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h](https://github.com/oneapi-src/oneDPL/blob/main/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h), line 493:
```
assert(__offset + __n <= __size);
```

Example for reproduce this assert:
```
    dpct::device_ext& dev_ct1 = dpct::get_current_device();
    sycl::queue& q_ct1 = dev_ct1.default_queue(); // device iterator
    const int N = 6;
    int A[N] = {-2, 0, -1, 0, 1, 2};
    int B[N - 2];
    int ans[N - 2] = {-2, -1, 1, 2};
    dpct::device_vector<int> V(A, A + N);
    dpct::device_vector<int> result(B, B + N - 2);

    oneapi::dpl::remove_copy(oneapi::dpl::execution::make_device_policy(q_ct1), V.begin(), V.end(), result.begin(), 0);

```
In this example the size of output buffer ```result``` is less then the size of source buffer ```V``` and we have failed statement in assert.
But there are no requirements for this algorithm about output buffer size at [cppreference](https://en.cppreference.com/w/cpp/algorithm/remove_copy).

This issue was introduced in PR [Fix assert in reduce_by_segment_impl #573](https://github.com/oneapi-src/oneDPL/pull/573)