### PR TITLE
Address SYCL 2020 deprecations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,9 +145,9 @@ if (ONEDPL_BACKEND MATCHES "^(tbb|dpcpp|dpcpp_only)$")
                 string(TOLOWER ${ONEDPL_AOT_ARCH} ONEDPL_AOT_ARCH)
                 message(STATUS "Ahead of time compilation for ${ONEDPL_AOT_ARCH} architecture")
             endif()
-            set(ONEDPL_AOT_COMP_OPTION_REL "-Xs \"-device ${ONEDPL_AOT_ARCH}\"")
-            set(ONEDPL_AOT_COMP_OPTION_DEB "-Xs \"-device ${ONEDPL_AOT_ARCH} -internal_options -cl-kernel-debug-enable -options -cl-opt-disable\"")
-            set(ONEDPL_AOT_COMP_OPTION_RELDEB "-Xs \"-device ${ONEDPL_AOT_ARCH} -internal_options -cl-kernel-debug-enable\"")
+            set(ONEDPL_AOT_COMP_OPTION_REL "-Xsycl-target-backend \"-device ${ONEDPL_AOT_ARCH}\"")
+            set(ONEDPL_AOT_COMP_OPTION_DEB "-Xsycl-target-backend \"-device ${ONEDPL_AOT_ARCH} -internal_options -cl-kernel-debug-enable -options -cl-opt-disable\"")
+            set(ONEDPL_AOT_COMP_OPTION_RELDEB "-Xsycl-target-backend \"-device ${ONEDPL_AOT_ARCH} -internal_options -cl-kernel-debug-enable\"")
         endif()
 
         # check device type
@@ -210,7 +210,7 @@ if (ONEDPL_BACKEND MATCHES "^(tbb|dpcpp|dpcpp_only)$")
             $<$<OR:$<BOOL:${ONEDPL_USE_DEVICE_FPGA_HW}>,$<BOOL:${ONEDPL_USE_DEVICE_FPGA_EMU}>>:-fintelfpga>
             $<$<BOOL:${ONEDPL_USE_DEVICE_FPGA_HW}>:-Xshardware>
             $<$<AND:$<BOOL:${ONEDPL_USE_DEVICE_FPGA_HW}>,$<BOOL:${ONEDPL_FPGA_STATIC_REPORT}>>:-fsycl-link>
-            $<$<BOOL:${ONEDPL_USE_AOT_COMPILATION}>:-fsycl-targets=spir64_gen-unknown-unknown-sycldevice>
+            $<$<BOOL:${ONEDPL_USE_AOT_COMPILATION}>:-fsycl-targets=spir64_gen>
             $<$<AND:$<CONFIG:Release>,$<BOOL:${ONEDPL_USE_AOT_COMPILATION}>>:${ONEDPL_AOT_COMP_OPTION_REL}>
             $<$<AND:$<CONFIG:Debug>,$<BOOL:${ONEDPL_USE_AOT_COMPILATION}>>:${ONEDPL_AOT_COMP_OPTION_DEB}>
             $<$<AND:$<CONFIG:RelWithDebInfo>,$<BOOL:${ONEDPL_USE_AOT_COMPILATION}>>:${ONEDPL_AOT_COMP_OPTION_RELDEB}>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,9 +145,9 @@ if (ONEDPL_BACKEND MATCHES "^(tbb|dpcpp|dpcpp_only)$")
                 string(TOLOWER ${ONEDPL_AOT_ARCH} ONEDPL_AOT_ARCH)
                 message(STATUS "Ahead of time compilation for ${ONEDPL_AOT_ARCH} architecture")
             endif()
-            set(ONEDPL_AOT_COMP_OPTION_REL "-Xsycl-target-backend \"-device ${ONEDPL_AOT_ARCH}\"")
-            set(ONEDPL_AOT_COMP_OPTION_DEB "-Xsycl-target-backend \"-device ${ONEDPL_AOT_ARCH} -internal_options -cl-kernel-debug-enable -options -cl-opt-disable\"")
-            set(ONEDPL_AOT_COMP_OPTION_RELDEB "-Xsycl-target-backend \"-device ${ONEDPL_AOT_ARCH} -internal_options -cl-kernel-debug-enable\"")
+            set(ONEDPL_AOT_COMP_OPTION_REL "-Xs \"-device ${ONEDPL_AOT_ARCH}\"")
+            set(ONEDPL_AOT_COMP_OPTION_DEB "-Xs \"-device ${ONEDPL_AOT_ARCH} -internal_options -cl-kernel-debug-enable -options -cl-opt-disable\"")
+            set(ONEDPL_AOT_COMP_OPTION_RELDEB "-Xs \"-device ${ONEDPL_AOT_ARCH} -internal_options -cl-kernel-debug-enable\"")
         endif()
 
         # check device type

