### PR TITLE
Adding missing underscore to template parameter name

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -198,7 +198,7 @@ __joint_exclusive_scan(_Args&&... __args)
 #if _ONEDPL_SYCL2020_COLLECTIVES_PRESENT
     return sycl::joint_exclusive_scan(::std::forward<_Args>(__args)...);
 #else
-    return sycl::ONEAPI::exclusive_scan(::std::forward<Args>(__args)...);
+    return sycl::ONEAPI::exclusive_scan(::std::forward<_Args>(__args)...);
 #endif
 }
 


### PR DESCRIPTION
The 'Args' template parameter in the joint_exclusive_scan wrapper implementation used when SYCL 2020 collectives are not available is missing a leading underscore.