### PR TITLE
Improve Performance of Group Reductions with Unknown Identities

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -298,7 +298,7 @@ struct reduce_over_group
         auto __local_idx = __item_id.get_local_id(0);
         auto __group_size = __item_id.get_local_range().size();
 
-        for (_Size __k = 1; __k < __group_size; __k <<= 1)
+        for (::std::uint32_t __k = 1; __k < __group_size; __k <<= 1)
         {
             __dpl_sycl::__group_barrier(__item_id);
             if (__local_idx % (2 * __k) == 0 && __local_idx + __k < __group_size && __global_idx + __k < __n)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -301,7 +301,7 @@ struct reduce_over_group
         for (::std::uint32_t __k = 1; __k < __group_size; __k <<= 1)
         {
             __dpl_sycl::__group_barrier(__item_id);
-            if (__local_idx % (2 * __k) == 0 && __local_idx + __k < __group_size && __global_idx + __k < __n)
+            if ((__local_idx & (2 * __k - 1)) == 0 && __local_idx + __k < __group_size && __global_idx + __k < __n)
             {
                 __local_mem[__local_idx] = __bin_op1(__local_mem[__local_idx], __local_mem[__local_idx + __k]);
             }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -298,18 +298,14 @@ struct reduce_over_group
         auto __local_idx = __item_id.get_local_id(0);
         auto __group_size = __item_id.get_local_range().size();
 
-        auto __k = 1;
-
-        do
+        for (_Size __k = 1; __k < __group_size; __k <<= 1)
         {
             __dpl_sycl::__group_barrier(__item_id);
-            if (__local_idx % (2 * __k) == 0 && __local_idx + __k < __group_size && __global_idx < __n &&
-                __global_idx + __k < __n)
+            if (__local_idx % (2 * __k) == 0 && __local_idx + __k < __group_size && __global_idx + __k < __n)
             {
                 __local_mem[__local_idx] = __bin_op1(__local_mem[__local_idx], __local_mem[__local_idx + __k]);
             }
-            __k *= 2;
-        } while (__k < __group_size);
+        }
         return __local_mem[__local_idx];
     }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -298,12 +298,13 @@ struct reduce_over_group
         auto __local_idx = __item_id.get_local_id(0);
         auto __group_size = __item_id.get_local_range().size();
 
-        for (::std::uint32_t __k = 1; __k < __group_size; __k <<= 1)
+        for (::std::uint32_t __power_2 = 1; __power_2 < __group_size; __power_2 *= 2)
         {
             __dpl_sycl::__group_barrier(__item_id);
-            if ((__local_idx & (2 * __k - 1)) == 0 && __local_idx + __k < __group_size && __global_idx + __k < __n)
+            if ((__local_idx & (2 * __power_2 - 1)) == 0 && __local_idx + __power_2 < __group_size &&
+                __global_idx + __power_2 < __n)
             {
-                __local_mem[__local_idx] = __bin_op1(__local_mem[__local_idx], __local_mem[__local_idx + __k]);
+                __local_mem[__local_idx] = __bin_op1(__local_mem[__local_idx], __local_mem[__local_idx + __power_2]);
             }
         }
         return __local_mem[__local_idx];


### PR DESCRIPTION
This patch improves the throughput of the group reductions with unknown identities. These are used in many algorithms with specialized or used-defined operators or data types including the `min_element()`, `max_element()`, `minmax_element()`, `is_partitioned()`, and `lexicographical_compare()` algorithms.

The main changes are the switch from a while loop to a for loop and the removal of the `__global_idx < __n` check which is covered by the `__global_idx + __k < __n`.

This change preserves the same memory ordering and allows for non-commutative algorithms. While the memory access patterns could be improved by using a decreasing stride instead of the used increasing stride, this would require commutative algorithms.