### PR TITLE
Fix error in make_device_policy call

### DIFF
--- a/test/general/test_policies.pass.cpp
+++ b/test/general/test_policies.pass.cpp
@@ -69,7 +69,7 @@ main()
     // make_device_policy
     test_policy_instance(make_device_policy<class Kernel_11>(q));
 #if _ONEDPL_LIBSYCL_VERSION < 60000
-    // make_device_policy requires a sycl::queue as argument.
+    // make_device_policy requires a sycl::queue as an argument.
     // Currently, there is no implicit conversion (implicit syc::queue constructor by a device selector)
     // from a device selector to a queue.
     // The same test call with explicit queue creation we have below in line 78.

--- a/test/general/test_policies.pass.cpp
+++ b/test/general/test_policies.pass.cpp
@@ -68,7 +68,24 @@ main()
 
     // make_device_policy
     test_policy_instance(make_device_policy<class Kernel_11>(q));
+#if _ONEDPL_LIBSYCL_VERSION >= 60000
+    // In new versions of SYCL library this constructor of sycl::queue is explicit:
+    //      template <typename DeviceSelector,
+    //                typename =
+    //                    detail::EnableIfSYCL2020DeviceSelectorInvocable<DeviceSelector>>
+    //      explicit queue(const DeviceSelector &deviceSelector,
+    //                     const async_handler &AsyncHandler,
+    //                     const property_list &PropList = {})
+    //          : queue(detail::select_device(deviceSelector), AsyncHandler, PropList) {}
+    // Please see details in https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:interface.queue.class
+    test_policy_instance(make_device_policy<class Kernel_12>(sycl::queue{TestUtils::default_selector}));
+#else
+    // In previous versions this constructor was not explicit:
+    //      queue(const device_selector &DeviceSelector,
+    //            const property_list &PropList = {})
+    //          : queue(DeviceSelector.select_device(), async_handler{}, PropList) {}
     test_policy_instance(make_device_policy<class Kernel_12>(TestUtils::default_selector));
+#endif
     test_policy_instance(make_device_policy<class Kernel_13>(sycl::device{TestUtils::default_selector}));
     test_policy_instance(make_device_policy<class Kernel_14>(sycl::queue{TestUtils::default_selector, sycl::property::queue::in_order()}));
     test_policy_instance(make_device_policy<class Kernel_15>(dpcpp_default));

--- a/test/general/test_policies.pass.cpp
+++ b/test/general/test_policies.pass.cpp
@@ -68,7 +68,14 @@ main()
 
     // make_device_policy
     test_policy_instance(make_device_policy<class Kernel_11>(q));
-    // The next call is incompatible with SYCL 2020 library version because the constructor of sycl::queue now is explicit.
+    // The next call is incompatible with SYCL 2020 library version because the constructor of sycl::queue now is explicit:
+    //      template <typename DeviceSelector,
+    //                typename =
+    //                    detail::EnableIfSYCL2020DeviceSelectorInvocable<DeviceSelector>>
+    //      explicit queue(const DeviceSelector &deviceSelector,
+    //                     const async_handler &AsyncHandler,
+    //                     const property_list &PropList = {})
+    //          : queue(detail::select_device(deviceSelector), AsyncHandler, PropList) {}
     // We have the same test in line 77 with explicit instantiation of sycl::queue
 #if _ONEDPL_LIBSYCL_VERSION < 60000
     test_policy_instance(make_device_policy<class Kernel_12>(TestUtils::default_selector));

--- a/test/general/test_policies.pass.cpp
+++ b/test/general/test_policies.pass.cpp
@@ -68,16 +68,13 @@ main()
 
     // make_device_policy
     test_policy_instance(make_device_policy<class Kernel_11>(q));
-    // The next call is incompatible with SYCL 2020 library version because the constructor of sycl::queue now is explicit:
-    //      template <typename DeviceSelector,
-    //                typename =
-    //                    detail::EnableIfSYCL2020DeviceSelectorInvocable<DeviceSelector>>
-    //      explicit queue(const DeviceSelector &deviceSelector,
-    //                     const async_handler &AsyncHandler,
-    //                     const property_list &PropList = {})
-    //          : queue(detail::select_device(deviceSelector), AsyncHandler, PropList) {}
-    // We have the same test in line 77 with explicit instantiation of sycl::queue
 #if _ONEDPL_LIBSYCL_VERSION < 60000
+    // The next call is incompatible with SYCL 2020 library version because the constructor of sycl::queue now is explicit:
+    //      template <typename DeviceSelector, typename = detail::EnableIfSYCL2020DeviceSelectorInvocable<DeviceSelector>>
+    //      explicit queue(const DeviceSelector& deviceSelector, const property_list& PropList = {});
+    // With previous version we call in this line make_device_policy(sycl::queue q)
+    // because we had ability to create sylc::queue implici
+    // We have the same test in line 80 with explicit instantiation of sycl::queue
     test_policy_instance(make_device_policy<class Kernel_12>(TestUtils::default_selector));
 #endif
     test_policy_instance(make_device_policy<class Kernel_13>(sycl::device{TestUtils::default_selector}));

