### PR TITLE
Fix include guard names in oneDPL header files

### DIFF
--- a/include/oneapi/dpl/array
+++ b/include/oneapi/dpl/array
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __ONEDPL_array
-#define __ONEDPL_array
+#ifndef _ONEDPL_ARRAY
+#define _ONEDPL_ARRAY
 
 #include "oneapi/dpl/internal/common_config.h"
 #include <array>
@@ -33,4 +33,4 @@ using ::std::tuple_size;
 
 namespace dpl = oneapi::dpl;
 
-#endif // __ONEDPL_array
+#endif // _ONEDPL_ARRAY

--- a/include/oneapi/dpl/cmath
+++ b/include/oneapi/dpl/cmath
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __ONEDPL_cmath
-#define __ONEDPL_cmath
+#ifndef _ONEDPL_CMATH
+#define _ONEDPL_CMATH
 
 #include "oneapi/dpl/internal/common_config.h"
 #include <cmath>
@@ -92,4 +92,4 @@ using ::std::truncf;
 
 namespace dpl = oneapi::dpl;
 
-#endif // __ONEDPL_cmath
+#endif // _ONEDPL_CMATH

--- a/include/oneapi/dpl/complex
+++ b/include/oneapi/dpl/complex
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __ONEDPL_complex
-#define __ONEDPL_complex
+#ifndef _ONEDPL_COMPLEX
+#define _ONEDPL_COMPLEX
 
 #include "oneapi/dpl/internal/common_config.h"
 #include <complex>
@@ -56,4 +56,4 @@ using ::std::tanh;
 
 namespace dpl = oneapi::dpl;
 
-#endif // __ONEDPL_complex
+#endif // _ONEDPL_COMPLEX

--- a/include/oneapi/dpl/cstddef
+++ b/include/oneapi/dpl/cstddef
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __ONEDPL_cstddef
-#define __ONEDPL_cstddef
+#ifndef _ONEDPL_CSTDDEF
+#define _ONEDPL_CSTDDEF
 
 #include "oneapi/dpl/internal/common_config.h"
 #include <cstddef>
@@ -32,4 +32,4 @@ using ::std::size_t;
 
 namespace dpl = oneapi::dpl;
 
-#endif // __ONEDPL_cstddef
+#endif // _ONEDPL_CSTDDEF

--- a/include/oneapi/dpl/cstring
+++ b/include/oneapi/dpl/cstring
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __ONEDPL_cstring
-#define __ONEDPL_cstring
+#ifndef _ONEDPL_CSTRING
+#define _ONEDPL_CSTRING
 
 #include "oneapi/dpl/internal/common_config.h"
 #include <cstring>
@@ -31,4 +31,4 @@ using ::std::memset;
 
 namespace dpl = oneapi::dpl;
 
-#endif // __ONEDPL_cstring
+#endif // _ONEDPL_CSTRING

--- a/include/oneapi/dpl/functional
+++ b/include/oneapi/dpl/functional
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __ONEDPL_functional
-#define __ONEDPL_functional
+#ifndef _ONEDPL_FUNCTIONAL
+#define _ONEDPL_FUNCTIONAL
 
 #include "oneapi/dpl/internal/common_config.h"
 #include <functional>
@@ -91,4 +91,4 @@ struct minimum
 
 namespace dpl = oneapi::dpl;
 
-#endif // __DPSTD_functional
+#endif // _ONEDPL_FUNCTIONAL

--- a/include/oneapi/dpl/internal/async_extension_defs.h
+++ b/include/oneapi/dpl/internal/async_extension_defs.h
@@ -182,4 +182,4 @@ transform_inclusive_scan_async(_ExecutionPolicy&& __exec, _ForwardIt1 __first1, 
 
 } // namespace oneapi
 
-#endif /* _ONEDPL_ASYNC_EXTENSION_DEFS_H */
+#endif // _ONEDPL_ASYNC_EXTENSION_DEFS_H

--- a/include/oneapi/dpl/internal/async_impl/async_impl.h
+++ b/include/oneapi/dpl/internal/async_impl/async_impl.h
@@ -92,4 +92,4 @@ sort_async(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAcce
 
 } // namespace oneapi
 
-#endif /* _ONEDPL_GLUE_ASYNC_IMPL_H */
+#endif // _ONEDPL_GLUE_ASYNC_IMPL_H

--- a/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
+++ b/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
@@ -270,4 +270,4 @@ __pattern_transform_scan_async(_ExecutionPolicy&& __exec, _Iterator1 __first, _I
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_ASYNC_IMPL_HETERO_H */
+#endif // _ONEDPL_ASYNC_IMPL_HETERO_H

--- a/include/oneapi/dpl/internal/async_impl/async_utils.h
+++ b/include/oneapi/dpl/internal/async_impl/async_utils.h
@@ -51,4 +51,4 @@ using __enable_if_device_execution_policy_double_no_default = typename ::std::en
 
 } // namespace oneapi
 
-#endif /* _ONEDPL_ASYNC_UTILS_H */
+#endif // _ONEDPL_ASYNC_UTILS_H

--- a/include/oneapi/dpl/internal/async_impl/glue_async_impl.h
+++ b/include/oneapi/dpl/internal/async_impl/glue_async_impl.h
@@ -278,4 +278,4 @@ transform_inclusive_scan_async(_ExecutionPolicy&& __exec, _ForwardIt1 __first1, 
 
 } // namespace oneapi
 
-#endif /* _ONEDPL_GLUE_ASYNC_IMPL_H */
+#endif // _ONEDPL_GLUE_ASYNC_IMPL_H

--- a/include/oneapi/dpl/internal/binary_search_extension_defs.h
+++ b/include/oneapi/dpl/internal/binary_search_extension_defs.h
@@ -62,4 +62,4 @@ binary_search(Policy&& policy, InputIterator1 start, InputIterator1 end, InputIt
 } // end namespace dpl
 } // end namespace oneapi
 
-#endif
+#endif // _ONEDPL_BINARY_SEARCH_EXTENSION_DEFS_H

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -265,4 +265,4 @@ binary_search(Policy&& policy, InputIterator1 start, InputIterator1 end, InputIt
 } // end namespace dpl
 } // end namespace oneapi
 
-#endif
+#endif // _ONEDPL_BINARY_SEARCH_IMPL_H

--- a/include/oneapi/dpl/internal/by_segment_extension_defs.h
+++ b/include/oneapi/dpl/internal/by_segment_extension_defs.h
@@ -86,4 +86,4 @@ reduce_by_segment(Policy&& policy, InputIterator1 first1, InputIterator1 last1, 
 } // end namespace dpl
 } // end namespace oneapi
 
-#endif
+#endif // _ONEDPL_BY_SEGMENT_EXTENSION_DEFS_H

--- a/include/oneapi/dpl/internal/common_config.h
+++ b/include/oneapi/dpl/internal/common_config.h
@@ -43,4 +43,4 @@
 #    endif
 #endif // __cplusplus >= 201703L
 
-#endif
+#endif // _ONEDPL_COMMON_CONFIG_H

--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -236,4 +236,4 @@ exclusive_scan_by_key(Policy&& policy, InputIterator1 first1, InputIterator1 las
 } // end namespace dpl
 } // end namespace oneapi
 
