### PR TITLE
Fix error in iterator comparison

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -183,8 +183,8 @@ __pattern_transform_scan_base(_ExecutionPolicy&& __exec, _Iterator1 __first, _It
     const auto __n = __last - __first;
 
     // This is a temporary workaround for an in-place exclusive scan while the SYCL backend scan pattern is not fixed.
-    const bool bInplaceExclusiveScan = __n > 1 && !_Inclusive{} && __is_equal_iterators(__first, __result);
-    if (!bInplaceExclusiveScan)
+    const bool __is_scan_inplace_exclusive = __n > 1 && !_Inclusive{} && __is_equal_iterators(__first, __result);
+    if (!__is_scan_inplace_exclusive)
     {
         __pattern_transform_scan_base_impl(__exec, __first, __last, __result, __unary_op, __init, __binary_op,
                                            _Inclusive{});

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -166,7 +166,7 @@ template <typename Iterator1, typename Iterator2, std::enable_if_t<!std::is_same
 constexpr bool
 __is_equal_iterators(Iterator1 it1, Iterator2 it2)
 {
-    static_assert("In-place exclusive scan works correctly only if an input and an output iterators are the same type.");
+    // In-place exclusive scan works correctly only if an input and an output iterators are the same type.
     return false;
 }
 

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -155,17 +155,18 @@ __pattern_transform_scan_base_impl(_ExecutionPolicy&& __exec, _Iterator1 __first
         .wait();
 }
 
-template <typename Iterator1, typename Iterator2, std::enable_if_t<std::is_same_v<Iterator1, Iterator2>, int> = 0>
+template <typename Iterator1, typename Iterator2>
 constexpr bool
 __is_equal_iterators(Iterator1 it1, Iterator2 it2)
 {
-    return it1 == it2;
-}
+    using DecayIt1 = std::decay_t<Iterator1>;
+    using DecayIt2 = std::decay_t<Iterator2>;
 
-template <typename Iterator1, typename Iterator2, std::enable_if_t<!std::is_same_v<Iterator1, Iterator2>, int> = 0>
-constexpr bool
-__is_equal_iterators(Iterator1 it1, Iterator2 it2)
-{
+    if constexpr (std::is_same_v<DecayIt1, DecayIt2>)
+    {
+        return it1 == it2;
+    }
+
     // In-place exclusive scan works correctly only if an input and an output iterators are the same type.
     return false;
 }

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -159,12 +159,9 @@ template <typename _Iterator1, typename _Iterator2>
 constexpr bool
 __check_equal_iterators(_Iterator1 __it1, _Iterator2 __it2)
 {
-    using _Decay_Iterator1 = std::decay_t<_Iterator1>;
-    using _Decay_Iterator2 = std::decay_t<_Iterator2>;
-
     // In-place exclusive scan works correctly only if an input and an output iterators are the same type.
     // Otherwise, there is no way to check an in-place case and a workaround below is not applied.
-    if constexpr (std::is_same_v<_Decay_Iterator1, _Decay_Iterator2>)
+    if constexpr (::std::is_same_v<::std::decay_t<_Iterator1>, ::std::decay_t<_Iterator2>>)
     {
         return __it1 == __it2;
     }

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -155,26 +155,19 @@ __pattern_transform_scan_base_impl(_ExecutionPolicy&& __exec, _Iterator1 __first
         .wait();
 }
 
-template <typename Iterator>
-bool
-__is_equal_iterators_impl(Iterator it1, Iterator it2)
+template <typename Iterator1, typename Iterator2, std::enable_if_t<std::is_same_v<Iterator1, Iterator2>, int> = 0>
+constexpr bool
+__is_equal_iterators(Iterator1 it1, Iterator2 it2)
 {
     return it1 == it2;
 }
 
-template <typename Iterator1, typename Iterator2>
-bool
-__is_equal_iterators_impl(Iterator1 it1, Iterator2 it2)
+template <typename Iterator1, typename Iterator2, std::enable_if_t<!std::is_same_v<Iterator1, Iterator2>, int> = 0>
+constexpr bool
+__is_equal_iterators(Iterator1 it1, Iterator2 it2)
 {
     static_assert("In-place exclusive scan works correctly only if an input and an output iterators are the same type.");
     return false;
-}
-
-template <typename Iterator1, typename Iterator2>
-bool
-__is_equal_iterators(Iterator1 it1, Iterator2 it2)
-{
-    return __is_equal_iterators_impl(::std::decay_t<Iterator1>(it1), ::std::decay_t<Iterator2>(it2));
 }
 
 template <typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2, typename _UnaryOperation,

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -170,13 +170,6 @@ __is_equal_iterators_impl(Iterator1 it1, Iterator2 it2)
     return false;
 }
 
-template <typename Iterator>
-bool
-__is_equal_iterators(Iterator it1, Iterator it2)
-{
-    return __is_equal_iterators_impl(it1, it2);
-}
-
 template <typename Iterator1, typename Iterator2>
 bool
 __is_equal_iterators(Iterator1 it1, Iterator2 it2)

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -155,14 +155,14 @@ __pattern_transform_scan_base_impl(_ExecutionPolicy&& __exec, _Iterator1 __first
         .wait();
 }
 
-template <typename Iterator1, typename Iterator2>
+template <typename _Iterator1, typename _Iterator2>
 constexpr bool
-__is_equal_iterators(Iterator1 it1, Iterator2 it2)
+__is_equal_iterators(_Iterator1 it1, _Iterator2 it2)
 {
-    using DecayIt1 = std::decay_t<Iterator1>;
-    using DecayIt2 = std::decay_t<Iterator2>;
+    using _Decay_Iterator1 = std::decay_t<_Iterator1>;
+    using _Decay_Iterator2 = std::decay_t<_Iterator2>;
 
-    if constexpr (std::is_same_v<DecayIt1, DecayIt2>)
+    if constexpr (std::is_same_v<_Decay_Iterator1, _Decay_Iterator2>)
     {
         return it1 == it2;
     }

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -162,12 +162,13 @@ __check_equal_iterators(_Iterator1 it1, _Iterator2 it2)
     using _Decay_Iterator1 = std::decay_t<_Iterator1>;
     using _Decay_Iterator2 = std::decay_t<_Iterator2>;
 
+    // In-place exclusive scan works correctly only if an input and an output iterators are the same type.
+    // Otherwise, there is no way to check an in-place case and a workaround below is not applied.
     if constexpr (std::is_same_v<_Decay_Iterator1, _Decay_Iterator2>)
     {
         return it1 == it2;
     }
 
-    // In-place exclusive scan works correctly only if an input and an output iterators are the same type.
     return false;
 }
 

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -155,19 +155,16 @@ __pattern_transform_scan_base_impl(_ExecutionPolicy&& __exec, _Iterator1 __first
         .wait();
 }
 
-template <typename Iterator1, typename Iterator2, std::enable_if_t<std::is_same_v<Iterator1, Iterator2>, int> = 0>
+template <typename Iterator1, typename Iterator2>
 constexpr bool
 __is_equal_iterators(Iterator1 it1, Iterator2 it2)
 {
-    return it1 == it2;
-}
+    if constexpr (!std::is_same_v<Iterator1, Iterator2>)
+    {
+        static_assert("In-place exclusive scan works correctly only if an input and an output iterators are the same type.");
+    }
 
-template <typename Iterator1, typename Iterator2, std::enable_if_t<!std::is_same_v<Iterator1, Iterator2>, int> = 0>
-constexpr bool
-__is_equal_iterators(Iterator1 it1, Iterator2 it2)
-{
-    static_assert("In-place exclusive scan works correctly only if an input and an output iterators are the same type.");
-    return false;
+    return it1 == it2;
 }
 
 template <typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2, typename _UnaryOperation,

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -157,7 +157,7 @@ __pattern_transform_scan_base_impl(_ExecutionPolicy&& __exec, _Iterator1 __first
 
 template <typename _Iterator1, typename _Iterator2>
 constexpr bool
-__is_equal_iterators(_Iterator1 it1, _Iterator2 it2)
+__check_equal_iterators(_Iterator1 it1, _Iterator2 it2)
 {
     using _Decay_Iterator1 = std::decay_t<_Iterator1>;
     using _Decay_Iterator2 = std::decay_t<_Iterator2>;
@@ -183,7 +183,7 @@ __pattern_transform_scan_base(_ExecutionPolicy&& __exec, _Iterator1 __first, _It
     const auto __n = __last - __first;
 
     // This is a temporary workaround for an in-place exclusive scan while the SYCL backend scan pattern is not fixed.
-    const bool __is_scan_inplace_exclusive = __n > 1 && !_Inclusive{} && __is_equal_iterators(__first, __result);
+    const bool __is_scan_inplace_exclusive = __n > 1 && !_Inclusive{} && __check_equal_iterators(__first, __result);
     if (!__is_scan_inplace_exclusive)
     {
         __pattern_transform_scan_base_impl(__exec, __first, __last, __result, __unary_op, __init, __binary_op,
@@ -193,7 +193,7 @@ __pattern_transform_scan_base(_ExecutionPolicy&& __exec, _Iterator1 __first, _It
     {
         assert(__n > 1);
         assert(!_Inclusive{});
-        assert(__is_equal_iterators(__first, __result));
+        assert(__check_equal_iterators(__first, __result));
 
         using _Type = typename _InitType::__value_type;
 

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -155,6 +155,35 @@ __pattern_transform_scan_base_impl(_ExecutionPolicy&& __exec, _Iterator1 __first
         .wait();
 }
 
+template <typename Iterator>
+bool
+__is_equal_iterators_impl(Iterator it1, Iterator it2)
+{
+    return it1 == it2;
+}
+
+template <typename Iterator1, typename Iterator2>
+bool
+__is_equal_iterators_impl(Iterator1 it1, Iterator2 it2)
+{
+    static_assert("Unable to compare the iterators of different types");
+    return false;
+}
+
+template <typename Iterator>
+bool
+__is_equal_iterators(Iterator it1, Iterator it2)
+{
+    return __is_equal_iterators_impl(it1, it2);
+}
+
+template <typename Iterator1, typename Iterator2>
+bool
+__is_equal_iterators(Iterator1 it1, Iterator2 it2)
+{
+    return __is_equal_iterators_impl(::std::decay_t<Iterator1>(it1), ::std::decay_t<Iterator2>(it2));
+}
+
 template <typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2, typename _UnaryOperation,
           typename _InitType, typename _BinaryOperation, typename _Inclusive>
 oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, _Iterator2>
@@ -167,7 +196,7 @@ __pattern_transform_scan_base(_ExecutionPolicy&& __exec, _Iterator1 __first, _It
     const auto __n = __last - __first;
 
     // This is a temporary workaround for an in-place exclusive scan while the SYCL backend scan pattern is not fixed.
-    const bool bInplaceExclusiveScan = __n > 1 && !_Inclusive{} && __first == __result;
+    const bool bInplaceExclusiveScan = __n > 1 && !_Inclusive{} && __is_equal_iterators(__first, __result);
     if (!bInplaceExclusiveScan)
     {
         __pattern_transform_scan_base_impl(__exec, __first, __last, __result, __unary_op, __init, __binary_op,
@@ -177,7 +206,7 @@ __pattern_transform_scan_base(_ExecutionPolicy&& __exec, _Iterator1 __first, _It
     {
         assert(__n > 1);
         assert(!_Inclusive{});
-        assert(__result == __first);
+        assert(__is_equal_iterators(__first, __result));
 
         using _Type = typename _InitType::__value_type;
 

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -155,16 +155,19 @@ __pattern_transform_scan_base_impl(_ExecutionPolicy&& __exec, _Iterator1 __first
         .wait();
 }
 
-template <typename Iterator1, typename Iterator2>
+template <typename Iterator1, typename Iterator2, std::enable_if_t<std::is_same_v<Iterator1, Iterator2>, int> = 0>
 constexpr bool
 __is_equal_iterators(Iterator1 it1, Iterator2 it2)
 {
-    if constexpr (!std::is_same_v<Iterator1, Iterator2>)
-    {
-        static_assert("In-place exclusive scan works correctly only if an input and an output iterators are the same type.");
-    }
-
     return it1 == it2;
+}
+
+template <typename Iterator1, typename Iterator2, std::enable_if_t<!std::is_same_v<Iterator1, Iterator2>, int> = 0>
+constexpr bool
+__is_equal_iterators(Iterator1 it1, Iterator2 it2)
+{
+    static_assert("In-place exclusive scan works correctly only if an input and an output iterators are the same type.");
+    return false;
 }
 
 template <typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2, typename _UnaryOperation,

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -157,7 +157,7 @@ __pattern_transform_scan_base_impl(_ExecutionPolicy&& __exec, _Iterator1 __first
 
 template <typename _Iterator1, typename _Iterator2>
 constexpr bool
-__check_equal_iterators(_Iterator1 it1, _Iterator2 it2)
+__check_equal_iterators(_Iterator1 __it1, _Iterator2 __it2)
 {
     using _Decay_Iterator1 = std::decay_t<_Iterator1>;
     using _Decay_Iterator2 = std::decay_t<_Iterator2>;
@@ -166,7 +166,7 @@ __check_equal_iterators(_Iterator1 it1, _Iterator2 it2)
     // Otherwise, there is no way to check an in-place case and a workaround below is not applied.
     if constexpr (std::is_same_v<_Decay_Iterator1, _Decay_Iterator2>)
     {
-        return it1 == it2;
+        return __it1 == __it2;
     }
 
     return false;

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -166,7 +166,7 @@ template <typename Iterator1, typename Iterator2>
 bool
 __is_equal_iterators_impl(Iterator1 it1, Iterator2 it2)
 {
-    static_assert("Unable to compare the iterators of different types");
+    static_assert("In-place exclusive scan works correctly only if an input and an output iterators are the same type.");
     return false;
 }
 


### PR DESCRIPTION
In this PR we fix an error in the comparison of input and output iterators which was introduced in https://github.com/oneapi-src/oneDPL/pull/761 :
in this comparison we receive compile error in DPC++ compiler (win) ```Error GE509BDA3 invalid operands to binary expression```