### PR TITLE
Fix warning C4515: 'execution': namespace uses itself

### DIFF
--- a/include/oneapi/dpl/execution
+++ b/include/oneapi/dpl/execution
@@ -67,16 +67,6 @@ _PSTL_PRAGMA_MESSAGE_POLICIES(
     "The <Parallel STL> execution policies are injected into the standard namespace std::execution")
 #endif // _ONEDPL_CPP17_EXECUTION_POLICIES_PRESENT
 
-namespace oneapi
-{
-namespace dpl
-{
-namespace execution
-{
-} // end namespace execution
-} // end namespace dpl
-} // end namespace oneapi
-
 namespace dpl = oneapi::dpl;
 
 #endif // _ONEDPL_EXECUTION

--- a/include/oneapi/dpl/execution
+++ b/include/oneapi/dpl/execution
@@ -73,7 +73,6 @@ namespace dpl
 {
 namespace execution
 {
-using namespace oneapi::dpl::execution;
 } // end namespace execution
 } // end namespace dpl
 } // end namespace oneapi


### PR DESCRIPTION
In this PR we fix warning C4515: 'execution': namespace uses itself
Please see https://github.com/oneapi-src/oneDPL/issues/759 for additional info.