### PR TITLE
Remove deprecated code from oneDPL documentation

### DIFF
--- a/documentation/library_guide/api_for_sycl_kernels/random.rst
+++ b/documentation/library_guide/api_for_sycl_kernels/random.rst
@@ -88,10 +88,10 @@ Random number generation is available for SYCL* device-side and host-side code. 
 
 .. code:: cpp
 
+    #include <oneapi/dpl/random>
+    #include <sycl/sycl.hpp>
     #include <iostream>
     #include <vector>
-    #include <sycl/sycl.hpp>
-    #include <oneapi/dpl/random>
 
     int main() {
         sycl::queue queue(sycl::default_selector_v);

--- a/documentation/library_guide/api_for_sycl_kernels/tested_standard_cpp_api.rst
+++ b/documentation/library_guide/api_for_sycl_kernels/tested_standard_cpp_api.rst
@@ -14,8 +14,8 @@ Below is an example code that shows how to use ``oneapi::dpl::swap`` in SYCL dev
 
 .. code:: cpp
 
-  #include <sycl/sycl.hpp>
   #include <oneapi/dpl/utility>
+  #include <sycl/sycl.hpp>
   #include <iostream>
   constexpr sycl::access::mode sycl_read_write = sycl::access::mode::read_write;
   class KernelSwap;

--- a/documentation/library_guide/introduction/onedpl_gsg.rst
+++ b/documentation/library_guide/introduction/onedpl_gsg.rst
@@ -128,7 +128,7 @@ fit into the square *S*. Random number generation is performed in scalar manner 
 
     float estimated_pi;
     {
-        sycl::queue q(sycl::gpu_selector{});
+        sycl::queue q(sycl::gpu_selector_v);
         auto policy = oneapi::dpl::execution::make_device_policy(q);
 
         float sum = std::transform_reduce( policy,

--- a/documentation/library_guide/onedpl_gsg.rst
+++ b/documentation/library_guide/onedpl_gsg.rst
@@ -131,7 +131,7 @@ fit into the square *S*. Random number generation is performed in scalar manner 
 
     float estimated_pi;
     {
-        sycl::queue q(sycl::gpu_selector{});
+        sycl::queue q(sycl::gpu_selector_v);
         auto policy = oneapi::dpl::execution::make_device_policy(q);
 
         float sum = std::transform_reduce( policy,

--- a/documentation/library_guide/parallel_api/execution_policies.rst
+++ b/documentation/library_guide/parallel_api/execution_policies.rst
@@ -122,12 +122,12 @@ and ``using namespace sycl;`` directives when referring to policy classes and fu
 
 .. code:: cpp
 
-  auto policy_b = device_policy<class PolicyB> {device{gpu_selector{}}};
+  auto policy_b = device_policy<class PolicyB> {device{gpu_selector_v}};
   std::for_each(policy_b, ...);
 
 .. code:: cpp
 
-  auto policy_c = device_policy<class PolicyС> {cpu_selector{}};
+  auto policy_c = device_policy<class PolicyC> {device{cpu_selector_v}};
   std::for_each(policy_c, ...);
 
 .. code:: cpp


### PR DESCRIPTION
In this PR we make the next things:
- remove deprecated SYCL code from oneDPL documentation;
- unify order of included headers in documentations examples.