### PR TITLE
Add implementation of oneapi::dpl::cbegin() and oneapi::dpl::cend() V3

### DIFF
--- a/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
+++ b/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
@@ -172,11 +172,7 @@ template <typename _ExecutionPolicy, typename _ForwardIterator, typename _T,
 auto
 __pattern_fill_async(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _T& __value)
 {
-    return __pattern_walk1_async(
-        ::std::forward<_ExecutionPolicy>(__exec),
-        __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::write>(__first),
-        __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::write>(__last),
-        fill_functor<_T>{__value});
+    return __pattern_walk1_async(::std::forward<_ExecutionPolicy>(__exec), __first, __last, fill_functor<_T>{__value});
 }
 
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/internal/function.h
+++ b/include/oneapi/dpl/internal/function.h
@@ -58,40 +58,6 @@ using oneapi::dpl::__internal::is_hetero_iterator;
 using oneapi::dpl::__par_backend_hetero::__internal::__buffer;
 #endif
 
-#if _ONEDPL_BACKEND_SYCL
-// Helpers used to get indexable access to the data passed to the SYCL implementation of an
-// algorithm from either a SYCL iterator or a USM pointer.
-template <sycl::access::mode Mode, typename Policy, typename Iterator>
-auto
-get_access(Policy, Iterator i, typename ::std::enable_if<is_hetero_iterator<Iterator>::value, void>::type* = nullptr)
-    -> decltype(i.get_buffer().template get_access<Mode>())
-{
-    return i.get_buffer().template get_access<Mode>();
-}
-
-template <sycl::access::mode Mode, typename Policy, typename Iterator>
-Iterator
-get_access(Policy, Iterator i, typename ::std::enable_if<!is_hetero_iterator<Iterator>::value, void>::type* = nullptr)
-{
-    return i;
-}
-
-template <sycl::access::mode Mode, typename Policy, typename T>
-counting_iterator<T>
-get_access(Policy, counting_iterator<T> i)
-{
-    return i;
-}
-
-template <sycl::access::mode Mode, typename Policy, typename T>
-T*
-get_access(const Policy& policy, T* ptr)
-{
-    assert(sycl::get_pointer_type(ptr, policy.queue().get_context()) == sycl::usm::alloc::shared);
-    return ptr;
-}
-#endif
-
 // struct for checking if iterator is a discard_iterator or not
 template <typename Iter, typename Void = void> // for non-discard iterators
 struct is_discard_iterator : ::std::false_type

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -47,13 +47,6 @@ namespace dpl
 namespace __par_backend_hetero
 {
 
-template <access_mode outMode, typename _Iterator>
-auto
-make_iter_mode(const _Iterator& __it) -> decltype(iter_mode<outMode>()(__it))
-{
-    return iter_mode<outMode>()(__it);
-}
-
 // set of class templates to name kernels
 
 template <typename... _Name>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -48,69 +48,6 @@ namespace __par_backend_hetero
 {
 
 //-----------------------------------------------------------------------------
-//- iter_mode_resolver
-//-----------------------------------------------------------------------------
-
-// iter_mode_resolver resolves the situations when
-// the access mode provided by a user differs (inMode) from
-// the access mode required by an algorithm (outMode).
-// In general case iter_mode_resolver accepts the only situations
-// when inMode == outMode,
-// whereas the template specializations describe cases with specific
-// inMode and outMode and the preferred access mode between the two.
-template <access_mode inMode, access_mode outMode>
-struct iter_mode_resolver
-{
-    static_assert(inMode == outMode, "Access mode provided by user conflicts with the one required by the algorithm");
-    static constexpr access_mode value = inMode;
-};
-
-template <>
-struct iter_mode_resolver<access_mode::read, access_mode::read_write>
-{
-    static constexpr access_mode value = access_mode::read;
-};
-
-template <>
-struct iter_mode_resolver<access_mode::write, access_mode::read_write>
-{
-    static constexpr access_mode value = access_mode::write;
-};
-
-template <>
-struct iter_mode_resolver<access_mode::read_write, access_mode::read>
-{
-    //TODO: warn user that the access mode is changed
-    static constexpr access_mode value = access_mode::read;
-};
-
-template <>
-struct iter_mode_resolver<access_mode::read_write, access_mode::write>
-{
-    //TODO: warn user that the access mode is changed
-    static constexpr access_mode value = access_mode::write;
-};
-
-template <>
-struct iter_mode_resolver<access_mode::discard_write, access_mode::write>
-{
-    static constexpr access_mode value = access_mode::discard_write;
-};
-
-template <>
-struct iter_mode_resolver<access_mode::discard_read_write, access_mode::write>
-{
-    //TODO: warn user that the access mode is changed
-    static constexpr access_mode value = access_mode::write;
-};
-
-template <>
-struct iter_mode_resolver<access_mode::discard_read_write, access_mode::read_write>
-{
-    static constexpr access_mode value = access_mode::discard_read_write;
-};
-
-//-----------------------------------------------------------------------------
 //- iter_mode
 //-----------------------------------------------------------------------------
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -64,8 +64,7 @@ struct sycl_iterator
     }
 
     sycl_iterator(const sycl_iterator<access_mode::read_write, T, Allocator>& in)
-        : buffer(in.get_buffer()),
-          idx(in.get_index())
+        : buffer(in.get_buffer()), idx(in.get_index())
     {
         static_assert(Mode == access_mode::read_write || Mode == access_mode::read || Mode == access_mode::write,
                       "We are able to convert 'read_write' interator only to 'read' or 'write' iterator");

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -99,8 +99,9 @@ struct sycl_iterator
     {
         return it - forward;
     }
+    template <access_mode inMode>
     difference_type
-    operator-(const sycl_iterator& it) const
+    operator-(const sycl_iterator<inMode, T, Allocator>& it) const
     {
         return eval_diff_with(it);
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -67,7 +67,7 @@ struct sycl_iterator
         : buffer(in.get_buffer()), idx(in.get_index())
     {
         static_assert(Mode == access_mode::read_write || Mode == access_mode::read || Mode == access_mode::write,
-                      "We are able to convert 'read_write' interator only to 'read' or 'write' iterator");
+                      "We are able to convert 'read_write' iterator only to 'read' or 'write' iterator");
     }
     sycl_iterator&
     operator=(const sycl_iterator& in)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -55,13 +55,13 @@ struct sycl_iterator
         : buffer(vec), idx(index)
     {
     }
-    // required for iter_mode
-    sycl_iterator(const sycl_iterator<access_mode::read_write, T, Allocator>& in,
-                  typename ::std::enable_if<Mode == access_mode::read, void>::type* = nullptr)
-        : buffer(in.get_buffer())
+
+    sycl_iterator(const sycl_iterator<access_mode::read_write, T, Allocator>& in)
+        : buffer(in.get_buffer()),
+          idx(in.get_index())
     {
-        auto old_iter = sycl_iterator<inMode, T, Allocator>{in.get_buffer(), 0};
-        idx = in - old_iter;
+        static_assert(Mode == access_mode::read_write || Mode == access_mode::read || Mode == access_mode::write,
+                      "We are able to convert 'read_write' interator only to 'read' or 'write' iterator");
     }
     sycl_iterator&
     operator=(const sycl_iterator& in)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -56,8 +56,9 @@ struct sycl_iterator
     {
     }
     // required for iter_mode
-    template <access_mode inMode>
-    sycl_iterator(const sycl_iterator<inMode, T, Allocator>& in) : buffer(in.get_buffer())
+    sycl_iterator(const sycl_iterator<access_mode::read_write, T, Allocator>& in,
+                  typename ::std::enable_if<Mode == access_mode::read, void>::type* = nullptr)
+        : buffer(in.get_buffer())
     {
         auto old_iter = sycl_iterator<inMode, T, Allocator>{in.get_buffer(), 0};
         idx = in - old_iter;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -200,6 +200,22 @@ __internal::sycl_iterator<access_mode::discard_read_write, T, Allocator> end(syc
     return __internal::sycl_iterator<access_mode::discard_read_write, T, Allocator>{buf,
                                                                                     __dpl_sycl::__get_buffer_size(buf)};
 }
+
+// cbegin / cend
+template <typename T, typename Allocator>
+__internal::sycl_const_iterator<T, Allocator>
+cbegin(sycl::buffer<T, /*dim=*/1, Allocator> buf)
+{
+    return __internal::sycl_const_iterator<T, Allocator>{buf, 0};
+}
+
+template <typename T, typename Allocator>
+__internal::sycl_const_iterator<T, Allocator>
+cend(sycl::buffer<T, /*dim=*/1, Allocator> buf)
+{
+    return __internal::sycl_const_iterator<T, Allocator>{buf, __dpl_sycl::__get_buffer_size(buf)};
+}
+
 } // namespace dpl
 } // namespace oneapi
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -65,8 +65,11 @@ struct sycl_iterator
     sycl_iterator&
     operator=(const sycl_iterator& in)
     {
-        buffer = in.buffer;
-        idx = in.idx;
+        if (&in != this)
+        {
+            buffer = in.buffer;
+            idx = in.idx;
+        }
         return *this;
     }
     sycl_iterator

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -121,6 +121,9 @@ struct sycl_iterator
     }
 };
 