--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -118,7 +118,7 @@ exclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIter
     internal::__buffer<policy_type, FlagType> _flags(policy, n);
     {
         auto flag_buf = _flags.get_buffer();
-        auto flags = flag_buf.get_host_access();
+        auto flags = flag_buf.get_host_access(sycl::read_write);
         flags[0] = 1;
     }
 
@@ -129,7 +129,7 @@ exclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIter
     internal::__buffer<policy_type, OutputType> _temp(policy, n);
     {
         auto temp_buf = _temp.get_buffer();
-        auto temp = temp_buf.get_host_access();
+        auto temp = temp_buf.get_host_access(sycl::read_write);
 
         temp[0] = init;
     }

--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -118,7 +118,7 @@ exclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIter
     internal::__buffer<policy_type, FlagType> _flags(policy, n);
     {
         auto flag_buf = _flags.get_buffer();
-        auto flags = flag_buf.template get_access<sycl::access::mode::read_write>();
+        auto flags = flag_buf.get_host_access();
         flags[0] = 1;
     }
 
@@ -129,7 +129,7 @@ exclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIter
     internal::__buffer<policy_type, OutputType> _temp(policy, n);
     {
         auto temp_buf = _temp.get_buffer();
-        auto temp = temp_buf.template get_access<sycl::access::mode::read_write>();
+        auto temp = temp_buf.get_host_access();
 
         temp[0] = init;
     }

--- a/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
@@ -94,7 +94,7 @@ inclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIter
     internal::__buffer<policy_type, FlagType> _mask(policy, n);
     {
         auto mask_buf = _mask.get_buffer();
-        auto mask = mask_buf.get_host_access();
+        auto mask = mask_buf.get_host_access(sycl::read_write);
 
         mask[0] = initial_mask;
     }

