### PR TITLE
Rename variables in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ endif()
 
 if (ONEDPL_BACKEND MATCHES "^(tbb|dpcpp|dpcpp_only)$")
     string(TOUPPER "${ONEDPL_BACKEND}" ONEDPL_BACKEND_NAME)
-    set(ONEDPL_USE_BACKEND_${ONEDPL_BACKEND_NAME} TRUE)
+    set(SET_BACKEND_${ONEDPL_BACKEND_NAME} TRUE)
 
     if (ONEDPL_BACKEND MATCHES "^(tbb|dpcpp)$")
         find_package(TBB 2021 REQUIRED tbb OPTIONAL_COMPONENTS tbbmalloc)
@@ -124,8 +124,8 @@ if (ONEDPL_BACKEND MATCHES "^(tbb|dpcpp|dpcpp_only)$")
     target_compile_definitions(oneDPL INTERFACE
         $<$<CONFIG:Debug>:TBB_USE_DEBUG=1>
         $<$<CONFIG:Debug>:PSTL_USE_DEBUG>
-        $<$<BOOL:${ONEDPL_USE_BACKEND_DPCPP_ONLY}>:ONEDPL_USE_TBB_BACKEND=0>
-        $<$<BOOL:${ONEDPL_USE_BACKEND_TBB}>:ONEDPL_USE_DPCPP_BACKEND=0>
+        $<$<BOOL:${SET_BACKEND_DPCPP_ONLY}>:ONEDPL_USE_TBB_BACKEND=0>
+        $<$<BOOL:${SET_BACKEND_TBB}>:ONEDPL_USE_DPCPP_BACKEND=0>
         )
 
     if (ONEDPL_BACKEND MATCHES "^(dpcpp|dpcpp_only)$")


### PR DESCRIPTION
In this PR we rename some internal variables in the ```CMakeLists.txt``` file.
The goal of this renaming - do not use prefix of oneDPL macros for names of internal variables in the file ```CMakeLists.txt```.
What were renamed:
- ```ONEDPL_USE_BACKEND_DPCPP``` -> ```SET_BACKEND_DPCPP```
- ```ONEDPL_USE_BACKEND_DPCPP_ONLY``` -> ```SET_BACKEND_DPCPP_ONLY```
- ```ONEDPL_USE_BACKEND_TBB``` -> ```SET_BACKEND_TBB```