+template <typename T, typename Allocator = __dpl_sycl::__buffer_allocator<T>>
+using sycl_const_iterator = sycl_iterator<access_mode::read, T, Allocator>;
+
 // mode converter when property::noinit present
 template <access_mode __mode>
 struct _ModeConverter

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -203,15 +203,13 @@ __internal::sycl_iterator<access_mode::discard_read_write, T, Allocator> end(syc
 
 // cbegin / cend
 template <typename T, typename Allocator>
-__internal::sycl_const_iterator<T, Allocator>
-cbegin(sycl::buffer<T, /*dim=*/1, Allocator> buf)
+__internal::sycl_const_iterator<T, Allocator> cbegin(sycl::buffer<T, /*dim=*/1, Allocator> buf)
 {
     return __internal::sycl_const_iterator<T, Allocator>{buf, 0};
 }
 
 template <typename T, typename Allocator>
-__internal::sycl_const_iterator<T, Allocator>
-cend(sycl::buffer<T, /*dim=*/1, Allocator> buf)
+__internal::sycl_const_iterator<T, Allocator> cend(sycl::buffer<T, /*dim=*/1, Allocator> buf)
 {
     return __internal::sycl_const_iterator<T, Allocator>{buf, __dpl_sycl::__get_buffer_size(buf)};
 }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -157,10 +157,10 @@ __internal::sycl_iterator<Mode, T, Allocator>
 }
 
 template <typename T, typename Allocator>
-__internal::sycl_iterator<access_mode::discard_read_write, T, Allocator>
+__internal::sycl_iterator<access_mode::read_write, T, Allocator>
     begin(sycl::buffer<T, /*dim=*/1, Allocator> buf, __dpl_sycl::__no_init)
 {
-    return __internal::sycl_iterator<access_mode::discard_read_write, T, Allocator>{buf, 0};
+    return __internal::sycl_iterator<access_mode::read_write, T, Allocator>{buf, 0};
 }
 
 // end
@@ -179,11 +179,11 @@ __internal::sycl_iterator<Mode, T, Allocator>
 }
 
 template <typename T, typename Allocator>
-__internal::sycl_iterator<access_mode::discard_read_write, T, Allocator> end(sycl::buffer<T, /*dim=*/1, Allocator> buf,
+__internal::sycl_iterator<access_mode::read_write, T, Allocator> end(sycl::buffer<T, /*dim=*/1, Allocator> buf,
                                                                              __dpl_sycl::__no_init)
 {
-    return __internal::sycl_iterator<access_mode::discard_read_write, T, Allocator>{buf,
-                                                                                    __dpl_sycl::__get_buffer_size(buf)};
+    return __internal::sycl_iterator<access_mode::read_write, T, Allocator>{buf,
+                                                                            __dpl_sycl::__get_buffer_size(buf)};
 }
 
 // cbegin / cend

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -128,25 +128,6 @@ struct sycl_iterator
 template <typename T, typename Allocator = __dpl_sycl::__buffer_allocator<T>>
 using sycl_const_iterator = sycl_iterator<access_mode::read, T, Allocator>;
 
-// mode converter when property::noinit present
-template <access_mode __mode>
-struct _ModeConverter
-{
-    static constexpr access_mode __value = __mode;
-};
-
-template <>
-struct _ModeConverter<access_mode::read_write>
-{
-    static constexpr access_mode __value = access_mode::discard_read_write;
-};
-
-template <>
-struct _ModeConverter<access_mode::write>
-{
-    static constexpr access_mode __value = access_mode::discard_write;
-};
-
 } // namespace __internal
 
 template <typename T, typename Allocator>
@@ -169,10 +150,10 @@ __internal::sycl_iterator<Mode, T, Allocator> begin(sycl::buffer<T, /*dim=*/1, A
 }
 
 template <typename T, typename Allocator, access_mode Mode>
-__internal::sycl_iterator<__internal::_ModeConverter<Mode>::__value, T, Allocator>
+__internal::sycl_iterator<Mode, T, Allocator>
     begin(sycl::buffer<T, /*dim=*/1, Allocator> buf, sycl::mode_tag_t<Mode>, __dpl_sycl::__no_init)
 {
-    return __internal::sycl_iterator<__internal::_ModeConverter<Mode>::__value, T, Allocator>{buf, 0};
+    return __internal::sycl_iterator<Mode, T, Allocator>{buf, 0};
 }
 
 template <typename T, typename Allocator>
@@ -190,10 +171,10 @@ __internal::sycl_iterator<Mode, T, Allocator> end(sycl::buffer<T, /*dim=*/1, All
 }
 
 template <typename T, typename Allocator, access_mode Mode>
-__internal::sycl_iterator<__internal::_ModeConverter<Mode>::__value, T, Allocator>
+__internal::sycl_iterator<Mode, T, Allocator>
     end(sycl::buffer<T, /*dim=*/1, Allocator> buf, sycl::mode_tag_t<Mode>, __dpl_sycl::__no_init)
 {
-    return __internal::sycl_iterator<__internal::_ModeConverter<Mode>::__value, T, Allocator>{
+    return __internal::sycl_iterator<Mode, T, Allocator>{
         buf, __dpl_sycl::__get_buffer_size(buf)};
 }
 

--- a/test/general/buffer_wrapper.pass.cpp
+++ b/test/general/buffer_wrapper.pass.cpp
@@ -58,6 +58,7 @@ main()
     test(oneapi::dpl::begin(buf, sycl::write_only, __dpl_sycl::__no_init{}), oneapi::dpl::end(buf, sycl::write_only, __dpl_sycl::__no_init{}), data_ptr, size);
     test(oneapi::dpl::begin(buf, __dpl_sycl::__no_init{}), oneapi::dpl::end(buf, __dpl_sycl::__no_init{}), data_ptr, size);
 
+    test(oneapi::dpl::cbegin(buf), oneapi::dpl::cend(buf), data_ptr, size);
 #endif
     return done(TEST_DPCPP_BACKEND_PRESENT);
 }

--- a/test/general/sycl_iterator/sycl_iterator_operations.pass.cpp
+++ b/test/general/sycl_iterator/sycl_iterator_operations.pass.cpp
@@ -206,6 +206,29 @@ test_sycl_const_iterator_less()
     EXPECT_FALSE(it_end < it_cbegin, "Wrong compare result of two iterators");
 }
 