--- a/test/general/test_policies.pass.cpp
+++ b/test/general/test_policies.pass.cpp
@@ -68,6 +68,8 @@ main()
 
     // make_device_policy
     test_policy_instance(make_device_policy<class Kernel_11>(q));
+    // The next call is incompatible with SYCL 2020 library version because the constructor of sycl::queue now is explicit.
+    // We have the same test in line 77 with explicit instantiation of sycl::queue
 #if _ONEDPL_LIBSYCL_VERSION < 60000
     test_policy_instance(make_device_policy<class Kernel_12>(TestUtils::default_selector));
 #endif

--- a/test/general/test_policies.pass.cpp
+++ b/test/general/test_policies.pass.cpp
@@ -68,22 +68,7 @@ main()
 
     // make_device_policy
     test_policy_instance(make_device_policy<class Kernel_11>(q));
-#if _ONEDPL_LIBSYCL_VERSION >= 60000
-    // In new versions of SYCL library this constructor of sycl::queue is explicit:
-    //      template <typename DeviceSelector,
-    //                typename =
-    //                    detail::EnableIfSYCL2020DeviceSelectorInvocable<DeviceSelector>>
-    //      explicit queue(const DeviceSelector &deviceSelector,
-    //                     const async_handler &AsyncHandler,
-    //                     const property_list &PropList = {})
-    //          : queue(detail::select_device(deviceSelector), AsyncHandler, PropList) {}
-    // Please see details in https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:interface.queue.class
-    test_policy_instance(make_device_policy<class Kernel_12>(sycl::queue{TestUtils::default_selector}));
-#else
-    // In previous versions this constructor was not explicit:
-    //      queue(const device_selector &DeviceSelector,
-    //            const property_list &PropList = {})
-    //          : queue(DeviceSelector.select_device(), async_handler{}, PropList) {}
+#if _ONEDPL_LIBSYCL_VERSION < 60000
     test_policy_instance(make_device_policy<class Kernel_12>(TestUtils::default_selector));
 #endif
     test_policy_instance(make_device_policy<class Kernel_13>(sycl::device{TestUtils::default_selector}));

--- a/test/general/test_policies.pass.cpp
+++ b/test/general/test_policies.pass.cpp
@@ -69,12 +69,10 @@ main()
     // make_device_policy
     test_policy_instance(make_device_policy<class Kernel_11>(q));
 #if _ONEDPL_LIBSYCL_VERSION < 60000
-    // The next call is incompatible with SYCL 2020 library version because the constructor of sycl::queue now is explicit:
-    //      template <typename DeviceSelector, typename = detail::EnableIfSYCL2020DeviceSelectorInvocable<DeviceSelector>>
-    //      explicit queue(const DeviceSelector& deviceSelector, const property_list& PropList = {});
-    // With previous version we call in this line make_device_policy(sycl::queue q)
-    // because we had ability to create sylc::queue implici
-    // We have the same test in line 80 with explicit instantiation of sycl::queue
+    // make_device_policy requires a sycl::queue as argument.
+    // Currently, there is no implicit conversion (implicit syc::queue constructor by a device selector)
+    // from a device selector to a queue.
+    // The same test call with explicit queue creation we have below in line 78.
     test_policy_instance(make_device_policy<class Kernel_12>(TestUtils::default_selector));
 #endif
     test_policy_instance(make_device_policy<class Kernel_13>(sycl::device{TestUtils::default_selector}));


### PR DESCRIPTION
In this PR we fix compile error in test test/general/test_policies.pass.cpp :
 ```error: no matching function for call to 'make_device_policy'```

The next call in the file [test/general/test_policies.pass.cpp](https://github.com/oneapi-src/oneDPL/blob/main/test/general/test_policies.pass.cpp#L71)
```
test_policy_instance(make_device_policy<class Kernel_12>(TestUtils::default_selector));
```
is incompatible with SYCL 2020 library version because the constructor of sycl::queue now is **explicit** (please see paragraph ["4.6.5.1. Queue interface"](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_queue_interface) for details) :
```
  template <typename DeviceSelector,
            typename =
                detail::EnableIfSYCL2020DeviceSelectorInvocable<DeviceSelector>>
  explicit queue(const DeviceSelector &deviceSelector,
                 const property_list &PropList = {})
      : queue(detail::select_device(deviceSelector),
              detail::defaultAsyncHandler, PropList) {}
```

In previous versions of DPC++ compiler we called in this case the next function from file [include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h](https://github.com/oneapi-src/oneDPL/blob/main/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h#L133) :
```
template <typename KernelName = DefaultKernelName>
device_policy<KernelName>
make_device_policy(sycl::queue q)
{
    return device_policy<KernelName>(q);
}
```
so we had ability to construct sycl::queue this line of test code.

This problem was introduced in [PR#740](https://github.com/oneapi-src/oneDPL/pull/740) when we start use ```sycl::default_selector_v``` instead of deprecated ```sycl::default_selector```.