### PR TITLE
Fix header path in pkg-config files generated without OS subdir

### DIFF
--- a/cmake/README.md
+++ b/cmake/README.md
@@ -108,4 +108,8 @@ This section is applicable for oneDPL packaging creation process, but not for us
 
 How to use:
 
-`cmake [-DOUTPUT_DIR=<output_dir>] -P cmake/scripts/generate_config.cmake`
+`cmake [-DSKIP_HEADERS_SUBDIR=<TRUE|FALSE>] [-DOUTPUT_DIR=<output_dir>] -P cmake/scripts/generate_config.cmake`
+
+When `SKIP_HEADERS_SUBDIR` is set to false or not defined (by default), the script adds the subdirectories:
+- `windows` and `linux` for headers in `<prefix></subdirectory>/include` pattern.
+- `pkgconfig-win` and `pkgconfig-lin` for pkg-config files in `<prefix></subdirectory>/dpl.pc` pattern.

--- a/cmake/scripts/generate_config.cmake
+++ b/cmake/scripts/generate_config.cmake
@@ -48,19 +48,14 @@ configure_file("${ONEDPL_ROOT}/cmake/templates/oneDPLConfigVersion.cmake.in"
                "${OUTPUT_DIR}/oneDPLConfigVersion.cmake"
                @ONLY)
 
-set(_onedpl_pkgconfig_header_suffix include)
-if (NOT SKIP_HEADERS_SUBDIR)
+if (SKIP_HEADERS_SUBDIR)
+    set(_onedpl_pkgconfig_header_suffix include)
+    configure_file("${ONEDPL_ROOT}/integration/pkgconfig/dpl.pc.in" "${OUTPUT_DIR}/dpl.pc" @ONLY)
+else()
     set(_onedpl_pkgconfig_header_suffix windows/include)
-endif()
-configure_file("${ONEDPL_ROOT}/integration/pkgconfig/dpl.pc.in"
-               "${OUTPUT_DIR}/pkgconfig-win/dpl.pc"
-               @ONLY)
-
-if (NOT SKIP_HEADERS_SUBDIR)
+    configure_file("${ONEDPL_ROOT}/integration/pkgconfig/dpl.pc.in" "${OUTPUT_DIR}/pkgconfig-win/dpl.pc" @ONLY)
     set(_onedpl_pkgconfig_header_suffix linux/include)
+    configure_file("${ONEDPL_ROOT}/integration/pkgconfig/dpl.pc.in" "${OUTPUT_DIR}/pkgconfig-lin/dpl.pc" @ONLY)
 endif()
-configure_file("${ONEDPL_ROOT}/integration/pkgconfig/dpl.pc.in"
-               "${OUTPUT_DIR}/pkgconfig-lin/dpl.pc"
-               @ONLY)
 
 message(STATUS "oneDPL ${PROJECT_VERSION} configuration files were created in '${OUTPUT_DIR}'")

--- a/cmake/scripts/generate_config.cmake
+++ b/cmake/scripts/generate_config.cmake
@@ -48,12 +48,17 @@ configure_file("${ONEDPL_ROOT}/cmake/templates/oneDPLConfigVersion.cmake.in"
                "${OUTPUT_DIR}/oneDPLConfigVersion.cmake"
                @ONLY)
 
-set(_onedpl_headers_subdir windows)
+set(_onedpl_pkgconfig_header_suffix include)
+if (NOT SKIP_HEADERS_SUBDIR)
+    set(_onedpl_pkgconfig_header_suffix windows/include)
+endif()
 configure_file("${ONEDPL_ROOT}/integration/pkgconfig/dpl.pc.in"
                "${OUTPUT_DIR}/pkgconfig-win/dpl.pc"
                @ONLY)
 
-set(_onedpl_headers_subdir linux)
+if (NOT SKIP_HEADERS_SUBDIR)
+    set(_onedpl_pkgconfig_header_suffix linux/include)
+endif()
 configure_file("${ONEDPL_ROOT}/integration/pkgconfig/dpl.pc.in"
                "${OUTPUT_DIR}/pkgconfig-lin/dpl.pc"
                @ONLY)

--- a/integration/pkgconfig/dpl.pc.in
+++ b/integration/pkgconfig/dpl.pc.in
@@ -13,7 +13,7 @@
 ##===----------------------------------------------------------------------===##
 
 prefix=${pcfiledir}/../../
-includedir=${prefix}/@_onedpl_headers_subdir@/include
+includedir=${prefix}/@_onedpl_pkgconfig_header_suffix@
 
 Name: oneDPL
 Description: Intel(R) DPC++ Library.


### PR DESCRIPTION
This generates the right header path for the package config files when they are generated with `SKIP_HEADERS_SUBDIR` set to `TRUE`.
This is useful for creation of e.g., conda packages which do not have `windows` or `linux` subdirectories.