+void
+test_sycl_const_iterator_minus()
+{
+    constexpr std::size_t count = 10;
+
+    sycl::buffer<float> buf{count};
+
+    const auto it_cbegin = oneapi::dpl::cbegin(buf);
+    const auto it_cbegin_1 = oneapi::dpl::cbegin(buf) + 1;
+    const auto it_begin = oneapi::dpl::begin(buf);
+    const auto it_begin_1 = oneapi::dpl::begin(buf) + 1;
+    const auto it_cend = oneapi::dpl::cend(buf);
+    const auto it_end = oneapi::dpl::end(buf);
+
+    EXPECT_TRUE(0 == (it_cbegin - it_cbegin), "Wrong diff result of two iterators");
+    EXPECT_TRUE(1 == (it_cbegin_1 - it_cbegin), "Wrong diff result of two iterators");
+    EXPECT_TRUE(0 == (it_begin - it_begin), "Wrong diff result of two iterators");
+    EXPECT_TRUE(1 == (it_begin_1 - it_begin), "Wrong diff result of two iterators");
+
+    EXPECT_TRUE(count == (it_end - it_cbegin), "Wrong diff result of two iterators");
+    EXPECT_TRUE(count == (it_cend - it_begin), "Wrong diff result of two iterators");
+}
+
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
 std::int32_t
@@ -220,6 +243,7 @@ main()
     test_sycl_const_iterator_equal();
     test_sycl_const_iterator_not_equal();
     test_sycl_const_iterator_less();
+    test_sycl_const_iterator_minus();
 
 #endif // TEST_DPCPP_BACKEND_PRESENT
 

--- a/test/general/sycl_iterator/sycl_iterator_operations.pass.cpp
+++ b/test/general/sycl_iterator/sycl_iterator_operations.pass.cpp
@@ -175,6 +175,37 @@ test_sycl_const_iterator_not_equal()
     EXPECT_TRUE(it_cbegin != it_cend, "Wrong compare result of two iterators");
 }
 
+void
+test_sycl_const_iterator_less()
+{
+    constexpr std::size_t count = 10;
+
+    sycl::buffer<float> buf{count};
+
+    const auto it_cbegin = oneapi::dpl::cbegin(buf);
+    const auto it_cbegin_1 = oneapi::dpl::cbegin(buf) + 1;
+    const auto it_begin = oneapi::dpl::begin(buf);
+    const auto it_begin_1 = oneapi::dpl::begin(buf) + 1;
+    const auto it_cend = oneapi::dpl::cend(buf);
+    const auto it_end = oneapi::dpl::end(buf);
+
+    EXPECT_TRUE(it_begin < it_begin_1, "Wrong compare result of two iterators");
+    EXPECT_TRUE(it_begin < it_cend, "Wrong compare result of two iterators");
+    EXPECT_TRUE(it_begin < it_end, "Wrong compare result of two iterators");
+    EXPECT_TRUE(it_cbegin < it_cend, "Wrong compare result of two iterators");
+    EXPECT_TRUE(it_cbegin < it_end, "Wrong compare result of two iterators");
+
+    EXPECT_FALSE(it_begin_1 < it_begin, "Wrong compare result of two iterators");
+    EXPECT_FALSE(it_cend < it_begin, "Wrong compare result of two iterators");
+    EXPECT_FALSE(it_end < it_begin, "Wrong compare result of two iterators");
+    EXPECT_FALSE(it_cend < it_cbegin, "Wrong compare result of two iterators");
+    EXPECT_FALSE(it_end < it_cbegin, "Wrong compare result of two iterators");
+
+    EXPECT_TRUE(it_cbegin < it_cbegin_1, "Wrong compare result of two iterators");
+    EXPECT_TRUE(it_cbegin < it_end, "Wrong compare result of two iterators");
+    EXPECT_FALSE(it_end < it_cbegin, "Wrong compare result of two iterators");
+}
+
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
 std::int32_t
@@ -188,6 +219,7 @@ main()
     test_sycl_const_iterator_assignment();
     test_sycl_const_iterator_equal();
     test_sycl_const_iterator_not_equal();
+    test_sycl_const_iterator_less();
 
 #endif // TEST_DPCPP_BACKEND_PRESENT
 

--- a/test/general/sycl_iterator/sycl_iterator_operations.pass.cpp
+++ b/test/general/sycl_iterator/sycl_iterator_operations.pass.cpp
@@ -107,6 +107,50 @@ test_iterators_possibly_equal()
 }
 };
 
+void
+test_sycl_const_iterator_equal()
+{
+    constexpr std::size_t count = 10;
+
+    sycl::buffer<float> buf{count};
+
+    const auto it_cbegin = oneapi::dpl::cbegin(buf);
+    const auto it_begin = oneapi::dpl::begin(buf);
+    const auto it_cend = oneapi::dpl::cend(buf);
+    const auto it_end = oneapi::dpl::end(buf);
+
+    EXPECT_TRUE(it_cbegin == it_begin, "Wrong compare result of two iterators");
+    EXPECT_TRUE(it_begin == it_cbegin, "Wrong compare result of two iterators");
+
+    EXPECT_TRUE(it_cbegin != it_end, "Wrong compare result of two iterators");
+    EXPECT_TRUE(it_end != it_cbegin, "Wrong compare result of two iterators");
+
+    EXPECT_TRUE(it_cend == it_end, "Wrong compare result of two iterators");
+    EXPECT_FALSE(it_cbegin == it_cend, "Wrong compare result of two iterators");
+}
+
+void
+test_sycl_const_iterator_not_equal()
+{
+    constexpr std::size_t count = 10;
+
+    sycl::buffer<float> buf{count};
+
+    const auto it_cbegin = oneapi::dpl::cbegin(buf);
+    const auto it_begin = oneapi::dpl::begin(buf);
+    const auto it_cend = oneapi::dpl::cend(buf);
+    const auto it_end = oneapi::dpl::end(buf);
+
+    EXPECT_FALSE(it_cbegin != it_begin, "Wrong compare result of two iterators");
+    EXPECT_FALSE(it_begin != it_cbegin, "Wrong compare result of two iterators");
+
+    EXPECT_FALSE(it_cbegin == it_end, "Wrong compare result of two iterators");
+    EXPECT_FALSE(it_end == it_cbegin, "Wrong compare result of two iterators");
+
+    EXPECT_FALSE(it_cend != it_end, "Wrong compare result of two iterators");
+    EXPECT_TRUE(it_cbegin != it_cend, "Wrong compare result of two iterators");
+}
+
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
 std::int32_t
@@ -116,6 +160,9 @@ main()
 
     // Check the correctness of oneapi::dpl::__internal::__iterators_possibly_equal
     oneapi::dpl::__internal::test_iterators_possibly_equal();
+
+    test_sycl_const_iterator_equal();
+    test_sycl_const_iterator_not_equal();
 
 #endif // TEST_DPCPP_BACKEND_PRESENT
 

--- a/test/general/sycl_iterator/sycl_iterator_operations.pass.cpp
+++ b/test/general/sycl_iterator/sycl_iterator_operations.pass.cpp
@@ -124,6 +124,9 @@ test_sycl_const_iterator_assignment()
     TSyclConstIterator it_const = it;
     it_const = it_const;
 
+    //TSyclIterator it1 = it_const;
+    //it1;
+
     TSyclConstIterator it_const1(it_const);
     EXPECT_TRUE(it_const1 == it_const, "Wrong compare result of two iterators");
 }

--- a/test/general/sycl_iterator/sycl_iterator_operations.pass.cpp
+++ b/test/general/sycl_iterator/sycl_iterator_operations.pass.cpp
@@ -108,6 +108,27 @@ test_iterators_possibly_equal()
 };
 
 void
