### PR TITLE
CMake: require C++17 when using oneDPL from source files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,7 @@ endif()
 # Setup the oneDPL library target
 ###############################################################################
 add_library(oneDPL INTERFACE)
+target_compile_features(oneDPL INTERFACE cxx_std_17)
 
 if (CMAKE_BUILD_TYPE)
     message(STATUS "Build type is ${CMAKE_BUILD_TYPE}")


### PR DESCRIPTION
oneDPL removed support of C++11 and C++14 since 2022.0.0 release, and these changes help to avoid issues related to using older standards when oneDPL is integrated via CMake.

There are 2 ways to integrate oneDPL via CMake:
1. As source code: https://github.com/oneapi-src/oneDPL/tree/main/cmake#using-onedpl-source-files
2. As a package: https://github.com/oneapi-src/oneDPL/tree/main/cmake#using-onedpl-package

This PR adds a requirement for using C++17 as a minimum standard version for the option (1). 
This change was inspired by #739, which adds this requirement for the option (2).

`target_compile_features(oneDPL INTERFACE cxx_std_17)` will force c++17 as a minimum standard version for targets using oneDPL. If a user requests C++11, then C++17 will be silently used. Using newer standards is allowed as before.

Signed-off-by: Dmitriy Sobolev <dmitriy.sobolev@intel.com>