--- a/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
@@ -94,7 +94,7 @@ inclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIter
     internal::__buffer<policy_type, FlagType> _mask(policy, n);
     {
         auto mask_buf = _mask.get_buffer();
-        auto mask = mask_buf.template get_access<sycl::access::mode::read_write>();
+        auto mask = mask_buf.get_host_access();
 
         mask[0] = initial_mask;
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -63,7 +63,7 @@ using __enable_if_t = typename ::std::enable_if<__flag, _T>::type;
 // Bitwise type casting, same as C++20 std::bit_cast
 template <typename _Dst, typename _Src>
 __enable_if_t<
-    sizeof(_Dst) == sizeof(_Src) && ::std::is_trivially_copyable_v<_Dst> && ::std::is_trivially_copyable_v<_Src>, _Dst>
+    sizeof(_Dst) == sizeof(_Src) && ::std::is_trivially_copyable_v<_Dst>&& ::std::is_trivially_copyable_v<_Src>, _Dst>
 __dpl_bit_cast(const _Src& __src) noexcept
 {
 #if _ONEDPL_LIBSYCL_VERSION >= 50300
@@ -81,10 +81,11 @@ __dpl_bit_cast(const _Src& __src) noexcept
 
 // The max power of 2 not exceeding the given value, same as C++20 std::bit_floor
 template <typename _T>
-__enable_if_t<::std::is_integral<_T>::value && ::std::is_unsigned<_T>::value, _T>
+__enable_if_t<::std::is_integral<_T>::value&& ::std::is_unsigned<_T>::value, _T>
 __dpl_bit_floor(_T __x) noexcept
 {
-    if (__x == 0) return 0;
+    if (__x == 0)
+        return 0;
 #if SYCL_LANGUAGE_VERSION
     // Use the count-leading-zeros function
     return 1 << (sycl::clz(_T{0}) - sycl::clz(__x) - 1);
@@ -95,9 +96,12 @@ __dpl_bit_floor(_T __x) noexcept
     __x |= (__x >> 1);
     __x |= (__x >> 2);
     __x |= (__x >> 4);
-    if constexpr (sizeof(_T) > 1) __x |= (__x >> 8);
-    if constexpr (sizeof(_T) > 2) __x |= (__x >> 16);
-    if constexpr (sizeof(_T) > 4) __x |= (__x >> 32);
+    if constexpr (sizeof(_T) > 1)
+        __x |= (__x >> 8);
+    if constexpr (sizeof(_T) > 2)
+        __x |= (__x >> 16);
+    if constexpr (sizeof(_T) > 4)
+        __x |= (__x >> 32);
     __x += 1; // Now it equals to the next greater power of 2, or 0 in case of wraparound
     return (__x == 0) ? 1 << (sizeof(_T) * 8 - 1) : __x >> 1;
 #endif
@@ -491,7 +495,7 @@ class __future : private std::tuple<_Args...>
         return __val;
     }
 
-public:
+  public:
     __future(_Event __e, _Args... __args) : std::tuple<_Args...>(__args...), __my_event(__e) {}
     __future(_Event __e, std::tuple<_Args...> __t) : std::tuple<_Args...>(__t), __my_event(__e) {}
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -480,7 +480,7 @@ class __future : private std::tuple<_Args...>
     __wait_and_get_value(sycl::buffer<_T>& __buf)
     {
         //according to a contract, returned value is one-element sycl::buffer
-        return __buf.get_host_access()[0];
+        return __buf.get_host_access(sycl::read_only)[0];
     }
 
     template <typename _T>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -480,7 +480,7 @@ class __future : private std::tuple<_Args...>
     __wait_and_get_value(sycl::buffer<_T>& __buf)
     {
         //according to a contract, returned value is one-element sycl::buffer
-        return __buf.template get_access<access_mode::read>()[0];
+        return __buf.get_host_access()[0];
     }
 
     template <typename _T>

--- a/test/parallel_api/experimental/asynch.pass.cpp
+++ b/test/parallel_api/experimental/asynch.pass.cpp
@@ -78,7 +78,7 @@ void test1_with_buffers()
         const int expected1 = (n * (n + 1) / 2) * ((n + 3) * (n + 4) / 2 - 6);
         const int expected2 = (n * (n + 1) / 2) * 10;
         auto result1 = beta.get();
-        auto result2 = y.get_access<sycl::access::mode::read>()[0];
+        auto result2 = y.get_host_access()[0];
 
         EXPECT_TRUE(result1 == expected1 && result2 == expected2, "wrong effect from async test (I) with sycl buffer");
     }
@@ -108,8 +108,8 @@ void test2_with_buffers()
         auto my_policy7 = oneapi::dpl::execution::make_device_policy<class Scan2b>(my_policy);
         auto gamma = oneapi::dpl::experimental::inclusive_scan_async(my_policy7, input1, input1 + n, oneapi::dpl::begin(z), std::plus<float>(), 0.0f);
 
-        auto result1 = gamma.get().get_buffer().get_access<sycl::access::mode::read>()[n-1];
-        auto result2 = beta.get().get_buffer().get_access<sycl::access::mode::read>()[n-1];
+        auto result1 = gamma.get().get_buffer().get_host_access()[n-1];
+        auto result2 = beta.get().get_buffer().get_host_access()[n-1];
 
         const float expected1 = static_cast<float>(n * (n - 1) / 2);
         EXPECT_TRUE(fabs(result1-expected1) <= 0.001f && fabs(result2-expected1) <= 0.001f, "wrong effect from async test (II) with sycl buffer");

--- a/test/parallel_api/experimental/asynch.pass.cpp
+++ b/test/parallel_api/experimental/asynch.pass.cpp
@@ -78,7 +78,7 @@ void test1_with_buffers()
         const int expected1 = (n * (n + 1) / 2) * ((n + 3) * (n + 4) / 2 - 6);
         const int expected2 = (n * (n + 1) / 2) * 10;
         auto result1 = beta.get();
-        auto result2 = y.get_host_access()[0];
+        auto result2 = y.get_host_access(sycl::read_only)[0];
 
         EXPECT_TRUE(result1 == expected1 && result2 == expected2, "wrong effect from async test (I) with sycl buffer");
     }
@@ -108,8 +108,8 @@ void test2_with_buffers()
         auto my_policy7 = oneapi::dpl::execution::make_device_policy<class Scan2b>(my_policy);
         auto gamma = oneapi::dpl::experimental::inclusive_scan_async(my_policy7, input1, input1 + n, oneapi::dpl::begin(z), std::plus<float>(), 0.0f);
 