-#endif
+#endif // _ONEDPL_EXCLUSIVE_SCAN_BY_SEGMENT_IMPL_H

--- a/include/oneapi/dpl/internal/function.h
+++ b/include/oneapi/dpl/internal/function.h
@@ -216,4 +216,4 @@ class transform_if_stencil_fun
 } // namespace internal
 } // namespace dpl
 } // namespace oneapi
-#endif
+#endif // _ONEDPL_INTERNAL_FUNCTION_H

--- a/include/oneapi/dpl/internal/gcd_impl.h
+++ b/include/oneapi/dpl/internal/gcd_impl.h
@@ -14,8 +14,8 @@
  *  limitations under the License.
  */
 
-#ifndef _ONEDPL_GCD_IMPL
-#define _ONEDPL_GCD_IMPL
+#ifndef _ONEDPL_GCD_IMPL_H
+#define _ONEDPL_GCD_IMPL_H
 
 #include <limits>
 #include <type_traits>
@@ -101,4 +101,4 @@ lcm(_Mn __m, _Nn __n)
 } // end namespace dpl
 } // end namespace oneapi
 
-#endif
+#endif // _ONEDPL_GCD_IMPL_H

--- a/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
@@ -171,4 +171,4 @@ inclusive_scan_by_key(Policy&& policy, InputIter1 first1, InputIter1 last1, Inpu
 } // end namespace dpl
 } // end namespace oneapi
 
-#endif
+#endif // _ONEDPL_INCLUSIVE_SCAN_BY_SEGMENT_IMPL_H

--- a/include/oneapi/dpl/internal/iterator_impl.h
+++ b/include/oneapi/dpl/internal/iterator_impl.h
@@ -58,4 +58,4 @@ struct extract_accessor<oneapi::dpl::__internal::sycl_iterator<Mode, T, Allocato
 } // end namespace dpl
 } // end namespace oneapi
 
-#endif /* __DPSTD_iterator_impl_H */
+#endif // _ONEDPL_ITERATOR_IMPL_H

--- a/include/oneapi/dpl/internal/random_impl/bernoulli_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/bernoulli_distribution.h
@@ -17,8 +17,8 @@
 //
 // Public header file provides implementation for Bernoulli Distribution
 
-#ifndef _ONEDPL_BERNOULLI_DISTRIBUTION
-#define _ONEDPL_BERNOULLI_DISTRIBUTION
+#ifndef _ONEDPL_BERNOULLI_DISTRIBUTION_H
+#define _ONEDPL_BERNOULLI_DISTRIBUTION_H
 
 namespace oneapi
 {
@@ -208,4 +208,4 @@ class bernoulli_distribution
 } // namespace dpl
 } // namespace oneapi
 
-#endif // #ifndf _ONEDPL_BERNOULLI_DISTRIBUTION
+#endif // _ONEDPL_BERNOULLI_DISTRIBUTION_H

--- a/include/oneapi/dpl/internal/random_impl/cauchy_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/cauchy_distribution.h
@@ -17,8 +17,8 @@
 //
 // Public header file provides implementation for Cauchy Distribution
 
-#ifndef _ONEDPL_CAUCHY_DISTRIBUTION
-#define _ONEDPL_CAUCHY_DISTRIBUTION
+#ifndef _ONEDPL_CAUCHY_DISTRIBUTION_H
+#define _ONEDPL_CAUCHY_DISTRIBUTION_H
 
 namespace oneapi
 {
@@ -218,4 +218,4 @@ class cauchy_distribution
 } // namespace dpl
 } // namespace oneapi
 
-#endif // #ifndf _ONEDPL_CAUCHY_DISTRIBUTION
+#endif // _ONEDPL_CAUCHY_DISTRIBUTION_H

--- a/include/oneapi/dpl/internal/random_impl/discard_block_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/discard_block_engine.h
@@ -17,8 +17,8 @@
 //
 // Public header file provides implementation for Discard Block Engine
 
-#ifndef _ONEDPL_DISCARD_BLOCK_ENGINE
-#define _ONEDPL_DISCARD_BLOCK_ENGINE
+#ifndef _ONEDPL_DISCARD_BLOCK_ENGINE_H
+#define _ONEDPL_DISCARD_BLOCK_ENGINE_H
 
 #include <cstddef>
 #include <utility>
@@ -216,4 +216,4 @@ class discard_block_engine
 } // namespace dpl
 } // namespace oneapi
 
-#endif // ifndef _ONEDPL_DISCARD_BLOCK_ENGINE
+#endif // _ONEDPL_DISCARD_BLOCK_ENGINE_H

--- a/include/oneapi/dpl/internal/random_impl/exponential_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/exponential_distribution.h
@@ -17,8 +17,8 @@
 //
 // Public header file provides implementation for Exponential Distribution
 
-#ifndef _ONEDPL_EXPONENTIAL_DISTRIBUTION
-#define _ONEDPL_EXPONENTIAL_DISTRIBUTION
+#ifndef _ONEDPL_EXPONENTIAL_DISTRIBUTION_H
+#define _ONEDPL_EXPONENTIAL_DISTRIBUTION_H
 
 namespace oneapi
 {
@@ -210,4 +210,4 @@ class exponential_distribution
 } // namespace dpl
 } // namespace oneapi
 
-#endif // #ifndf _ONEDPL_EXPONENTIAL_DISTRIBUTION
+#endif // _ONEDPL_EXPONENTIAL_DISTRIBUTION_H

--- a/include/oneapi/dpl/internal/random_impl/extreme_value_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/extreme_value_distribution.h
@@ -17,8 +17,8 @@
 //
 // Public header file provides implementation for Extreme Value Distribution
 
-#ifndef _ONEDPL_EXTREME_VALUE_DISTRIBUTION
-#define _ONEDPL_EXTREME_VALUE_DISTRIBUTION
+#ifndef _ONEDPL_EXTREME_VALUE_DISTRIBUTION_H
+#define _ONEDPL_EXTREME_VALUE_DISTRIBUTION_H
 
 namespace oneapi
 {
@@ -242,4 +242,4 @@ class extreme_value_distribution
 } // namespace dpl
 } // namespace oneapi
 
-#endif // #ifndf _ONEDPL_EXTREME_VALUE_DISTRIBUTION
+#endif // _ONEDPL_EXTREME_VALUE_DISTRIBUTION_H

--- a/include/oneapi/dpl/internal/random_impl/geometric_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/geometric_distribution.h
@@ -17,8 +17,8 @@
 //
 // Public header file provides implementation for Geometric Distribution
 
-#ifndef _ONEDPL_GEOMETRIC_DISTRIBUTION
-#define _ONEDPL_GEOMETRIC_DISTRIBUTION
+#ifndef _ONEDPL_GEOMETRIC_DISTRIBUTION_H
+#define _ONEDPL_GEOMETRIC_DISTRIBUTION_H
 
 namespace oneapi
 {
@@ -207,4 +207,4 @@ class geometric_distribution
 } // namespace dpl
 } // namespace oneapi
 
-#endif // #ifndf _ONEDPL_GEOMETRIC_DISTRIBUTION
+#endif // _ONEDPL_GEOMETRIC_DISTRIBUTION_H

--- a/include/oneapi/dpl/internal/random_impl/linear_congruential_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/linear_congruential_engine.h
@@ -17,8 +17,8 @@
 //
 // Public header file provides implementation for Linear Congruential Engine
 
