### PR TITLE
Correct usage of _HasDefaultName utility

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -201,7 +201,7 @@ class __sort_global_kernel;
 template <typename... _Name>
 class __sort_copy_back_kernel;
 
-template <::std::uint16_t _ElemsPerWG, bool _IsFullGroup, bool _Inclusive, typename... _Name>
+template <typename... _Name>
 class __scan_single_wg_kernel;
 
 template <typename... _Name>
@@ -606,16 +606,19 @@ __pattern_transform_scan_single_group(_ExecutionPolicy&& __exec, _InRng&& __in_r
                 return __parallel_transform_scan_static_single_group_submitter<
                     _Inclusive::value, __num_elems_per_item, __wg_size,
                     /* _IsFullGroup= */ true,
-                    oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<__scan_single_wg_kernel<
-                        __wg_size * __num_elems_per_item, /* _IsFullGroup= */ true, _Inclusive::value, _CustomName>>>()(
+                    oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
+                        __scan_single_wg_kernel<::std::integral_constant<::std::uint16_t, __wg_size>,
+                                                ::std::integral_constant<::std::uint16_t, __num_elems_per_item>,
+                                                /* _IsFullGroup= */ std::true_type, _Inclusive, _CustomName>>>()(
                     __exec, __in_rng.all_view(), __out_rng.all_view(), __n, __init, __binary_op, __unary_op);
             else
                 return __parallel_transform_scan_static_single_group_submitter<
                     _Inclusive::value, __num_elems_per_item, __wg_size,
                     /* _IsFullGroup= */ false,
                     oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
-                        __scan_single_wg_kernel<__wg_size * __num_elems_per_item, /* _IsFullGroup= */ false,
-                                                _Inclusive::value, _CustomName>>>()(
+                        __scan_single_wg_kernel<::std::integral_constant<::std::uint16_t, __wg_size>,
+                                                ::std::integral_constant<::std::uint16_t, __num_elems_per_item>,
+                                                /* _IsFullGroup= */ ::std::false_type, _Inclusive, _CustomName>>>()(
                     __exec, __in_rng.all_view(), __out_rng.all_view(), __n, __init, __binary_op, __unary_op);
         };
         if (__n <= 16)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -36,7 +36,7 @@ namespace __par_backend_hetero
 template <typename... _Name>
 class __reduce_seq_kernel;
 
-template <::std::uint16_t _WorkGroupSize, ::std::uint16_t _ItersPerWorkItem, typename... _Name>
+template <typename... _Name>
 class __reduce_small_kernel;
 
 template <bool _IsGPU, typename... _Name>
@@ -159,7 +159,8 @@ __parallel_transform_reduce_small_impl(_ExecutionPolicy&& __exec, _Size __n, _Re
     using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
     using _CustomName = typename _Policy::kernel_name;
     using _ReduceKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
-        __reduce_small_kernel<__work_group_size, __iters_per_work_item, _CustomName>>;
+        __reduce_small_kernel<::std::integral_constant<::std::uint16_t, __work_group_size>,
+                              ::std::integral_constant<::std::size_t, __iters_per_work_item>, _CustomName>>;
 
     return __parallel_transform_reduce_small_submitter<__work_group_size, __iters_per_work_item, _Tp, _ReduceKernel>()(
         ::std::forward<_ExecutionPolicy>(__exec), __n, __reduce_op, __transform_op, __init,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -170,10 +170,10 @@ struct _HasDefaultName
         ;
 };
 
-template <template <typename...> class _ExternalName, typename _InternalName>
-struct _HasDefaultName<_ExternalName<_InternalName>>
+template <template <typename...> class _ExternalName, typename... _InternalName>
+struct _HasDefaultName<_ExternalName<_InternalName...>>
 {
-    static constexpr bool value = _HasDefaultName<_InternalName>::value;
+    static constexpr bool value = (... || _HasDefaultName<_InternalName>::value);
 };
 
 template <typename... _Name>


### PR DESCRIPTION
The `_HasDefaultName` utility does not match kernel names that have multiple template parameters. This PR fixes the utility to check if any of the template parameters is the default name.

Co-authored with @rarutyun.