### PR TITLE
[oneDPL] + a default constructor for sycl_iterator

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -50,7 +50,9 @@ struct sycl_iterator
     static constexpr access_mode mode = Mode;
 
     // required for make_sycl_iterator
-    sycl_iterator(sycl::buffer<T, dim, Allocator> vec, Size index) : buffer(vec), idx(index) {}
+    //TODO: sycl::buffer doesn't have a default constructor (SYCL API issue), so we have to create a trivial size buffer
+    sycl_iterator(sycl::buffer<T, dim, Allocator> vec = sycl::buffer<T, dim, Allocator>(0), Size index = 0)
+        : buffer(vec), idx(index) {}
     // required for iter_mode
     template <access_mode inMode>
     sycl_iterator(const sycl_iterator<inMode, T, Allocator>& in) : buffer(in.get_buffer())

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -52,7 +52,9 @@ struct sycl_iterator
     // required for make_sycl_iterator
     //TODO: sycl::buffer doesn't have a default constructor (SYCL API issue), so we have to create a trivial size buffer
     sycl_iterator(sycl::buffer<T, dim, Allocator> vec = sycl::buffer<T, dim, Allocator>(0), Size index = 0)
-        : buffer(vec), idx(index) {}
+        : buffer(vec), idx(index)
+    {
+    }
     // required for iter_mode
     template <access_mode inMode>
     sycl_iterator(const sycl_iterator<inMode, T, Allocator>& in) : buffer(in.get_buffer())


### PR DESCRIPTION
A fix for following error
```
include\oneapi/dpl/internal/../pstl/iterator_impl.h(428,37): error: no matching constructor for initialization of 'oneapi::dpl::__internal::sycl_iterator<sycl::access::mode::read_write, int>'
    transform_iterator(_Iter __it = _Iter(), _UnaryFunc __unary_func = _UnaryFunc())
                                    ^
include\concepts(106,8): note: in instantiation of default function argument expression for 'transform_iterator<oneapi::dpl::__internal::sycl_iterator<sycl::access::mode::read_write, int>, (lambda at test\parallel_api\iterator\transform_iterator.pass.cpp:86:27)>' required here
    && __is_constructible(_Ty, _ArgTys...);
       ^
include\concepts(106,8): note: while substituting template arguments into constraint expression here
    && __is_constructible(_Ty, _ArgTys...);
       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
include\concepts(109,33): note: while checking the satisfaction of concept 'constructible_from<oneapi::dpl::transform_iterator<oneapi::dpl::__internal::sycl_iterator<sycl::access::mode::read_write, int>, (lambda at test\parallel_api\iterator\transform_iterator.pass.cpp:86:27)>>' requested here
concept default_initializable = constructible_from<_Ty>
                                ^~~~~~~~~~~~~~~~~~~~~~~
include\concepts(109,33): note: while substituting template arguments into constraint expression here
concept default_initializable = constructible_from<_Ty>
                                ^~~~~~~~~~~~~~~~~~~~~~~
include\concepts(249,40): note: while checking the satisfaction of concept 'default_initializable<oneapi::dpl::transform_iterator<oneapi::dpl::__internal::sycl_iterator<sycl::access::mode::read_write, int>, (lambda at test\parallel_api\iterator\transform_iterator.pass.cpp:86:27)>>' requested here
concept semiregular = copyable<_Ty> && default_initializable<_Ty>;


```