+test_sycl_const_iterator_assignment()
+{
+    constexpr std::size_t count = 10;
+
+    sycl::buffer<float> buf{count};
+
+    using TSyclConstIterator = decltype(oneapi::dpl::cbegin(buf));
+    using TSyclIterator = decltype(oneapi::dpl::begin(buf));
+
+    static_assert(::std::is_same_v<TSyclConstIterator, decltype(oneapi::dpl::cend(buf))>, "");
+    static_assert(::std::is_same_v<TSyclIterator, decltype(oneapi::dpl::end(buf))>, "");
+
+    TSyclIterator it = oneapi::dpl::begin(buf);
+    TSyclConstIterator it_const = it;
+    it_const = it_const;
+
+    TSyclConstIterator it_const1(it_const);
+    EXPECT_TRUE(it_const1 == it_const, "Wrong compare result of two iterators");
+}
+
+void
 test_sycl_const_iterator_equal()
 {
     constexpr std::size_t count = 10;
@@ -161,6 +182,7 @@ main()
     // Check the correctness of oneapi::dpl::__internal::__iterators_possibly_equal
     oneapi::dpl::__internal::test_iterators_possibly_equal();
 
+    test_sycl_const_iterator_assignment();
     test_sycl_const_iterator_equal();
     test_sycl_const_iterator_not_equal();
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
@@ -107,7 +107,7 @@ DEFINE_TEST(test_binary_search)
         TestDataTransfer<UDTKind::eKeys, Size> host_keys(*this, n);
 
         // call algorithm with no optional arguments
-        initialize_data(get_fill_keys(host_keys, first, n), value_first, result_first, n);
+        initialize_data(get_non_const_it(host_keys, first, n), value_first, result_first, n);
 
         auto res1 = oneapi::dpl::binary_search(exec, first, last, value_first, value_last, result_first);
         check_and_clean(result_first, n);

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
@@ -104,8 +104,10 @@ DEFINE_TEST(test_binary_search)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type ValueT;
 
+        TestDataTransfer<UDTKind::eKeys, Size> host_keys(*this, n);
+
         // call algorithm with no optional arguments
-        initialize_data(first, value_first, result_first, n);
+        initialize_data(get_fill_keys(host_keys, first, n), value_first, result_first, n);
 
         auto res1 = oneapi::dpl::binary_search(exec, first, last, value_first, value_last, result_first);
         check_and_clean(result_first, n);

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
@@ -140,11 +140,7 @@ main()
     test3buffers<sycl::usm::alloc::device, test_binary_search<ValueType>>();
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-#if TEST_DPCPP_BACKEND_PRESENT
     test_algo_three_sequences<test_binary_search<ValueType>>();
-#else
-    test_algo_three_sequences<ValueType, test_binary_search>();
-#endif // TEST_DPCPP_BACKEND_PRESENT
 
     return TestUtils::done();
 }

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
@@ -135,11 +135,7 @@ main()
     test3buffers<sycl::usm::alloc::device, test_lower_bound<ValueType>>();
 #endif // #if TEST_DPCPP_BACKEND_PRESENT
 
-#if TEST_DPCPP_BACKEND_PRESENT
     test_algo_three_sequences<test_lower_bound<ValueType>>();
-#else
-    test_algo_three_sequences<ValueType, test_lower_bound>();
-#endif // TEST_DPCPP_BACKEND_PRESENT
 
     return TestUtils::done();
 }

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
@@ -98,8 +98,11 @@ DEFINE_TEST(test_lower_bound)
                Iterator3 result_first, Iterator3 result_last, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type ValueT;
+
+        TestDataTransfer<UDTKind::eKeys, Size> host_keys(*this, n);
+
         // call algorithm with no optional arguments
-        initialize_data(first, value_first, result_first, n);
+        initialize_data(get_fill_keys(host_keys, first, n), value_first, result_first, n);
 
         auto res1 = oneapi::dpl::lower_bound(exec, first, last, value_first, value_last, result_first);
         check_and_clean(result_first, value_first, n);

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
@@ -102,7 +102,7 @@ DEFINE_TEST(test_lower_bound)
         TestDataTransfer<UDTKind::eKeys, Size> host_keys(*this, n);
 
         // call algorithm with no optional arguments
-        initialize_data(get_fill_keys(host_keys, first, n), value_first, result_first, n);
+        initialize_data(get_non_const_it(host_keys, first, n), value_first, result_first, n);
 
         auto res1 = oneapi::dpl::lower_bound(exec, first, last, value_first, value_last, result_first);
         check_and_clean(result_first, value_first, n);

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
@@ -105,8 +105,11 @@ DEFINE_TEST(test_upper_bound)
                Iterator3 result_first, Iterator3 result_last, Size n)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type ValueT;
+
+        TestDataTransfer<UDTKind::eKeys, Size> host_keys(*this, n);
+
         // call algorithm with no optional arguments
-        initialize_data(first, value_first, result_first, n);
+        initialize_data(get_fill_keys(host_keys, first, n), value_first, result_first, n);
 
         auto res1 = oneapi::dpl::upper_bound(exec, first, last, value_first, value_last, result_first);
         check_and_clean(result_first, value_first, n);

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
@@ -142,11 +142,7 @@ main()
     test3buffers<sycl::usm::alloc::device, test_upper_bound<ValueType>>();
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-#if TEST_DPCPP_BACKEND_PRESENT
     test_algo_three_sequences<test_upper_bound<ValueType>>();
-#else
-    test_algo_three_sequences<ValueType, test_upper_bound>();
-#endif // TEST_DPCPP_BACKEND_PRESENT
 
     return TestUtils::done();
 }

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
@@ -109,7 +109,7 @@ DEFINE_TEST(test_upper_bound)
         TestDataTransfer<UDTKind::eKeys, Size> host_keys(*this, n);
 
         // call algorithm with no optional arguments
-        initialize_data(get_fill_keys(host_keys, first, n), value_first, result_first, n);
+        initialize_data(get_non_const_it(host_keys, first, n), value_first, result_first, n);
 
         auto res1 = oneapi::dpl::upper_bound(exec, first, last, value_first, value_last, result_first);
         check_and_clean(result_first, value_first, n);

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
@@ -165,24 +165,26 @@ DEFINE_TEST(test_exclusive_scan_by_segment)
         const ValT init = 1;
         const ValT zero = 0;
 
+        TestDataTransfer<UDTKind::eKeys, Size> host_keys(*this, n);
+
         // call algorithm with no optional arguments
-        initialize_data(keys_first, vals_first, val_res_first, n);
+        initialize_data(get_fill_keys(host_keys, keys_first, n), vals_first, val_res_first, n);
         auto res1 = oneapi::dpl::exclusive_scan_by_segment(exec, keys_first, keys_last, vals_first, val_res_first);
         check_values(keys_first, val_res_first, zero, n);
 
         // call algorithm with initial value
-        initialize_data(keys_first, vals_first, val_res_first, n);
+        initialize_data(get_fill_keys(host_keys, keys_first, n), vals_first, val_res_first, n);
         auto res2 = oneapi::dpl::exclusive_scan_by_segment(exec, keys_first, keys_last, vals_first, val_res_first, init);
         check_values(keys_first, val_res_first, init, n);
 
         // call algorithm with equality comparator
-        initialize_data(keys_first, vals_first, val_res_first, n);
+        initialize_data(get_fill_keys(host_keys, keys_first, n), vals_first, val_res_first, n);
         auto res3 = oneapi::dpl::exclusive_scan_by_segment(exec, keys_first, keys_last, vals_first, val_res_first, zero,
                                                            [](KeyT first, KeyT second) { return first == second; });
         check_values(keys_first, val_res_first, zero, n);
 
         // call algorithm with addition operator
