### PR TITLE
Ensure Complex Test Kernels Finish before Main Ends

### DIFF
--- a/test/support/test_complex.h
+++ b/test/support/test_complex.h
@@ -151,6 +151,7 @@ namespace TestUtils
                             [fncDoubleHasntSupportInRuntime]() { fncDoubleHasntSupportInRuntime(); });
                     });
             }
+            deviceQueue.wait_and_throw();
         }
         catch (const std::exception& exc)
         {


### PR DESCRIPTION
An identified issue on many systems has been segfaulting test cases when the CPU is selected as the device. I have reproduced this issue and identified the cause as the program exiting main prior to the submitted kernels finishing. There is no implicit wait in any of these kernels or an explicit wait within the test code. This PR adds a wait after kernel submission in `test/support/test_complex.h`. Adding this wait has resolved this issue on the systems I have reproduced the error on.