-        auto result1 = gamma.get().get_buffer().get_host_access()[n-1];
-        auto result2 = beta.get().get_buffer().get_host_access()[n-1];
+        auto result1 = gamma.get().get_buffer().get_host_access(sycl::read_only)[n-1];
+        auto result2 = beta.get().get_buffer().get_host_access(sycl::read_only)[n-1];
 
         const float expected1 = static_cast<float>(n * (n - 1) / 2);
         EXPECT_TRUE(fabs(result1-expected1) <= 0.001f && fabs(result2-expected1) <= 0.001f, "wrong effect from async test (II) with sycl buffer");

--- a/test/parallel_api/iterator/transform_iterator.pass.cpp
+++ b/test/parallel_api/iterator/transform_iterator.pass.cpp
@@ -90,7 +90,7 @@ void test_simple_copy(size_t buffer_size)
 
     int identity = 0;
     auto& sycl_src_buf = test_base_data.get_buffer(UDTKind::eKeys);
-    auto host_source_begin = sycl_src_buf.get_host_access(sycl::write).get_pointer();
+    auto host_source_begin = sycl_src_buf.get_host_access(sycl::write_only).get_pointer();
     ::std::fill_n(host_source_begin, buffer_size, identity);
 
     test_copy<int> test(test_base_data);
@@ -108,8 +108,8 @@ void test_ignore_copy(size_t buffer_size)
     auto& source_buf = test_base_data.get_buffer(UDTKind::eKeys);
     auto& result_buf = test_base_data.get_buffer(UDTKind::eVals);
 
-    auto host_source_begin = source_buf.get_host_access(sycl::write).get_pointer();
-    auto host_result_begin = result_buf.get_host_access(sycl::write).get_pointer();
+    auto host_source_begin = source_buf.get_host_access(sycl::write_only).get_pointer();
+    auto host_result_begin = result_buf.get_host_access(sycl::write_only).get_pointer();
 
     auto sycl_source_begin = oneapi::dpl::begin(source_buf);
     auto sycl_source_end = oneapi::dpl::end(source_buf);
@@ -140,7 +140,7 @@ void test_multi_transform_copy(size_t buffer_size)
     sycl::buffer<int>& source_buf = test_base_data.get_buffer(UDTKind::eKeys);
     sycl::buffer<int>& result_buf = test_base_data.get_buffer(UDTKind::eVals);
 
-    auto host_source_begin = source_buf.get_host_access(sycl::write).get_pointer();
+    auto host_source_begin = source_buf.get_host_access(sycl::write_only).get_pointer();
 
     auto sycl_source_begin = oneapi::dpl::begin(source_buf);
     auto sycl_source_end = sycl_source_begin + buffer_size;

--- a/test/parallel_api/iterator/transform_iterator.pass.cpp
+++ b/test/parallel_api/iterator/transform_iterator.pass.cpp
@@ -90,7 +90,7 @@ void test_simple_copy(size_t buffer_size)
 
     int identity = 0;
     auto& sycl_src_buf = test_base_data.get_buffer(UDTKind::eKeys);
-    auto host_source_begin = sycl_src_buf.get_access<sycl::access::mode::write>().get_pointer();
+    auto host_source_begin = sycl_src_buf.get_host_access().get_pointer();
     ::std::fill_n(host_source_begin, buffer_size, identity);
 
     test_copy<int> test(test_base_data);
@@ -108,8 +108,8 @@ void test_ignore_copy(size_t buffer_size)
     auto& source_buf = test_base_data.get_buffer(UDTKind::eKeys);
     auto& result_buf = test_base_data.get_buffer(UDTKind::eVals);
 
-    auto host_source_begin = source_buf.template get_access<sycl::access::mode::write>().get_pointer();
-    auto host_result_begin = result_buf.template get_access<sycl::access::mode::write>().get_pointer();
+    auto host_source_begin = source_buf.get_host_access().get_pointer();
+    auto host_result_begin = result_buf.get_host_access().get_pointer();
 
     auto sycl_source_begin = oneapi::dpl::begin(source_buf);
     auto sycl_source_end = oneapi::dpl::end(source_buf);