-        initialize_data(keys_first, vals_first, val_res_first, n);
+        initialize_data(get_fill_keys(host_keys, keys_first, n), vals_first, val_res_first, n);
         auto res4 = oneapi::dpl::exclusive_scan_by_segment(exec, keys_first, keys_last, vals_first, val_res_first,
                                                            init, [](KeyT first, KeyT second) { return first == second; },
                                                            [](ValT first, ValT second) { return first + second; });

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
@@ -168,23 +168,23 @@ DEFINE_TEST(test_exclusive_scan_by_segment)
         TestDataTransfer<UDTKind::eKeys, Size> host_keys(*this, n);
 
         // call algorithm with no optional arguments
-        initialize_data(get_fill_keys(host_keys, keys_first, n), vals_first, val_res_first, n);
+        initialize_data(get_non_const_it(host_keys, keys_first, n), vals_first, val_res_first, n);
         auto res1 = oneapi::dpl::exclusive_scan_by_segment(exec, keys_first, keys_last, vals_first, val_res_first);
         check_values(keys_first, val_res_first, zero, n);
 
         // call algorithm with initial value
-        initialize_data(get_fill_keys(host_keys, keys_first, n), vals_first, val_res_first, n);
+        initialize_data(get_non_const_it(host_keys, keys_first, n), vals_first, val_res_first, n);
         auto res2 = oneapi::dpl::exclusive_scan_by_segment(exec, keys_first, keys_last, vals_first, val_res_first, init);
         check_values(keys_first, val_res_first, init, n);
 
         // call algorithm with equality comparator
-        initialize_data(get_fill_keys(host_keys, keys_first, n), vals_first, val_res_first, n);
+        initialize_data(get_non_const_it(host_keys, keys_first, n), vals_first, val_res_first, n);
         auto res3 = oneapi::dpl::exclusive_scan_by_segment(exec, keys_first, keys_last, vals_first, val_res_first, zero,
                                                            [](KeyT first, KeyT second) { return first == second; });
         check_values(keys_first, val_res_first, zero, n);
 
         // call algorithm with addition operator
-        initialize_data(get_fill_keys(host_keys, keys_first, n), vals_first, val_res_first, n);
+        initialize_data(get_non_const_it(host_keys, keys_first, n), vals_first, val_res_first, n);
         auto res4 = oneapi::dpl::exclusive_scan_by_segment(exec, keys_first, keys_last, vals_first, val_res_first,
                                                            init, [](KeyT first, KeyT second) { return first == second; },
                                                            [](ValT first, ValT second) { return first + second; });

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
@@ -212,11 +212,7 @@ int main()
     test3buffers<sycl::usm::alloc::device, test_exclusive_scan_by_segment<ValueType>>();
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-#if TEST_DPCPP_BACKEND_PRESENT
     test_algo_three_sequences<test_exclusive_scan_by_segment<ValueType>>();
-#else
-    test_algo_three_sequences<ValueType, test_exclusive_scan_by_segment>();
-#endif // TEST_DPCPP_BACKEND_PRESENT
 
     return TestUtils::done();
 }

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -230,11 +230,7 @@ int main()
         test3buffers<sycl::usm::alloc::device, test_inclusive_scan_by_segment<ValueType, BinaryOperation>>();
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-#if TEST_DPCPP_BACKEND_PRESENT
         test_algo_three_sequences<test_inclusive_scan_by_segment<ValueType, BinaryOperation>>();
-#else
-        test_algo_three_sequences<ValueType, test_inclusive_scan_by_segment<BinaryOperation>>();
-#endif // TEST_DPCPP_BACKEND_PRESENT
     }
 
     {
@@ -249,11 +245,7 @@ int main()
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
 #if !_PSTL_ICC_TEST_SIMD_UDS_BROKEN
-#if TEST_DPCPP_BACKEND_PRESENT
         test_algo_three_sequences<test_inclusive_scan_by_segment<ValueType, BinaryOperation>>();
-#else
-        test_algo_three_sequences<ValueType, test_inclusive_scan_by_segment<BinaryOperation>>();
-#endif // TEST_DPCPP_BACKEND_PRESENT
 #endif // !_PSTL_ICC_TEST_SIMD_UDS_BROKEN
 
     }

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -177,19 +177,21 @@ DEFINE_TEST_1(test_inclusive_scan_by_segment, BinaryOperation)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type KeyT;
 
+        TestDataTransfer<UDTKind::eKeys, Size> host_keys(*this, n);
+
         // call algorithm with no optional arguments
-        initialize_data(keys_first, vals_first, val_res_first, n);
+        initialize_data(get_fill_keys(host_keys, keys_first, n), vals_first, val_res_first, n);
         auto res1 = oneapi::dpl::inclusive_scan_by_segment(exec, keys_first, keys_last, vals_first, val_res_first);
         check_values(keys_first, vals_first, val_res_first, n);
 
         // call algorithm with equality comparator
-        initialize_data(keys_first, vals_first, val_res_first, n);
+        initialize_data(get_fill_keys(host_keys, keys_first, n), vals_first, val_res_first, n);
         auto res2 = oneapi::dpl::inclusive_scan_by_segment(exec, keys_first, keys_last, vals_first, val_res_first,
                                                            [](KeyT first, KeyT second) { return first == second; });
         check_values(keys_first, vals_first, val_res_first, n);
 
         // call algorithm with addition operator
-        initialize_data(keys_first, vals_first, val_res_first, n);
+        initialize_data(get_fill_keys(host_keys, keys_first, n), vals_first, val_res_first, n);
         auto res3 = oneapi::dpl::inclusive_scan_by_segment(exec, keys_first, keys_last, vals_first, val_res_first,
                                                            [](KeyT first, KeyT second) { return first == second; },
                                                            BinaryOperation());

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -180,18 +180,18 @@ DEFINE_TEST_1(test_inclusive_scan_by_segment, BinaryOperation)
         TestDataTransfer<UDTKind::eKeys, Size> host_keys(*this, n);
 
         // call algorithm with no optional arguments
-        initialize_data(get_fill_keys(host_keys, keys_first, n), vals_first, val_res_first, n);
+        initialize_data(get_non_const_it(host_keys, keys_first, n), vals_first, val_res_first, n);
         auto res1 = oneapi::dpl::inclusive_scan_by_segment(exec, keys_first, keys_last, vals_first, val_res_first);
         check_values(keys_first, vals_first, val_res_first, n);
 
         // call algorithm with equality comparator
-        initialize_data(get_fill_keys(host_keys, keys_first, n), vals_first, val_res_first, n);
+        initialize_data(get_non_const_it(host_keys, keys_first, n), vals_first, val_res_first, n);
         auto res2 = oneapi::dpl::inclusive_scan_by_segment(exec, keys_first, keys_last, vals_first, val_res_first,
                                                            [](KeyT first, KeyT second) { return first == second; });
         check_values(keys_first, vals_first, val_res_first, n);
 
         // call algorithm with addition operator
-        initialize_data(get_fill_keys(host_keys, keys_first, n), vals_first, val_res_first, n);
+        initialize_data(get_non_const_it(host_keys, keys_first, n), vals_first, val_res_first, n);
         auto res3 = oneapi::dpl::inclusive_scan_by_segment(exec, keys_first, keys_last, vals_first, val_res_first,
                                                            [](KeyT first, KeyT second) { return first == second; },
                                                            BinaryOperation());

--- a/test/parallel_api/numeric/numeric.ops/scan_2.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan_2.pass.cpp
@@ -227,6 +227,20 @@ DEFINE_TEST_1(test_scan_non_inplace, TestingAlgoritm)
     }
 };
 