-#ifndef _ONEDPL_LINEAR_CONGRUENTIAL_ENGINE
-#define _ONEDPL_LINEAR_CONGRUENTIAL_ENGINE
+#ifndef _ONEDPL_LINEAR_CONGRUENTIAL_ENGINE_H
+#define _ONEDPL_LINEAR_CONGRUENTIAL_ENGINE_H
 
 namespace oneapi
 {
@@ -256,4 +256,4 @@ class linear_congruential_engine
 } // namespace dpl
 } // namespace oneapi
 
-#endif // ifndef _ONEDPL_LINEAR_CONGRUENTIAL_ENGINE
+#endif // _ONEDPL_LINEAR_CONGRUENTIAL_ENGINE_H

--- a/include/oneapi/dpl/internal/random_impl/lognormal_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/lognormal_distribution.h
@@ -17,8 +17,8 @@
 //
 // Public header file provides implementation for Lognormal Distribution
 
-#ifndef _ONEDPL_LOGNORMAL_DISTRIBUTION
-#define _ONEDPL_LOGNORMAL_DISTRIBUTION
+#ifndef _ONEDPL_LOGNORMAL_DISTRIBUTION_H
+#define _ONEDPL_LOGNORMAL_DISTRIBUTION_H
 
 namespace oneapi
 {
@@ -233,4 +233,4 @@ class lognormal_distribution
 } // namespace dpl
 } // namespace oneapi
 
-#endif // #ifndf _ONEDPL_LOGNORMAL_DISTRIBUTION
+#endif // _ONEDPL_LOGNORMAL_DISTRIBUTION_H

--- a/include/oneapi/dpl/internal/random_impl/normal_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/normal_distribution.h
@@ -17,8 +17,8 @@
 //
 // Public header file provides implementation for Normal Distribution
 
-#ifndef _ONEDPL_NORMAL_DISTRIBUTION
-#define _ONEDPL_NORMAL_DISTRIBUTION
+#ifndef _ONEDPL_NORMAL_DISTRIBUTION_H
+#define _ONEDPL_NORMAL_DISTRIBUTION_H
 
 namespace oneapi
 {
@@ -421,4 +421,4 @@ class normal_distribution
 } // namespace dpl
 } // namespace oneapi
 
-#endif // #ifndf _ONEDPL_NORMAL_DISTRIBUTION
+#endif // _ONEDPL_NORMAL_DISTRIBUTION_H

--- a/include/oneapi/dpl/internal/random_impl/random_common.h
+++ b/include/oneapi/dpl/internal/random_impl/random_common.h
@@ -17,8 +17,8 @@
 //
 // Public header file provides common utils for random implementation
 
-#ifndef _ONEDPL_RANDOM_COMMON
-#define _ONEDPL_RANDOM_COMMON
+#ifndef _ONEDPL_RANDOM_COMMON_H
+#define _ONEDPL_RANDOM_COMMON_H
 
 namespace oneapi
 {
@@ -56,4 +56,4 @@ typedef union {
 } // namespace dpl
 } // namespace oneapi
 
-#endif // #ifndf _ONEDPL_RANDOM_COMMON
+#endif // _ONEDPL_RANDOM_COMMON_H

--- a/include/oneapi/dpl/internal/random_impl/subtract_with_carry_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/subtract_with_carry_engine.h
@@ -17,8 +17,8 @@
 //
 // Public header file provides implementation for Subtract with Carry Engine
 
-#ifndef _ONEDPL_SUBTRACT_WITH_CARRY_ENGINE
-#define _ONEDPL_SUBTRACT_WITH_CARRY_ENGINE
+#ifndef _ONEDPL_SUBTRACT_WITH_CARRY_ENGINE_H
+#define _ONEDPL_SUBTRACT_WITH_CARRY_ENGINE_H
 
 namespace oneapi
 {
@@ -180,4 +180,4 @@ class subtract_with_carry_engine
 } // namespace dpl
 } // namespace oneapi
 
-#endif // ifndef _ONEDPL_SUBTRACT_WITH_CARRY_ENGINE
+#endif // _ONEDPL_SUBTRACT_WITH_CARRY_ENGINE_H

--- a/include/oneapi/dpl/internal/random_impl/uniform_int_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/uniform_int_distribution.h
@@ -17,8 +17,8 @@
 //
 // Public header file provides implementation for Uniform Int Distribution
 
-#ifndef _ONEDPL_UNIFORM_INT_DISTRIBUTION
-#define _ONEDPL_UNIFORM_INT_DISTRIBUTION
+#ifndef _ONEDPL_UNIFORM_INT_DISTRIBUTION_H
+#define _ONEDPL_UNIFORM_INT_DISTRIBUTION_H
 
 namespace oneapi
 {
@@ -218,4 +218,4 @@ class uniform_int_distribution
 } // namespace dpl
 } // namespace oneapi
 
-#endif // #ifndf _ONEDPL_UNIFORM_INT_DISTRIBUTION
+#endif // _ONEDPL_UNIFORM_INT_DISTRIBUTION_H

--- a/include/oneapi/dpl/internal/random_impl/uniform_real_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/uniform_real_distribution.h
@@ -17,8 +17,8 @@
 //
 // Public header file provides implementation for Uniform Real Distribution
 
-#ifndef _ONEDPL_UNIFORM_REAL_DISTRIBUTION
-#define _ONEDPL_UNIFORM_REAL_DISTRIBUTION
+#ifndef _ONEDPL_UNIFORM_REAL_DISTRIBUTION_H
+#define _ONEDPL_UNIFORM_REAL_DISTRIBUTION_H
 
 namespace oneapi
 {
@@ -372,4 +372,4 @@ class uniform_real_distribution
 } // namespace dpl
 } // namespace oneapi
 
-#endif // #ifndf _ONEDPL_UNIFORM_REAL_DISTRIBUTION
+#endif // _ONEDPL_UNIFORM_REAL_DISTRIBUTION_H

--- a/include/oneapi/dpl/internal/random_impl/weibull_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/weibull_distribution.h
@@ -17,8 +17,8 @@
 //
 // Public header file provides implementation for Weibull Distribution
 
-#ifndef _ONEDPL_WEIBULL_DISTRIBUTION
-#define _ONEDPL_WEIBULL_DISTRIBUTION
+#ifndef _ONEDPL_WEIBULL_DISTRIBUTION_H
+#define _ONEDPL_WEIBULL_DISTRIBUTION_H
 
 namespace oneapi
 {
@@ -219,4 +219,4 @@ class weibull_distribution
 } // namespace dpl
 } // namespace oneapi
 
-#endif // #ifndf _ONEDPL_WEIBULL_DISTRIBUTION
+#endif // _ONEDPL_WEIBULL_DISTRIBUTION_H

--- a/include/oneapi/dpl/internal/reduce_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/reduce_by_segment_impl.h
@@ -244,4 +244,4 @@ reduce_by_key(Policy&& policy, InputIt1 first1, InputIt1 last1, InputIt2 first2,
 } // end namespace dpl
 } // end namespace oneapi
 
-#endif
+#endif // _ONEDPL_REDUCE_BY_SEGMENT_IMPL_H

