### PR TITLE
CI: fix "Node.js 12 actions are deprecated" warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
       - name: Install prerequisites
         run: |
           echo GITHUB_SHA_SHORT=${GITHUB_SHA::8} >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           mkdir html
           sphinx-build -b html documentation/library_guide/ html/
       - name: Archive build directory
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v1
         with:
             name: onedpl-html-docs-${{ env.GITHUB_SHA_SHORT }}
             path: html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v2
       - name: Install prerequisites
         run: |
           echo GITHUB_SHA_SHORT=${GITHUB_SHA::8} >> $GITHUB_ENV

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
   clang-format:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Get clang-format
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install prerequisites
         run: |
           sudo apt update && sudo apt install -y codespell
@@ -55,8 +55,8 @@ jobs:
   documentation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
       - name: Install prerequisites
         run: |
           echo GITHUB_SHA_SHORT=${GITHUB_SHA::8} >> $GITHUB_ENV
@@ -66,7 +66,7 @@ jobs:
           mkdir html
           sphinx-build -b html documentation/library_guide/ html/
       - name: Archive build directory
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v3
         with:
             name: onedpl-html-docs-${{ env.GITHUB_SHA_SHORT }}
             path: html
@@ -146,7 +146,7 @@ jobs:
             backend: serial
             device_type: HOST
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Intel® oneAPI Threading Building Blocks (oneTBB)
         run: $CONDA/bin/conda install -c intel tbb-devel
       - name: Install Intel® oneAPI DPC++/C++ Compiler
@@ -204,7 +204,7 @@ jobs:
             backend: dpcpp
             device_type: CPU
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Intel® oneAPI Threading Building Blocks (oneTBB)
         shell: cmd
         run: |
@@ -262,7 +262,7 @@ jobs:
             build_type: release
             backend: omp
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Intel® oneAPI C++ Compiler Classic and Intel® oneAPI Threading Building Blocks
         run: |
           wget ${MACOS_ONEAPI_DOWNLOAD_LINK}


### PR DESCRIPTION
Using the latest actions versions is needed to fix deprecations, e.g.:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/setup-python@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

Specifying the latest version for python resulted in another warning:
> The `python-version` input is not set. The version of Python currently in `PATH` will be used.

That is why the latest stable (3.x) version of python was explicitly specified according to https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#using-the-python-version-input

The latest versions of the actions are found in https://github.com/actions (search for repositories in this channel and their latest major versions).