+namespace TestUtils
+{
+// struct for checking if iterator is heterogeneous or not
+template <typename Iter, typename Void = void> // for non-heterogeneous iterators
+struct is_hetero_iterator : ::std::false_type
+{
+};
+
+template <typename Iter> // for heterogeneous iterators
+struct is_hetero_iterator<Iter, typename ::std::enable_if<Iter::is_hetero::value, void>::type> : ::std::true_type
+{
+};
+} // namespace TestUtils
+
 DEFINE_TEST_1(test_scan_inplace, TestingAlgoritm)
 {
     DEFINE_TEST_CONSTRUCTOR(test_scan_inplace)
@@ -255,11 +269,12 @@ DEFINE_TEST_1(test_scan_inplace, TestingAlgoritm)
         EXPECT_EQ_N(expected.cbegin(), keys_first, n, testingAlgo.getMsg(true));
     }
 
-    // specialization for hetero policy
+    // specialization for hetero policy and non-hetero iterators
     template <typename Policy, typename Iterator1, typename Size>
     typename ::std::enable_if<
         oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<Policy>::type>::value &&
-            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value,
+            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value &&
+            !TestUtils::is_hetero_iterator<Iterator1>::value,
         void>::type
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last,
                Size n)
@@ -285,6 +300,60 @@ DEFINE_TEST_1(test_scan_inplace, TestingAlgoritm)
         std::vector<KeyT> expected(n);
         testingAlgo.call_serial(source_host_keys_state.cbegin(), source_host_keys_state.cend(), expected.data());
         EXPECT_EQ_N(expected.cbegin(), host_keys.get(), n, testingAlgo.getMsg(true));
+    }
+
+    template <bool UseCBeginCEnd, typename Policy, typename Iterator1, typename Size>
+    void
+    run_test_hetero_impl(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Size n)
+    {
+        using KeyT = typename ::std::iterator_traits<Iterator1>::value_type;
+
+        TestingAlgoritm testingAlgo;
+
+        TestDataTransfer<UDTKind::eKeys, Size> host_keys(*this, n);
+
+        // Initialize source data in the buffer [keys_first, keys_last)
+        initialize_data(host_keys.get(), n);
+        const std::vector<KeyT> source_host_keys_state(host_keys.get(), host_keys.get() + n);
+
+        // Copy data from the buffer [keys_first, keys_last) to a device.
+        update_data(host_keys);
+
+        // Now we are ready to call tested algorithm
+        if constexpr (UseCBeginCEnd)
+        {
+            using ItBegin = decltype(oneapi::dpl::cbegin(keys_first.get_buffer()));
+            using ItEnd   = decltype(oneapi::dpl::cend(keys_first.get_buffer()));
+            ItBegin itCBegin(keys_first);
+            ItEnd   itCEnd = itCBegin + (keys_last - keys_first);
+            testingAlgo.call_onedpl(make_new_policy<new_kernel_name<Policy, 0>>(exec), itCBegin, itCEnd, keys_first);
+        }
+        else
+        {
+            testingAlgo.call_onedpl(make_new_policy<new_kernel_name<Policy, 0>>(exec), keys_first, keys_last, keys_first);
+        }
+
+        retrieve_data(host_keys);
+
+        std::vector<KeyT> expected(n);
+        testingAlgo.call_serial(source_host_keys_state.cbegin(), source_host_keys_state.cend(), expected.data());
+        EXPECT_EQ_N(expected.cbegin(), host_keys.get(), n, testingAlgo.getMsg(true));
+    }
+
+    // specialization for hetero policy and hetero iterators
+    template <typename Policy, typename Iterator1, typename Size>
+    typename ::std::enable_if<
+        oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<Policy>::type>::value &&
+            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value &&
+            TestUtils::is_hetero_iterator<Iterator1>::value,
+        void>::type
+    operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last,
+               Size n)
+    {
+        // Pass iterators into algorithm as is
+        run_test_hetero_impl<false>(exec, keys_first, keys_last, n);
+        // Pass iterators into algorithm with transform (keys_first, keys_last) to sycl const iterators
+        run_test_hetero_impl<true>(exec, keys_first, keys_last, n);
     }
 
     // specialization for non-random_access iterators

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -260,7 +260,7 @@ test3buffers(int mult = kDefaultMultValue)
                                              { max_n * mult, inout3_offset } });
 
         // 2. create pointers at first+offset
-        auto inout1_offset_first = test_base_data.get_start_from(UDTKind::eKeys);
+        auto inout1_offset_first = test_base_data.get_start_from(UDTKind::eKeys, kConstIterator);
         auto inout2_offset_first = test_base_data.get_start_from(UDTKind::eVals);
         auto inout3_offset_first = test_base_data.get_start_from(UDTKind::eRes);
 
@@ -286,7 +286,7 @@ test3buffers(int mult = kDefaultMultValue)
                                       { max_n * mult, inout3_offset } });
 
         // 2. create iterators over buffers
-        auto inout1_offset_first = test_base_data.get_start_from(UDTKind::eKeys);
+        auto inout1_offset_first = test_base_data.get_start_from(UDTKind::eKeys, kConstIterator);
         auto inout2_offset_first = test_base_data.get_start_from(UDTKind::eVals);
         auto inout3_offset_first = test_base_data.get_start_from(UDTKind::eRes);
 

--- a/test/support/utils_test_base.h
+++ b/test/support/utils_test_base.h
@@ -316,12 +316,6 @@ struct test_base
          */
         TestValueType* get();
 
