### PR TITLE
Updated Ubuntu 18.04 to Ubuntu latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,13 +99,13 @@ jobs:
             build_type: release
             backend: omp
             device_type: HOST
-          - os: ubuntu-18.04
+          - os: ubuntu-latest
             cxx_compiler: g++
             std: 17
             build_type: release
             backend: omp
             device_type: HOST
-          - os: ubuntu-18.04
+          - os: ubuntu-latest
             cxx_compiler: g++
             std: 17
             build_type: release
@@ -129,7 +129,7 @@ jobs:
             build_type: release
             backend: omp
             device_type: HOST
-          - os: ubuntu-18.04
+          - os: ubuntu-latest
             cxx_compiler: clang++
             std: 17
             build_type: release


### PR DESCRIPTION
Ubuntu 18.04 will not be supported after March. I have updated the 18.04 version of Ubuntu to latest, via the script. I tested the changes and they passed successfully.

