### PR TITLE
Move ESIMD algorithms into a separate header

### DIFF
--- a/include/oneapi/dpl/experimental/kernel_templates
+++ b/include/oneapi/dpl/experimental/kernel_templates
@@ -1,0 +1,14 @@
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _ONEDPL_KERNEL_TEMPLATES
+#define _ONEDPL_KERNEL_TEMPLATES
+
+#include "../pstl/hetero/dpcpp/parallel_backend_esimd_radix_sort.h"
+
+#endif // _ONEDPL_KERNEL_TEMPLATES

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -40,10 +40,6 @@
 #    include "parallel_backend_sycl_radix_sort.h"
 #endif
 
-#if USE_ESIMD_SORT
-#   include "parallel_backend_esimd_radix_sort.h"
-#endif
-
 namespace oneapi
 {
 namespace dpl

--- a/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
+++ b/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
@@ -17,6 +17,7 @@
 
 #include "support/test_config.h"
 
+#include <oneapi/dpl/experimental/kernel_templates>
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/algorithm>
 #if _ENABLE_RANGES_TESTING


### PR DESCRIPTION
I think this stuff should go into its own header, instead of `<algorithm>` etc.