### PR TITLE
Modify to only test feature macro for `<bit>`

### DIFF
--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -30,9 +30,11 @@
 #    include "hetero/dpcpp/sycl_iterator.h"
 #endif
 
-#if __cpp_lib_bit_cast >= 201806L && __has_include(<bit>)
+#if __has_include(<bit>)
 #    include <bit>
-#else
+#endif
+
+#if !(__cpp_lib_bit_cast >= 201806L)
 #    ifndef __has_builtin
 #        define __has_builtin(__x) 0
 #    endif
@@ -587,7 +589,7 @@ template <typename _Dst, typename _Src>
     sizeof(_Dst) == sizeof(_Src) && ::std::is_trivially_copyable_v<_Dst> && ::std::is_trivially_copyable_v<_Src>, _Dst>
 __dpl_bit_cast(const _Src& __src) noexcept
 {
-#if __cpp_lib_bit_cast >= 201806L && __has_include(<bit>)
+#if __cpp_lib_bit_cast >= 201806L
     return ::std::bit_cast<_Dst>(__src);
 #elif _ONEDPL_BACKEND_SYCL && _ONEDPL_LIBSYCL_VERSION >= 50300
     return sycl::bit_cast<_Dst>(__src);
@@ -607,7 +609,7 @@ __dpl_bit_floor(_T __x) noexcept
 {
     if (__x == 0)
         return 0;
-#if __cpp_lib_int_pow2 >= 202002L || _ONEDPL___cplusplus >= 202002L && __has_include(<bit>)
+#if __cpp_lib_int_pow2 >= 202002L
     return ::std::bit_floor(__x);
 #elif _ONEDPL_BACKEND_SYCL
     // Use the count-leading-zeros function

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -584,7 +584,7 @@ struct __lifetime_keeper : public __lifetime_keeper_base
 // Bitwise type casting, same as C++20 std::bit_cast
 template <typename _Dst, typename _Src>
 ::std::enable_if_t<
-    sizeof(_Dst) == sizeof(_Src) && ::std::is_trivially_copyable_v<_Dst> && ::std::is_trivially_copyable_v<_Src>, _Dst>
+    sizeof(_Dst) == sizeof(_Src) && ::std::is_trivially_copyable_v<_Dst>&& ::std::is_trivially_copyable_v<_Src>, _Dst>
 __dpl_bit_cast(const _Src& __src) noexcept
 {
 #if __cpp_lib_bit_cast >= 201806L && __has_include(<bit>)
@@ -602,7 +602,7 @@ __dpl_bit_cast(const _Src& __src) noexcept
 
 // The max power of 2 not exceeding the given value, same as C++20 std::bit_floor
 template <typename _T>
-::std::enable_if_t<::std::is_integral_v<_T> && ::std::is_unsigned_v<_T>, _T>
+::std::enable_if_t<::std::is_integral_v<_T>&& ::std::is_unsigned_v<_T>, _T>
 __dpl_bit_floor(_T __x) noexcept
 {
     if (__x == 0)
@@ -617,9 +617,12 @@ __dpl_bit_floor(_T __x) noexcept
     __x |= (__x >> 1);
     __x |= (__x >> 2);
     __x |= (__x >> 4);
-    if constexpr (sizeof(_T) > 1) __x |= (__x >> 8);
-    if constexpr (sizeof(_T) > 2) __x |= (__x >> 16);
-    if constexpr (sizeof(_T) > 4) __x |= (__x >> 32);
+    if constexpr (sizeof(_T) > 1)
+        __x |= (__x >> 8);
+    if constexpr (sizeof(_T) > 2)
+        __x |= (__x >> 16);
+    if constexpr (sizeof(_T) > 4)
+        __x |= (__x >> 32);
     __x += 1; // Now it equals to the next greater power of 2, or 0 in case of wraparound
     return (__x == 0) ? 1 << (sizeof(_T) * CHAR_BIT - 1) : __x >> 1;
 #endif

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -30,7 +30,7 @@
 #    include "hetero/dpcpp/sycl_iterator.h"
 #endif
 
-#if _ONEDPL___cplusplus >= 202002L && __has_include(<bit>)
+#if __cpp_lib_bit_cast >= 201806L && __has_include(<bit>)
 #    include <bit>
 #else
 #    ifndef __has_builtin
@@ -587,7 +587,7 @@ template <typename _Dst, typename _Src>
     sizeof(_Dst) == sizeof(_Src) && ::std::is_trivially_copyable_v<_Dst> && ::std::is_trivially_copyable_v<_Src>, _Dst>
 __dpl_bit_cast(const _Src& __src) noexcept
 {
-#if __cpp_lib_bit_cast >= 201806L || _ONEDPL___cplusplus >= 202002L && __has_include(<bit>)
+#if __cpp_lib_bit_cast >= 201806L && __has_include(<bit>)
     return ::std::bit_cast<_Dst>(__src);
 #elif _ONEDPL_BACKEND_SYCL && _ONEDPL_LIBSYCL_VERSION >= 50300
     return sycl::bit_cast<_Dst>(__src);

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -30,9 +30,11 @@
 #    include "hetero/dpcpp/sycl_iterator.h"
 #endif
 
-#if __cpp_lib_bit_cast >= 201806L && __has_include(<bit>)
+#if __has_include(<bit>)
 #    include <bit>
-#else
+#endif
+
+#if !(__cpp_lib_bit_cast >= 201806L)
 #    ifndef __has_builtin
 #        define __has_builtin(__x) 0
 #    endif
@@ -584,10 +586,10 @@ struct __lifetime_keeper : public __lifetime_keeper_base
 // Bitwise type casting, same as C++20 std::bit_cast
 template <typename _Dst, typename _Src>
 ::std::enable_if_t<
-    sizeof(_Dst) == sizeof(_Src) && ::std::is_trivially_copyable_v<_Dst> && ::std::is_trivially_copyable_v<_Src>, _Dst>
+    sizeof(_Dst) == sizeof(_Src) && ::std::is_trivially_copyable_v<_Dst>&& ::std::is_trivially_copyable_v<_Src>, _Dst>
 __dpl_bit_cast(const _Src& __src) noexcept
 {
-#if __cpp_lib_bit_cast >= 201806L && __has_include(<bit>)
+#if __cpp_lib_bit_cast >= 201806L
     return ::std::bit_cast<_Dst>(__src);
 #elif _ONEDPL_BACKEND_SYCL && _ONEDPL_LIBSYCL_VERSION >= 50300
     return sycl::bit_cast<_Dst>(__src);
@@ -602,12 +604,12 @@ __dpl_bit_cast(const _Src& __src) noexcept
 
 // The max power of 2 not exceeding the given value, same as C++20 std::bit_floor
 template <typename _T>
-::std::enable_if_t<::std::is_integral_v<_T> && ::std::is_unsigned_v<_T>, _T>
+::std::enable_if_t<::std::is_integral_v<_T>&& ::std::is_unsigned_v<_T>, _T>
 __dpl_bit_floor(_T __x) noexcept
 {
     if (__x == 0)
         return 0;
-#if __cpp_lib_int_pow2 >= 202002L || _ONEDPL___cplusplus >= 202002L && __has_include(<bit>)
+#if __cpp_lib_int_pow2 >= 202002L
     return ::std::bit_floor(__x);
 #elif _ONEDPL_BACKEND_SYCL
     // Use the count-leading-zeros function
@@ -617,9 +619,12 @@ __dpl_bit_floor(_T __x) noexcept
     __x |= (__x >> 1);
     __x |= (__x >> 2);
     __x |= (__x >> 4);
-    if constexpr (sizeof(_T) > 1) __x |= (__x >> 8);
-    if constexpr (sizeof(_T) > 2) __x |= (__x >> 16);
-    if constexpr (sizeof(_T) > 4) __x |= (__x >> 32);
+    if constexpr (sizeof(_T) > 1)
+        __x |= (__x >> 8);
+    if constexpr (sizeof(_T) > 2)
+        __x |= (__x >> 16);
+    if constexpr (sizeof(_T) > 4)
+        __x |= (__x >> 32);
     __x += 1; // Now it equals to the next greater power of 2, or 0 in case of wraparound
     return (__x == 0) ? 1 << (sizeof(_T) * CHAR_BIT - 1) : __x >> 1;
 #endif

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -584,7 +584,7 @@ struct __lifetime_keeper : public __lifetime_keeper_base
 // Bitwise type casting, same as C++20 std::bit_cast
 template <typename _Dst, typename _Src>
 ::std::enable_if_t<
-    sizeof(_Dst) == sizeof(_Src) && ::std::is_trivially_copyable_v<_Dst>&& ::std::is_trivially_copyable_v<_Src>, _Dst>
+    sizeof(_Dst) == sizeof(_Src) && ::std::is_trivially_copyable_v<_Dst> && ::std::is_trivially_copyable_v<_Src>, _Dst>
 __dpl_bit_cast(const _Src& __src) noexcept
 {
 #if __cpp_lib_bit_cast >= 201806L && __has_include(<bit>)
@@ -602,7 +602,7 @@ __dpl_bit_cast(const _Src& __src) noexcept
 
 // The max power of 2 not exceeding the given value, same as C++20 std::bit_floor
 template <typename _T>
-::std::enable_if_t<::std::is_integral_v<_T>&& ::std::is_unsigned_v<_T>, _T>
+::std::enable_if_t<::std::is_integral_v<_T> && ::std::is_unsigned_v<_T>, _T>
 __dpl_bit_floor(_T __x) noexcept
 {
     if (__x == 0)
@@ -617,12 +617,9 @@ __dpl_bit_floor(_T __x) noexcept
     __x |= (__x >> 1);
     __x |= (__x >> 2);
     __x |= (__x >> 4);
-    if constexpr (sizeof(_T) > 1)
-        __x |= (__x >> 8);
-    if constexpr (sizeof(_T) > 2)
-        __x |= (__x >> 16);
-    if constexpr (sizeof(_T) > 4)
-        __x |= (__x >> 32);
+    if constexpr (sizeof(_T) > 1) __x |= (__x >> 8);
+    if constexpr (sizeof(_T) > 2) __x |= (__x >> 16);
+    if constexpr (sizeof(_T) > 4) __x |= (__x >> 32);
     __x += 1; // Now it equals to the next greater power of 2, or 0 in case of wraparound
     return (__x == 0) ? 1 << (sizeof(_T) * CHAR_BIT - 1) : __x >> 1;
 #endif


### PR DESCRIPTION
Modify `utils.h` to only check the feature test macro for `<bit>`, instead of also looking at the C++ version.

This was causing a compilation error in the most recent version of intel/llvm compiling with libstdc++ 9.