### PR TITLE
Improve utility functions

### DIFF
--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
@@ -73,7 +73,7 @@ void one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, uint32_t THREAD_PER_TG, con
     #pragma unroll
     for (uint32_t s = 0; s<PROCESS_SIZE; s+=16) {
         simd_mask<16> m = (io_offset+lane_id+s)<n;
-        keys.template select<16, 1>(s) = merge(utils::gather(input, lane_id, io_offset + s), simd<KeyT, 16>(-1), m);
+        keys.template select<16, 1>(s) = merge(utils::gather<KeyT, 16>(input, lane_id * sizeof(KeyT), (io_offset + s) * sizeof(KeyT)), simd<KeyT, 16>(-1), m);
     }
 
     for (uint32_t stage=0; stage < STAGES; stage++) {

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
@@ -73,7 +73,7 @@ void one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, uint32_t THREAD_PER_TG, con
     #pragma unroll
     for (uint32_t s = 0; s<PROCESS_SIZE; s+=16) {
         simd_mask<16> m = (io_offset+lane_id+s)<n;
-        keys.template select<16, 1>(s) = merge(utils::gather<KeyT, 16>(input, lane_id * sizeof(KeyT), (io_offset + s) * sizeof(KeyT)), simd<KeyT, 16>(-1), m);
+        keys.template select<16, 1>(s) = merge(utils::gather<KeyT, 16>(input, lane_id, io_offset + s), simd<KeyT, 16>(-1), m);
     }
 
     for (uint32_t stage=0; stage < STAGES; stage++) {
@@ -182,8 +182,7 @@ void one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, uint32_t THREAD_PER_TG, con
     }
     #pragma unroll
     for (uint32_t s = 0; s<PROCESS_SIZE; s+=16) {
-        utils::scatter<KeyT, 16>(input, write_addr.template select<16, 1>(s) * sizeof(KeyT),
-                                 keys.template select<16, 1>(s),
+        utils::scatter<KeyT, 16>(input, write_addr.template select<16, 1>(s), keys.template select<16, 1>(s),
                                  (local_tid * PROCESS_SIZE + lane_id + s) < n);
     }
 }

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
@@ -78,7 +78,7 @@ void global_histogram(sycl::nd_item<1> idx, size_t __n, const InputT& input, uin
     device_addr_t read_addr;
     for (read_addr = tid * PROCESS_SIZE; read_addr < __n; read_addr += addr_step) {
         if (read_addr+PROCESS_SIZE < __n) {
-            utils::simd_load(keys, input, read_addr);
+            utils::load_simd(keys, input, read_addr);
         }
         else
         {
@@ -200,7 +200,7 @@ void onesweep_kernel(sycl::nd_item<1> idx, uint32_t __n, uint32_t stage, const I
         simd<KeyT, PROCESS_SIZE> keys;
         simd<bin_t, PROCESS_SIZE> bins;
         if (io_offset+PROCESS_SIZE < __n) {
-            utils::simd_load(keys, input, io_offset);
+            utils::load_simd(keys, input, io_offset);
         }
         else if (io_offset >= __n) {
             keys = -1;

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
@@ -78,7 +78,7 @@ void global_histogram(sycl::nd_item<1> idx, size_t __n, const InputT& input, uin
     device_addr_t read_addr;
     for (read_addr = tid * PROCESS_SIZE; read_addr < __n; read_addr += addr_step) {
         if (read_addr+PROCESS_SIZE < __n) {
-            utils::load_simd(keys, input, read_addr);
+            utils::copy_from(input, read_addr, keys);
         }
         else
         {
@@ -200,7 +200,7 @@ void onesweep_kernel(sycl::nd_item<1> idx, uint32_t __n, uint32_t stage, const I
         simd<KeyT, PROCESS_SIZE> keys;
         simd<bin_t, PROCESS_SIZE> bins;
         if (io_offset+PROCESS_SIZE < __n) {
-            utils::load_simd(keys, input, io_offset);
+            utils::copy_from(input, io_offset, keys);
         }
         else if (io_offset >= __n) {
             keys = -1;

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
@@ -78,7 +78,7 @@ void global_histogram(sycl::nd_item<1> idx, size_t __n, const InputT& input, uin
     device_addr_t read_addr;
     for (read_addr = tid * PROCESS_SIZE; read_addr < __n; read_addr += addr_step) {
         if (read_addr+PROCESS_SIZE < __n) {
-            utils::copy_from(keys, input, read_addr);
+            utils::simd_load(keys, input, read_addr);
         }
         else
         {
@@ -200,7 +200,7 @@ void onesweep_kernel(sycl::nd_item<1> idx, uint32_t __n, uint32_t stage, const I
         simd<KeyT, PROCESS_SIZE> keys;
         simd<bin_t, PROCESS_SIZE> bins;
         if (io_offset+PROCESS_SIZE < __n) {
-            utils::copy_from(keys, input, io_offset);
+            utils::simd_load(keys, input, io_offset);
         }
         else if (io_offset >= __n) {
             keys = -1;

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -20,28 +20,28 @@ using is_sycl_accessor_v = is_sycl_accessor<T>::value;
 
 template <typename SIMD, typename Input>
 typename ::std::enable_if_t<::std::is_pointer_v<Input>, void>
-simd_load(SIMD& simd, const Input& input, uint32_t offset)
+load_simd(SIMD& simd, const Input& input, uint32_t offset)
 {
     simd.copy_from(input + offset);
 }
 
 template <typename SIMD, typename Input>
 typename ::std::enable_if_t<is_sycl_accessor_v<Input>, void>
-simd_load(SIMD& simd, const Input& input, uint32_t offset)
+load_simd(SIMD& simd, const Input& input, uint32_t offset)
 {
     simd.copy_from(input, offset);
 }
 
 template <typename SIMD, typename Output>
 typename ::std::enable_if_t<::std::is_pointer_v<Output>, void>
-simd_store(const SIMD& simd, Output& output, uint32_t offset)
+store_simd(const SIMD& simd, Output& output, uint32_t offset)
 {
     simd.copy_to(output + offset);
 }
 
 template <typename SIMD, typename Output>
 typename ::std::enable_if_t<is_sycl_accessor_v<Output>, void>
-simd_store(const SIMD& simd, Output& output, uint32_t offset)
+store_simd(const SIMD& simd, Output& output, uint32_t offset)
 {
     simd.copy_to(output, offset);
 }

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -63,7 +63,7 @@ void
 scatter(T* output, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets,
         sycl::ext::intel::esimd::simd<T, N> values, sycl::ext::intel::esimd::simd_mask<N> mask = 1)
 {
-    return sycl::ext::intel::esimd::scatter(output, offsets * size32<T>, values, mask);
+    sycl::ext::intel::esimd::scatter(output, offsets * size32<T>, values, mask);
 }
 
 template<typename T, int N, sycl::access_mode Mode, sycl::access::placeholder P>

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -18,7 +18,7 @@ copy_from(T* input, ::std::uint32_t base_offset, sycl::ext::intel::esimd::simd<T
 
 template <typename T, int N, typename... Args>
 void
-copy_from(const sycl::accessor<Args...>& input, ::std::uint32_t base_offset, sycl::ext::intel::esimd::simd<T, N>& values)
+copy_from(const sycl::accessor<T, 1, Args...>& input, ::std::uint32_t base_offset, sycl::ext::intel::esimd::simd<T, N>& values)
 {
     values.copy_from(input, base_offset);
 }
@@ -32,7 +32,7 @@ copy_to(T* output, ::std::uint32_t base_offset, const sycl::ext::intel::esimd::s
 
 template <typename T, int N, typename... Args>
 void
-copy_to(sycl::accessor<Args...>& output, ::std::uint32_t base_offset, const sycl::ext::intel::esimd::simd<T, N>& values)
+copy_to(sycl::accessor<T, 1, Args...>& output, ::std::uint32_t base_offset, const sycl::ext::intel::esimd::simd<T, N>& values)
 {
     values.copy_to(output, base_offset);
 }
@@ -46,7 +46,7 @@ gather(T* input, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets, ::st
 
 template <typename T, int N, typename... Args>
 sycl::ext::intel::esimd::simd<T, N>
-gather(const sycl::accessor<Args...>& input, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets,
+gather(const sycl::accessor<T, 1, Args...>& input, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets,
        ::std::uint32_t base_offset)
 {
     return sycl::ext::intel::esimd::gather<T>(input, offsets, base_offset);
@@ -62,7 +62,7 @@ scatter(T* output, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets,
 
 template<typename T, int N, typename... Args>
 void
-scatter(sycl::accessor<Args...>& output, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets,
+scatter(sycl::accessor<T, 1, Args...>& output, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets,
         sycl::ext::intel::esimd::simd<T, N> values, sycl::ext::intel::esimd::simd_mask<N> mask = 1)
 {
     sycl::ext::intel::esimd::scatter(output, offsets, values, /*global_offset*/ 0, mask);

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -25,7 +25,7 @@ copy_from(const sycl::accessor<Args...>& input, ::std::uint32_t offset, sycl::ex
 
 template <typename T, int N>
 void
-copy_to(T* input, ::std::uint32_t offset, const sycl::ext::intel::esimd::simd<T, N>& simd)
+copy_to(T* output, ::std::uint32_t offset, const sycl::ext::intel::esimd::simd<T, N>& simd)
 {
     simd.copy_to(output + offset);
 }
@@ -54,18 +54,18 @@ gather(const sycl::accessor<Args...>& input, sycl::ext::intel::esimd::simd<::std
 
 template <typename T, int N>
 void
-scatter(T* input, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets,
+scatter(T* output, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets,
         sycl::ext::intel::esimd::simd<T, N> vals, sycl::ext::intel::esimd::simd_mask<N> mask = 1)
 {
-    return sycl::ext::intel::esimd::scatter(input, offsets, vals, mask);
+    return sycl::ext::intel::esimd::scatter(output, offsets, vals, mask);
 }
 
 template<typename T, int N, typename... Args>
 void
-scatter(sycl::accessor<Args...>& input, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets,
+scatter(sycl::accessor<Args...>& output, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets,
         sycl::ext::intel::esimd::simd<T, N> vals, sycl::ext::intel::esimd::simd_mask<N> mask = 1)
 {
-    sycl::ext::intel::esimd::scatter(input, offsets, vals, /*global_offset*/ 0, mask);
+    sycl::ext::intel::esimd::scatter(output, offsets, vals, /*global_offset*/ 0, mask);
 }
 
 template <typename T, uint32_t R, uint32_t C>

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -79,7 +79,6 @@ class simd2d : public sycl::ext::intel::esimd::simd<T, R*C> {
 };
 
 template <typename RT, typename T>
-inline
 sycl::ext::intel::esimd::simd<RT, 32>
 scan(sycl::ext::intel::esimd::simd<T, 32> src)
 {
@@ -99,7 +98,7 @@ scan(sycl::ext::intel::esimd::simd<T, 32> src)
 }
 
 template <typename RT, typename T>
-inline sycl::ext::intel::esimd::simd<RT, 16>
+sycl::ext::intel::esimd::simd<RT, 16>
 scan(sycl::ext::intel::esimd::simd<T, 16> src)
 {
 	sycl::ext::intel::esimd::simd<RT, 16> result;
@@ -132,7 +131,6 @@ __order_preserving_cast(sycl::ext::intel::esimd::simd<bool, _N> __src)
 }
 
 template <bool __is_ascending, typename _UInt, int _N>
-inline
 typename ::std::enable_if_t<::std::is_unsigned_v<_UInt>, sycl::ext::intel::esimd::simd<_UInt, _N>>
 __order_preserving_cast(sycl::ext::intel::esimd::simd<_UInt, _N> __src)
 {

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -11,7 +11,7 @@ namespace oneapi::dpl::experimental::esimd::impl::utils
 
 template <typename T, int N>
 void
-copy_from(T* input, ::std::uint32_t base_offset, sycl::ext::intel::esimd::simd<T, N>& values)
+copy_from(const T* input, ::std::uint32_t base_offset, sycl::ext::intel::esimd::simd<T, N>& values)
 {
     values.copy_from(input + base_offset);
 }
@@ -39,7 +39,7 @@ copy_to(sycl::accessor<T, 1, Args...>& output, ::std::uint32_t base_offset, cons
 
 template <typename T, int N>
 sycl::ext::intel::esimd::simd<T, N>
-gather(T* input, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets, ::std::uint32_t base_offset)
+gather(const T* input, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets, ::std::uint32_t base_offset)
 {
     return sycl::ext::intel::esimd::gather(input + base_offset, offsets * sizeof(T));
 }

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -16,9 +16,10 @@ copy_from(const T* input, ::std::uint32_t base_offset, sycl::ext::intel::esimd::
     values.copy_from(input + base_offset);
 }
 
-template <typename T, int N, typename... Args>
+template <typename T, int N, sycl::access_mode Mode, sycl::access::placeholder P>
 void
-copy_from(const sycl::accessor<T, 1, Args...>& input, ::std::uint32_t base_offset, sycl::ext::intel::esimd::simd<T, N>& values)
+copy_from(const sycl::accessor<T, 1, Mode, sycl::target::device, P>& input, ::std::uint32_t base_offset,
+          sycl::ext::intel::esimd::simd<T, N>& values)
 {
     values.copy_from(input, base_offset * sizeof(T));
 }
@@ -30,9 +31,10 @@ copy_to(T* output, ::std::uint32_t base_offset, const sycl::ext::intel::esimd::s
     values.copy_to(output + base_offset);
 }
 
-template <typename T, int N, typename... Args>
+template <typename T, int N, sycl::access_mode Mode, sycl::access::placeholder P>
 void
-copy_to(sycl::accessor<T, 1, Args...>& output, ::std::uint32_t base_offset, const sycl::ext::intel::esimd::simd<T, N>& values)
+copy_to(sycl::accessor<T, 1, Mode, sycl::target::device, P>& output, ::std::uint32_t base_offset,
+        const sycl::ext::intel::esimd::simd<T, N>& values)
 {
     values.copy_to(output, base_offset * sizeof(T));
 }
@@ -44,10 +46,10 @@ gather(const T* input, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets
     return sycl::ext::intel::esimd::gather(input + base_offset, offsets * sizeof(T));
 }
 
-template <typename T, int N, typename... Args>
+template <typename T, int N, sycl::access_mode Mode, sycl::access::placeholder P>
 sycl::ext::intel::esimd::simd<T, N>
-gather(const sycl::accessor<T, 1, Args...>& input, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets,
-       ::std::uint32_t base_offset)
+gather(const sycl::accessor<T, 1, Mode, sycl::target::device, P>& input,
+       sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets, ::std::uint32_t base_offset)
 {
     return sycl::ext::intel::esimd::gather<T>(input, offsets * sizeof(T), base_offset * sizeof(T));
 }
@@ -60,9 +62,9 @@ scatter(T* output, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets,
     return sycl::ext::intel::esimd::scatter(output, offsets * sizeof(T), values, mask);
 }
 
-template<typename T, int N, typename... Args>
+template<typename T, int N, sycl::access_mode Mode, sycl::access::placeholder P>
 void
-scatter(sycl::accessor<T, 1, Args...>& output, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets,
+scatter(sycl::accessor<T, 1, Mode, sycl::target::device, P>& output, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets,
         sycl::ext::intel::esimd::simd<T, N> values, sycl::ext::intel::esimd::simd_mask<N> mask = 1)
 {
     sycl::ext::intel::esimd::scatter(output, offsets * sizeof(T), values, /*global_offset*/ 0, mask);

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -9,6 +9,10 @@
 namespace oneapi::dpl::experimental::esimd::impl::utils
 {
 
+// converts sizeof(T) to 32 bits, so that it could be used in operations with 32-bit SIMD without changing the type
+template <typename T>
+inline constexpr ::std::uint32_t size32 = sizeof(T);
+
 template <typename T, int N>
 void
 copy_from(const T* input, ::std::uint32_t base_offset, sycl::ext::intel::esimd::simd<T, N>& values)
@@ -18,10 +22,10 @@ copy_from(const T* input, ::std::uint32_t base_offset, sycl::ext::intel::esimd::
 
 template <typename T, int N, sycl::access_mode Mode, sycl::access::placeholder P>
 void
-copy_from(const sycl::accessor<T, 1, Mode, sycl::target::device, P>& input, ::std::uint32_t base_offset,
+copy_from(sycl::accessor<T, 1, Mode, sycl::target::device, P> input, ::std::uint32_t base_offset,
           sycl::ext::intel::esimd::simd<T, N>& values)
 {
-    values.copy_from(input, base_offset * sizeof(T));
+    values.copy_from(input, base_offset * size32<T>);
 }
 
 template <typename T, int N>
@@ -33,25 +37,25 @@ copy_to(T* output, ::std::uint32_t base_offset, const sycl::ext::intel::esimd::s
 
 template <typename T, int N, sycl::access_mode Mode, sycl::access::placeholder P>
 void
-copy_to(sycl::accessor<T, 1, Mode, sycl::target::device, P>& output, ::std::uint32_t base_offset,
+copy_to(sycl::accessor<T, 1, Mode, sycl::target::device, P> output, ::std::uint32_t base_offset,
         const sycl::ext::intel::esimd::simd<T, N>& values)
 {
-    values.copy_to(output, base_offset * sizeof(T));
+    values.copy_to(output, base_offset * size32<T>);
 }
 
 template <typename T, int N>
 sycl::ext::intel::esimd::simd<T, N>
 gather(const T* input, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets, ::std::uint32_t base_offset)
 {
-    return sycl::ext::intel::esimd::gather(input + base_offset, offsets * sizeof(T));
+    return sycl::ext::intel::esimd::gather(input + base_offset, offsets * size32<T>);
 }
 
 template <typename T, int N, sycl::access_mode Mode, sycl::access::placeholder P>
 sycl::ext::intel::esimd::simd<T, N>
-gather(const sycl::accessor<T, 1, Mode, sycl::target::device, P>& input,
+gather(sycl::accessor<T, 1, Mode, sycl::target::device, P> input,
        sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets, ::std::uint32_t base_offset)
 {
-    return sycl::ext::intel::esimd::gather<T>(input, offsets * sizeof(T), base_offset * sizeof(T));
+    return sycl::ext::intel::esimd::gather<T>(input, offsets * size32<T>, base_offset * size32<T>);
 }
 
 template <typename T, int N>
@@ -59,15 +63,15 @@ void
 scatter(T* output, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets,
         sycl::ext::intel::esimd::simd<T, N> values, sycl::ext::intel::esimd::simd_mask<N> mask = 1)
 {
-    return sycl::ext::intel::esimd::scatter(output, offsets * sizeof(T), values, mask);
+    return sycl::ext::intel::esimd::scatter(output, offsets * size32<T>, values, mask);
 }
 
 template<typename T, int N, sycl::access_mode Mode, sycl::access::placeholder P>
 void
-scatter(sycl::accessor<T, 1, Mode, sycl::target::device, P>& output, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets,
+scatter(sycl::accessor<T, 1, Mode, sycl::target::device, P> output, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets,
         sycl::ext::intel::esimd::simd<T, N> values, sycl::ext::intel::esimd::simd_mask<N> mask = 1)
 {
-    sycl::ext::intel::esimd::scatter(output, offsets * sizeof(T), values, /*global_offset*/ 0, mask);
+    sycl::ext::intel::esimd::scatter(output, offsets * size32<T>, values, /*global_offset*/ 0, mask);
 }
 
 template <typename T, uint32_t R, uint32_t C>

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -20,7 +20,7 @@ template <typename T, int N, typename... Args>
 void
 copy_from(const sycl::accessor<T, 1, Args...>& input, ::std::uint32_t base_offset, sycl::ext::intel::esimd::simd<T, N>& values)
 {
-    values.copy_from(input, base_offset);
+    values.copy_from(input, base_offset * sizeof(T));
 }
 
 template <typename T, int N>
@@ -34,14 +34,14 @@ template <typename T, int N, typename... Args>
 void
 copy_to(sycl::accessor<T, 1, Args...>& output, ::std::uint32_t base_offset, const sycl::ext::intel::esimd::simd<T, N>& values)
 {
-    values.copy_to(output, base_offset);
+    values.copy_to(output, base_offset * sizeof(T));
 }
 
 template <typename T, int N>
 sycl::ext::intel::esimd::simd<T, N>
 gather(T* input, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets, ::std::uint32_t base_offset)
 {
-    return sycl::ext::intel::esimd::gather(input + base_offset, offsets);
+    return sycl::ext::intel::esimd::gather(input + base_offset, offsets * sizeof(T));
 }
 
 template <typename T, int N, typename... Args>
@@ -49,7 +49,7 @@ sycl::ext::intel::esimd::simd<T, N>
 gather(const sycl::accessor<T, 1, Args...>& input, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets,
        ::std::uint32_t base_offset)
 {
-    return sycl::ext::intel::esimd::gather<T>(input, offsets, base_offset);
+    return sycl::ext::intel::esimd::gather<T>(input, offsets * sizeof(T), base_offset * sizeof(T));
 }
 
 template <typename T, int N>
@@ -57,7 +57,7 @@ void
 scatter(T* output, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets,
         sycl::ext::intel::esimd::simd<T, N> values, sycl::ext::intel::esimd::simd_mask<N> mask = 1)
 {
-    return sycl::ext::intel::esimd::scatter(output, offsets, values, mask);
+    return sycl::ext::intel::esimd::scatter(output, offsets * sizeof(T), values, mask);
 }
 
 template<typename T, int N, typename... Args>
@@ -65,7 +65,7 @@ void
 scatter(sycl::accessor<T, 1, Args...>& output, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets,
         sycl::ext::intel::esimd::simd<T, N> values, sycl::ext::intel::esimd::simd_mask<N> mask = 1)
 {
-    sycl::ext::intel::esimd::scatter(output, offsets, values, /*global_offset*/ 0, mask);
+    sycl::ext::intel::esimd::scatter(output, offsets * sizeof(T), values, /*global_offset*/ 0, mask);
 }
 
 template <typename T, uint32_t R, uint32_t C>

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -11,30 +11,30 @@ namespace oneapi::dpl::experimental::esimd::impl::utils
 
 template <typename T, int N>
 void
-copy_from(T* input, ::std::uint32_t offset, sycl::ext::intel::esimd::simd<T, N>& simd)
+copy_from(T* input, ::std::uint32_t base_offset, sycl::ext::intel::esimd::simd<T, N>& values)
 {
-    simd.copy_from(input + offset);
+    values.copy_from(input + base_offset);
 }
 
 template <typename T, int N, typename... Args>
 void
-copy_from(const sycl::accessor<Args...>& input, ::std::uint32_t offset, sycl::ext::intel::esimd::simd<T, N>& simd)
+copy_from(const sycl::accessor<Args...>& input, ::std::uint32_t base_offset, sycl::ext::intel::esimd::simd<T, N>& values)
 {
-    simd.copy_from(input, offset);
+    values.copy_from(input, base_offset);
 }
 
 template <typename T, int N>
 void
-copy_to(T* output, ::std::uint32_t offset, const sycl::ext::intel::esimd::simd<T, N>& simd)
+copy_to(T* output, ::std::uint32_t base_offset, const sycl::ext::intel::esimd::simd<T, N>& values)
 {
-    simd.copy_to(output + offset);
+    values.copy_to(output + base_offset);
 }
 
 template <typename T, int N, typename... Args>
 void
-copy_to(sycl::accessor<Args...>& output, ::std::uint32_t offset, const sycl::ext::intel::esimd::simd<T, N>& simd)
+copy_to(sycl::accessor<Args...>& output, ::std::uint32_t base_offset, const sycl::ext::intel::esimd::simd<T, N>& values)
 {
-    simd.copy_to(output, offset);
+    values.copy_to(output, base_offset);
 }
 
 template <typename T, int N>
@@ -55,17 +55,17 @@ gather(const sycl::accessor<Args...>& input, sycl::ext::intel::esimd::simd<::std
 template <typename T, int N>
 void
 scatter(T* output, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets,
-        sycl::ext::intel::esimd::simd<T, N> vals, sycl::ext::intel::esimd::simd_mask<N> mask = 1)
+        sycl::ext::intel::esimd::simd<T, N> values, sycl::ext::intel::esimd::simd_mask<N> mask = 1)
 {
-    return sycl::ext::intel::esimd::scatter(output, offsets, vals, mask);
+    return sycl::ext::intel::esimd::scatter(output, offsets, values, mask);
 }
 
 template<typename T, int N, typename... Args>
 void
 scatter(sycl::accessor<Args...>& output, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets,
-        sycl::ext::intel::esimd::simd<T, N> vals, sycl::ext::intel::esimd::simd_mask<N> mask = 1)
+        sycl::ext::intel::esimd::simd<T, N> values, sycl::ext::intel::esimd::simd_mask<N> mask = 1)
 {
-    sycl::ext::intel::esimd::scatter(output, offsets, vals, /*global_offset*/ 0, mask);
+    sycl::ext::intel::esimd::scatter(output, offsets, values, /*global_offset*/ 0, mask);
 }
 
 template <typename T, uint32_t R, uint32_t C>

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -9,30 +9,30 @@
 namespace oneapi::dpl::experimental::esimd::impl::utils
 {
 
-template <typename SIMD, typename T>
+template <typename T, int N>
 void
-load_simd(SIMD& simd, T* input, ::std::uint32_t offset)
+copy_from(T* input, ::std::uint32_t offset, sycl::ext::intel::esimd::simd<T, N>& simd)
 {
     simd.copy_from(input + offset);
 }
 
-template <typename SIMD, typename... Args>
+template <typename T, int N, typename... Args>
 void
-load_simd(SIMD& simd, const sycl::accessor<Args...>& input, ::std::uint32_t offset)
+copy_from(const sycl::accessor<Args...>& input, ::std::uint32_t offset, sycl::ext::intel::esimd::simd<T, N>& simd)
 {
     simd.copy_from(input, offset);
 }
 
-template <typename SIMD, typename T>
+template <typename T, int N>
 void
-store_simd(const SIMD& simd, T* input, ::std::uint32_t offset)
+copy_to(T* input, ::std::uint32_t offset, const sycl::ext::intel::esimd::simd<T, N>& simd)
 {
     simd.copy_to(output + offset);
 }
 
-template <typename SIMD, typename... Args>
+template <typename T, int N, typename... Args>
 void
-store_simd(const SIMD& simd, sycl::accessor<Args...>& output, ::std::uint32_t offset)
+copy_to(sycl::accessor<Args...>& output, ::std::uint32_t offset, const sycl::ext::intel::esimd::simd<T, N>& simd)
 {
     simd.copy_to(output, offset);
 }

--- a/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
+++ b/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
@@ -28,7 +28,12 @@
 #include "support/utils.h"
 
 #if TEST_DPCPP_BACKEND_PRESENT
+#if __has_include(<sycl/sycl.hpp>)
 #include <sycl/sycl.hpp>
+#else
+#include <CL/sycl.hpp>
+#endif
+
 #include <vector>
 #include <algorithm>
 #include <random>


### PR DESCRIPTION
The patch refactors the SIMD utility functions for load, store, gather, and scatter:

* Removes `enable_if` SFINAE, instead using specific parameter types
* Aligns the API semantics (parameter order, types, and names)
* For `gather`, also fixes the result type to differ from offsets, and moves items-to-bytes conversion to the caller (consistent to `scatter`)

Also it removes unneeded `inline` specifiers and adds missed standard headers.