### PR TITLE
Testing workaround to avoid unsupported calls in kernel

### DIFF
--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/max_init_list.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/max_init_list.pass.cpp
@@ -21,6 +21,11 @@
 //   T
 //   max(initializer_list<T> t);
 
+// In Windows, as a temporary workaround, we disable vector algorithms for calls inside sycl kernels
+#if defined(_MSC_VER)
+#    define _USE_STD_VECTOR_ALGORITHMS 0
+#endif
+
 #include "support/test_complex.h"
 #include "support/test_macros.h"
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/max_init_list.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/max_init_list.pass.cpp
@@ -21,7 +21,7 @@
 //   T
 //   max(initializer_list<T> t);
 
-// In Windows, as a temporary workaround, we disable vector algorithms for calls inside sycl kernels
+// In Windows, as a temporary workaround, disable vector algorithm calls to avoid calls within sycl kernels
 #if defined(_MSC_VER)
 #    define _USE_STD_VECTOR_ALGORITHMS 0
 #endif

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/min_init_list.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/min_init_list.pass.cpp
@@ -21,6 +21,11 @@
 //   T
 //   min(initializer_list<T> t);
 
+// In Windows, as a temporary workaround, we disable vector algorithms for calls inside sycl kernels
+#if defined(_MSC_VER)
+#    define _USE_STD_VECTOR_ALGORITHMS 0
+#endif
+
 #include "support/test_complex.h"
 #include "support/test_macros.h"
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/min_init_list.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/min_init_list.pass.cpp
@@ -21,7 +21,7 @@
 //   T
 //   min(initializer_list<T> t);
 
-// In Windows, as a temporary workaround, we disable vector algorithms for calls inside sycl kernels
+// In Windows, as a temporary workaround, disable vector algorithm calls to avoid calls within sycl kernels
 #if defined(_MSC_VER)
 #    define _USE_STD_VECTOR_ALGORITHMS 0
 #endif

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.find/xpu_find.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.find/xpu_find.pass.cpp
@@ -12,6 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+// In Windows, as a temporary workaround, we disable vector algorithms for calls inside sycl kernels
+#if defined(_MSC_VER)
+#    define _USE_STD_VECTOR_ALGORITHMS 0
+#endif
+
 #include <oneapi/dpl/algorithm>
 
 #include "support/utils_sycl.h"

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.find/xpu_find.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.find/xpu_find.pass.cpp
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// In Windows, as a temporary workaround, we disable vector algorithms for calls inside sycl kernels
+// In Windows, as a temporary workaround, disable vector algorithm calls to avoid calls within sycl kernels
 #if defined(_MSC_VER)
 #    define _USE_STD_VECTOR_ALGORITHMS 0
 #endif


### PR DESCRIPTION
Temporary testing workaround to avoid currently unsupported calls to vector algorithms from inside sycl kernels when calling `find()` or initializer list overloads of `min()` and `max()` on Windows at runtime.

Define must be set prior to include of the standard library headers. There is no natural unified location, given the need to precede the standard library headers.  It seems best to add the workaround in each test individually.  This also provides more apparent documentation of the known limitation.