### PR TITLE
Fix errors in test buffer_wrapper.pass

### DIFF
--- a/test/general/buffer_wrapper.pass.cpp
+++ b/test/general/buffer_wrapper.pass.cpp
@@ -34,7 +34,7 @@ struct test_buffer_wrapper
         EXPECT_TRUE(end - begin == size, "wrong effect of iterator's operator - iterator");
 
         auto buf = begin.get_buffer();
-        sycl::host_accessor<T, 1, sycl::access_mode::read> buf_accessor(buf);
+        sycl::host_accessor buf_accessor(buf, sycl::read_only);
         T* actual_data = buf_accessor.get_pointer();
 
         EXPECT_TRUE(actual_data == expected_data, "wrong effect of iterator's method get_buffer");
@@ -50,7 +50,7 @@ main()
     std::size_t size = 1000;
     sycl::buffer<std::uint32_t> buf{size};
     test_buffer_wrapper test{};
-    sycl::host_accessor<DataType, 1, sycl::access_mode::read> buf_accessor(buf);
+    sycl::host_accessor buf_accessor(buf, sycl::read_only);
     auto data_ptr = buf_accessor.get_pointer();
 
     test(oneapi::dpl::begin(buf), oneapi::dpl::end(buf), data_ptr, size);

--- a/test/general/buffer_wrapper.pass.cpp
+++ b/test/general/buffer_wrapper.pass.cpp
@@ -34,7 +34,9 @@ struct test_buffer_wrapper
         EXPECT_TRUE(end - begin == size, "wrong effect of iterator's operator - iterator");
 
         auto buf = begin.get_buffer();
-        T* actual_data = sycl::host_accessor<T, 1, sycl::access_mode::read>(buf).get_pointer();
+        sycl::host_accessor<T, 1, sycl::access_mode::read> buf_accessor(buf);
+        T* actual_data = buf_accessor.get_pointer();
+
         EXPECT_TRUE(actual_data == expected_data, "wrong effect of iterator's method get_buffer");
     }
 };
@@ -48,7 +50,8 @@ main()
     std::size_t size = 1000;
     sycl::buffer<std::uint32_t> buf{size};
     test_buffer_wrapper test{};
-    auto data_ptr = sycl::host_accessor<std::uint32_t, 1, sycl::access_mode::read>(buf).get_pointer();
+    sycl::host_accessor<DataType, 1, sycl::access_mode::read> buf_accessor(buf);
+    auto data_ptr = buf_accessor.get_pointer();
 
     test(oneapi::dpl::begin(buf), oneapi::dpl::end(buf), data_ptr, size);
     test(oneapi::dpl::begin(buf, sycl::write_only), oneapi::dpl::end(buf, sycl::write_only), data_ptr, size);

--- a/test/general/buffer_wrapper.pass.cpp
+++ b/test/general/buffer_wrapper.pass.cpp
@@ -35,7 +35,7 @@ struct test_buffer_wrapper
 
         auto buf = begin.get_buffer();
         sycl::host_accessor buf_accessor(buf, sycl::read_only);
-        T* actual_data = buf_accessor.get_pointer();
+        auto actual_data = buf_accessor.get_pointer();
 
         EXPECT_TRUE(actual_data == expected_data, "wrong effect of iterator's method get_buffer");
     }

--- a/test/general/buffer_wrapper.pass.cpp
+++ b/test/general/buffer_wrapper.pass.cpp
@@ -34,7 +34,7 @@ struct test_buffer_wrapper
         EXPECT_TRUE(end - begin == size, "wrong effect of iterator's operator - iterator");
 
         auto buf = begin.get_buffer();
-        sycl::host_accessor buf_accessor(buf, sycl::read_only);
+        sycl::host_accessor buf_accessor(buf);
         auto actual_data = buf_accessor.get_pointer();
 
         EXPECT_TRUE(actual_data == expected_data, "wrong effect of iterator's method get_buffer");
@@ -50,7 +50,7 @@ main()
     std::size_t size = 1000;
     sycl::buffer<std::uint32_t> buf{size};
     test_buffer_wrapper test{};
-    sycl::host_accessor buf_accessor(buf, sycl::read_only);
+    sycl::host_accessor buf_accessor(buf);
     auto data_ptr = buf_accessor.get_pointer();
 
     test(oneapi::dpl::begin(buf), oneapi::dpl::end(buf), data_ptr, size);


### PR DESCRIPTION
In this PR we fix compile error from the issue https://github.com/oneapi-src/oneDPL/issues/788 :
```
test/general/buffer_wrapper.pass.cpp:37:26: error: no matching conversion for functional-style cast from 'sycl::buffer<unsigned int, dim, aligned_allocator<unsigned int>>' to 'sycl::host_accessor<const unsigned int, 1, sycl::access_mode::read>'
        T* actual_data = sycl::host_accessor<T, 1, sycl::access_mode::read>(buf).get_pointer();
                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This error were introduced in https://github.com/oneapi-src/oneDPL/pull/281