### PR TITLE
Make the loop boundaries uniform for group operations

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -497,7 +497,7 @@ __radix_sort_reorder_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments,
                 ::std::size_t __seg_end =
                     sycl::min(__seg_start + __block_size * __blocks_per_segment, __inout_buf_size);
                 // ensure that each work item in a subgroup does the same number of loop iterations
-                const ::std::uint32_t __residual = (__seg_end - __seg_start) % __sg_size;
+                const ::std::uint16_t __residual = (__seg_end - __seg_start) % __sg_size;
                 __seg_end -= __residual;
 
                 // find offsets for the same values within a segment and fill the resulting buffer
@@ -515,7 +515,7 @@ __radix_sort_reorder_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments,
                         ::std::uint32_t __is_current_bucket = (__bucket == __radix_state_idx);
                         ::std::uint32_t __sg_total_offset = __peer_prefix_hlp.__peer_contribution(
                             __new_offset_idx, __offset_arr[__radix_state_idx], __is_current_bucket);
-                        __offset_arr[__radix_state_idx] = __offset_arr[__radix_state_idx] + __sg_total_offset;
+                        __offset_arr[__radix_state_idx] += __sg_total_offset;
                     }
                     __output_rng[__new_offset_idx] = __in_val;
                 }
@@ -535,7 +535,7 @@ __radix_sort_reorder_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments,
                         ::std::uint32_t __is_current_bucket = (__bucket == __radix_state_idx);
                         ::std::uint32_t __sg_total_offset = __peer_prefix_hlp.__peer_contribution(
                             __new_offset_idx, __offset_arr[__radix_state_idx], __is_current_bucket);
-                        __offset_arr[__radix_state_idx] = __offset_arr[__radix_state_idx] + __sg_total_offset;
+                        __offset_arr[__radix_state_idx] += __sg_total_offset;
                     }
                     if (__self_lidx < __residual)
                         __output_rng[__new_offset_idx] = __in_val;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -402,8 +402,7 @@ struct __peer_prefix_helper<_OffsetT, __peer_prefix_algo::subgroup_ballot>
         __peer_mask.extract_bits(__peer_mask_bits);
         ::std::uint32_t __sg_total_offset = sycl::popcount(__peer_mask_bits);
 
-        // get the local offset index from the bits set in the peer mask with index less than the work
-        // items's ID
+        // get the local offset index from the bits set in the peer mask with index less than the work item ID
         __peer_mask &= __item_sg_mask;
         __peer_mask.extract_bits(__peer_mask_bits);
         __new_offset_idx |= __is_current_bucket * (__offset_prefix + sycl::popcount(__peer_mask_bits));
@@ -470,7 +469,7 @@ __radix_sort_reorder_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments,
                 // item info
                 const ::std::size_t __self_lidx = __self_item.get_local_id(0);
                 const ::std::size_t __wgroup_idx = __self_item.get_group(0);
-                const ::std::size_t __start_idx = __blocks_per_segment * __block_size * __wgroup_idx + __self_lidx;
+                const ::std::size_t __seg_start = __blocks_per_segment * __block_size * __wgroup_idx;
 
                 _PeerHelper __peer_prefix_hlp(__self_item, __peer_temp);
 
@@ -491,14 +490,12 @@ __radix_sort_reorder_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments,
                     __offset_arr[__radix_state_idx] = __scanned_bin + __offset_rng[__local_offset_idx];
                 }
 
-                const ::std::size_t __outside_of_segment =
-                    sycl::min(__start_idx + __block_size * __blocks_per_segment, __inout_buf_size);
-                const ::std::uint32_t __residual = __outside_of_segment % __sg_size;
-                const ::std::size_t __end_idx = __outside_of_segment - __residual;
-
+                ::std::size_t __seg_end =
+                    sycl::min(__seg_start + __block_size * __blocks_per_segment, __inout_buf_size);
+                const ::std::uint32_t __residual = (__seg_end - __seg_start) % __sg_size;
+                __seg_end -= __residual;
                 // find offsets for the same values within a segment and fill the resulting buffer
-                ::std::size_t __val_idx;
-                for (__val_idx = __start_idx; __val_idx < __end_idx; __val_idx += __sg_size)
+                for (::std::size_t __val_idx = __seg_start + __self_lidx; __val_idx < __seg_end; __val_idx += __sg_size)
                 {
                     _InputT __in_val = __input_rng[__val_idx];
                     // get the bucket for the bit-ordered input value, applying the offset and mask for radix bits
@@ -518,16 +515,12 @@ __radix_sort_reorder_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments,
                 if (__residual > 0)
                 {
                     _InputT __in_val{};
-                    ::std::uint32_t __bucket;
+                    ::std::uint32_t __bucket = __radix_states; // greater than any actual radix state
                     if (__self_lidx < __residual)
                     {
-                        __in_val = __input_rng[__val_idx];
+                        __in_val = __input_rng[__seg_end + __self_lidx];
                         __bucket = __get_bucket<(1 << __radix_bits) - 1>(
                             __order_preserving_cast<__is_ascending>(__in_val), __radix_offset);
-                    }
-                    else
-                    {
-                        __bucket = __radix_states; // does not match any real radix state
                     }
                     _OffsetT __new_offset_idx = 0;
                     for (::std::uint32_t __radix_state_idx = 0; __radix_state_idx < __radix_states; ++__radix_state_idx)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -186,14 +186,15 @@ __radix_sort_count_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments, :
                 // item info
                 const ::std::size_t __self_lidx = __self_item.get_local_id(0);
                 const ::std::size_t __wgroup_idx = __self_item.get_group(0);
-                const ::std::size_t __start_idx = __blocks_per_segment * __block_size * __wgroup_idx + __self_lidx;
+                const ::std::size_t __seg_start = __blocks_per_segment * __block_size * __wgroup_idx;
 
                 // 1.1. count per witem: create a private array for storing count values
                 _CountT __count_arr[__radix_states] = {0};
                 // 1.2. count per witem: count values and write result to private count array
-                const ::std::size_t __outside_of_segment =
-                    sycl::min(__start_idx + __block_size * __blocks_per_segment, __val_buf_size);
-                for (::std::size_t __val_idx = __start_idx; __val_idx < __outside_of_segment; __val_idx += __block_size)
+                const ::std::size_t __seg_end =
+                    sycl::min(__seg_start + __block_size * __blocks_per_segment, __val_buf_size);
+                for (::std::size_t __val_idx = __seg_start + __self_lidx; __val_idx < __seg_end;
+                     __val_idx += __block_size)
                 {
                     // get the bucket for the bit-ordered input value, applying the offset and mask for radix bits
                     auto __val = __order_preserving_cast<__is_ascending>(__val_rng[__val_idx]);


### PR DESCRIPTION
The implementation of reorder phase made in PR #716 has an issue of making the loop boundaries non-uniform within a workgroup/subgroup. This have made the use of group operations (in "peer contribution") incorrect, and caused test failures.

The patch makes the loop boundaries uniform, with the non-uniform residual processed separately after the loop. Also, a similar loop in the count phase is modified to use a similar approach for computing the loop boundary, though still leaves it non-uniform, as group operations are not used there.