### PR TITLE
[oneDPL] a hot fix for 'permutation_view_simple' pseudo range

### DIFF
--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -342,7 +342,7 @@ struct transform_view_simple
 
 template <typename _Map>
 auto
-test_map_view(int) -> decltype(::std::declval<_Map>().begin(), ::std::true_type{});
+test_map_view(int) -> decltype(::std::declval<_Map>()[0], ::std::true_type{});
 
 template <typename _Map>
 auto


### PR DESCRIPTION
[oneDPL] a hot fix for 'permutation_view_simple' pseudo range.

The oneDPL internal views ("pseudo" ranges or "simple" views) have limited semantic and don't have begin/end for most of them, just subscription operator and size/empty methods.
Everywhere the impl doesn't rely on begin/end. just on operator[]/size/empty methods.

But one place remains and a customer faced to compilation issue with 'permutation_view_simple':

`error: implicit instantiation of undefined template 'oneapi::dpl::__ranges::permutation_view_simple<oneapi::dpl::__ranges::guard_view<int *>, oneapi::dpl::__ranges::transform_view_simple<oneapi::dpl::__ranges::guard_view<int *>, (lambda at par_amg_setup.c:20:16)>>'`

We have got unexpected specialization being chosen based on SFINAE helper `struct permutation_view_simple<_R, _M, typename ::std::enable_if<is_map_view<_M>::value>::type>`, because `test_map_view(int)` returns `false`.

The change fixes that issue.