@@ -140,7 +140,7 @@ void test_multi_transform_copy(size_t buffer_size)
     sycl::buffer<int>& source_buf = test_base_data.get_buffer(UDTKind::eKeys);
     sycl::buffer<int>& result_buf = test_base_data.get_buffer(UDTKind::eVals);
 
-    auto host_source_begin = source_buf.template get_access<sycl::access::mode::write>().get_pointer();
+    auto host_source_begin = source_buf.get_host_access().get_pointer();
 
     auto sycl_source_begin = oneapi::dpl::begin(source_buf);
     auto sycl_source_end = sycl_source_begin + buffer_size;

--- a/test/parallel_api/iterator/transform_iterator.pass.cpp
+++ b/test/parallel_api/iterator/transform_iterator.pass.cpp
@@ -90,7 +90,7 @@ void test_simple_copy(size_t buffer_size)
 
     int identity = 0;
     auto& sycl_src_buf = test_base_data.get_buffer(UDTKind::eKeys);
-    auto host_source_begin = sycl_src_buf.get_host_access().get_pointer();
+    auto host_source_begin = sycl_src_buf.get_host_access(sycl::write).get_pointer();
     ::std::fill_n(host_source_begin, buffer_size, identity);
 
     test_copy<int> test(test_base_data);
@@ -108,8 +108,8 @@ void test_ignore_copy(size_t buffer_size)
     auto& source_buf = test_base_data.get_buffer(UDTKind::eKeys);
     auto& result_buf = test_base_data.get_buffer(UDTKind::eVals);
 
-    auto host_source_begin = source_buf.get_host_access().get_pointer();
-    auto host_result_begin = result_buf.get_host_access().get_pointer();
+    auto host_source_begin = source_buf.get_host_access(sycl::write).get_pointer();
+    auto host_result_begin = result_buf.get_host_access(sycl::write).get_pointer();
 
     auto sycl_source_begin = oneapi::dpl::begin(source_buf);
     auto sycl_source_end = oneapi::dpl::end(source_buf);
@@ -140,7 +140,7 @@ void test_multi_transform_copy(size_t buffer_size)
     sycl::buffer<int>& source_buf = test_base_data.get_buffer(UDTKind::eKeys);
     sycl::buffer<int>& result_buf = test_base_data.get_buffer(UDTKind::eVals);
 
