### PR TITLE
Fix mangled name

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -834,7 +834,7 @@ __parallel_find_or(_ExecutionPolicy&& __exec, _Brick __f, _BrickTag __brick_tag,
     using _AtomicType = typename _BrickTag::_AtomicType;
     using _FindOrKernel =
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<__find_or_kernel, _CustomName, _Brick,
-                                                                               _Ranges...>;
+                                                                               _BrickTag, _Ranges...>;
 
     constexpr bool __or_tag_check = ::std::is_same_v<_BrickTag, __parallel_or_tag>;
     auto __rng_n = oneapi::dpl::__ranges::__get_first_range_size(__rngs...);


### PR DESCRIPTION
In this PR we fix mangled name which have place in ixpc compiler with options ```-fsycl``` and ```-fsycl-unnamed-lambda``` too :
```
In file included from include/oneapi/dpl/execution:61:
In file included from include/oneapi/dpl/pstl/algorithm_impl.h:31:
In file included from include/oneapi/dpl/pstl/parallel_backend.h:19:
include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:430:86: error: definition with same mangled name '_ZTSN6oneapi3dpl20__par_backend_hetero10__internal11__compositeINS1_31__scan_single_wg_dynamic_kernelIJEEEJLc95ELc90ELc84ELc83ELc78ELc54ELc111ELc110ELc101ELc97ELc112ELc105ELc51ELc100ELc112ELc108ELc50ELc48ELc95ELc95ELc112ELc97ELc114ELc95ELc98ELc97ELc99ELc107ELc101ELc110ELc100ELc95ELc104ELc101ELc116ELc101ELc114ELc111ELc51ELc49ELc95ELc95ELc115ELc99ELc97ELc110ELc95ELc115ELc105ELc110ELc103ELc108ELc101ELc95ELc119ELc103ELc95ELc100ELc121ELc110ELc97ELc109ELc105ELc99ELc95ELc107ELc101ELc114ELc110ELc101ELc108ELc73ELc74ELc78ELc83ELc48ELc95ELc57ELc101ELc120ELc101ELc99ELc117ELc116ELc105ELc111ELc110ELc53ELc95ELc95ELc100ELc112ELc108ELc49ELc55ELc68ELc101ELc102ELc97ELc117ELc108ELc116ELc75ELc101ELc114ELc110ELc101ELc108ELc78ELc97ELc109ELc101ELc69ELc83ELc116ELc52ELc112ELc108ELc117ELc115ELc73ELc105ELc69ELc82ELc78ELc83ELc48ELc95ELc56ELc95ELc95ELc114ELc97ELc110ELc103ELc101ELc115ELc49ELc52ELc95ELc95ELc114ELc97ELc110ELc103ELc101ELc95ELc104ELc111ELc108ELc100ELc101ELc114ELc73ELc78ELc83ELc56ELc95ELc49ELc48ELc103ELc117ELc97ELc114ELc100ELc95ELc118ELc105ELc101ELc119ELc73ELc80ELc105ELc69ELc69ELc69ELc69ELc83ELc68ELc95ELc69ELc69ELc69EEEE' as another definition
            __hdl.parallel_for<_KernelName>(sycl::nd_range<1>(__wg_size, __wg_size), [=](sycl::nd_item<1> __self_item) {
                                                                                     ^
include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:430:86: note: previous definition is here
include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:430:86: error: definition with same mangled name '_ZTSN6oneapi3dpl20__par_backend_hetero10__internal11__compositeINS1_31__scan_single_wg_dynamic_kernelIJEEEJLc95ELc90ELc84ELc83ELc78ELc54ELc111ELc110ELc101ELc97ELc112ELc105ELc51ELc100ELc112ELc108ELc50ELc48ELc95ELc95ELc112ELc97ELc114ELc95ELc98ELc97ELc99ELc107ELc101ELc110ELc100ELc95ELc104ELc101ELc116ELc101ELc114ELc111ELc51ELc49ELc95ELc95ELc115ELc99ELc97ELc110ELc95ELc115ELc105ELc110ELc103ELc108ELc101ELc95ELc119ELc103ELc95ELc100ELc121ELc110ELc97ELc109ELc105ELc99ELc95ELc107ELc101ELc114ELc110ELc101ELc108ELc73ELc74ELc78ELc83ELc48ELc95ELc49ELc48ELc95ELc95ELc105ELc110ELc116ELc101ELc114ELc110ELc97ELc108ELc50ELc50ELc69ELc120ELc101ELc99ELc117ELc116ELc105ELc111ELc110ELc80ELc111ELc108ELc105ELc99ELc121ELc87ELc114ELc97ELc112ELc112ELc101ELc114ELc73ELc78ELc83ELc48ELc95ELc57ELc101ELc120ELc101ELc99ELc117ELc116ELc105ELc111ELc110ELc53ELc95ELc95ELc100ELc112ELc108ELc49ELc55ELc68ELc101ELc102ELc97ELc117ELc108ELc116ELc75ELc101ELc114ELc110ELc101ELc108ELc78ELc97ELc109ELc101ELc69ELc69ELc69ELc83ELc116ELc52ELc112ELc108ELc117ELc115ELc73ELc105ELc69ELc82ELc78ELc83ELc48ELc95ELc56ELc95ELc95ELc114ELc97ELc110ELc103ELc101ELc115ELc49ELc52ELc95ELc95ELc114ELc97ELc110ELc103ELc101ELc95ELc104ELc111ELc108ELc100ELc101ELc114ELc73ELc78ELc83ELc66ELc95ELc49ELc48ELc103ELc117ELc97ELc114ELc100ELc95ELc118ELc105ELc101ELc119ELc73ELc80ELc105ELc69ELc69ELc69ELc69ELc78ELc83ELc67ELc95ELc73ELc78ELc83ELc66ELc95ELc56ELc97ELc108ELc108ELc95ELc118ELc105ELc101ELc119ELc73ELc105ELc76ELc78ELc52ELc115ELc121ELc99ELc108ELc51ELc95ELc86ELc49ELc54ELc97ELc99ELc99ELc101ELc115ELc115ELc52ELc109ELc111ELc100ELc101ELc69ELc49ELc48ELc50ELc53ELc69ELc76ELc78ELc83ELc76ELc95ELc54ELc116ELc97ELc114ELc103ELc101ELc116ELc69ELc50ELc48ELc49ELc52ELc69ELc76ELc78ELc83ELc76ELc95ELc49ELc49ELc112ELc108ELc97ELc99ELc101ELc104ELc111ELc108ELc100ELc101ELc114ELc69ELc49ELc69ELc69ELc69ELc69ELc69ELc69ELc69ELc69EEEE' as another definition
            __hdl.parallel_for<_KernelName>(sycl::nd_range<1>(__wg_size, __wg_size), [=](sycl::nd_item<1> __self_item) {
                                                                                     ^
include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:430:86: note: previous definition is here
```

From my point of view the root cause of this compile error is in the PR https://github.com/oneapi-src/oneDPL/pull/783

This PR should be applied ONLY after 
- https://github.com/oneapi-src/oneDPL/pull/818
- https://github.com/oneapi-src/oneDPL/pull/819
- https://github.com/oneapi-src/oneDPL/pull/820 ????