### PR TITLE
Make CI job names more readable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,7 +251,7 @@ jobs:
           ctest --timeout %TEST_TIMEOUT% -C ${{ matrix.build_type }} --output-on-failure %ctest_flags%
 
   macos-testing:
-    name: be=${{ matrix.backend }},cmplr=${{ matrix.cxx_compiler }},os=${{ matrix.os }},std=${{ matrix.std }},cfg=${{ matrix.build_type }}
+    name: be=${{ matrix.backend }},device=HOST,cmplr=${{ matrix.cxx_compiler }},os=${{ matrix.os }},std=${{ matrix.std }},cfg=${{ matrix.build_type }}
     runs-on: ['${{ matrix.os }}']
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
             path: html
 
   linux-testing:
-    name: ${{ matrix.os }}_${{ matrix.cxx_compiler }}_backend=${{ matrix.backend }}_device=${{ matrix.device_type }}_cxx${{ matrix.std }}_${{ matrix.build_type }}
+    name: os=${{ matrix.os }},compiler=${{ matrix.cxx_compiler }},backend=${{ matrix.backend }},device=${{ matrix.device_type }},cxx=${{ matrix.std }},build_type=${{ matrix.build_type }}
     runs-on: ['${{ matrix.os }}']
     timeout-minutes: 60
     strategy:
@@ -180,7 +180,7 @@ jobs:
           ctest --timeout ${TEST_TIMEOUT} --output-on-failure ${ctest_flags}
 
   windows-testing:
-    name: ${{ matrix.os }}_${{ matrix.cxx_compiler }}_backend=${{ matrix.backend }}_device=${{ matrix.device_type }}_cxx${{ matrix.std }}_${{ matrix.build_type }}
+    name: os=${{ matrix.os }},compiler=${{ matrix.cxx_compiler }},backend=${{ matrix.backend }},device=${{ matrix.device_type }},cxx=${{ matrix.std }},build_type=${{ matrix.build_type }}
     runs-on: ['${{ matrix.os }}']
     timeout-minutes: 60
     strategy:
@@ -251,7 +251,7 @@ jobs:
           ctest --timeout %TEST_TIMEOUT% -C ${{ matrix.build_type }} --output-on-failure %ctest_flags%
 
   macos-testing:
-    name: ${{ matrix.os }}_${{ matrix.cxx_compiler }}_backend=${{ matrix.backend }}_cxx${{ matrix.std }}_${{ matrix.build_type }}
+    name: os=${{ matrix.os }},compiler=${{ matrix.cxx_compiler }},backend=${{ matrix.backend }},cxx=${{ matrix.std }},build_type=${{ matrix.build_type }}
     runs-on: ['${{ matrix.os }}']
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
             path: html
 
   linux-testing:
-    name: ${{ matrix.backend }},device=${{ matrix.device_type }},cmplr=${{ matrix.cxx_compiler }},os=${{ matrix.os }},std=${{ matrix.std }},cfg=${{ matrix.build_type }}
+    name: be=${{ matrix.backend }},device=${{ matrix.device_type }},cmplr=${{ matrix.cxx_compiler }},os=${{ matrix.os }},std=${{ matrix.std }},cfg=${{ matrix.build_type }}
     runs-on: ['${{ matrix.os }}']
     timeout-minutes: 60
     strategy:
@@ -180,7 +180,7 @@ jobs:
           ctest --timeout ${TEST_TIMEOUT} --output-on-failure ${ctest_flags}
 
   windows-testing:
-    name: ${{ matrix.backend }},device=${{ matrix.device_type }},cmplr=${{ matrix.cxx_compiler }},os=${{ matrix.os }},std=${{ matrix.std }},cfg=${{ matrix.build_type }}
+    name: be=${{ matrix.backend }},device=${{ matrix.device_type }},cmplr=${{ matrix.cxx_compiler }},os=${{ matrix.os }},std=${{ matrix.std }},cfg=${{ matrix.build_type }}
     runs-on: ['${{ matrix.os }}']
     timeout-minutes: 60
     strategy:
@@ -251,7 +251,7 @@ jobs:
           ctest --timeout %TEST_TIMEOUT% -C ${{ matrix.build_type }} --output-on-failure %ctest_flags%
 
   macos-testing:
-    name: ${{ matrix.backend }},cmplr=${{ matrix.cxx_compiler }},os=${{ matrix.os }},std=${{ matrix.std }},cfg=${{ matrix.build_type }}
+    name: be=${{ matrix.backend }},cmplr=${{ matrix.cxx_compiler }},os=${{ matrix.os }},std=${{ matrix.std }},cfg=${{ matrix.build_type }}
     runs-on: ['${{ matrix.os }}']
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
             path: html
 
   linux-testing:
-    name: ${{ matrix.os }},cmplr=${{ matrix.cxx_compiler }},backend=${{ matrix.backend }},device=${{ matrix.device_type }},std=${{ matrix.std }},build_type=${{ matrix.build_type }}
+    name: ${{ matrix.backend }},device=${{ matrix.device_type }},cmplr=${{ matrix.cxx_compiler }},os=${{ matrix.os }},std=${{ matrix.std }},cfg=${{ matrix.build_type }}
     runs-on: ['${{ matrix.os }}']
     timeout-minutes: 60
     strategy:
@@ -180,7 +180,7 @@ jobs:
           ctest --timeout ${TEST_TIMEOUT} --output-on-failure ${ctest_flags}
 
   windows-testing:
-    name: ${{ matrix.os }},cmplr=${{ matrix.cxx_compiler }},backend=${{ matrix.backend }},device=${{ matrix.device_type }},std=${{ matrix.std }},build_type=${{ matrix.build_type }}
+    name: ${{ matrix.backend }},device=${{ matrix.device_type }},cmplr=${{ matrix.cxx_compiler }},os=${{ matrix.os }},std=${{ matrix.std }},cfg=${{ matrix.build_type }}
     runs-on: ['${{ matrix.os }}']
     timeout-minutes: 60
     strategy:
@@ -215,7 +215,7 @@ jobs:
       - name: Install Intel® oneAPI DPC++/C++ Compiler
         if: matrix.cxx_compiler == 'icpx' || matrix.cxx_compiler == 'icx' || matrix.cxx_compiler == 'icx-cl' || matrix.cxx_compiler == 'dpcpp' || matrix.cxx_compiler == 'dpcpp-cl'
         shell: cmd
-        run: | 
+        run: |
           call %CONDA%/condabin/conda.bat activate base
           conda install -c intel dpcpp_win-64
       - name: Run testing
@@ -251,7 +251,7 @@ jobs:
           ctest --timeout %TEST_TIMEOUT% -C ${{ matrix.build_type }} --output-on-failure %ctest_flags%
 
   macos-testing:
-    name: ${{ matrix.os }},cmplr=${{ matrix.cxx_compiler }},backend=${{ matrix.backend }},std=${{ matrix.std }},build_type=${{ matrix.build_type }}
+    name: ${{ matrix.backend }},cmplr=${{ matrix.cxx_compiler }},os=${{ matrix.os }},std=${{ matrix.std }},cfg=${{ matrix.build_type }}
     runs-on: ['${{ matrix.os }}']
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
             path: html
 
   linux-testing:
-    name: os=${{ matrix.os }},compiler=${{ matrix.cxx_compiler }},backend=${{ matrix.backend }},device=${{ matrix.device_type }},cxx=${{ matrix.std }},build_type=${{ matrix.build_type }}
+    name: os=${{ matrix.os }},compiler=${{ matrix.cxx_compiler }},backend=${{ matrix.backend }},device=${{ matrix.device_type }},std=${{ matrix.std }},build_type=${{ matrix.build_type }}
     runs-on: ['${{ matrix.os }}']
     timeout-minutes: 60
     strategy:
@@ -180,7 +180,7 @@ jobs:
           ctest --timeout ${TEST_TIMEOUT} --output-on-failure ${ctest_flags}
 
   windows-testing:
-    name: os=${{ matrix.os }},compiler=${{ matrix.cxx_compiler }},backend=${{ matrix.backend }},device=${{ matrix.device_type }},cxx=${{ matrix.std }},build_type=${{ matrix.build_type }}
+    name: os=${{ matrix.os }},compiler=${{ matrix.cxx_compiler }},backend=${{ matrix.backend }},device=${{ matrix.device_type }},std=${{ matrix.std }},build_type=${{ matrix.build_type }}
     runs-on: ['${{ matrix.os }}']
     timeout-minutes: 60
     strategy:
@@ -251,7 +251,7 @@ jobs:
           ctest --timeout %TEST_TIMEOUT% -C ${{ matrix.build_type }} --output-on-failure %ctest_flags%
 
   macos-testing:
-    name: os=${{ matrix.os }},compiler=${{ matrix.cxx_compiler }},backend=${{ matrix.backend }},cxx=${{ matrix.std }},build_type=${{ matrix.build_type }}
+    name: os=${{ matrix.os }},compiler=${{ matrix.cxx_compiler }},backend=${{ matrix.backend }},std=${{ matrix.std }},build_type=${{ matrix.build_type }}
     runs-on: ['${{ matrix.os }}']
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
             path: html
 
   linux-testing:
-    name: be=${{ matrix.backend }},device=${{ matrix.device_type }},cmplr=${{ matrix.cxx_compiler }},os=${{ matrix.os }},std=${{ matrix.std }},cfg=${{ matrix.build_type }}
+    name: ${{ matrix.device_type }},bknd=${{ matrix.backend }},cmplr=${{ matrix.cxx_compiler }},${{ matrix.os }},std${{ matrix.std }},cfg=${{ matrix.build_type }}
     runs-on: ['${{ matrix.os }}']
     timeout-minutes: 60
     strategy:
@@ -180,7 +180,7 @@ jobs:
           ctest --timeout ${TEST_TIMEOUT} --output-on-failure ${ctest_flags}
 
   windows-testing:
-    name: be=${{ matrix.backend }},device=${{ matrix.device_type }},cmplr=${{ matrix.cxx_compiler }},os=${{ matrix.os }},std=${{ matrix.std }},cfg=${{ matrix.build_type }}
+    name: ${{ matrix.device_type }},bknd=${{ matrix.backend }},cmplr=${{ matrix.cxx_compiler }},${{ matrix.os }},std${{ matrix.std }},cfg=${{ matrix.build_type }}
     runs-on: ['${{ matrix.os }}']
     timeout-minutes: 60
     strategy:
@@ -251,7 +251,7 @@ jobs:
           ctest --timeout %TEST_TIMEOUT% -C ${{ matrix.build_type }} --output-on-failure %ctest_flags%
 
   macos-testing:
-    name: be=${{ matrix.backend }},device=HOST,cmplr=${{ matrix.cxx_compiler }},os=${{ matrix.os }},std=${{ matrix.std }},cfg=${{ matrix.build_type }}
+    name: HOST,bknd=${{ matrix.backend }},cmplr=${{ matrix.cxx_compiler }},${{ matrix.os }},std${{ matrix.std }},cfg=${{ matrix.build_type }}
     runs-on: ['${{ matrix.os }}']
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
             path: html
 
   linux-testing:
-    name: os=${{ matrix.os }},compiler=${{ matrix.cxx_compiler }},backend=${{ matrix.backend }},device=${{ matrix.device_type }},std=${{ matrix.std }},build_type=${{ matrix.build_type }}
+    name: ${{ matrix.os }},cmplr=${{ matrix.cxx_compiler }},backend=${{ matrix.backend }},device=${{ matrix.device_type }},std=${{ matrix.std }},build_type=${{ matrix.build_type }}
     runs-on: ['${{ matrix.os }}']
     timeout-minutes: 60
     strategy:
@@ -180,7 +180,7 @@ jobs:
           ctest --timeout ${TEST_TIMEOUT} --output-on-failure ${ctest_flags}
 
   windows-testing:
-    name: os=${{ matrix.os }},compiler=${{ matrix.cxx_compiler }},backend=${{ matrix.backend }},device=${{ matrix.device_type }},std=${{ matrix.std }},build_type=${{ matrix.build_type }}
+    name: ${{ matrix.os }},cmplr=${{ matrix.cxx_compiler }},backend=${{ matrix.backend }},device=${{ matrix.device_type }},std=${{ matrix.std }},build_type=${{ matrix.build_type }}
     runs-on: ['${{ matrix.os }}']
     timeout-minutes: 60
     strategy:
@@ -251,7 +251,7 @@ jobs:
           ctest --timeout %TEST_TIMEOUT% -C ${{ matrix.build_type }} --output-on-failure %ctest_flags%
 
   macos-testing:
-    name: os=${{ matrix.os }},compiler=${{ matrix.cxx_compiler }},backend=${{ matrix.backend }},std=${{ matrix.std }},build_type=${{ matrix.build_type }}
+    name: ${{ matrix.os }},cmplr=${{ matrix.cxx_compiler }},backend=${{ matrix.backend }},std=${{ matrix.std }},build_type=${{ matrix.build_type }}
     runs-on: ['${{ matrix.os }}']
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
             path: html
 
   linux-testing:
-    name: ${{ matrix.device_type }},bknd=${{ matrix.backend }},cmplr=${{ matrix.cxx_compiler }},${{ matrix.os }},std${{ matrix.std }},cfg=${{ matrix.build_type }}
+    name: ${{ matrix.device_type }},bknd=${{ matrix.backend }},cmplr=${{ matrix.cxx_compiler }},${{ matrix.os }},std=с++${{ matrix.std }},cfg=${{ matrix.build_type }}
     runs-on: ['${{ matrix.os }}']
     timeout-minutes: 60
     strategy:
@@ -180,7 +180,7 @@ jobs:
           ctest --timeout ${TEST_TIMEOUT} --output-on-failure ${ctest_flags}
 
   windows-testing:
-    name: ${{ matrix.device_type }},bknd=${{ matrix.backend }},cmplr=${{ matrix.cxx_compiler }},${{ matrix.os }},std${{ matrix.std }},cfg=${{ matrix.build_type }}
+    name: ${{ matrix.device_type }},bknd=${{ matrix.backend }},cmplr=${{ matrix.cxx_compiler }},${{ matrix.os }},std=c++${{ matrix.std }},cfg=${{ matrix.build_type }}
     runs-on: ['${{ matrix.os }}']
     timeout-minutes: 60
     strategy:
@@ -251,7 +251,7 @@ jobs:
           ctest --timeout %TEST_TIMEOUT% -C ${{ matrix.build_type }} --output-on-failure %ctest_flags%
 
   macos-testing:
-    name: HOST,bknd=${{ matrix.backend }},cmplr=${{ matrix.cxx_compiler }},${{ matrix.os }},std${{ matrix.std }},cfg=${{ matrix.build_type }}
+    name: HOST,bknd=${{ matrix.backend }},cmplr=${{ matrix.cxx_compiler }},${{ matrix.os }},std=c++${{ matrix.std }},cfg=${{ matrix.build_type }}
     runs-on: ['${{ matrix.os }}']
     timeout-minutes: 60
     strategy:


### PR DESCRIPTION
Change mixed approach for naming jobs to "name=value,name_1=value_1,...,name_n=value_n" for values which need keys for clarity. 

Name before the changes:
`ubuntu-20.04_g++_backend=tbb_device=HOST_cxx17_release`
Name after the changes:
`ubuntu-20.04,cmplr=g++,backend=tbb,device=HOST,std=17,build_type=release`

Upd. The most important properties are shown first due to 28-symbol limit of the view panel:
`HOST,bknd=tbb,cmplr=g++,ubuntu-20.04,std=c++17,cfg=release`

Previous '_' separator might have confused c++ developers. For example, ones may get surprised to find 'tbb_device'. 