-    auto host_source_begin = source_buf.get_host_access().get_pointer();
+    auto host_source_begin = source_buf.get_host_access(sycl::write).get_pointer();
 
     auto sycl_source_begin = oneapi::dpl::begin(source_buf);
     auto sycl_source_end = sycl_source_begin + buffer_size;

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -44,10 +44,10 @@ void test_with_buffers()
     sycl::buffer<T, 1> val_res_buf{ sycl::range<1>(13) };
 
     {
-        auto keys    = key_buf.get_host_access();
-        auto vals    = val_buf.get_host_access();
-        auto keys_res    = key_res_buf.get_host_access();
-        auto vals_res    = val_res_buf.get_host_access();
+        auto keys    = key_buf.get_host_access(sycl::read_write);
+        auto vals    = val_buf.get_host_access(sycl::read_write);
+        auto keys_res    = key_res_buf.get_host_access(sycl::read_write);
+        auto vals_res    = val_res_buf.get_host_access(sycl::read_write);
 
         //T keys[n1] = { 1, 2, 3, 4, 1, 1, 3, 3, 1, 1, 3, 3, 0 };
         //T vals[n1] = { 1, 2, 3, 4, 1, 1, 3, 3, 1, 1, 3, 3, 0 };
@@ -88,8 +88,8 @@ void test_with_buffers()
 
     {
         // check values
-        auto keys_res    = key_res_buf.get_host_access();
-        auto vals_res    = val_res_buf.get_host_access();
+        auto keys_res    = key_res_buf.get_host_access(sycl::read_write);
+        auto vals_res    = val_res_buf.get_host_access(sycl::read_write);
         int n = std::distance(key_res_beg, res1.first);
         for (auto i = 0; i != n; ++i) {
             if (i < 4) {

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -44,10 +44,10 @@ void test_with_buffers()
     sycl::buffer<T, 1> val_res_buf{ sycl::range<1>(13) };
 
     {
-        auto keys    = key_buf.template get_access<sycl::access::mode::read_write>();
-        auto vals    = val_buf.template get_access<sycl::access::mode::read_write>();
-        auto keys_res    = key_res_buf.template get_access<sycl::access::mode::read_write>();
-        auto vals_res    = val_res_buf.template get_access<sycl::access::mode::read_write>();
+        auto keys    = key_buf.get_host_access();
+        auto vals    = val_buf.get_host_access();
+        auto keys_res    = key_res_buf.get_host_access();
+        auto vals_res    = val_res_buf.get_host_access();
 
         //T keys[n1] = { 1, 2, 3, 4, 1, 1, 3, 3, 1, 1, 3, 3, 0 };
         //T vals[n1] = { 1, 2, 3, 4, 1, 1, 3, 3, 1, 1, 3, 3, 0 };
@@ -88,8 +88,8 @@ void test_with_buffers()
 
     {
         // check values
-        auto keys_res    = key_res_buf.template get_access<sycl::access::mode::read_write>();
-        auto vals_res    = val_res_buf.template get_access<sycl::access::mode::read_write>();
+        auto keys_res    = key_res_buf.get_host_access();
+        auto vals_res    = val_res_buf.get_host_access();
         int n = std::distance(key_res_beg, res1.first);
         for (auto i = 0; i != n; ++i) {
             if (i < 4) {

--- a/test/support/utils_test_base.h
+++ b/test/support/utils_test_base.h
@@ -550,7 +550,7 @@ void
 TestUtils::test_base_data_buffer<TestValueType>::retrieve_data(UDTKind kind, TestValueType* __it_from, TestValueType* __it_to)
 {
     auto& data_item = data.at(enum_val_to_index(kind));
-    auto acc = data_item.src_data_buf.template get_access<sycl::access::mode::read_write>();
+    auto acc = data_item.src_data_buf.get_host_access();
 
     auto __index = data_item.offset;
     for (auto __it = __it_from; __it != __it_to; ++__it, ++__index)
@@ -565,7 +565,7 @@ void
 TestUtils::test_base_data_buffer<TestValueType>::update_data(UDTKind kind, TestValueType* __it_from, TestValueType* __it_to)
 {
     auto& data_item = data.at(enum_val_to_index(kind));
-    auto acc = data_item.src_data_buf.template get_access<sycl::access::mode::read_write>();
+    auto acc = data_item.src_data_buf.get_host_access();
 
     auto __index = data_item.offset;
     for (auto __it = __it_from; __it != __it_to; ++__it, ++__index)

--- a/test/support/utils_test_base.h
+++ b/test/support/utils_test_base.h
@@ -550,7 +550,7 @@ void
 TestUtils::test_base_data_buffer<TestValueType>::retrieve_data(UDTKind kind, TestValueType* __it_from, TestValueType* __it_to)
 {
     auto& data_item = data.at(enum_val_to_index(kind));
-    auto acc = data_item.src_data_buf.get_host_access();
+    auto acc = data_item.src_data_buf.get_host_access(sycl::read_write);
 
     auto __index = data_item.offset;
     for (auto __it = __it_from; __it != __it_to; ++__it, ++__index)
@@ -565,7 +565,7 @@ void
 TestUtils::test_base_data_buffer<TestValueType>::update_data(UDTKind kind, TestValueType* __it_from, TestValueType* __it_to)
 {
     auto& data_item = data.at(enum_val_to_index(kind));
-    auto acc = data_item.src_data_buf.get_host_access();
+    auto acc = data_item.src_data_buf.get_host_access(sycl::read_write);
 
     auto __index = data_item.offset;
     for (auto __it = __it_from; __it != __it_to; ++__it, ++__index)

--- a/test/xpu_api/random/interface_tests/engines_methods.pass.cpp
+++ b/test/xpu_api/random/interface_tests/engines_methods.pass.cpp
@@ -140,7 +140,7 @@ public:
                         dpstd_acc[offset] = is_inequal;
                     });
                 });
-                auto dpstd_acc = dpstd_buffer.get_host_access();
+                auto dpstd_acc = dpstd_buffer.get_host_access(sycl::write);
                 for (int i = 0; i < N_GEN; ++i)
                 {
                     sum += dpstd_acc[i];
@@ -216,7 +216,7 @@ public:
                         dpstd_acc[offset] = is_inequal;
                     });
                 });
-                auto dpstd_acc = dpstd_buffer.get_host_access();
+                auto dpstd_acc = dpstd_buffer.get_host_access(sycl::write);
                 for (int i = 0; i < N_GEN; ++i)
                 {
                     sum += dpstd_acc[i];
@@ -284,7 +284,7 @@ public:
                         }
                     });
                 });
-                auto dpstd_acc = dpstd_buffer.get_host_access();
+                auto dpstd_acc = dpstd_buffer.get_host_access(sycl::write);
                 for (int i = 0; i < N_GEN; ++i)
                 {
                     sum += dpstd_acc[i];
@@ -355,7 +355,7 @@ public:
                         }
                     });
                 });