-        TestValueType* begin();
-        TestValueType* end();
-
-        const TestValueType* cbegin() const;
-        const TestValueType* cend() const;
-
         /// Retrieve data
         /**
          * Method copy data from test source data storage (USM shared/device buffer, SYCL buffer)
@@ -747,54 +741,6 @@ TestUtils::test_base<TestValueType>::TestDataTransfer<kind, Size>::get()
         return __host_buffer.data();
 
     return __test_base.base_data_ref.get_data(kind, NonConstType{});
-}
-
-//--------------------------------------------------------------------------------------------------------------------//
-template <typename TestValueType>
-template <TestUtils::UDTKind kind, typename Size>
-TestValueType*
-TestUtils::test_base<TestValueType>::TestDataTransfer<kind, Size>::begin()
-{
-    if (__host_buffering_required)
-        return __host_buffer.data();
-
-    return __test_base.base_data_ref.get_data(kind, NonConstType{});
-}
-
-//--------------------------------------------------------------------------------------------------------------------//
-template <typename TestValueType>
-template <TestUtils::UDTKind kind, typename Size>
-TestValueType*
-TestUtils::test_base<TestValueType>::TestDataTransfer<kind, Size>::end()
-{
-    if (__host_buffering_required)
-        return __host_buffer.data() + __count;
-
-    return __test_base.base_data_ref.get_data(kind, NonConstType{}) + __count;
-}
-
-//--------------------------------------------------------------------------------------------------------------------//
-template <typename TestValueType>
-template <TestUtils::UDTKind kind, typename Size>
-const TestValueType*
-TestUtils::test_base<TestValueType>::TestDataTransfer<kind, Size>::cbegin() const
-{
-    if (__host_buffering_required)
-        return __host_buffer.data() + __count;
-
-    return __test_base.base_data_ref.get_data(kind, ConstType{}) + __count;
-}
-
-//--------------------------------------------------------------------------------------------------------------------//
-template <typename TestValueType>
-template <TestUtils::UDTKind kind, typename Size>
-const TestValueType*
-TestUtils::test_base<TestValueType>::TestDataTransfer<kind, Size>::cend() const
-{
-    if (__host_buffering_required)
-        return __host_buffer.data() + __count;
-
-    return __test_base.base_data_ref.get_data(kind, ConstType{}) + __count;
 }
 
 //--------------------------------------------------------------------------------------------------------------------//

--- a/test/support/utils_test_base.h
+++ b/test/support/utils_test_base.h
@@ -363,10 +363,10 @@ public:
 
 protected:
 
-    test_base_data<TestValueType>& __base_data_ref; // Test base data class ref
-    bool       __host_buffering_required = false;
-    HostData   __host_buffer;   // Local test data buffer
-    const Size __count = 0;     // Count of items in test data
+    test_base_data<TestValueType>& __base_data_ref;                     // Reference to source test data
+    bool                           __host_buffering_required = false;
+    HostData                       __host_buffer;                       // Local test data buffer
+    const Size                     __count = 0;                         // Count of items in test data
 };
 
 template <typename Iterator>

--- a/test/support/utils_test_base.h
+++ b/test/support/utils_test_base.h
@@ -487,17 +487,10 @@ using UsedValueType = TestValueType;
 
 //--------------------------------------------------------------------------------------------------------------------//
 template <typename T, typename TestName, typename TestBaseData>
-typename ::std::enable_if<::std::is_base_of<test_base<T>, TestName>::value, TestName>::type
+TestName
 create_test_obj(TestBaseData& data)
 {
     return TestName(data);
-}
-
-template <typename T, typename TestName, typename TestBaseData>
-typename ::std::enable_if<!::std::is_base_of<test_base<T>, TestName>::value, TestName>::type
-create_test_obj(TestBaseData&)
-{
-    return TestName();
 }
 
 //--------------------------------------------------------------------------------------------------------------------//

--- a/test/support/utils_test_base.h
+++ b/test/support/utils_test_base.h
@@ -404,21 +404,22 @@ template <typename HostData, typename Iterator, typename Size>
 auto
 get_non_const_it(HostData& host_data, Iterator first, Size n)
 {
+    // If the source iterator is non-const then return it
     if constexpr (!is_const_it(Iterator{}))
     {
         return first;
     }
+
+    // If the source iterator is not reverse (and it is const) return iterator for the source data
+    else if constexpr (!is_reverse_it(Iterator{}))
+    {
+        return host_data.begin();
+    }
+
+    // If the source iterator is const and reverse return reverse iterator for the source data
     else
     {
-        // const iterator -> required to return non-const iterator
-        if constexpr (!is_reverse_it(Iterator{}))
-        {
-            return host_data.begin();
-        }
-        else
-        {
-            return ::std::make_reverse_iterator(host_data.begin() + n);
-        }
+        return ::std::make_reverse_iterator(host_data.begin() + n);
     }
 }
 

--- a/test/support/utils_test_base.h
+++ b/test/support/utils_test_base.h
@@ -463,48 +463,27 @@ void update_data(TTestDataTransfer& helper, Args&& ...args)
     update_data(::std::forward<Args>(args)...);
 }
 
-// 1) define class as
-//      template <typename TestValueType>
-//      struct TestClassName : TestUtils::test_base<TestValueType>
-// 2) define class as
-//      struct TestClassName
-#if TEST_DPCPP_BACKEND_PRESENT
-#define DEFINE_TEST(TestClassName)                                                  \
-    template <typename TestValueType>                                               \
-    struct TestClassName : TestUtils::test_base<TestValueType>
-#else
-#define DEFINE_TEST(TestClassName)                                                  \
-    struct TestClassName
-#endif // TEST_DPCPP_BACKEND_PRESENT
+// define class as
+//   template <typename TestValueType>
+//   struct TestClassName : TestUtils::test_base<TestValueType>
+#define DEFINE_TEST(TestClassName)                                                          \
+template <typename TestValueType>                                                           \
+struct TestClassName : TestUtils::test_base<TestValueType>
 
-#if TEST_DPCPP_BACKEND_PRESENT
-#define DEFINE_TEST_1(TestClassName, TemplateParams)                                \
-    template <typename TestValueType, typename TemplateParams>                      \
-    struct TestClassName : TestUtils::test_base<TestValueType>
-#else
-#define DEFINE_TEST_1(TestClassName, TemplateParams)                                \
-    template <typename TemplateParams>                                              \
-    struct TestClassName
-#endif // TEST_DPCPP_BACKEND_PRESENT
+#define DEFINE_TEST_1(TestClassName, TemplateParams)                                        \
+template <typename TestValueType, typename TemplateParams>                                  \
+struct TestClassName : TestUtils::test_base<TestValueType>
 
-#if TEST_DPCPP_BACKEND_PRESENT
-#define DEFINE_TEST_CONSTRUCTOR(TestClassName)                                                                    \
-    TestClassName(test_base_data<TestValueType>& _test_base_data)                                                 \
-        : TestUtils::test_base<TestValueType>(_test_base_data)                                                    \
-    {                                                                                                             \
-    }                                                                                                             \
-                                                                                                                  \
-    template <UDTKind kind, typename Size>                                                                        \
-    using TestDataTransfer = TestUtils::template TestDataTransfer<TestValueType, kind, Size>;                     \
-                                                                                                                  \
-    using UsedValueType = TestValueType;
-#else
-#define DEFINE_TEST_CONSTRUCTOR()                                                                                 \
-    TestClassName() = default;                                                                                    \
-                                                                                                                  \
-    template <UDTKind kind, typename Size>                                                                        \
-    using TestDataTransfer = TestUtils::template TestDataTransfer<TestValueType, kind, Size>;
-#endif // TEST_DPCPP_BACKEND_PRESENT
+#define DEFINE_TEST_CONSTRUCTOR(TestClassName)                                              \
+TestClassName(test_base_data<TestValueType>& _test_base_data)                               \
+    : TestUtils::test_base<TestValueType>(_test_base_data)                                  \
+{                                                                                           \
+}                                                                                           \
+                                                                                            \
+template <UDTKind kind, typename Size>                                                      \
+using TestDataTransfer = TestUtils::template TestDataTransfer<TestValueType, kind, Size>;   \
+                                                                                            \
+using UsedValueType = TestValueType;
 
 //--------------------------------------------------------------------------------------------------------------------//
 template <typename T, typename TestName, typename TestBaseData>

--- a/test/support/utils_test_base.h
+++ b/test/support/utils_test_base.h
@@ -361,7 +361,7 @@ struct test_base
 
     protected:
 
-        test_base& __test_base;     // Test base class ref
+        test_base_data<TestValueType>& __base_data_ref; // Test base data class ref
         bool       __host_buffering_required = false;
         HostData   __host_buffer;   // Local test data buffer
         const Size __count = 0;     // Count of items in test data
@@ -847,7 +847,7 @@ TestUtils::test_base<TestValueType>::host_buffering_required() const
 template <typename TestValueType>
 template <TestUtils::UDTKind kind, typename Size>
 TestUtils::test_base<TestValueType>::TestDataTransfer<kind, Size>::TestDataTransfer(test_base& _test_base, Size _count)
-    : __test_base(_test_base)
+    : __base_data_ref(_test_base.base_data_ref)
     , __host_buffering_required(_test_base.host_buffering_required())
     , __host_buffer(__host_buffering_required ? _count : 0)
     , __count(_count)
@@ -863,7 +863,7 @@ TestUtils::test_base<TestValueType>::TestDataTransfer<kind, Size>::get()
     if (__host_buffering_required)
         return __host_buffer.data();
 
-    return __test_base.base_data_ref.get_data(kind, NonConstType{});
+    return __base_data_ref.get_data(kind, NonConstType{});
 }
 
 //--------------------------------------------------------------------------------------------------------------------//
@@ -872,7 +872,7 @@ template <TestUtils::UDTKind kind, typename Size>
 typename std::vector<TestValueType>::iterator
 TestUtils::test_base<TestValueType>::TestDataTransfer<kind, Size>::begin()
 {
-    return __test_base.base_data_ref.begin(kind);
+    return __base_data_ref.begin(kind);
 }
 
 //--------------------------------------------------------------------------------------------------------------------//
@@ -883,7 +883,7 @@ TestUtils::test_base<TestValueType>::TestDataTransfer<kind, Size>::retrieve_data
 {
     if (__host_buffering_required)
     {
-        __test_base.base_data_ref.retrieve_data(kind,
+        __base_data_ref.retrieve_data(kind,
             __host_buffer.data(),
             __host_buffer.data() + __host_buffer.size());
     }
@@ -902,7 +902,7 @@ TestUtils::test_base<TestValueType>::TestDataTransfer<kind, Size>::update_data(S
         if (count == 0)
             count = __count;
 
-        __test_base.base_data_ref.update_data(kind,
+        __base_data_ref.update_data(kind,
             __host_buffer.data(),
             __host_buffer.data() + count);
     }

--- a/test/support/utils_test_base.h
+++ b/test/support/utils_test_base.h
@@ -402,7 +402,7 @@ is_const_it(Iterator)
 
 template <typename HostData, typename Iterator, typename Size>
 auto
-get_fill_keys(HostData& host_data, Iterator first, Size n)
+get_non_const_it(HostData& host_data, Iterator first, Size n)
 {
     if constexpr (!is_const_it(Iterator{}))
     {

--- a/test/support/utils_test_base.h
+++ b/test/support/utils_test_base.h
@@ -366,13 +366,6 @@ struct test_base
         HostData   __host_buffer;   // Local test data buffer
         const Size __count = 0;     // Count of items in test data
     };
-
-    template <typename Size>
-    auto
-    get_keys_data_transfer(Size n)
-    {
-        return TestDataTransfer<UDTKind::eKeys, Size>(*this, n);
-    }
 };
 
 template <typename Iterator>

--- a/test/support/utils_test_base.h
+++ b/test/support/utils_test_base.h
@@ -376,19 +376,15 @@ protected:
     const Size                     __count = 0;                         // Count of items in test data
 };
 
-template <typename Iterator, typename ReverseIterator = ::std::reverse_iterator<Iterator>>
-constexpr bool
-is_reverse_it()
+template <typename Iterator>
+struct is_reverse_it : ::std::false_type
 {
-    return true;
-}
+};
 
 template <typename Iterator>
-constexpr bool
-is_reverse_it(Iterator)
+struct is_reverse_it<::std::reverse_iterator<Iterator>> : ::std::true_type
 {
-    return false;
-}
+};
 
 template <typename T>
 struct is_const_reference : ::std::false_type

--- a/test/support/utils_test_base.h
+++ b/test/support/utils_test_base.h
@@ -337,6 +337,13 @@ public:
     template <typename TestBase>
     TestDataTransfer(TestBase& _test_base, Size _count);
 
+    /// Constructor
+    /**
+     * @param test_base_data<TestValueType>& _test_base_data - reference to test base data class
+     * @param Size _count - count of objects in source test storage
+     */
+    TestDataTransfer(test_base_data<TestValueType>& _test_base_data, Size _count);
+
     /// Get pointer to internal data buffer
     /**
      * @return TestValueType* - pointer to internal data buffer
@@ -854,6 +861,16 @@ template <typename TestBase>
 TestUtils::TestDataTransfer<TestValueType, kind, Size>::TestDataTransfer(TestBase& _test_base, Size _count)
     : __base_data_ref(_test_base.base_data_ref)
     , __host_buffering_required(_test_base.host_buffering_required())
+    , __host_buffer(__host_buffering_required ? _count : 0)
+    , __count(_count)
+{
+}
+
+//--------------------------------------------------------------------------------------------------------------------//
+template <typename TestValueType, TestUtils::UDTKind kind, typename Size>
+TestUtils::TestDataTransfer<TestValueType, kind, Size>::TestDataTransfer(test_base_data<TestValueType>& _test_base_data, Size _count)
+    : __base_data_ref(_test_base_data)
+    , __host_buffering_required(_test_base_data.host_buffering_required())
     , __host_buffer(__host_buffering_required ? _count : 0)
     , __count(_count)
 {

--- a/test/support/utils_test_base.h
+++ b/test/support/utils_test_base.h
@@ -376,9 +376,9 @@ protected:
     const Size                     __count = 0;                         // Count of items in test data
 };
 
-template <typename Iterator>
+template <typename Iterator, typename ReverseIterator = ::std::reverse_iterator<Iterator>>
 constexpr bool
-is_reverse_it(::std::reverse_iterator<Iterator>)
+is_reverse_it()
 {
     return true;
 }
@@ -402,7 +402,7 @@ struct is_const_reference<T const&> : ::std::true_type
 
 template <typename Iterator>
 constexpr bool
-is_const_it(Iterator)
+is_const_it()
 {
     using ValueRef = typename ::std::iterator_traits<Iterator>::reference;
     return is_const_reference<ValueRef>::value;
@@ -413,13 +413,13 @@ auto
 get_non_const_it(HostData& host_data, Iterator first, Size n)
 {
     // If the source iterator is non-const then return it
-    if constexpr (!is_const_it(Iterator{}))
+    if constexpr (!is_const_it<Iterator>())
     {
         return first;
     }
 
     // If the source iterator is not reverse (and it is const) return iterator for the source data
-    else if constexpr (!is_reverse_it(Iterator{}))
+    else if constexpr (!is_reverse_it<Iterator>())
     {
         return host_data.begin();
     }

--- a/test/support/utils_test_base.h
+++ b/test/support/utils_test_base.h
@@ -522,23 +522,12 @@ test_algo_three_sequences(KeysIsConst keysIsConst)
 }
 
 //--------------------------------------------------------------------------------------------------------------------//
-// Used with algorithms that have two input sequences and one output sequences
-template <typename T, typename TestName>
+template <typename TestName>
 void
 test_algo_three_sequences()
 {
-    test_algo_three_sequences<T, TestName>(kConstIterator);
-    test_algo_three_sequences<T, TestName>(kNonConstIterator);
-}
-
-//--------------------------------------------------------------------------------------------------------------------//
-template <typename TestName>
-typename ::std::enable_if<
-    ::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value,
-    void>::type
-test_algo_three_sequences()
-{
-    test_algo_three_sequences<typename TestName::UsedValueType, TestName>();
+    test_algo_three_sequences<typename TestName::UsedValueType, TestName>(kNonConstIterator);
+    test_algo_three_sequences<typename TestName::UsedValueType, TestName>(kConstIterator);
 }
 
 }; // namespace TestUtils


### PR DESCRIPTION
In this PR we have added some new functional into oneDPL library and tests:
- hetero const iterator - alias ```sycl_const_iterator``` :
```
template <typename T, typename Allocator = __dpl_sycl::__buffer_allocator<T>>
using sycl_const_iterator = sycl_iterator<access_mode::read, T, Allocator>;
```
- implementation of ```oneapi::dpl::cbegin()```;
- implementation of ```oneapi::dpl::cend()```;
- modified iterators checks from PR https://github.com/oneapi-src/oneDPL/pull/785 : now we compare iterators not only when they has the same type but also then ```operator==``` for their (different) types exist: we made this for case the same source buffer for inplace exclussive scan algorithm described by two different iterator types: when the same```sycl::buffer``` described through the input iterators ```sycl_const_iterator``` and through the output iterators ```sycl_iterator```.

In this PR some functional was removed from oneDPL code as already not required:
- ```make_iter_mode``` function;
- ```struct _ModeConverter```;
- usage of ```access_mode::discard_read_write```.

In tests we add tests for the next functional:
- we may check equality of ```sycl_iterator``` and ```sycl_const_iterator```;
- for check that ```oneapi::dpl::cbegin()``` and ```oneapi::dpl::cend()``` is working;
- in the file ```scan2.pass.cpp``` we add test for in-place exclusive scan when the same```sycl::buffer``` described through the input iterators ```sycl_const_iterator``` and through the output iterators ```sycl_iterator```;
- modified tests system for algorithm tests when used three pairs of hetero iterators: keys (from, to), vals (from, to) and results (from, to), In this case tests system now using ```sycl_const_iterator``` iterators for keys.