### PR TITLE
Add known limitations and differences

### DIFF
--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -60,6 +60,20 @@ To use Parallel API with the device execution policies, you need to install the 
 
 * A C++ compiler with support for SYCL 2020
 
+Difference with C++ parallel algorithms
+***************************************
+
+* oneDPL execution policies only result in parallel execution if random access iterators are provided,
+  while for other iterator types the execution will remain serial.
+* Semantics of the following algorithms does not allow unsequenced execution:
+  ``includes``, ``inplace_merge``, ``merge``, ``set_difference``, ``set_intersection``,
+  ``set_symmetric_difference``, ``set_union``, ``stable_partition``, ``unique``.
+* The following algorithms require additional O(n) memory space for parallel
+  execution: ``copy_if``, ``inplace_merge``, ``partial_sort``, ``partial_sort_copy``,
+  ``partition_copy``, ``remove``, ``remove_if``, ``rotate``, ``sort``, ``stable_sort``, ``unique``,
+  ``unique_copy``.
+
+
 Restrictions
 ************
 
@@ -98,6 +112,20 @@ Known Limitations
 * Due to specifics of Microsoft* Visual C++, some standard floating-point math functions
   (including ``std::ldexp``, ``std::frexp``, ``std::sqrt(std::complex<float>)``) require device support
   for double precision. 
+* The initial value type for ``exclusive_scan``, ``inclusive_scan``, ``exclusive_scan_by_segment``,
+  ``inclusive_scan_by_segment``, ``transform_exclusive_scan``, ``transform_inclusive_scan`` shall satisfy
+  the ``DefaultConstructible`` requirements. A default constructed-instance
+  of the initial value type shall be the identity element for binary_op. 
+* The initial value type for ``exclusive_scan``, ``inclusive_scan``, ``exclusive_scan_by_segment``,
+  ``inclusive_scan_by_segment``, ``reduce``, ``reduce_by_segment``, ``transform_reduce``, ``transform_exclusive_scan``,
+  ``transform_inclusive_scan`` shall additionally satisfy the ``MoveAssignable`` and the ``CopyConstructible``
+  requirements.
+* For ``max_element``, ``min_element``, ``minmax_element``, ``partial_sort``,
+  ``partial_sort_copy``, ``sort``, ``stable_sort`` the dereferenced value type of
+  the provided iterators shall be ``DefaultConstructible``.
+* For ``remove``, ``remove_if``, ``unique`` the dereferenced value type of the provided
+  iterators shall be ``MoveConstructible``.
+        
 
 Build Your Code with |onedpl_short|
 ===================================


### PR DESCRIPTION
Added new section "Difference with C++ parallel algorithms" 
Added limitations to "Known Limitations" section. 
The list is inherited from PSTL: https://github.com/oneapi-src/oneDPL/blob/20200330/Release_Notes.txt#L86