--- a/include/oneapi/dpl/internal/serial_numeric_impl.h
+++ b/include/oneapi/dpl/internal/serial_numeric_impl.h
@@ -54,4 +54,4 @@ using ::std::reduce;
 } // namespace dpl
 } // namespace oneapi
 #endif // _ONEDPL___cplusplus >= 201703L
-#endif /* _ONEDPL_SERIAL_NUMERIC_IMPL_H */
+#endif // _ONEDPL_SERIAL_NUMERIC_IMPL_H

--- a/include/oneapi/dpl/limits
+++ b/include/oneapi/dpl/limits
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __ONEDPL_limits
-#define __ONEDPL_limits
+#ifndef _ONEDPL_LIMITS
+#define _ONEDPL_LIMITS
 
 #include "oneapi/dpl/internal/common_config.h"
 #include <limits>
@@ -30,4 +30,4 @@ using numeric_limits = ::std::numeric_limits<T>;
 
 namespace dpl = oneapi::dpl;
 
-#endif // __ONEDPL_limits
+#endif // _ONEDPL_LIMITS

--- a/include/oneapi/dpl/optional
+++ b/include/oneapi/dpl/optional
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __ONEDPL_optional
-#define __ONEDPL_optional
+#ifndef _ONEDPL_OPTIONAL
+#define _ONEDPL_OPTIONAL
 
 #include "oneapi/dpl/internal/common_config.h"
 #include <optional>
@@ -32,4 +32,4 @@ using ::std::optional;
 
 namespace dpl = oneapi::dpl;
 
-#endif // __ONEDPL_optional
+#endif // _ONEDPL_OPTIONAL

--- a/include/oneapi/dpl/pstl/algorithm_fwd.h
+++ b/include/oneapi/dpl/pstl/algorithm_fwd.h
@@ -1343,4 +1343,4 @@ __pattern_shift_right(_ExecutionPolicy&&, _BidirectionalIterator, _Bidirectional
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_ALGORITHM_FWD_H */
+#endif // _ONEDPL_ALGORITHM_FWD_H

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -4140,4 +4140,4 @@ __pattern_shift_right(_ExecutionPolicy&& __exec, _BidirectionalIterator __first,
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_ALGORITHM_IMPL_H */
+#endif // _ONEDPL_ALGORITHM_IMPL_H

--- a/include/oneapi/dpl/pstl/execution_defs.h
+++ b/include/oneapi/dpl/pstl/execution_defs.h
@@ -237,4 +237,4 @@ using __value_t = typename __range_traits<_R>::__value_t;
 #    include "hetero/dpcpp/execution_sycl_defs.h"
 #endif
 
-#endif /* _ONEDPL_EXECUTION_POLICY_DEFS_H */
+#endif // _ONEDPL_EXECUTION_POLICY_DEFS_H

--- a/include/oneapi/dpl/pstl/execution_impl.h
+++ b/include/oneapi/dpl/pstl/execution_impl.h
@@ -151,4 +151,4 @@ struct __prefer_parallel_tag
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_EXECUTION_IMPL_H */
+#endif // _ONEDPL_EXECUTION_IMPL_H

--- a/include/oneapi/dpl/pstl/experimental/algorithm
+++ b/include/oneapi/dpl/pstl/experimental/algorithm
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_experimental_algorithm
-#define _ONEDPL_experimental_algorithm
+#ifndef _ONEDPL_EXPERIMENTAL_ALGORITHM
+#define _ONEDPL_EXPERIMENTAL_ALGORITHM
 
 #define __cpp_lib_experimental_parallel_for_loop 201711
 
@@ -50,4 +50,4 @@ using oneapi::dpl::experimental::reduction_plus;
 } // namespace experimental
 } // namespace std
 
-#endif /* _ONEDPL_experimental_algorithm */
+#endif // _ONEDPL_EXPERIMENTAL_ALGORITHM

--- a/include/oneapi/dpl/pstl/experimental/internal/for_loop.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/for_loop.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_experimental_for_loop_H
-#define _ONEDPL_experimental_for_loop_H
+#ifndef _ONEDPL_EXPERIMENTAL_FOR_LOOP_H
+#define _ONEDPL_EXPERIMENTAL_FOR_LOOP_H
 
 #include <tuple>
 
@@ -124,4 +124,4 @@ for_loop_n_strided(_Ip __start, _Size __n, _Sp __stride, _Rest&&... __rest)
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_experimental_for_loop_H */
+#endif // _ONEDPL_EXPERIMENTAL_FOR_LOOP_H

--- a/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_experimental_for_loop_impl_H
-#define _ONEDPL_experimental_for_loop_impl_H
+#ifndef _ONEDPL_EXPERIMENTAL_FOR_LOOP_IMPL_H
+#define _ONEDPL_EXPERIMENTAL_FOR_LOOP_IMPL_H
 
 #include <iterator>
 #include <type_traits>
@@ -583,4 +583,4 @@ __for_loop_repack_n(_ExecutionPolicy&& __exec, _Ip __start, _Size __n, _Sp __str
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_experimental_for_loop_impl_H */
+#endif // _ONEDPL_EXPERIMENTAL_FOR_LOOP_IMPL_H

--- a/include/oneapi/dpl/pstl/experimental/internal/induction.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/induction.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_experimental_induction_H
-#define _ONEDPL_experimental_induction_H
+#ifndef _ONEDPL_EXPERIMENTAL_INDUCTION_H
+#define _ONEDPL_EXPERIMENTAL_INDUCTION_H
 
 #include <type_traits>
 
@@ -48,4 +48,4 @@ induction(_Tp&& __var, _Sp __stride)
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_experimental_induction_H */
+#endif // _ONEDPL_EXPERIMENTAL_INDUCTION_H

--- a/include/oneapi/dpl/pstl/experimental/internal/induction_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/induction_impl.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_experimental_induction_impl_H
-#define _ONEDPL_experimental_induction_impl_H
+#ifndef _ONEDPL_EXPERIMENTAL_INDUCTION_IMPL_H
+#define _ONEDPL_EXPERIMENTAL_INDUCTION_IMPL_H
 
 #include <type_traits>
 
@@ -120,4 +120,4 @@ class __induction_object<_Tp, void>
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_experimental_induction_impl_H */
+#endif // _ONEDPL_EXPERIMENTAL_INDUCTION_IMPL_H

--- a/include/oneapi/dpl/pstl/experimental/internal/reduction.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/reduction.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_experimental_reduction_H
-#define _ONEDPL_experimental_reduction_H
+#ifndef _ONEDPL_EXPERIMENTAL_REDUCTION_H
+#define _ONEDPL_EXPERIMENTAL_REDUCTION_H
 
 #include <type_traits>
 #include <functional>
@@ -95,4 +95,4 @@ reduction_max(_Tp& __var)
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_experimental_reduction_H */
+#endif // _ONEDPL_EXPERIMENTAL_REDUCTION_H

--- a/include/oneapi/dpl/pstl/experimental/internal/reduction_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/reduction_impl.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_experimental_reduction_impl_H
-#define _ONEDPL_experimental_reduction_impl_H
+#ifndef _ONEDPL_EXPERIMENTAL_REDUCTION_IMPL_H
+#define _ONEDPL_EXPERIMENTAL_REDUCTION_IMPL_H
 
 #include <type_traits>
 #include <algorithm>
@@ -92,4 +92,4 @@ class __reduction_object
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_experimental_reduction_impl_H */
+#endif // _ONEDPL_EXPERIMENTAL_REDUCTION_IMPL_H

--- a/include/oneapi/dpl/pstl/glue_algorithm_defs.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_defs.h
@@ -589,4 +589,4 @@ shift_right(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _Bidirect
 
 } // namespace dpl
 } // namespace oneapi
