### PR TITLE
ForwardIterator operator-> with pointer specialization

### DIFF
--- a/test/support/iterator_utils.h
+++ b/test/support/iterator_utils.h
@@ -42,7 +42,17 @@ class ForwardIterator
     ForwardIterator() = default;
     explicit ForwardIterator(Iterator i) : my_iterator(i) {}
     reference operator*() const { return *my_iterator; }
-    pointer operator->() const { return ::std::addressof(this->operator*()); }
+    pointer operator->() const
+    {
+        if constexpr (::std::is_pointer<Iterator>::value)
+        {
+            return my_iterator;
+        }
+        else
+        {
+            return my_iterator.operator->();
+        }
+    }
     
     ForwardIterator&
     operator++()


### PR DESCRIPTION
As mentioned in the comments of https://github.com/oneapi-src/oneDPL/pull/763#discussion_r1090450525, this implementation is more correct than `::std::addressof`, which will always return a raw pointer.  If a smart pointer or some other complex type was defined to `pointer` for the incoming iterator, there would be a type mismatch between the return type of `operator->()` and the value returned in the previous implementation.