### PR TITLE
Remove unused functions in namespace TestUtils

### DIFF
--- a/test/support/utils_test_base.h
+++ b/test/support/utils_test_base.h
@@ -319,9 +319,6 @@ struct test_base
 
 namespace
 {
-void update_data()
-{
-}
 };
 
 /// Copy data from source test data storage into local buffers

--- a/test/support/utils_test_base.h
+++ b/test/support/utils_test_base.h
@@ -319,10 +319,6 @@ struct test_base
 
 namespace
 {
-void retrieve_data()
-{
-}
-
 void update_data()
 {
 }

--- a/test/support/utils_test_base.h
+++ b/test/support/utils_test_base.h
@@ -317,10 +317,6 @@ struct test_base
     };
 };
 
-namespace
-{
-};
-
 /// Copy data from source test data storage into local buffers
 template <typename TTestDataTransfer, typename... Args>
 void retrieve_data(TTestDataTransfer& helper, Args&& ...args)


### PR DESCRIPTION
In this PR we fix compile warnings:
- unused function 'retrieve_data' [-Wunused-function]
- unused function 'update_data' [-Wunused-function]