-#endif /* _ONEDPL_GLUE_ALGORITHM_DEFS_H */
+#endif // _ONEDPL_GLUE_ALGORITHM_DEFS_H

--- a/include/oneapi/dpl/pstl/glue_algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_impl.h
@@ -1214,4 +1214,4 @@ shift_right(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _Bidirect
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_GLUE_ALGORITHM_IMPL_H */
+#endif // _ONEDPL_GLUE_ALGORITHM_IMPL_H

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_defs.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_defs.h
@@ -356,4 +356,4 @@ reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2&& __value
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_GLUE_ALGORITHM_RANGES_DEFS_H */
+#endif // _ONEDPL_GLUE_ALGORITHM_RANGES_DEFS_H

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -683,4 +683,4 @@ reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2&& __value
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_GLUE_ALGORITHM_RANGES_IMPL_H */
+#endif // _ONEDPL_GLUE_ALGORITHM_RANGES_IMPL_H

--- a/include/oneapi/dpl/pstl/glue_execution_defs.h
+++ b/include/oneapi/dpl/pstl/glue_execution_defs.h
@@ -60,4 +60,4 @@ using oneapi::dpl::execution::unsequenced_policy;
 #include "numeric_impl.h"
 #include "parallel_backend.h"
 
-#endif /* _ONEDPL_GLUE_EXECUTION_DEFS_H */
+#endif // _ONEDPL_GLUE_EXECUTION_DEFS_H

--- a/include/oneapi/dpl/pstl/glue_memory_defs.h
+++ b/include/oneapi/dpl/pstl/glue_memory_defs.h
@@ -85,4 +85,4 @@ uninitialized_value_construct_n(_ExecutionPolicy&& __exec, _ForwardIterator __fi
 
 } // namespace dpl
 } // namespace oneapi
-#endif /* _ONEDPL_GLUE_MEMORY_DEFS_H */
+#endif // _ONEDPL_GLUE_MEMORY_DEFS_H

--- a/include/oneapi/dpl/pstl/glue_memory_impl.h
+++ b/include/oneapi/dpl/pstl/glue_memory_impl.h
@@ -370,4 +370,4 @@ uninitialized_value_construct_n(_ExecutionPolicy&& __exec, _ForwardIterator __fi
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_GLUE_MEMORY_IMPL_H */
+#endif // _ONEDPL_GLUE_MEMORY_IMPL_H

--- a/include/oneapi/dpl/pstl/glue_numeric_defs.h
+++ b/include/oneapi/dpl/pstl/glue_numeric_defs.h
@@ -165,4 +165,4 @@ adjacent_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _Forwa
 
 } // namespace dpl
 } // namespace oneapi
-#endif /* _ONEDPL_GLUE_NUMERIC_DEFS_H */
+#endif // _ONEDPL_GLUE_NUMERIC_DEFS_H

--- a/include/oneapi/dpl/pstl/glue_numeric_impl.h
+++ b/include/oneapi/dpl/pstl/glue_numeric_impl.h
@@ -299,4 +299,4 @@ adjacent_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _Forwa
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_GLUE_NUMERIC_IMPL_H */
+#endif // _ONEDPL_GLUE_NUMERIC_IMPL_H

