### PR TITLE
ForwardIterator operator->() partially revert

### DIFF
--- a/test/support/test_iterators.h
+++ b/test/support/test_iterators.h
@@ -99,7 +99,7 @@ class input_iterator
     }
 
     reference operator*() const { return *it_; }
-    pointer operator->() const { return ::std::addressof(this->operator*()); }
+    pointer operator->() const { return it_; }
 
     input_iterator&
     operator++()
@@ -173,7 +173,7 @@ class forward_iterator
     }
 
     reference operator*() const { return *it_; }
-    pointer operator->() const { return ::std::addressof(this->operator*()); }
+    pointer operator->() const { return it_; }
 
 
     forward_iterator&
@@ -248,7 +248,7 @@ class bidirectional_iterator
     }
 
     reference operator*() const { return *it_; }
-    pointer operator->() const { return ::std::addressof(this->operator*()); }
+    pointer operator->() const { return it_; }
 
 
     bidirectional_iterator&
@@ -326,7 +326,7 @@ class random_access_iterator
     }
 
     reference operator*() const { return *it_; }
-    pointer operator->() const { return ::std::addressof(this->operator*()); }
+    pointer operator->() const { return it_; }
 
 
     random_access_iterator&

--- a/test/support/test_iterators.h
+++ b/test/support/test_iterators.h
@@ -175,7 +175,6 @@ class forward_iterator
     reference operator*() const { return *it_; }
     pointer operator->() const { return it_; }
 
-
     forward_iterator&
     operator++()
     {
@@ -249,7 +248,6 @@ class bidirectional_iterator
 
     reference operator*() const { return *it_; }
     pointer operator->() const { return it_; }
-
 
     bidirectional_iterator&
     operator++()
@@ -327,7 +325,6 @@ class random_access_iterator
 
     reference operator*() const { return *it_; }
     pointer operator->() const { return it_; }
-
 
     random_access_iterator&
     operator++()


### PR DESCRIPTION
I think that required partially revert changes from https://github.com/oneapi-src/oneDPL/pull/763
in places where ```pointer``` in iterator class defiled as iterator :
```
typedef It pointer;
```

In this case required to restore previous implementation of operator:
```
pointer operator->() const { return it_; }
```