### PR TITLE
Implement `direct_iterator` and `make_direct_iterator`

### DIFF
--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -887,6 +887,140 @@ class discard_iterator
     difference_type __my_position_;
 };
 
+template <typename _Iter>
+class direct_iterator
+{
+  public:
+    typedef typename ::std::iterator_traits<_Iter>::value_type value_type;
+    typedef typename ::std::iterator_traits<_Iter>::difference_type difference_type;
+    typedef typename ::std::iterator_traits<_Iter>::reference reference;
+    using pointer = iterator;
+
+    using iterator_category = std::random_access_iterator_tag;
+
+    using iterator = direct_iterator<Iter>;
+
+    using is_passed_directly = ::std::true_type;
+
+    direct_iterator(_Iter iter) noexcept : __iter(iter) {}
+    direct_iterator() noexcept = default;
+    ~direct_iterator() noexcept = default;
+    direct_iterator(const direct_iterator&) noexcept = default;
+    direct_iterator&
+    operator=(const direct_iterator&) noexcept = default;
+
+    bool
+    operator==(const direct_iterator&) const noexcept = default;
+    bool
+    operator!=(const direct_iterator&) const noexcept = default;
+
+    iterator
+    operator+(difference_type offset) const noexcept
+    {
+        return iterator(__iter + offset);
+    }
+
+    iterator
+    operator-(difference_type offset) const noexcept
+    {
+        return iterator(__iter - offset);
+    }
+
+    difference_type
+    operator-(iterator other) const noexcept
+    {
+        return __iter - other.__iter;
+    }
+
+    bool
+    operator<(iterator other) const noexcept
+    {
+        return __iter < other.__iter;
+    }
+
+    bool
+    operator>(iterator other) const noexcept
+    {
+        return __iter > __iter;
+    }
+
+    bool
+    operator<=(iterator other) const noexcept
+    {
+        return __iter <= other.__iter;
+    }
+
+    bool
+    operator>=(iterator other) const noexcept
+    {
+        return __iter >= other.__iter;
+    }
+
+    iterator&
+    operator++() noexcept
+    {
+        ++__iter;
+        return *this;
+    }
+
+    iterator
+    operator++(int) noexcept
+    {
+        iterator other = *this;
+        ++(*this);
+        return other;
+    }
+
+    iterator&
+    operator--() noexcept
+    {
+        --__iter;
+        return *this;
+    }
+
+    iterator
+    operator--(int) noexcept
+    {
+        iterator other = *this;
+        --(*this);
+        return other;
+    }
+
+    iterator&
+    operator+=(difference_type offset) noexcept
+    {
+        __iter += offset;
+        return *this;
+    }
+
+    iterator&
+    operator-=(difference_type offset) noexcept
+    {
+        __iter -= offset;
+        return *this;
+    }
+
+    reference operator*() const noexcept { return *__iter; }
+
+    reference operator[](difference_type offset) const noexcept { return reference(*(*this + offset)); }
+
+    friend iterator
+    operator+(difference_type n, iterator iter)
+    {
+        return iter.__iter + n;
+    }
+
+  private:
+    _Iter __iter;
+};
+
+template <typename Iterator>
+direct_iterator<Iterator>
+make_direct_iterator(Iterator iterator)
+{
+    return direct_iterator<Iterator>(iterator);
+}
+
 } // namespace dpl
 } // namespace oneapi
 

--- a/test/general/direct_iterator.pass.cpp
+++ b/test/general/direct_iterator.pass.cpp
@@ -1,0 +1,71 @@
+// -*- C++ -*-
+//===-- direct_iterator.pass.cpp ------------------------------------------===//
+//
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#include <oneapi/dpl/execution>
+#include <oneapi/dpl/algorithm>
+#include <oneapi/dpl/iterator>
+#include <oneapi/dpl/functional>
+
+#include "support/utils.h"
+
+#include <iostream>
+#include <vector>
+#include <numeric>
+
+#if __cpp_lib_span >= 202002L
+#include <span>
+#endif
+
+int
+main()
+{
+#if TEST_DPCPP_BACKEND_PRESENT
+    using T = int;
+
+    const int n = 1000;
+
+    std::vector<T> v(n);
+    std::iota(v.begin(), v.end(), 0);
+
+    sycl::queue q(sycl::default_selector_v);
+
+    T* p = sycl::malloc_device<T>(n, q);
+
+    q.memcpy(p, v.data(), n * sizeof(T)).wait();
+
+    auto v_ref = std::reduce(v.begin(), v.end(), 0);
+
+    dpl::make_direct_iterator d_first(p);
+    dpl::make_direct_iterator d_last(p + n);
+
+    auto v_dev = dpl::reduce(d_first, d_last, 0);
+
+    EXPECT_EQ(v_ref, v_dev);
+
+#if __cpp_lib_span >= 202002L
+
+    std::span<T> x(p, n);
+
+    dpl::make_direct_iterator s_first(p);
+    dpl::make_direct_iterator s_last(p + n);
+
+    auto s_dev = dpl::reduce(s_first, s_last, 0);
+
+    EXPECT_EQ(v_ref, s_dev);
+#endif
+#endif
+
+    return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT);
+}


### PR DESCRIPTION
Implement `direct_iterator` and `make_direct_iterator`, which allow users to wrap device iterators that should be used directly inside SYCL kernels by oneDPL.  This PR addresses #855 and #854.

This will likely require some work before being accepted, but I just wanted articulate my proposed fix for these issues.