### PR TITLE
ForwardIterator operator->() fix

### DIFF
--- a/test/support/iterator_utils.h
+++ b/test/support/iterator_utils.h
@@ -42,7 +42,7 @@ class ForwardIterator
     ForwardIterator() = default;
     explicit ForwardIterator(Iterator i) : my_iterator(i) {}
     reference operator*() const { return *my_iterator; }
-    pointer operator->() const { return std::addressof(this->operator*()); }
+    pointer operator->() const { return ::std::addressof(this->operator*()); }
     
     ForwardIterator&
     operator++()

--- a/test/support/iterator_utils.h
+++ b/test/support/iterator_utils.h
@@ -42,7 +42,6 @@ class ForwardIterator
     ForwardIterator() = default;
     explicit ForwardIterator(Iterator i) : my_iterator(i) {}
     reference operator*() const { return *my_iterator; }
-    Iterator operator->() const { return my_iterator; }
     ForwardIterator&
     operator++()
     {

--- a/test/support/iterator_utils.h
+++ b/test/support/iterator_utils.h
@@ -42,7 +42,19 @@ class ForwardIterator
     ForwardIterator() = default;
     explicit ForwardIterator(Iterator i) : my_iterator(i) {}
     reference operator*() const { return *my_iterator; }
-    pointer operator->() const { return my_iterator.operator->(); }
+    pointer
+    operator->() const
+    {
+        if constexpr (::std::is_pointer<Iterator>::value)
+        {
+            return my_iterator;
+        }
+        else
+        {
+            return my_iterator.operator->();
+        }
+    }
+    
     ForwardIterator&
     operator++()
     {

--- a/test/support/iterator_utils.h
+++ b/test/support/iterator_utils.h
@@ -42,18 +42,7 @@ class ForwardIterator
     ForwardIterator() = default;
     explicit ForwardIterator(Iterator i) : my_iterator(i) {}
     reference operator*() const { return *my_iterator; }
-    pointer
-    operator->() const
-    {
-        if constexpr (::std::is_pointer<Iterator>::value)
-        {
-            return my_iterator;
-        }
-        else
-        {
-            return my_iterator.operator->();
-        }
-    }
+    pointer operator->() const { return std::addressof(this->operator*()); }
     
     ForwardIterator&
     operator++()

--- a/test/support/iterator_utils.h
+++ b/test/support/iterator_utils.h
@@ -42,6 +42,7 @@ class ForwardIterator
     ForwardIterator() = default;
     explicit ForwardIterator(Iterator i) : my_iterator(i) {}
     reference operator*() const { return *my_iterator; }
+    pointer operator->() const { return my_iterator.operator->(); }
     ForwardIterator&
     operator++()
     {

--- a/test/support/test_iterators.h
+++ b/test/support/test_iterators.h
@@ -99,7 +99,7 @@ class input_iterator
     }
 
     reference operator*() const { return *it_; }
-    pointer operator->() const { return it_; }
+    pointer operator->() const { return ::std::addressof(this->operator*()); }
 
     input_iterator&
     operator++()
@@ -173,7 +173,8 @@ class forward_iterator
     }
 
     reference operator*() const { return *it_; }
-    pointer operator->() const { return it_; }
+    pointer operator->() const { return ::std::addressof(this->operator*()); }
+
 
     forward_iterator&
     operator++()
@@ -247,7 +248,8 @@ class bidirectional_iterator
     }
 
     reference operator*() const { return *it_; }
-    pointer operator->() const { return it_; }
+    pointer operator->() const { return ::std::addressof(this->operator*()); }
+
 
     bidirectional_iterator&
     operator++()
@@ -324,7 +326,8 @@ class random_access_iterator
     }
 
     reference operator*() const { return *it_; }
-    pointer operator->() const { return it_; }
+    pointer operator->() const { return ::std::addressof(this->operator*()); }
+
 
     random_access_iterator&
     operator++()


### PR DESCRIPTION
The implementation of `ForwardIterator` in `test/support/iterator_utils.h` defines `operator->()`  to returns an `Iterator` rather than a its wrapped Iterator's `pointer`.  This causes issues with the Microsoft STL c++20 implementation of `std::reverse_iterator(ForwardIterator)` in the `noexcept` section of `operator->()`.  It forces the return of the `ForwardIterator::operator->()` to be implicitly convertible to its `ForwardIterator::pointer`, which was not the case until this change.

The point of this `ForwardIterator` class is to restrict the iterator in question to a LegacyForwardIterator.  Therefore, it can be assumed that the wrapped `Iterator` satisfies LegacyForwardIterator, and has `operator->()` available, or it is a pointer itself.

This resolves a compilation error in tests reverse.pass, reverse_copy.pass, and shift_left_right.pass on Windows using c++20 and dpcpp backend.