-                auto dpstd_acc = dpstd_buffer.get_host_access();
+                auto dpstd_acc = dpstd_buffer.get_host_access(sycl::write);
                 for (int i = 0; i < N_GEN; ++i)
                 {
                     sum += dpstd_acc[i];

--- a/test/xpu_api/random/interface_tests/engines_methods.pass.cpp
+++ b/test/xpu_api/random/interface_tests/engines_methods.pass.cpp
@@ -140,7 +140,7 @@ public:
                         dpstd_acc[offset] = is_inequal;
                     });
                 });
-                auto dpstd_acc = dpstd_buffer.template get_access<sycl::access::mode::write>();
+                auto dpstd_acc = dpstd_buffer.get_host_access();
                 for (int i = 0; i < N_GEN; ++i)
                 {
                     sum += dpstd_acc[i];
@@ -216,7 +216,7 @@ public:
                         dpstd_acc[offset] = is_inequal;
                     });
                 });
-                auto dpstd_acc = dpstd_buffer.template get_access<sycl::access::mode::write>();
+                auto dpstd_acc = dpstd_buffer.get_host_access();
                 for (int i = 0; i < N_GEN; ++i)
                 {
                     sum += dpstd_acc[i];
@@ -284,7 +284,7 @@ public:
                         }
                     });
                 });
-                auto dpstd_acc = dpstd_buffer.template get_access<sycl::access::mode::write>();
+                auto dpstd_acc = dpstd_buffer.get_host_access();
                 for (int i = 0; i < N_GEN; ++i)
                 {
                     sum += dpstd_acc[i];
@@ -355,7 +355,7 @@ public:
                         }
                     });
                 });
-                auto dpstd_acc = dpstd_buffer.template get_access<sycl::access::mode::write>();
+                auto dpstd_acc = dpstd_buffer.get_host_access();
                 for (int i = 0; i < N_GEN; ++i)
                 {
                     sum += dpstd_acc[i];

--- a/test/xpu_api/random/interface_tests/engines_methods.pass.cpp
+++ b/test/xpu_api/random/interface_tests/engines_methods.pass.cpp
@@ -140,7 +140,7 @@ public:
                         dpstd_acc[offset] = is_inequal;
                     });
                 });
-                auto dpstd_acc = dpstd_buffer.get_host_access(sycl::write);
+                auto dpstd_acc = dpstd_buffer.get_host_access(sycl::write_only);
                 for (int i = 0; i < N_GEN; ++i)
                 {
                     sum += dpstd_acc[i];
@@ -216,7 +216,7 @@ public:
                         dpstd_acc[offset] = is_inequal;
                     });
                 });
-                auto dpstd_acc = dpstd_buffer.get_host_access(sycl::write);
+                auto dpstd_acc = dpstd_buffer.get_host_access(sycl::write_only);
                 for (int i = 0; i < N_GEN; ++i)
                 {
                     sum += dpstd_acc[i];
@@ -284,7 +284,7 @@ public:
                         }
                     });
                 });
-                auto dpstd_acc = dpstd_buffer.get_host_access(sycl::write);
+                auto dpstd_acc = dpstd_buffer.get_host_access(sycl::write_only);
                 for (int i = 0; i < N_GEN; ++i)
                 {
                     sum += dpstd_acc[i];
@@ -355,7 +355,7 @@ public:
                         }
                     });
                 });
-                auto dpstd_acc = dpstd_buffer.get_host_access(sycl::write);
+                auto dpstd_acc = dpstd_buffer.get_host_access(sycl::write_only);
                 for (int i = 0; i < N_GEN; ++i)
                 {
                     sum += dpstd_acc[i];


### PR DESCRIPTION
1. AoT: `spir64_gen-unknown-unknown-sycldevice` to `spir64_gen`, `-Xs` to `-Xsycl-target-backend`
2. get_access() host to get_host_access() APIs