### PR TITLE
Fix Hanging buffer_wrapper.pass Test

### DIFF
--- a/test/general/buffer_wrapper.pass.cpp
+++ b/test/general/buffer_wrapper.pass.cpp
@@ -34,7 +34,7 @@ struct test_buffer_wrapper
         EXPECT_TRUE(end - begin == size, "wrong effect of iterator's operator - iterator");
 
         auto buf = begin.get_buffer();
-        sycl::host_accessor buf_accessor(buf);
+        sycl::host_accessor buf_accessor(buf, sycl::read_only);
         auto actual_data = buf_accessor.get_pointer();
 
         EXPECT_TRUE(actual_data == expected_data, "wrong effect of iterator's method get_buffer");
@@ -50,7 +50,7 @@ main()
     std::size_t size = 1000;
     sycl::buffer<std::uint32_t> buf{size};
     test_buffer_wrapper test{};
-    sycl::host_accessor buf_accessor(buf);
+    sycl::host_accessor buf_accessor(buf, sycl::read_only);
     auto data_ptr = buf_accessor.get_pointer();
 
     test(oneapi::dpl::begin(buf), oneapi::dpl::end(buf), data_ptr, size);


### PR DESCRIPTION
An issue on certain systems is that the `buffer_wrapper.pass` test case hangs indefinitely. The cause of this issue has been identified as the presence of multiple host accessors with write access to the same underlying buffer. When the second host accessor is created, its constructor may hang waiting for the first to destruct which will never happen. Since we only perform read operations with these accessors, we can explicitly mark them as `sycl::read_only`. This change resolves the issue as the accessors no longer have the ability to modify the underlying buffer and the construction of subsequent accessors will no longer block.