### PR TITLE
Explicit naming of workaround for GNU-like compiler drivers on windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,13 +227,13 @@ jobs:
           ) else (
             set ninja_targets=build-onedpl-tests
           )
-          if "${{ matrix.cxx_compiler }}" == "dpcpp"(
+          if "${{ matrix.cxx_compiler }}" == "dpcpp" (
             set TOOLCHAIN_FILE_ENABLED=TRUE
           )
-          if "${{ matrix.cxx_compiler }}" == "icpx"(
+          if "${{ matrix.cxx_compiler }}" == "icpx" (
             set TOOLCHAIN_FILE_ENABLED=TRUE
           )
-          if defined TOOLCHAIN_FILE_ENABLED(
+          if %TOOLCHAIN_FILE_ENABLED% == TRUE (
             powershell $output = ${{ matrix.cxx_compiler}} --version; Write-Host ::warning::Compiler: $output
             set toolchain_option=-DCMAKE_TOOLCHAIN_FILE=../cmake/windows-dpcpp-toolchain.cmake
             powershell -command "(Get-Content %CONDA_PREFIX%\Library\lib\cl.cfg) -replace 'CL_CONFIG_TBB_DLL_PATH =', 'CL_CONFIG_TBB_DLL_PATH = %CONDA_PREFIX%\Library\bin' | Out-File -encoding ASCII %CONDA_PREFIX%\Library\lib\cl.cfg"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,10 +227,10 @@ jobs:
           ) else (
             set ninja_targets=build-onedpl-tests
           )
-          if ["${{ matrix.cxx_compiler }}" == "dpcpp"](
+          if "${{ matrix.cxx_compiler }}" == "dpcpp"(
             set TOOLCHAIN_FILE_ENABLED=TRUE
           )
-          if ["${{ matrix.cxx_compiler }}" == "icpx"](
+          if "${{ matrix.cxx_compiler }}" == "icpx"(
             set TOOLCHAIN_FILE_ENABLED=TRUE
           )
           if defined TOOLCHAIN_FILE_ENABLED(

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,11 +198,12 @@ jobs:
             backend: tbb
             device_type: HOST
           - os: windows-2019
-            cxx_compiler: icpx
+            cxx_compiler: dpcpp
             std: 17
             build_type: release
             backend: dpcpp
             device_type: CPU
+    # TODO enable icpx to work on windows
     steps:
       - uses: actions/checkout@v2
       - name: Install Intel® oneAPI Threading Building Blocks (oneTBB)
@@ -211,7 +212,7 @@ jobs:
           call %CONDA%/condabin/conda.bat activate base
           conda install -c intel tbb-devel
       - name: Install Intel® oneAPI DPC++/C++ Compiler
-        if: matrix.cxx_compiler == 'dpcpp' || matrix.cxx_compiler == 'icx' || matrix.cxx_compiler == 'icpx'
+        if: matrix.cxx_compiler == 'dpcpp' || matrix.cxx_compiler == 'icx'
         shell: cmd
         run: | 
           call %CONDA%/condabin/conda.bat activate base
@@ -228,12 +229,6 @@ jobs:
             set ninja_targets=build-onedpl-tests
           )
           if "${{ matrix.cxx_compiler }}" == "dpcpp" (
-            set TOOLCHAIN_FILE_ENABLED=TRUE
-          )
-          if "${{ matrix.cxx_compiler }}" == "icpx" (
-            set TOOLCHAIN_FILE_ENABLED=TRUE
-          )
-          if "%TOOLCHAIN_FILE_ENABLED%" == "TRUE" (
             powershell $output = ${{ matrix.cxx_compiler}} --version; Write-Host ::warning::Compiler: $output
             set toolchain_option=-DCMAKE_TOOLCHAIN_FILE=../cmake/windows-dpcpp-toolchain.cmake
             powershell -command "(Get-Content %CONDA_PREFIX%\Library\lib\cl.cfg) -replace 'CL_CONFIG_TBB_DLL_PATH =', 'CL_CONFIG_TBB_DLL_PATH = %CONDA_PREFIX%\Library\bin' | Out-File -encoding ASCII %CONDA_PREFIX%\Library\lib\cl.cfg"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
             backend: tbb
             device_type: HOST
           - os: windows-2019
-            cxx_compiler: dpcpp
+            cxx_compiler: icpx
             std: 17
             build_type: release
             backend: dpcpp
@@ -227,8 +227,14 @@ jobs:
           ) else (
             set ninja_targets=build-onedpl-tests
           )
-          if "${{ matrix.cxx_compiler }}" == "dpcpp" (
-            powershell $output = dpcpp --version; Write-Host ::warning::Compiler: $output
+          if ["${{ matrix.cxx_compiler }}" == "dpcpp"](
+            set TOOLCHAIN_FILE_ENABLED=TRUE
+          )
+          if ["${{ matrix.cxx_compiler }}" == "icpx"](
+            set TOOLCHAIN_FILE_ENABLED=TRUE
+          )
+          if defined TOOLCHAIN_FILE_ENABLED(
+            powershell $output = ${{ matrix.cxx_compiler}} --version; Write-Host ::warning::Compiler: $output
             set toolchain_option=-DCMAKE_TOOLCHAIN_FILE=../cmake/windows-dpcpp-toolchain.cmake
             powershell -command "(Get-Content %CONDA_PREFIX%\Library\lib\cl.cfg) -replace 'CL_CONFIG_TBB_DLL_PATH =', 'CL_CONFIG_TBB_DLL_PATH = %CONDA_PREFIX%\Library\bin' | Out-File -encoding ASCII %CONDA_PREFIX%\Library\lib\cl.cfg"
           )

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,7 @@ jobs:
           if "${{ matrix.cxx_compiler }}" == "icpx" (
             set TOOLCHAIN_FILE_ENABLED=TRUE
           )
-          if %TOOLCHAIN_FILE_ENABLED% == TRUE (
+          if "%TOOLCHAIN_FILE_ENABLED%" == "TRUE" (
             powershell $output = ${{ matrix.cxx_compiler}} --version; Write-Host ::warning::Compiler: $output
             set toolchain_option=-DCMAKE_TOOLCHAIN_FILE=../cmake/windows-dpcpp-toolchain.cmake
             powershell -command "(Get-Content %CONDA_PREFIX%\Library\lib\cl.cfg) -replace 'CL_CONFIG_TBB_DLL_PATH =', 'CL_CONFIG_TBB_DLL_PATH = %CONDA_PREFIX%\Library\bin' | Out-File -encoding ASCII %CONDA_PREFIX%\Library\lib\cl.cfg"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,7 @@ jobs:
           call %CONDA%/condabin/conda.bat activate base
           conda install -c intel tbb-devel
       - name: Install Intel® oneAPI DPC++/C++ Compiler
-        if: matrix.cxx_compiler == 'dpcpp' || matrix.cxx_compiler == 'icx'
+        if: matrix.cxx_compiler == 'dpcpp' || matrix.cxx_compiler == 'icx' || matrix.cxx_compiler == 'icpx'
         shell: cmd
         run: | 
           call %CONDA%/condabin/conda.bat activate base

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ endif()
 add_library(oneDPL INTERFACE)
 # This compiler check/requirement does not work on Windows with dpcpp and dpcpp-cl compiler drivers
 # icx-cl and icpx are not affected
-if (NOT (WIN32 AND CMAKE_CXX_COMPILER MATCHES ".*dpcpp(-cl)?(.exe)?$"))
+if (NOT (WIN32 AND CMAKE_CXX_COMPILER_ID MATCHES "IntelLLVM Workaround"))
     target_compile_features(oneDPL INTERFACE cxx_std_17)
 endif()
 

--- a/cmake/templates/oneDPLConfig.cmake.in
+++ b/cmake/templates/oneDPLConfig.cmake.in
@@ -25,7 +25,7 @@ if (EXISTS "${_onedpl_headers}")
 
         # This compiler check/requirement does not work on Windows with dpcpp and dpcpp-cl compiler drivers
         # icx-cl and icpx are not affected
-        if (NOT (WIN32 AND CMAKE_CXX_COMPILER MATCHES ".*dpcpp(-cl)?(.exe)?$"))
+        if (NOT (WIN32 AND CMAKE_CXX_COMPILER_ID MATCHES "IntelLLVM Workaround"))
             target_compile_features(oneDPL INTERFACE cxx_std_17)
         endif()
 

--- a/cmake/windows-dpcpp-toolchain.cmake
+++ b/cmake/windows-dpcpp-toolchain.cmake
@@ -23,9 +23,10 @@ set(CMAKE_EXE_LINKER_FLAGS_DEBUG_INIT "/debug")
 set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO_INIT "/debug")
 
 if (NOT ${CMAKE_VERSION} VERSION_LESS "3.20")
-	execute_process(COMMAND ${CMAKE_CXX_COMPILER} /clang:-dumpversion OUTPUT_VARIABLE COMPILER_VERSION)
-	string(REGEX REPLACE "\n" "" COMPILER_VERSION "${COMPILER_VERSION}")
-	set(CMAKE_CXX_COMPILER_ID "Clang ${COMPILER_VERSION}" CACHE STRING "Switch compiler identification" FORCE)
+    execute_process(COMMAND ${CMAKE_CXX_COMPILER} --version OUTPUT_VARIABLE VER)
+    string(REGEX MATCH "[0-9][0-9][0-9][0-9]\\.[0-9]\\.[0-9]" DPCPP_VER ${VER})
+	set(CMAKE_CXX_COMPILER_ID "IntelLLVM Workaround" CACHE STRING "Switch compiler identification" FORCE)
+	set(CMAKE_CXX_COMPILER_VERSION "${DPCPP_VER}" CACHE STRING "Switch compiler identification" FORCE)
 endif()
 
 include(Platform/Windows-Clang)


### PR DESCRIPTION
For the workaround for GNU-Like front ends on windows, this PR explicitly names the CMAKE_CXX_COMPILER_ID to "IntelLLVM Workaround", and CMAKE_CXX_COMPILER_VERSION to the accurate version number.  It previously was CMAKE_CXX_COMPILER_ID="Clang " (with a space) and did not set the version.
 
The workaround is designed to get around incorrect cmake handling of GNU-like intel compilers on windows and functions by changing CMAKE_CXX_COMPILER_ID to something unrecognized by cmake.  If we do instead set CMAKE_CXX_COMPILER_ID to "Clang" and attempt to masquerade as clang, other problems occur.  Therefore, it is less confusing to label it as an "IntelLLVM Workaround".

This PR changes the condition for avoiding `target_compile_features(oneDPL INTERFACE cxx_std_17)` to when "IntelLLVM Workaround" compiler is the CMAKE_CXX_COMPILER_ID to explicitly tie it to the workaround which is preventing usage.  The `target_compile_features(oneDPL INTERFACE cxx_std_17)` check relies upon a "known" CMAKE_CXX_COMPILER_ID to function properly, and we have deliberately modified it away from that knowledge.  

This PR re-enables the check when using `dpcpp-cl`, as it is fine to check `target_compile_features(oneDPL INTERFACE cxx_std_17)`, because the workaround should not be applied for that MSVC-like front end. 

The PR also adds a #TODO  for enabling icpx on windows, which currently does not work as it does not support some flags which are supplied on windows: `/bigobj /Zc:__cplusplus /EHsc`.