### PR TITLE
Remove inclusive_scan_serial and exclusive_scan_serial from tests

### DIFF
--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan.pass.cpp
@@ -57,7 +57,7 @@ test_with_usm(sycl::queue& q, const ::std::size_t count)
 
     // Check results
     std::vector<int> h_sval_expected(count);
-    exclusive_scan_serial(h_idx.begin(), h_idx.begin() + count, h_sval_expected.begin(), 0);
+    ::std::exclusive_scan(h_idx.begin(), h_idx.begin() + count, h_sval_expected.begin(), 0);
 
     EXPECT_EQ_N(h_sval_expected.begin(), h_val.begin(), count, "wrong effect from exclusive_scan");
 }

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan.pass.cpp
@@ -23,8 +23,7 @@
 
 #include <iostream>
 #include <vector>
-
-#include "support/scan_serial_impl.h"
+#include <algorithm>
 
 #if TEST_DPCPP_BACKEND_PRESENT
 

--- a/test/parallel_api/numeric/numeric.ops/in_place_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/in_place_scan.pass.cpp
@@ -47,7 +47,7 @@ int main()
   syclQue.memcpy(excl_input_dev, v.data(), v.size()*sizeof(int)).wait();  
 
   // Inclusive scan (in-place works)
-  inclusive_scan_serial(incl_input_host.begin(),
+  ::std::inclusive_scan(incl_input_host.begin(),
                       incl_input_host.end(),
                       incl_input_host.begin());
   oneapi::dpl::inclusive_scan(oneapi::dpl::execution::make_device_policy<class TempKernelName1>(syclQue),

--- a/test/parallel_api/numeric/numeric.ops/in_place_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/in_place_scan.pass.cpp
@@ -23,9 +23,9 @@
 #if TEST_DPCPP_BACKEND_PRESENT
 #    include "support/utils_sycl.h"
 #    include "support/sycl_alloc_utils.h"
-#    include "support/scan_serial_impl.h"
 
 #include <vector>
+#include <algorithm>
 #endif
 
 int main()

--- a/test/parallel_api/numeric/numeric.ops/in_place_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/in_place_scan.pass.cpp
@@ -62,7 +62,7 @@ int main()
   sycl::free(incl_input_dev, syclQue);
 
   // Exclusive scan (in-place, incorrect results)
-  exclusive_scan_serial( excl_input_host.begin(),
+  ::std::exclusive_scan(excl_input_host.begin(),
                        excl_input_host.end(),
                        excl_input_host.begin(),
                        0 );

--- a/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
@@ -61,7 +61,7 @@ struct test_exclusive_scan_with_plus
     {
         using namespace std;
 
-        exclusive_scan_serial(in_first, in_last, expected_first, init);
+        ::std::exclusive_scan(in_first, in_last, expected_first, init);
         auto orr = exclusive_scan(exec, in_first, in_last, out_first, init);
         EXPECT_TRUE(out_last == orr, "exclusive_scan returned wrong iterator");
         EXPECT_EQ_N(expected_first, out_first, n, "wrong result from exclusive_scan");
@@ -182,7 +182,7 @@ struct test_exclusive_scan_with_binary_op
     {
         using namespace std;
 
-        exclusive_scan_serial(in_first, in_last, expected_first, init, binary_op);
+        ::std::exclusive_scan(in_first, in_last, expected_first, init, binary_op);
 
         auto orr = exclusive_scan(exec, in_first, in_last, out_first, init, binary_op);
 

--- a/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
@@ -19,7 +19,8 @@
 #include _PSTL_TEST_HEADER(numeric)
 
 #include "support/utils.h"
-#include "support/scan_serial_impl.h"
+
+#include <algorithm>
 
 #if  !defined(_PSTL_TEST_INCLUSIVE_SCAN) && !defined(_PSTL_TEST_EXCLUSIVE_SCAN)
 #define _PSTL_TEST_INCLUSIVE_SCAN

--- a/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
@@ -43,7 +43,7 @@ struct test_inclusive_scan_with_plus
     {
         using namespace std;
 
-        inclusive_scan_serial(in_first, in_last, expected_first);
+        ::std::inclusive_scan(in_first, in_last, expected_first);
         auto orr = inclusive_scan(exec, in_first, in_last, out_first);
         EXPECT_TRUE(out_last == orr, "inclusive_scan returned wrong iterator");
         EXPECT_EQ_N(expected_first, out_first, n, "wrong result from inclusive_scan");
@@ -130,7 +130,7 @@ struct test_inclusive_scan_with_binary_op
     {
         using namespace std;
 
-        inclusive_scan_serial(in_first, in_last, expected_first, binary_op, init);
+        ::std::inclusive_scan(in_first, in_last, expected_first, binary_op, init);
         auto orr = inclusive_scan(exec, in_first, in_last, out_first, binary_op, init);
 
         EXPECT_TRUE(out_last == orr, "inclusive_scan with binary operator returned wrong iterator");
@@ -146,7 +146,7 @@ struct test_inclusive_scan_with_binary_op
     {
         using namespace std;
 
-        inclusive_scan_serial(in_first, in_last, expected_first, binary_op);
+        ::std::inclusive_scan(in_first, in_last, expected_first, binary_op);
         auto orr = inclusive_scan(exec, in_first, in_last, out_first, binary_op);
 
         EXPECT_TRUE(out_last == orr, "inclusive_scan with binary operator without init returned wrong iterator");

--- a/test/support/scan_serial_impl.h
+++ b/test/support/scan_serial_impl.h
@@ -19,44 +19,6 @@
 #include <iterator>
 
 // We provide the no execution policy versions of the exclusive_scan and inclusive_scan due checking correctness result of the versions with execution policies.
-//TODO: to add a macro for availability of ver implementations
-// Note: N4582 is missing the ", class T".  Issue was reported 2016-Apr-11 to cxxeditor@gmail.com
-template <class InputIterator, class OutputIterator, class BinaryOperation, class T>
-OutputIterator
-inclusive_scan_serial(InputIterator first, InputIterator last, OutputIterator result, BinaryOperation binary_op, T init)
-{
-    for (; first != last; ++first, ++result)
-    {
-        init = binary_op(init, *first);
-        *result = init;
-    }
-    return result;
-}
-
-template <class InputIterator, class OutputIterator, class BinaryOperation>
-OutputIterator
-inclusive_scan_serial(InputIterator first, InputIterator last, OutputIterator result, BinaryOperation binary_op)
-{
-    if (first != last)
-    {
-        auto tmp = *first;
-        *result = tmp;
-        return inclusive_scan_serial(++first, last, ++result, binary_op, tmp);
-    }
-    else
-    {
-        return result;
-    }
-}
-
-template <class InputIterator, class OutputIterator>
-OutputIterator
-inclusive_scan_serial(InputIterator first, InputIterator last, OutputIterator result)
-{
-    typedef typename ::std::iterator_traits<InputIterator>::value_type input_type;
-    return inclusive_scan_serial(first, last, result, ::std::plus<input_type>());
-}
-
 template<typename ViewKeys, typename ViewVals, typename Res, typename Size, typename BinaryOperation>
 void inclusive_scan_by_segment_serial(ViewKeys keys, ViewVals vals, Res& res, Size n, BinaryOperation binary_op)
 {

--- a/test/support/scan_serial_impl.h
+++ b/test/support/scan_serial_impl.h
@@ -20,32 +20,6 @@
 
 // We provide the no execution policy versions of the exclusive_scan and inclusive_scan due checking correctness result of the versions with execution policies.
 //TODO: to add a macro for availability of ver implementations
-template <class InputIterator, class OutputIterator, class T>
-OutputIterator
-exclusive_scan_serial(InputIterator first, InputIterator last, OutputIterator result, T init)
-{
-    for (; first != last; ++first, ++result)
-    {
-        auto res = init;
-        init = init + *first;
-        *result = res;
-    }
-    return result;
-}
-
-template <class InputIterator, class OutputIterator, class T, class BinaryOperation>
-OutputIterator
-exclusive_scan_serial(InputIterator first, InputIterator last, OutputIterator result, T init, BinaryOperation binary_op)
-{
-    for (; first != last; ++first, ++result)
-    {
-	auto res = init;
-        init = binary_op(init, *first);
-        *result = res;
-    }
-    return result;
-}
-
 // Note: N4582 is missing the ", class T".  Issue was reported 2016-Apr-11 to cxxeditor@gmail.com
 template <class InputIterator, class OutputIterator, class BinaryOperation, class T>
 OutputIterator


### PR DESCRIPTION
In this PR we remove exclusive_scan_serial and inclusive_scan_serial from tests because since C++17 we may use functions from [\<numeric\>](https://en.cppreference.com/w/cpp/header/numeric) header instead them:
- [::std::inclusive_scan](https://en.cppreference.com/w/cpp/algorithm/inclusive_scan)
- [::std::exclusive_scan](https://en.cppreference.com/w/cpp/algorithm/exclusive_scan)
