### PR TITLE
Do not require c++17 with dpcpp/dpcpp-cl on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,11 @@ endif()
 # Setup the oneDPL library target
 ###############################################################################
 add_library(oneDPL INTERFACE)
-target_compile_features(oneDPL INTERFACE cxx_std_17)
+# This compiler check/requirement does not work on Windows with dpcpp and dpcpp-cl compiler drivers
+# icx-cl and icpx are not affected
+if (NOT (WIN32 AND CMAKE_CXX_COMPILER MATCHES ".*dpcpp(-cl)?(.exe)?$"))
+    target_compile_features(oneDPL INTERFACE cxx_std_17)
+endif()
 
 if (CMAKE_BUILD_TYPE)
     message(STATUS "Build type is ${CMAKE_BUILD_TYPE}")

--- a/cmake/templates/oneDPLConfig.cmake.in
+++ b/cmake/templates/oneDPLConfig.cmake.in
@@ -22,7 +22,12 @@ if (EXISTS "${_onedpl_headers}")
 
         add_library(oneDPL INTERFACE IMPORTED)
         set_target_properties(oneDPL PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${_onedpl_headers}")
-        target_compile_features(oneDPL INTERFACE cxx_std_17)
+
+        # This compiler check/requirement does not work on Windows with dpcpp and dpcpp-cl compiler drivers
+        # icx-cl and icpx are not affected
+        if (NOT (WIN32 AND CMAKE_CXX_COMPILER MATCHES ".*dpcpp(-cl)?(.exe)?$"))
+            target_compile_features(oneDPL INTERFACE cxx_std_17)
+        endif()
 
         if (ONEDPL_PAR_BACKEND AND NOT ONEDPL_PAR_BACKEND MATCHES "^(tbb|openmp|serial)$")
             message(STATUS "oneDPL: ONEDPL_PAR_BACKEND=${ONEDPL_PAR_BACKEND} is requested, but not supported, available backends: tbb, openmp, serial")


### PR DESCRIPTION
cmake cannot properly detect c++17 with dpcpp and dpcpp-cl compiler drivers on Windows.
This results in the following issue:

```bash
CMake Error in test/CMakeLists.txt:
No known features for CXX compiler
"Clang "
version .
```
The changes from #822 fix that issue as well, but for some unknown (so far) reason, cmake cannot detect compiler features properly, e.g.:
```bash
-- The CXX compiler identification is IntelLLVM 2023.0.0 with MSVC-like command-line
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Miniconda/Library/bin/dpcpp.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring oneDPL 2022.1.0
-- Performing Test _fsycl_option
-- Performing Test _fsycl_option - Failed
-- Build type is release
-- Using parallel policies with DPCPP backend
icpx: warning: use of 'dpcpp' is deprecated and will be removed in a future release. Use 'icpx -fsycl' [-Wdeprecated]
-- Performing Test _fopenmp_simd_option
-- Performing Test _fopenmp_simd_option - Failed
-- Performing Test _Qopenmp_simd_option
-- Performing Test _Qopenmp_simd_option - Failed
-- Performing Test _qopenmp_simd_option
-- Performing Test _qopenmp_simd_option - Failed
-- Performing Test _openmp_simd_option
-- Performing Test _openmp_simd_option - Failed
-- oneDPL: no effect from enabled ONEDPL_ENABLE_SIMD; unsupported for current compiler
-- Found TBB: TBB::tbb;TBB::tbbmalloc (Required is at least version "2021") found components: tbb tbbmalloc 
CMake Error at CMakeLists.txt:137 (message):
-- oneDPL uses oneTBB 2021.8.0
  dpcpp.exe doesn't support -fsycl option.
```