### PR TITLE
[oneDPL] radix sort: moved some type aliases to place of using ones

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -679,7 +679,7 @@ __parallel_radix_sort(_ExecutionPolicy&& __exec, _Range&& __in_rng)
     {
         // Injecting ascending / descending status into a kernel name to prevent clashing kernel names
         using _RadixBitsType = ::std::integral_constant<::std::uint32_t, __radix_bits>;
-        using _AscendingType = ::std::bool_constant<__is_ascending>;        
+        using _AscendingType = ::std::bool_constant<__is_ascending>;
         using _CustomName = typename __decay_t<_ExecutionPolicy>::kernel_name;
         using _RadixSortKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
             __radix_sort_one_group, _CustomName, _RadixBitsType, _AscendingType, __decay_t<_Range>>;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -677,10 +677,9 @@ __parallel_radix_sort(_ExecutionPolicy&& __exec, _Range&& __in_rng)
     constexpr auto __wg_size = 64;
     if (__n <= 32768 && __wg_size * 8 <= __max_wg_size)
     {
+        // Injecting ascending / descending status into a kernel name to prevent clashing kernel names
         using _RadixBitsType = ::std::integral_constant<::std::uint32_t, __radix_bits>;
-        using _AscendingType = ::std::bool_constant<__is_ascending>;
-        
-        // Injecting ascending / descending status into custom name to prevent clashing kernel names
+        using _AscendingType = ::std::bool_constant<__is_ascending>;        
         using _CustomName = typename __decay_t<_ExecutionPolicy>::kernel_name;
         using _RadixSortKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
             __radix_sort_one_group, _CustomName, _RadixBitsType, _AscendingType, __decay_t<_Range>>;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -666,11 +666,6 @@ __parallel_radix_sort(_ExecutionPolicy&& __exec, _Range&& __in_rng)
     // radix bits represent number of processed bits in each value during one iteration
     constexpr ::std::uint32_t __radix_bits = 4;
 
-    // Injecting ascending / descending status into custom name to prevent clashing kernel names
-    using _RadixBitsType = ::std::integral_constant<::std::uint32_t, __radix_bits>;
-    using _AscendingType = ::std::bool_constant<__is_ascending>;
-    using _CustomName = typename __decay_t<_ExecutionPolicy>::kernel_name;
-
     sycl::buffer<::std::uint32_t, 1> __tmp_buf(sycl::range<1>(0));
     sycl::buffer<_T, 1> __val_buf(sycl::range<1>(0));
     sycl::event __event{};
@@ -682,6 +677,11 @@ __parallel_radix_sort(_ExecutionPolicy&& __exec, _Range&& __in_rng)
     constexpr auto __wg_size = 64;
     if (__n <= 32768 && __wg_size * 8 <= __max_wg_size)
     {
+        using _RadixBitsType = ::std::integral_constant<::std::uint32_t, __radix_bits>;
+        using _AscendingType = ::std::bool_constant<__is_ascending>;
+        
+        // Injecting ascending / descending status into custom name to prevent clashing kernel names
+        using _CustomName = typename __decay_t<_ExecutionPolicy>::kernel_name;
         using _RadixSortKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
             __radix_sort_one_group, _CustomName, _RadixBitsType, _AscendingType, __decay_t<_Range>>;
 


### PR DESCRIPTION
[oneDPL] radix sort: moved some type aliases to place of using ones.