### PR TITLE
Fix Integer Wraparound in Single Group Reduce

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -216,7 +216,7 @@ struct transform_reduce_known
                const ::std::size_t __global_offset, _AccLocal& __local_mem, const _Acc&... __acc) const
     {
         const ::std::size_t __adjusted_global_id = __global_offset + __iters_per_work_item * __global_id;
-        const ::std::int64_t __items_to_process = 
+        const ::std::int64_t __items_to_process =
             static_cast<std::int64_t>(__n) - static_cast<std::int64_t>(__iters_per_work_item * __global_id);
         // Add neighbour to the current __local_mem
         if (__items_to_process >= __iters_per_work_item)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -229,7 +229,7 @@ struct transform_reduce_known
         }
         else if (__adjusted_global_id < __adjusted_n)
         {
-            const _Size __items_to_process =__adjusted_n - __adjusted_global_id;
+            const _Size __items_to_process = __adjusted_n - __adjusted_global_id;
             // Keep these statements in the same scope to allow for better memory alignment
             typename _AccLocal::value_type __res = __unary_op(__adjusted_global_id, __acc...);
             for (_Size __i = 1; __i < __items_to_process; ++__i)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -215,11 +215,10 @@ struct transform_reduce_known
                const ::std::size_t /* unused __iters_per_work_item */, const ::std::size_t __global_id,
                const ::std::size_t __global_offset, _AccLocal& __local_mem, const _Acc&... __acc) const
     {
-        const ::std::size_t __adjusted_global_id = __global_offset + __iters_per_work_item * __global_id;
-        const ::std::int64_t __items_to_process =
-            static_cast<std::int64_t>(__n) - static_cast<std::int64_t>(__iters_per_work_item * __global_id);
+        const _Size __adjusted_global_id = __global_offset + __iters_per_work_item * __global_id;
+        const _Size __adjusted_n = __global_offset + __n;
         // Add neighbour to the current __local_mem
-        if (__items_to_process >= __iters_per_work_item)
+        if (__adjusted_global_id + __iters_per_work_item < __adjusted_n)
         {
             // Keep these statements in the same scope to allow for better memory alignment
             typename _AccLocal::value_type __res = __unary_op(__adjusted_global_id, __acc...);
@@ -228,8 +227,9 @@ struct transform_reduce_known
                 __res = __binary_op(__res, __unary_op(__adjusted_global_id + __i, __acc...));
             __local_mem[__local_id] = __res;
         }
-        else if (__items_to_process > 0)
+        else if (__adjusted_global_id < __adjusted_n)
         {
+            const _Size __items_to_process =__adjusted_n - __adjusted_global_id;
             // Keep these statements in the same scope to allow for better memory alignment
             typename _AccLocal::value_type __res = __unary_op(__adjusted_global_id, __acc...);
             for (_Size __i = 1; __i < __items_to_process; ++__i)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -216,7 +216,8 @@ struct transform_reduce_known
                const ::std::size_t __global_offset, _AccLocal& __local_mem, const _Acc&... __acc) const
     {
         const ::std::size_t __adjusted_global_id = __global_offset + __iters_per_work_item * __global_id;
-        const ::std::int64_t __items_to_process = __n - (__iters_per_work_item * __global_id);
+        const ::std::int64_t __items_to_process = 
+            static_cast<std::int64_t>(__n) - static_cast<std::int64_t>(__iters_per_work_item * __global_id);
         // Add neighbour to the current __local_mem
         if (__items_to_process >= __iters_per_work_item)
         {


### PR DESCRIPTION
One of the issues that has been identified with the new reduce implementation are segfaulting tests on certain operating systems when compiled with the latest DPC++ compiler in release mode with C++17 and ran on the CPU. This issue has been identified as an illegal memory access that stems from the incorrect result of [this](https://github.com/oneapi-src/oneDPL/blob/661cc91707e39a4efde47c7a573eb40c71cc971f/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h#L219) assignment.

Within `const ::std::int64_t __items_to_process = __n - (__iters_per_work_item * __global_id);`, `__n` and `__iters_per_work_item * __global_id` are both `std::size_t` datatypes. Despite assigning the result to a `std::int64_t` type, the result may wrap around to a large integer when `__iters_per_work_item * __global_id > __n` causing the incorrect branch to be taken and a segfault when memory is accessed with that offset. In practice, this behavior is uncommon but is the cause of these segfaults discussed above.

To remedy this issue and prevent this wraparound behavior, we explicitly cast the two terms to `std::int64_t` before the subtraction takes place.