### PR TITLE
Fix a compilation error in async algorithms introduced by #811

### DIFF
--- a/include/oneapi/dpl/internal/async_impl/async_utils.h
+++ b/include/oneapi/dpl/internal/async_impl/async_utils.h
@@ -35,14 +35,14 @@ template <typename _ExecPolicy, typename _T, typename _Op1, typename... _Events>
 using __enable_if_device_execution_policy_single_no_default = typename ::std::enable_if<
     oneapi::dpl::__internal::__is_device_execution_policy<typename ::std::decay<_ExecPolicy>::type>::value &&
         !::std::is_convertible<_Op1, sycl::event>::value &&
-        oneapi::dpl::__internal::__is_convertible_to_event<_Events...>::value,
+        oneapi::dpl::__internal::__is_convertible_to_event<_Events...>,
     _T>::type;
 
 template <typename _ExecPolicy, typename _T, typename _Op1, typename _Op2, typename... _Events>
 using __enable_if_device_execution_policy_double_no_default = typename ::std::enable_if<
     oneapi::dpl::__internal::__is_device_execution_policy<typename ::std::decay<_ExecPolicy>::type>::value &&
         !::std::is_convertible<_Op1, sycl::event>::value && !::std::is_convertible<_Op2, sycl::event>::value &&
-        oneapi::dpl::__internal::__is_convertible_to_event<_Events...>::value,
+        oneapi::dpl::__internal::__is_convertible_to_event<_Events...>,
     _T>::type;
 
 } // namespace __internal


### PR DESCRIPTION
My bad, forgot to change the use of `__is_convertible_to_event` after changing its definition from `bool_constant` to `bool`.