--- a/include/oneapi/dpl/pstl/glue_numeric_ranges_defs.h
+++ b/include/oneapi/dpl/pstl/glue_numeric_ranges_defs.h
@@ -115,4 +115,4 @@ transform_inclusive_scan(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& 
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_GLUE_NUMERIC_RANGES_DEFS_H */
+#endif // _ONEDPL_GLUE_NUMERIC_RANGES_DEFS_H

--- a/include/oneapi/dpl/pstl/glue_numeric_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_numeric_ranges_impl.h
@@ -192,4 +192,4 @@ transform_inclusive_scan(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& 
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_GLUE_NUMERIC_RANGES_IMPL_H */
+#endif // _ONEDPL_GLUE_NUMERIC_RANGES_IMPL_H

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_algorithm_impl_hetero_H
-#define _ONEDPL_algorithm_impl_hetero_H
+#ifndef _ONEDPL_ALGORITHM_IMPL_HETERO_H
+#define _ONEDPL_ALGORITHM_IMPL_HETERO_H
 
 #include "../algorithm_fwd.h"
 
@@ -1984,4 +1984,4 @@ __pattern_shift_right(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_algorithm_impl_hetero_H */
+#endif // _ONEDPL_ALGORITHM_IMPL_HETERO_H

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_algorithm_ranges_impl_hetero_H
-#define _ONEDPL_algorithm_ranges_impl_hetero_H
+#ifndef _ONEDPL_ALGORITHM_RANGES_IMPL_HETERO_H
+#define _ONEDPL_ALGORITHM_RANGES_IMPL_HETERO_H
 
 #include "../algorithm_fwd.h"
 #include "../parallel_backend.h"
@@ -797,4 +797,4 @@ __pattern_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_algorithm_ranges_impl_hetero_H */
+#endif // _ONEDPL_ALGORITHM_RANGES_IMPL_HETERO_H

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_execution_sycl_defs_H
-#define _ONEDPL_execution_sycl_defs_H
+#ifndef _ONEDPL_EXECUTION_SYCL_DEFS_H
+#define _ONEDPL_EXECUTION_SYCL_DEFS_H
 
 #include "../../onedpl_config.h"
 #include "../../execution_defs.h"
@@ -406,4 +406,4 @@ __kernel_sub_group_size(_ExecutionPolicy&& __policy, const sycl::kernel& __kerne
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_execution_sycl_defs_H */
+#endif // _ONEDPL_EXECUTION_SYCL_DEFS_H

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -17,8 +17,8 @@
 
 // This header guard is used to check inclusion of DPC++ backend.
 // Changing this macro may result in broken tests.
-#ifndef _ONEDPL_parallel_backend_sycl_H
-#define _ONEDPL_parallel_backend_sycl_H
+#ifndef _ONEDPL_PARALLEL_BACKEND_SYCL_H
+#define _ONEDPL_PARALLEL_BACKEND_SYCL_H
 
 #include <cassert>
 #include <algorithm>
@@ -1436,4 +1436,4 @@ __parallel_partial_sort(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator 
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_parallel_backend_sycl_H */
+#endif // _ONEDPL_PARALLEL_BACKEND_SYCL_H

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
@@ -17,8 +17,8 @@
 
 // This header guard is used to check inclusion of DPC++ backend for the FPGA.
 // Changing this macro may result in broken tests.
-#ifndef _ONEDPL_parallel_backend_sycl_fpga_H
-#define _ONEDPL_parallel_backend_sycl_fpga_H
+#ifndef _ONEDPL_PARALLEL_BACKEND_SYCL_FPGA_H
+#define _ONEDPL_PARALLEL_BACKEND_SYCL_FPGA_H
 
 #include <cassert>
 #include <algorithm>
@@ -262,4 +262,4 @@ __parallel_partial_sort(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator 
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_parallel_backend_sycl_fpga_H */
+#endif // _ONEDPL_PARALLEL_BACKEND_SYCL_FPGA_H

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_parallel_backend_sycl_radix_sort_H
-#define _ONEDPL_parallel_backend_sycl_radix_sort_H
+#ifndef _ONEDPL_PARALLEL_BACKEND_SYCL_RADIX_SORT_H
+#define _ONEDPL_PARALLEL_BACKEND_SYCL_RADIX_SORT_H
 
 #include <limits>
 #include <type_traits>
@@ -698,4 +698,4 @@ __parallel_radix_sort(_ExecutionPolicy&& __exec, _Range&& __in_rng)
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_parallel_backend_sycl_radix_sort_H */
+#endif // _ONEDPL_PARALLEL_BACKEND_SYCL_RADIX_SORT_H

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_parallel_backend_sycl_utils_H
-#define _ONEDPL_parallel_backend_sycl_utils_H
+#ifndef _ONEDPL_PARALLEL_BACKEND_SYCL_UTILS_H
+#define _ONEDPL_PARALLEL_BACKEND_SYCL_UTILS_H
 
 //!!! NOTE: This file should be included under the macro _ONEDPL_BACKEND_SYCL
 #include <type_traits>
@@ -537,4 +537,4 @@ public:
 } // namespace dpl
 } // namespace oneapi
 
-#endif //_ONEDPL_parallel_backend_sycl_utils_H
+#endif //_ONEDPL_PARALLEL_BACKEND_SYCL_UTILS_H

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -18,8 +18,8 @@
 //
 // Include this header instead of sycl.hpp throughout the project
 
-#ifndef _ONEDPL_sycl_defs_H
-#define _ONEDPL_sycl_defs_H
+#ifndef _ONEDPL_SYCL_DEFS_H
+#define _ONEDPL_SYCL_DEFS_H
 
 #if __has_include(<sycl/sycl.hpp>)
 #    include <sycl/sycl.hpp>
@@ -243,4 +243,4 @@ using __local_accessor =
 
 } // namespace __dpl_sycl
 
-#endif /* _ONEDPL_sycl_defs_H */
+#endif // _ONEDPL_SYCL_DEFS_H

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_sycl_iterator_H
-#define _ONEDPL_sycl_iterator_H
+#ifndef _ONEDPL_SYCL_ITERATOR_H
+#define _ONEDPL_SYCL_ITERATOR_H
 
 #include <iterator>
 #include "../../onedpl_config.h"
@@ -196,4 +196,4 @@ __internal::sycl_iterator<access_mode::discard_read_write, T, Allocator> end(syc
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_sycl_iterator_H */
+#endif // _ONEDPL_SYCL_ITERATOR_H

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -14,8 +14,8 @@
 //===----------------------------------------------------------------------===//
 
 //!!! NOTE: This file should be included under the macro _ONEDPL_BACKEND_SYCL
-#ifndef _ONEDPL_unseq_backend_sycl_H
-#define _ONEDPL_unseq_backend_sycl_H
+#ifndef _ONEDPL_UNSEQ_BACKEND_SYCL_H
+#define _ONEDPL_UNSEQ_BACKEND_SYCL_H
 
 #include <type_traits>
 
@@ -951,4 +951,4 @@ struct __brick_reduce_idx
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_unseq_backend_sycl_H */
+#endif // _ONEDPL_UNSEQ_BACKEND_SYCL_H

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -529,4 +529,4 @@ struct __get_sycl_range
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_UTILS_RANGES_SYCL_H */
+#endif // _ONEDPL_UTILS_RANGES_SYCL_H

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_numeric_impl_hetero_H
-#define _ONEDPL_numeric_impl_hetero_H
+#ifndef _ONEDPL_NUMERIC_IMPL_HETERO_H
+#define _ONEDPL_NUMERIC_IMPL_HETERO_H
 
 #include <iterator>
 #include "../parallel_backend.h"
@@ -254,4 +254,4 @@ __pattern_adjacent_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __fir
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_numeric_impl_hetero_H */
+#endif // _ONEDPL_NUMERIC_IMPL_HETERO_H

--- a/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_numeric_ranges_impl_hetero_H
-#define _ONEDPL_numeric_ranges_impl_hetero_H
+#ifndef _ONEDPL_NUMERIC_RANGES_IMPL_HETERO_H
+#define _ONEDPL_NUMERIC_RANGES_IMPL_HETERO_H
 
 #include "../numeric_fwd.h"
 #include "../parallel_backend.h"
@@ -174,4 +174,4 @@ __pattern_transform_scan(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& 
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_numeric_ranges_impl_hetero_H */
+#endif // _ONEDPL_NUMERIC_RANGES_IMPL_HETERO_H

--- a/include/oneapi/dpl/pstl/hetero/utils_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/utils_hetero.h
@@ -18,8 +18,8 @@
 //
 // Include this header instead of sycl.hpp throughout the project
 
-#ifndef _ONEDPL_utils_hetero_H
-#define _ONEDPL_utils_hetero_H
+#ifndef _ONEDPL_UTILS_HETERO_H
+#define _ONEDPL_UTILS_HETERO_H
 
 namespace oneapi
 {
@@ -148,4 +148,4 @@ struct acc_handler_count
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_utils_hetero_H */
+#endif // _ONEDPL_UTILS_HETERO_H

--- a/include/oneapi/dpl/pstl/iterator_defs.h
+++ b/include/oneapi/dpl/pstl/iterator_defs.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_iterator_defs_H
-#define _ONEDPL_iterator_defs_H
+#ifndef _ONEDPL_ITERATOR_DEFS_H
+#define _ONEDPL_ITERATOR_DEFS_H
 
 #include <iterator>
 #include <type_traits>
@@ -109,4 +109,4 @@ struct is_passed_directly<Iter, typename ::std::enable_if<::std::is_pointer<Iter
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_iterator_defs_H */
+#endif // _ONEDPL_ITERATOR_DEFS_H

--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_iterator_impl_H
-#define _ONEDPL_iterator_impl_H
+#ifndef _ONEDPL_ITERATOR_IMPL_H
+#define _ONEDPL_ITERATOR_IMPL_H
 
 #include <iterator>
 #include <tuple>
@@ -923,4 +923,4 @@ map_zip(F f, TBig<T...> in, RestTuples... rest)
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_iterator_impl_H */
+#endif // _ONEDPL_ITERATOR_IMPL_H

--- a/include/oneapi/dpl/pstl/memory_fwd.h
+++ b/include/oneapi/dpl/pstl/memory_fwd.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_memory_fwd_H
-#define _ONEDPL_memory_fwd_H
+#ifndef _ONEDPL_MEMORY_FWD_H
+#define _ONEDPL_MEMORY_FWD_H
 
 namespace oneapi
 {
@@ -45,4 +45,4 @@ struct __op_uninitialized_value_construct;
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_memory_fwd_H */
+#endif // _ONEDPL_MEMORY_FWD_H

--- a/include/oneapi/dpl/pstl/memory_impl.h
+++ b/include/oneapi/dpl/pstl/memory_impl.h
@@ -214,4 +214,4 @@ struct __op_uninitialized_value_construct<_ExecutionPolicy>
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_MEMORY_IMPL_H */
+#endif // _ONEDPL_MEMORY_IMPL_H

--- a/include/oneapi/dpl/pstl/numeric_fwd.h
+++ b/include/oneapi/dpl/pstl/numeric_fwd.h
@@ -156,4 +156,4 @@ __pattern_adjacent_difference(_ExecutionPolicy&&, _RandomAccessIterator, _Random
 } // namespace __internal
 } // namespace dpl
 } // namespace oneapi
-#endif /* _ONEDPL_NUMERIC_FWD_H */
+#endif // _ONEDPL_NUMERIC_FWD_H

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -396,4 +396,4 @@ __pattern_adjacent_difference(_ExecutionPolicy&& __exec, _RandomAccessIterator1 
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_NUMERIC_IMPL_H */
+#endif // _ONEDPL_NUMERIC_IMPL_H

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -283,4 +283,4 @@
 #    define _ONEDPL_SYCL_INTEL_COMPILER 1
 #endif
 
-#endif /* _ONEDPL_CONFIG_H */
+#endif // _ONEDPL_CONFIG_H

--- a/include/oneapi/dpl/pstl/parallel_backend.h
+++ b/include/oneapi/dpl/pstl/parallel_backend.h
@@ -53,4 +53,4 @@ namespace __par_backend = __serial_backend;
 _PSTL_PRAGMA_MESSAGE("Parallel backend was not specified");
 #endif
 
-#endif /* _ONEDPL_PARALLEL_BACKEND_H */
+#endif // _ONEDPL_PARALLEL_BACKEND_H

--- a/include/oneapi/dpl/pstl/parallel_backend_serial.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_serial.h
@@ -146,4 +146,4 @@ __parallel_for_each(_ExecutionPolicy&&, _ForwardIterator __begin, _ForwardIterat
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_PARALLEL_BACKEND_SERIAL_H */
+#endif // _ONEDPL_PARALLEL_BACKEND_SERIAL_H

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -1322,4 +1322,4 @@ __parallel_for_each(_ExecutionPolicy&&, _ForwardIterator __begin, _ForwardIterat
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_PARALLEL_BACKEND_TBB_H */
+#endif // _ONEDPL_PARALLEL_BACKEND_TBB_H

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -264,4 +264,4 @@ __set_symmetric_difference_construct(_ForwardIterator1 __first1, _ForwardIterato
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_PARALLEL_BACKEND_UTILS_H */
+#endif // _ONEDPL_PARALLEL_BACKEND_UTILS_H

--- a/include/oneapi/dpl/pstl/parallel_impl.h
+++ b/include/oneapi/dpl/pstl/parallel_impl.h
@@ -90,4 +90,4 @@ __parallel_or(_ExecutionPolicy&& __exec, _Index __first, _Index __last, _Brick _
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_PARALLEL_IMPL_H */
+#endif // _ONEDPL_PARALLEL_IMPL_H

--- a/include/oneapi/dpl/pstl/pstl_config.h
+++ b/include/oneapi/dpl/pstl/pstl_config.h
@@ -169,4 +169,4 @@
 // broken macros
 #define _PSTL_ICC_18_OMP_SIMD_BROKEN (__INTEL_COMPILER == 1800)
 
-#endif /* _PSTL_CONFIG_H */
+#endif // _PSTL_CONFIG_H

--- a/include/oneapi/dpl/pstl/ranges/nanorange_ext.h
+++ b/include/oneapi/dpl/pstl/ranges/nanorange_ext.h
@@ -271,4 +271,4 @@ NANO_INLINE_VAR(nano::detail::fill_view_fn, fill)
 
 NANO_END_NAMESPACE
 
-#endif //_ONEDPL_NANO_RANGES_EXT_H
+#endif // _ONEDPL_NANO_RANGES_EXT_H

--- a/include/oneapi/dpl/pstl/ranges_defs.h
+++ b/include/oneapi/dpl/pstl/ranges_defs.h
@@ -70,4 +70,4 @@ using __nanorange::nano::subrange;
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_RANGES_DEFS_H */
+#endif // _ONEDPL_RANGES_DEFS_H

--- a/include/oneapi/dpl/pstl/tuple_impl.h
+++ b/include/oneapi/dpl/pstl/tuple_impl.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_tuple_impl_H
-#define _ONEDPL_tuple_impl_H
+#ifndef _ONEDPL_TUPLE_IMPL_H
+#define _ONEDPL_TUPLE_IMPL_H
 
 #include <iterator>
 #include <tuple>
@@ -650,4 +650,4 @@ get(const oneapi::dpl::__internal::tuple<_Tp...>&& __a)
 }
 } // namespace std
 
-#endif /* _ONEDPL_tuple_impl_H */
+#endif // _ONEDPL_TUPLE_IMPL_H

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -895,4 +895,4 @@ __simd_remove_if(_RandomAccessIterator __first, _DifferenceType __n, _UnaryPredi
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_UNSEQ_BACKEND_SIMD_H */
+#endif // _ONEDPL_UNSEQ_BACKEND_SIMD_H

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -571,4 +571,4 @@ struct __lifetime_keeper : public __lifetime_keeper_base
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_UTILS_H */
+#endif // _ONEDPL_UTILS_H

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -466,4 +466,4 @@ struct __range_traits<oneapi::dpl::__ranges::zip_view<_Ranges...>>
 } // namespace dpl
 } // namespace oneapi
 
-#endif /* _ONEDPL_UTILS_RANGES_H */
+#endif // _ONEDPL_UTILS_RANGES_H

--- a/include/oneapi/dpl/random
+++ b/include/oneapi/dpl/random
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _ONEDPL_random
-#define _ONEDPL_random
+#ifndef _ONEDPL_RANDOM
+#define _ONEDPL_RANDOM
 
 #include "oneapi/dpl/internal/common_config.h"
 #include "oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h"
@@ -73,4 +73,4 @@ using ranlux48_vec = discard_block_engine<ranlux48_base_vec<_N>, 389, 11>;
 
 namespace dpl = oneapi::dpl;
 
-#endif // _ONEDPL_random
+#endif // _ONEDPL_RANDOM

--- a/include/oneapi/dpl/ratio
+++ b/include/oneapi/dpl/ratio
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __ONEDPL_ratio
-#define __ONEDPL_ratio
+#ifndef _ONEDPL_RATIO
+#define _ONEDPL_RATIO
 
 #include "oneapi/dpl/internal/common_config.h"
 #include <ratio>
@@ -39,4 +39,4 @@ using ::std::ratio_subtract;
 
 namespace dpl = oneapi::dpl;
 
-#endif // __ONEDPL_ratio
+#endif // _ONEDPL_RATIO

--- a/include/oneapi/dpl/tuple
+++ b/include/oneapi/dpl/tuple
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __ONEDPL_tuple
-#define __ONEDPL_tuple
+#ifndef _ONEDPL_TUPLE
+#define _ONEDPL_TUPLE
 
 #include "oneapi/dpl/internal/common_config.h"
 #include <tuple>
@@ -39,4 +39,4 @@ using ::std::tuple_size;
 
 namespace dpl = oneapi::dpl;
 
-#endif // __ONEDPL_tuple
+#endif // _ONEDPL_TUPLE

--- a/include/oneapi/dpl/type_traits
+++ b/include/oneapi/dpl/type_traits
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __ONEDPL_type_traits
-#define __ONEDPL_type_traits
+#ifndef _ONEDPL_TYPE_TRAITS
+#define _ONEDPL_TYPE_TRAITS
 
 #include "oneapi/dpl/internal/common_config.h"
 #include <type_traits>
@@ -220,4 +220,4 @@ using ::std::result_of_t;       // Deprecated in C++17, removed in C++20
 
 namespace dpl = oneapi::dpl;
 
-#endif // __ONEDPL_type_traits
+#endif // _ONEDPL_TYPE_TRAITS

--- a/include/oneapi/dpl/utility
+++ b/include/oneapi/dpl/utility
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __ONEDPL_utility
-#define __ONEDPL_utility
+#ifndef _ONEDPL_UTILITY
+#define _ONEDPL_UTILITY
 
 #include "oneapi/dpl/internal/common_config.h"
 #include <utility>
@@ -42,4 +42,4 @@ using ::std::tuple_size;
 
 namespace dpl = oneapi::dpl;
 
-#endif // __ONEDPL_utility
+#endif // _ONEDPL_UTILITY

--- a/test/support/scan_serial_impl.h
+++ b/test/support/scan_serial_impl.h
@@ -93,4 +93,4 @@ void inclusive_scan_by_segment_serial(ViewKeys keys, ViewVals vals, Res& res, Si
             res[i] = binary_op(res[i - 1], vals[i]);
 }
 
-#endif //  _SCAN_SERIAL_IMPL_H
+#endif // _SCAN_SERIAL_IMPL_H

--- a/test/support/sycl_alloc_utils.h
+++ b/test/support/sycl_alloc_utils.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __TEST_SYCL_ALLOC_UTILS_H
-#define __TEST_SYCL_ALLOC_UTILS_H
+#ifndef _TEST_SYCL_ALLOC_UTILS_H
+#define _TEST_SYCL_ALLOC_UTILS_H
 
 #if TEST_DPCPP_BACKEND_PRESENT
 
@@ -220,4 +220,4 @@ private:
 
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-#endif // __TEST_SYCL_ALLOC_UTILS_H
+#endif // _TEST_SYCL_ALLOC_UTILS_H

--- a/test/support/test_complex.h
+++ b/test/support/test_complex.h
@@ -167,4 +167,4 @@ namespace TestUtils
 
 } /* namespace TestUtils */
 
-#endif /* _TEST_COMPLEX_H */
+#endif // _TEST_COMPLEX_H

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _TEST_config_H
-#define _TEST_config_H
+#ifndef _TEST_CONFIG_H
+#define _TEST_CONFIG_H
 
 #define _PSTL_TEST_STRING(X) _PSTL_TEST_STRING_AUX(oneapi/dpl/X)
 #define _PSTL_TEST_STRING_AUX(X) #X
@@ -115,4 +115,4 @@
 #define _PSTL_CLANG_TEST_COMPLEX_ATAN_IS_CASE_BROKEN __clang__
 #define _PSTL_CLANG_TEST_COMPLEX_SIN_IS_CASE_BROKEN __clang__
 
-#endif /* _TEST_config_H */
+#endif // _TEST_CONFIG_H

--- a/test/support/test_macros.h
+++ b/test/support/test_macros.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef SUPPORT_TEST_MACROS_HPP
-#define SUPPORT_TEST_MACROS_HPP
+#ifndef _SUPPORT_TEST_MACROS_H
+#define _SUPPORT_TEST_MACROS_H
 
 // Attempt to get STL specific macros like _LIBCPP_VERSION using the most
 // minimal header possible. If we're testing libc++, we should use `<__config>`.
@@ -420,4 +420,4 @@ inline void DoNotOptimize(Tp const& value) {
 #define TEST_NO_UNIQUE_ADDRESS
 #endif
 
-#endif // SUPPORT_TEST_MACROS_HPP
+#endif // _SUPPORT_TEST_MACROS_H

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -13,8 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef __UTILS_H
-#define __UTILS_H
+#ifndef _UTILS_H
+#define _UTILS_H
 
 // File contains common utilities that tests rely on
 
@@ -697,4 +697,4 @@ struct can_use_default_less_operator<T, decltype(::std::declval<T>() < ::std::de
 
 } /* namespace TestUtils */
 
-#endif // __UTILS_H
+#endif // _UTILS_H

--- a/test/xpu_api/numerics/complex.number/cases.h
+++ b/test/xpu_api/numerics/complex.number/cases.h
@@ -10,8 +10,8 @@
 
 // test cases
 
-#ifndef CASES_H
-#define CASES_H
+#ifndef _CASES_H
+#define _CASES_H
 
 #include <oneapi/dpl/complex>
 #include <cassert>
@@ -247,4 +247,4 @@ is_about(const dpl::complex<T>& x, const dpl::complex<T>& y, const T eps = __tol
     return is_about(::std::abs(y - x), T(0.), eps);
 }
 
-#endif // CASES_H
+#endif // _CASES_H

--- a/test/xpu_api/random/conformance_tests/common_for_conformance_tests.hpp
+++ b/test/xpu_api/random/conformance_tests/common_for_conformance_tests.hpp
@@ -17,8 +17,8 @@
 //
 // Common functionality for conformance tests
 
-#ifndef DPSTD_RANDOM_CONFORMANCE_TESTS_COMMON
-#define DPSTD_RANDOM_CONFORMANCE_TESTS_COMMON
+#ifndef _DPSTD_RANDOM_CONFORMANCE_TESTS_COMMON_HPP
+#define _DPSTD_RANDOM_CONFORMANCE_TESTS_COMMON_HPP
 
 #include <vector>
 #include <random>
@@ -66,4 +66,4 @@ typename Engine::scalar_type test(sycl::queue& queue) {
     return dpstd_samples[REF_SAMPLE_ID];
 }
 
-#endif // ifndef DPSTD_RANDOM_CONFORMANCE_TESTS_COMMON
+#endif // _DPSTD_RANDOM_CONFORMANCE_TESTS_COMMON_HPP

--- a/test/xpu_api/random/device_tests/common_for_device_tests.h
+++ b/test/xpu_api/random/device_tests/common_for_device_tests.h
@@ -17,8 +17,8 @@
 //
 // Common functionality for device tests
 
-#ifndef _ONEDPL_RANDOM_DEVICE_TESTS_COMMON
-#define _ONEDPL_RANDOM_DEVICE_TESTS_COMMON
+#ifndef _ONEDPL_RANDOM_DEVICE_TESTS_COMMON_H
+#define _ONEDPL_RANDOM_DEVICE_TESTS_COMMON_H
 
 #include <oneapi/dpl/random>
 #include <limits>
@@ -104,4 +104,4 @@ int device_copyable_test(sycl::queue& queue) {
     return comparison(r_dev, r_host, N);
 }
 
-#endif // ifndef _ONEDPL_RANDOM_DEVICE_TESTS_COMMON
+#endif // _ONEDPL_RANDOM_DEVICE_TESTS_COMMON_H


### PR DESCRIPTION
In this PR we fix include guard names in oneDPL header files to common standard like:

- Do not change the name of the guards (only capitalize)
- Only fix two underscores to make it consistent
- Fix closing #endif comments to make them consistent (like //_ONEDPL_PARALLEL_BACKEND_OMP_H)
- Add _H / _HPP at the end no additional changes inside guard names