### PR TITLE
Switch to USM Host Memory for Reduction Result

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -343,7 +343,7 @@ struct __parallel_transform_reduce_impl
                 __cgh.depends_on(__reduce_event);
 
                 // get an access to data under SYCL buffer
-                oneapi::dpl::__ranges::__require_access(__cgh, __rngs...); 
+                oneapi::dpl::__ranges::__require_access(__cgh, __rngs...);
                 sycl::accessor __temp_acc{__temp, __cgh, sycl::read_write};
                 auto __res_acc = __res_container.get_acc(__cgh);
                 __dpl_sycl::__local_accessor<_Tp> __temp_local(sycl::range<1>(__work_group_size), __cgh);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -112,6 +112,7 @@ struct __parallel_transform_reduce_small_submitter<_Tp, __work_group_size, __ite
         auto __reduce_pattern = unseq_backend::reduce_over_group<_ExecutionPolicy, _ReduceOp, _Tp>{__reduce_op};
 
         const bool __has_usm_host_allocations = has_usm_host_allocations(__exec.queue());
+        SyclBufferUniqPtr<_Tp> __res_buf;
             __res_buf = ::std::make_unique<sycl::buffer<_Tp>>(sycl::range<1>(1));
         _Tp* __res_host_ptr = __has_usm_host_allocations ? sycl::malloc_host<_Tp>(1, __exec.queue()) : nullptr;
 
@@ -181,6 +182,7 @@ struct __parallel_transform_reduce_device_kernel_submitter<_Tp, __work_group_siz
         const _Size __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __size_per_work_group);
         _Size __n_items = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __iters_per_work_item);
 
+        SyclBufferUniqPtr<_Tp> __res_buf;
         sycl::buffer<_Tp> __res_buf(sycl::range<1>(1));
         _Tp* __res = sycl::malloc_host<_Tp>(1, __exec.queue());
         return __exec.queue().submit([&, __n, __n_items](sycl::handler& __cgh) {
@@ -338,6 +340,7 @@ struct __parallel_transform_reduce_impl
         _Size __offset_1 = 0;
         _Size __offset_2 = __n_groups;
 
+        SyclBufferUniqPtr<_Tp> __res_buf;
         sycl::buffer<_Tp> __res_buf(sycl::range<1>(1));
         sycl::event __reduce_event;
         do

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -127,6 +127,8 @@ struct __parallel_transform_reduce_small_submitter<_Tp, __work_group_size, __ite
                         *__res_host_ptr = __result;
                         (*__res_acc)[0] = __result;
                 });
+
+            delete __res_acc;
         });
 
         return __reduce_future<_ExecutionPolicy, sycl::event, _Tp>(
@@ -245,6 +247,8 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<_Tp, __work_group
                     __work_group_reduce_kernel<_Tp>(__item_id, __n, __n_items, __transform_pattern, __reduce_pattern,
                                                     __init, __temp_local, __res_acc, __temp_acc);
                 });
+
+            delete __res_acc;
         });
 
         return __reduce_future<_ExecutionPolicy, sycl::event, _Tp>(::std::forward<_ExecutionPolicy>(__exec),
@@ -379,6 +383,8 @@ struct __parallel_transform_reduce_impl
                             __temp_acc[__offset_1 + __group_idx] = __result;
                         }
                     });
+
+                    delete __res_acc;
             });
             if (__is_first)
                 __is_first = false;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -127,7 +127,8 @@ struct __parallel_transform_reduce_small_submitter<_Tp, __work_group_size, __ite
                 });
         });
 
-        return __future(__reduce_event, __res);
+        return __reduce_future<_ExecutionPolicy, sycl::event, _Tp>(::std::forward<_ExecutionPolicy>(__exec),
+                                                                   ::std::move(__reduce_event), __res);
     }
 }; // struct __parallel_transform_reduce_small_submitter
 
@@ -243,7 +244,8 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<_Tp, __work_group
                 });
         });
 
-        return __future(__reduce_event, __res);
+        return __reduce_future<_ExecutionPolicy, sycl::event, _Tp>(::std::forward<_ExecutionPolicy>(__exec),
+                                                                   ::std::move(__reduce_event), __res);
     }
 }; // struct __parallel_transform_reduce_work_group_kernel_submitter
 
@@ -381,7 +383,8 @@ struct __parallel_transform_reduce_impl
             __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __size_per_work_group);
         } while (__n > 1);
 
-        return __future(__reduce_event, __res);
+        return __reduce_future<_ExecutionPolicy, sycl::event, _Tp>(::std::forward<_ExecutionPolicy>(__exec),
+                                                                   ::std::move(__reduce_event), __res);
     }
 }; // struct __parallel_transform_reduce_impl
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -46,6 +46,36 @@ template <typename... _Name>
 class __reduce_kernel;
 
 template <typename _Tp>
+struct DeleteOnDestroy
+{
+    _Tp* __ptr = nullptr;
+
+    DeleteOnDestroy(_Tp* _ptr) : __ptr(_ptr) {}
+    ~DeleteOnDestroy() { delete __ptr; }
+};
+
+template <typename _Tp>
+auto
+__get_result_accesssor(sycl::handler& __cgh, ::std::unique_ptr<sycl::buffer<_Tp>>&& __res_buf)
+{
+    using acc_type = decltype(__res_buf->template get_access<access_mode::write>(__cgh));
+    acc_type* __res_acc = nullptr;
+    if (__res_buf)
+        __res_acc = new acc_type(__res_buf->template get_access<access_mode::write>(__cgh));
+    return __res_acc;
+}
+
+template <typename _Acc, typename _Tp>
+void
+__set_result(bool __use_usm, _Acc& __res_acc, _Tp* __res_host_ptr, _Tp& __result)
+{
+    if (__use_usm)
+        *__res_host_ptr = __result;
+    else
+        (*__res_acc)[0] = __result;
+}
+
+template <typename _Tp>
 // parallel_transform_reduce - async patterns
 // Please see the comment for __parallel_for_submitter for optional kernel name explanation
 //------------------------------------------------------------------------
@@ -100,18 +130,19 @@ struct __parallel_transform_reduce_small_submitter<_Tp, __work_group_size, __ite
               typename... _Ranges>
     auto
     operator()(_ExecutionPolicy&& __exec, const _Size __n, _ReduceOp __reduce_op, _TransformOp __transform_op,
-               _InitType __init, _Ranges&&... __rngs) const
+               _InitType __init, bool __use_usm, ::std::unique_ptr<sycl::buffer<_Tp>>&& __res_buf, _Tp* __res_host_ptr,
+               _Ranges&&... __rngs) const
     {
         auto __transform_pattern =
             unseq_backend::transform_reduce<_ExecutionPolicy, __iters_per_work_item, _ReduceOp, _TransformOp>{
                 __reduce_op, __transform_op};
         auto __reduce_pattern = unseq_backend::reduce_over_group<_ExecutionPolicy, _ReduceOp, _Tp>{__reduce_op};
 
-        const bool __has_usm_host_allocations = has_usm_host_allocations(__exec.queue());
+        const bool __use_usm = __has_usm_host_allocations(__exec.queue());
         SyclBufferUniqPtr<_Tp> __res_buf;
         if (!__has_usm_host_allocations)
             __res_buf = ::std::make_unique<sycl::buffer<_Tp>>(sycl::range<1>(1));
-        _Tp* __res_host_ptr = __has_usm_host_allocations ? sycl::malloc_host<_Tp>(1, __exec.queue()) : nullptr;
+        __storage __res_container = __storage<_ExecutionPolicy, _Tp>(__exec, __use_usm, 1);
 
         return __exec.queue().submit([&, __n](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...); // get an access to data under SYCL buffer
@@ -119,23 +150,22 @@ struct __parallel_transform_reduce_small_submitter<_Tp, __work_group_size, __ite
             auto __res_acc =
             if (__res_buf)
                 __get_result_accesssor(__cgh, ::std::forward<::std::unique_ptr<sycl::buffer<_Tp>>>(__res_buf));
-            auto __res_acc = __res_buf.template get_access<access_mode::write>(__cgh);
+            auto __res_acc = __res_container.get_acc(__cgh);
             __cgh.parallel_for<_Name...>(
                 sycl::nd_range<1>(sycl::range<1>(__work_group_size), sycl::range<1>(__work_group_size)),
                 [=](sycl::nd_item<1> __item_id) {
                     __work_group_reduce_kernel<_Tp>(__item_id, __n, __n_items, __transform_pattern, __reduce_pattern,
-                                                    __init, __temp_local, __res_acc, __rngs...);
+                auto __res_ptr = __res_acc.get_pointer();
                     if (__has_usm_host_allocations)
                     if (__use_usm)
                         *__res_host_ptr = __result;
                     else
-                        (*__res_acc)[0] = __result;
+                __res_ptr[0] = __result;
                 });
 
             delete __res_acc;
         });
-
-                                                                   ::std::move(__reduce_event), std::move(__res_buf),
+        return __future(__reduce_event, __res_container);
                                                                    __res_host_ptr);
     }
 }; // struct __parallel_transform_reduce_small_submitter
@@ -145,7 +175,8 @@ template <typename _Tp, ::std::uint16_t __work_group_size, ::std::uint8_t __iter
           oneapi::dpl::__internal::__enable_if_device_execution_policy<_ExecutionPolicy, int> = 0, typename... _Ranges>
 auto
 __parallel_transform_reduce_small_impl(_ExecutionPolicy&& __exec, const _Size __n, _ReduceOp __reduce_op,
-                                     _TransformOp __transform_op, _InitType __init, _Ranges&&... __rngs)
+                                     _TransformOp __transform_op, _InitType __init,
+                                     ::std::unique_ptr<sycl::buffer<_Tp>>&& __res_buf, _Tp* __res_host_ptr,
 {
     using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
     using _CustomName = typename _Policy::kernel_name;
@@ -154,6 +185,7 @@ __parallel_transform_reduce_small_impl(_ExecutionPolicy&& __exec, const _Size __
 
     return __parallel_transform_reduce_seq_submitter<_Tp, _ReduceKernel>()(
         ::std::forward<_ExecutionPolicy>(__exec), __n, __reduce_op, __transform_op, __init, __use_usm,
+        ::std::forward<::std::unique_ptr<sycl::buffer<_Tp>>>(__res_buf), __res_host_ptr,
                                                                            ::std::forward<_Ranges>(__rngs)...);
 }
 
@@ -181,8 +213,7 @@ struct __parallel_transform_reduce_device_kernel_submitter<_Tp, __work_group_siz
                 __reduce_op, __transform_op};
         auto __reduce_pattern = unseq_backend::reduce_over_group<_ExecutionPolicy, _ReduceOp, _Tp>{__reduce_op};
 
-        // number of buffer elements processed within workgroup
-        constexpr _Size __size_per_work_group = __iters_per_work_item * __work_group_size;
+        __storage __res_container = __storage<_ExecutionPolicy, _Tp>(__exec, __use_usm, 1);
         const _Size __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __size_per_work_group);
         _Size __n_items = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __iters_per_work_item);
 
@@ -190,12 +221,11 @@ struct __parallel_transform_reduce_device_kernel_submitter<_Tp, __work_group_siz
         SyclBufferUniqPtr<_Tp> __res_buf;
         if (!__has_usm_host_allocations)
 
-        sycl::event __reduce_event = __exec.queue().submit([&, __n, __n_items](sycl::handler& __cgh) {
+        return __exec.queue().submit([&, __n, __n_items](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...); // get an access to data under SYCL buffer
             using acc_type = decltype(__res_buf->template get_access<access_mode::write>(__cgh));
             auto __res_acc =
-            if (__res_buf)
-                __res_acc = new acc_type(__res_buf->template get_access<access_mode::write>(__cgh));
+            auto __res_acc = __res_container.get_acc(__cgh);
             __dpl_sycl::__local_accessor<_Tp> __temp_local(sycl::range<1>(__work_group_size), __cgh);
             __cgh.parallel_for<_KernelName...>(
                 sycl::nd_range<1>(sycl::range<1>(__n_groups * __work_group_size), sycl::range<1>(__work_group_size)),
@@ -225,7 +255,7 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<_Tp, __work_group
                _TransformOp __transform_op, _InitType __init, sycl::buffer<_Tp>& __temp) const
                         __set_result(__use_usm, __res_acc, __res_host_ptr, __result);
         using _NoOpFunctor = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;
-                            *__res_host_ptr = __result;
+                        __res_ptr[0] = __result;
             unseq_backend::transform_reduce<_ExecutionPolicy, __iters_per_work_item, _ReduceOp, _NoOpFunctor>{
                 __reduce_op, _NoOpFunctor{}};
         auto __reduce_pattern = unseq_backend::reduce_over_group<_ExecutionPolicy, _ReduceOp, _Tp>{__reduce_op};
@@ -258,8 +288,8 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<_Tp, __work_group
 
             delete __res_acc;
         });
-
-        return __reduce_future<_ExecutionPolicy, sycl::event, _Tp>(::std::forward<_ExecutionPolicy>(__exec),
+        // return __future(__reduce_event, __res);
+        return __future(__reduce_event, __res_container);
                                                                    __res_host_ptr);
     }
 }; // struct __parallel_transform_reduce_work_group_kernel_submitter
@@ -270,7 +300,8 @@ template <typename _Tp, ::std::uint16_t __work_group_size, ::std::uint8_t __iter
           oneapi::dpl::__internal::__enable_if_device_execution_policy<_ExecutionPolicy, int> = 0, typename... _Ranges>
 auto
 __parallel_transform_reduce_mid_impl(_ExecutionPolicy&& __exec, _Size __n, _ReduceOp __reduce_op,
-                                       _TransformOp __transform_op, _InitType __init, _Ranges&&... __rngs)
+                                       _TransformOp __transform_op, _InitType __init,
+                                       ::std::unique_ptr<sycl::buffer<_Tp>>&& __res_buf, _Tp* __res_host_ptr,
 {
     using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
     using _CustomName = typename _Policy::kernel_name;
@@ -297,6 +328,7 @@ __parallel_transform_reduce_mid_impl(_ExecutionPolicy&& __exec, _Size __n, _Redu
     return __parallel_transform_reduce_work_group_kernel_submitter<
         _Tp, __work_group_size, __iters_per_work_item_work_group_kernel, _ReduceWorkGroupKernel>()(
         ::std::forward<_ExecutionPolicy>(__exec), __n, __reduce_op, __transform_op, __init, __use_usm,
+        ::std::forward<::std::unique_ptr<sycl::buffer<_Tp>>>(__res_buf), __res_host_ptr,
 }
 
 // General implementation using a tree reduction
@@ -309,6 +341,7 @@ struct __parallel_transform_reduce_impl
     static auto
     submit(_ExecutionPolicy&& __exec, _Size __n, ::std::uint16_t __work_group_size, _ReduceOp __reduce_op,
            _TransformOp1 __transform_op1, _TransformOp2 __transform_op2, _InitType __init, bool __use_usm,
+           ::std::unique_ptr<sycl::buffer<_Tp>>&& __res_buf, _Tp* __res_host_ptr, _Ranges&&... __rngs)
     {
         using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
         using _CustomName = typename _Policy::kernel_name;
@@ -365,8 +398,7 @@ struct __parallel_transform_reduce_impl
                 using acc_type = decltype(__res_buf->template get_access<access_mode::write>(__cgh));
                 using acc_type = decltype(__res_buf->template get_access<access_mode::write>(__cgh));
                 auto __res_acc =
-                if (__res_buf)
-                    __res_acc = new acc_type(__res_buf->template get_access<access_mode::write>(__cgh));
+                auto __res_acc = __res_container.get_acc(__cgh);
                 __dpl_sycl::__local_accessor<_Tp> __temp_local(sycl::range<1>(__work_group_size), __cgh);
 #if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
                 __cgh.use_kernel_bundle(__kernel.get_kernel_bundle());
@@ -396,7 +428,7 @@ struct __parallel_transform_reduce_impl
                                 __reduce_pattern.apply_init(__init, __result);
                                 if (__use_usm)
                                 else
-                                    (*__res_acc)[0] = __result;
+                                __res_ptr[0] = __result;
                             }
 
                             __temp_acc[__offset_1 + __group_idx] = __result;
@@ -443,9 +475,19 @@ __parallel_transform_reduce(_ExecutionPolicy&& __exec, _ReduceOp __reduce_op, _T
     auto __n = oneapi::dpl::__ranges::__get_first_range_size(__rngs...);
     assert(__n > 0);
 
+    sycl::event __reduce_event;
+
+    const bool __use_usm = has_usm_host_allocations(__exec.queue());
+    ::std::unique_ptr<sycl::buffer<_Tp>> __res_buf;
+    if (!__use_usm)
+        __res_buf = ::std::make_unique<sycl::buffer<_Tp>>(sycl::range<1>(1));
+    _Tp* __res_host_ptr = __use_usm ? sycl::malloc_host<_Tp>(1, __exec.queue()) : nullptr;
+
 
     // TODO: find a way to generalize getting of reliable work-group size.
+        return __parallel_transform_reduce_seq_impl<_Tp>(
             ::std::forward<_ExecutionPolicy>(__exec), __n, __reduce_op, __transform_op, __init, __use_usm,
+            ::std::forward<::std::unique_ptr<sycl::buffer<_Tp>>>(__res_buf), __res_host_ptr,
             ::std::forward<_Ranges>(__rngs)...);
 
     if (__work_group_size >= 256)
@@ -462,38 +504,44 @@ __parallel_transform_reduce(_ExecutionPolicy&& __exec, _ReduceOp __reduce_op, _T
     {
         if (__n <= 128)
         {
+            return __parallel_transform_reduce_small_impl<128, 1, _Tp>(
                 ::std::forward<_ExecutionPolicy>(__exec), __n, __reduce_op, __transform_op, __init, __use_usm,
-                                                                       __reduce_op, __transform_op, __init,
+
                                                                        ::std::forward<_Ranges>(__rngs)...);
         }
         else if (__n <= 256 && __work_group_size >= 256)
         {
+            return __parallel_transform_reduce_small_impl<256, 1, _Tp>(
                 ::std::forward<_ExecutionPolicy>(__exec), __n, __reduce_op, __transform_op, __init, __use_usm,
-                                                                       __reduce_op, __transform_op, __init,
+
                                                                        ::std::forward<_Ranges>(__rngs)...);
         }
         else if (__n <= 512 && __work_group_size >= 512)
         {
+            return __parallel_transform_reduce_small_impl<512, 1, _Tp>(
                 ::std::forward<_ExecutionPolicy>(__exec), __n, __reduce_op, __transform_op, __init, __use_usm,
-                                                                       __reduce_op, __transform_op, __init,
+
                                                                        ::std::forward<_Ranges>(__rngs)...);
         }
         else if (__n <= 1024 && __work_group_size >= 512)
         {
+            return __parallel_transform_reduce_small_impl<512, 2, _Tp>(
                 ::std::forward<_ExecutionPolicy>(__exec), __n, __reduce_op, __transform_op, __init, __use_usm,
-                                                                       __reduce_op, __transform_op, __init,
+
                                                                        ::std::forward<_Ranges>(__rngs)...);
         }
         else if (__n <= 2048 && __work_group_size >= 512)
         {
+            return __parallel_transform_reduce_small_impl<512, 4, _Tp>(
                 ::std::forward<_ExecutionPolicy>(__exec), __n, __reduce_op, __transform_op, __init, __use_usm,
-                                                                       __reduce_op, __transform_op, __init,
+
                 ::std::forward<_Ranges>(__rngs)...);
         }
         else if (__n <= 4096 && __work_group_size >= 512)
         {
+            return __parallel_transform_reduce_small_impl<512, 8, _Tp>(
                 ::std::forward<_ExecutionPolicy>(__exec), __n, __reduce_op, __transform_op, __init, __use_usm,
-                                                                       __reduce_op, __transform_op, __init,
+
                 ::std::forward<_Ranges>(__rngs)...);
         }
 
@@ -502,26 +550,30 @@ __parallel_transform_reduce(_ExecutionPolicy&& __exec, _ReduceOp __reduce_op, _T
         // Second step reduces __work_group_size * __iters_per_work_item_work_group_kernel elements.
         else if (__n <= 8192 && __work_group_size >= 512)
         {
+            return __parallel_transform_reduce_small_impl<512, 16, _Tp>(
                 ::std::forward<_ExecutionPolicy>(__exec), __n, __reduce_op, __transform_op, __init, __use_usm,
-                                                                        __reduce_op, __transform_op, __init,
+
                 ::std::forward<_Ranges>(__rngs)...);
         }
         else if (__n <= 16384 && __work_group_size >= 512)
         {
+            return __parallel_transform_reduce_small_impl<512, 32, _Tp>(
                 ::std::forward<_ExecutionPolicy>(__exec), __n, __reduce_op, __transform_op, __init, __use_usm,
-                                                                        __reduce_op, __transform_op, __init,
+
                 ::std::forward<_Ranges>(__rngs)...);
         }
         else if (__n <= 32768 && __work_group_size >= 512)
         {
+            return __parallel_transform_reduce_small_impl<512, 64, _Tp>(
                 ::std::forward<_ExecutionPolicy>(__exec), __n, __reduce_op, __transform_op, __init, __use_usm,
-                                                                        __reduce_op, __transform_op, __init,
+
                 ::std::forward<_Ranges>(__rngs)...);
         }
         else if (__n <= 65536 && __work_group_size >= 512)
         {
+            return __parallel_transform_reduce_small_impl<512, 128, _Tp>(
                 ::std::forward<_ExecutionPolicy>(__exec), __n, __reduce_op, __transform_op, __init, __use_usm,
-                                                                         __reduce_op, __transform_op, __init,
+
                                                                          ::std::forward<_Ranges>(__rngs)...);
         }
     }
@@ -535,6 +587,7 @@ __parallel_transform_reduce(_ExecutionPolicy&& __exec, _ReduceOp __reduce_op, _T
             __reduce_event = __parallel_transform_reduce_impl<_Tp, ::std::true_type>::submit(
                 ::std::forward<_ExecutionPolicy>(__exec), __n, __work_group_size, __reduce_pattern,
                 __transform_pattern1, __transform_pattern2, __init, __use_usm,
+                ::std::forward<::std::unique_ptr<sycl::buffer<_Tp>>>(__res_buf), __res_host_ptr,
     }
         else if (__n <= 67108864)
     {
@@ -544,10 +597,12 @@ __parallel_transform_reduce(_ExecutionPolicy&& __exec, _ReduceOp __reduce_op, _T
             __reduce_event = __parallel_transform_reduce_impl<_Tp, ::std::false_type>::submit(
                 ::std::forward<_ExecutionPolicy>(__exec), __n, __work_group_size, __reduce_pattern,
                 __transform_pattern1, __transform_pattern2, __init, __use_usm,
-    }
+
         ::std::forward<_ExecutionPolicy>(__exec), ::std::move(__reduce_event), ::std::move(__res_buf), __res_host_ptr);
                                                              __work_group_size, __reduce_op, __transform_op, __init,
                                                              ::std::forward<_Ranges>(__rngs)...);
+    return __reduce_future<_ExecutionPolicy, sycl::event, _Tp>(
+        ::std::forward<_ExecutionPolicy>(__exec), ::std::move(__reduce_event), ::std::move(__res_buf), __res_host_ptr);
 }
 
 } // namespace __par_backend_hetero

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -178,6 +178,7 @@ struct __parallel_transform_reduce_device_kernel_submitter<_Tp, __work_group_siz
         const _Size __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __size_per_work_group);
         _Size __n_items = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __iters_per_work_item);
 
+        sycl::buffer<_Tp> __res_buf(sycl::range<1>(1));
         _Tp* __res = sycl::malloc_host<_Tp>(1, __exec.queue());
         return __exec.queue().submit([&, __n, __n_items](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...); // get an access to data under SYCL buffer
@@ -331,6 +332,7 @@ struct __parallel_transform_reduce_impl
         _Size __offset_1 = 0;
         _Size __offset_2 = __n_groups;
 
+        sycl::buffer<_Tp> __res_buf(sycl::range<1>(1));
         sycl::event __reduce_event;
         do
         {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -118,12 +118,12 @@ struct __parallel_transform_reduce_small_submitter<_Tp, __work_group_size, __ite
 
         sycl::event __reduce_event = __exec.queue().submit([&, __n, __n_items](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...); // get an access to data under SYCL buffer
-            auto __res_acc = __res_container.get_acc(__cgh);
+            auto __res_acc = __res_container.__get_acc(__cgh);
             __dpl_sycl::__local_accessor<_Tp> __temp_local(sycl::range<1>(__work_group_size), __cgh);
             __cgh.parallel_for<_Name...>(
                 sycl::nd_range<1>(sycl::range<1>(__work_group_size), sycl::range<1>(__work_group_size)),
                 [=](sycl::nd_item<1> __item_id) {
-                    auto __res_ptr = __res_acc.get_pointer();
+                    auto __res_ptr = __res_acc.__get_pointer();
                     __work_group_reduce_kernel<_Tp>(__item_id, __n, __n_items, __transform_pattern, __reduce_pattern,
                                                     __init, __temp_local, __res_ptr, __rngs...);
                 });
@@ -235,13 +235,13 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<_Tp, __work_group
             __cgh.depends_on(__reduce_event);
 
             sycl::accessor __temp_acc{__temp, __cgh, sycl::read_only};
-            auto __res_acc = __res_container.get_acc(__cgh);
+            auto __res_acc = __res_container.__get_acc(__cgh);
             __dpl_sycl::__local_accessor<_Tp> __temp_local(sycl::range<1>(__work_group_size2), __cgh);
 
             __cgh.parallel_for<_KernelName...>(
                 sycl::nd_range<1>(sycl::range<1>(__work_group_size2), sycl::range<1>(__work_group_size2)),
                 [=](sycl::nd_item<1> __item_id) {
-                    auto __res_ptr = __res_acc.get_pointer();
+                    auto __res_ptr = __res_acc.__get_pointer();
                     __work_group_reduce_kernel<_Tp>(__item_id, __n, __n_items, __transform_pattern, __reduce_pattern,
                                                     __init, __temp_local, __res_ptr, __temp_acc);
                 });
@@ -345,7 +345,7 @@ struct __parallel_transform_reduce_impl
                 // get an access to data under SYCL buffer
                 oneapi::dpl::__ranges::__require_access(__cgh, __rngs...);
                 sycl::accessor __temp_acc{__temp, __cgh, sycl::read_write};
-                auto __res_acc = __res_container.get_acc(__cgh);
+                auto __res_acc = __res_container.__get_acc(__cgh);
                 __dpl_sycl::__local_accessor<_Tp> __temp_local(sycl::range<1>(__work_group_size), __cgh);
 #if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
                 __cgh.use_kernel_bundle(__kernel.get_kernel_bundle());
@@ -357,7 +357,7 @@ struct __parallel_transform_reduce_impl
                     sycl::nd_range<1>(sycl::range<1>(__n_groups * __work_group_size),
                                       sycl::range<1>(__work_group_size)),
                     [=](sycl::nd_item<1> __item_id) {
-                        auto __res_ptr = __res_acc.get_pointer();
+                        auto __res_ptr = __res_acc.__get_pointer();
                         auto __local_idx = __item_id.get_local_id(0);
                         auto __group_idx = __item_id.get_group(0);
                         // 1. Initialization (transform part). Fill local memory

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -213,6 +213,7 @@ struct __parallel_transform_reduce_device_kernel_submitter<_Tp, __work_group_siz
                 __reduce_op, __transform_op};
         auto __reduce_pattern = unseq_backend::reduce_over_group<_ExecutionPolicy, _ReduceOp, _Tp>{__reduce_op};
 
+        const bool __use_usm = __use_USM_host_allocations(__exec.queue());
         __storage __res_container = __storage<_ExecutionPolicy, _Tp>(__exec, __use_usm, 1);
         const _Size __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __size_per_work_group);
         _Size __n_items = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __iters_per_work_item);
@@ -370,6 +371,7 @@ struct __parallel_transform_reduce_impl
 
         // Create temporary global buffers to store temporary values
         sycl::buffer<_Tp> __temp(sycl::range<1>(2 * __n_groups));
+        const bool __use_usm = __use_USM_host_allocations(__exec.queue());
         // __is_first == true. Reduce over each work_group
         // __is_first == false. Reduce between work groups
         bool __is_first = true;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -368,7 +368,7 @@ struct __parallel_transform_reduce_impl
                             if (__n_groups == 1)
                             {
                                 __reduce_pattern.apply_init(__init, __result);
-                                __res_acc[0] = __result;
+                                *__res = __result;
                             }
 
                             __temp_acc[__offset_1 + __group_idx] = __result;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -585,8 +585,9 @@ class __future : private std::tuple<_Args...>
     }
 };
 
-// value in the integer_sequence not less than the run-time integer. For example:
+// Only use USM host allocations on Intel GPUs. Other devices show significant slowdowns.
 __has_usm_host_allocations(sycl::queue __queue)
+    if (!__device.has(sycl::aspect::usm_host_allocations))
 
 // A contract for a future class for reduce: <execution policy, sycl::event, USM host memory for the reduced value>
 // Note that the integers provided in the integer_sequence must be monotonically increasing

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -521,7 +521,7 @@ struct __accessor
 
   public:
 // Compilers before 2023.1 don't provide a default constructor for sycl::accessor. Fallback to a buffer instead.
-#if __SYCL_COMPILER_VERSION == 20230320 || __SYCL_COMPILER_VERSION > 20230822
+#if __SYCL_COMPILER_VERSION == 20230320 || __SYCL_COMPILER_VERSION >= 20230820
     __accessor(sycl::handler& __cgh, bool __usm, ::std::shared_ptr<sycl::buffer<_T, 1>> m_sycl_buf,
                ::std::shared_ptr<_T> m_usm_buf)
         : m_usm(__usm)
@@ -580,8 +580,8 @@ struct __storage
         return m_usm ? *(m_usm_buf.get() + idx) : m_sycl_buf->get_host_access(sycl::read_only)[idx];
     }
 
-    const bool
-    get_usm()
+    bool
+    get_usm() const
     {
         return m_usm;
     }
@@ -666,9 +666,9 @@ class __future : private std::tuple<_Args...>
 inline bool
 __use_USM_host_allocations(sycl::queue __queue)
 {
-// The unified future above is currently only supported by DPCPP 2023.1 and compilers starting from 20230822.
+// The unified future above is currently only supported by DPCPP 2023.1 and compilers starting from 20230820.
 // A future on top of a buffer is used on other compilers.
-#if __SYCL_COMPILER_VERSION == 20230320 || __SYCL_COMPILER_VERSION > 20230822
+#if __SYCL_COMPILER_VERSION == 20230320 || __SYCL_COMPILER_VERSION >= 20230820
     auto __device = __queue.get_device();
     if (!__device.is_gpu())
         return false;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -575,7 +575,7 @@ class __future : private std::tuple<_Args...>
 };
 
 // value in the integer_sequence not less than the run-time integer. For example:
-// will call f<4>(), since 4 is the smallest value in the sequence not less than 3.
+__has_usm_host_allocations(sycl::queue __queue)
 
 // A contract for a future class for reduce: <execution policy, sycl::event, USM host memory for the reduced value>
 // Note that the integers provided in the integer_sequence must be monotonically increasing

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -574,14 +574,9 @@ class __future : private std::tuple<_Args...>
     }
 };
 
-// Invoke a callable and pass a compile-time integer based on a provided run-time integer.
-// The compile-time integer that will be provided to the callable is defined as the smallest
 // value in the integer_sequence not less than the run-time integer. For example:
-//
-//   __static_monotonic_dispatcher<::std::integer_sequence<::std::uint16_t, 2, 4, 8, 16>::__dispatch(f, 3);
-//
 // will call f<4>(), since 4 is the smallest value in the sequence not less than 3.
-//
+
 // A contract for a future class for reduce: <execution policy, sycl::event, USM host memory for the reduced value>
 // Note that the integers provided in the integer_sequence must be monotonically increasing
 template <typename>
@@ -601,7 +596,7 @@ class __static_monotonic_dispatcher<::std::integer_sequence<::std::uint16_t, _X,
         : __my_exec(::std::forward<_ExecutionPolicy>(__exec)), __my_event(::std::forward<_Event>(__e))
           __my_res(__res, __my_exec.queue())
         auto queue = __my_exec.queue();
-        __my_res = ResPointer(__res, [queue](_Res* __res) { ::sycl::free(__res, queue); });
+          __res_buf(::std::move(__buf)), __res_ptr(__res, __my_exec.queue())
     }
 
         auto queue = __my_exec.queue();

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -606,6 +606,10 @@ class __static_monotonic_dispatcher<::std::integer_sequence<::std::uint16_t, _X,
 #endif
                 return __static_monotonic_dispatcher<::std::integer_sequence<::std::uint16_t, _Xs...>>::__dispatch(
                     ::std::forward<_F>(__f), __x, ::std::forward<_Args>(args)...);
+        using _Tp = typename ::std::remove_pointer<_Res>::type;
+        _Tp __local_val = __my_res[0];
+        sycl::free(__my_res, __my_exec.queue());
+        return __my_res[0];
 } // namespace __par_backend_hetero
 } // namespace dpl
 } // namespace oneapi

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -666,8 +666,7 @@ class __future : private std::tuple<_Args...>
 inline bool
 __use_USM_host_allocations(sycl::queue __queue)
 {
-// The unified future above is currently only supported by DPCPP 2023.1 and compilers starting from 20230820.
-// A future on top of a buffer is used on other compilers.
+// A buffer is used by default. Supporting compilers use the unified future on top of USM host memory or a buffer.
 #if _ONEDPL_SYCL_USM_HOST_PRESENT
     auto __device = __queue.get_device();
     if (!__device.is_gpu())

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -19,6 +19,7 @@
 //!!! NOTE: This file should be included under the macro _ONEDPL_BACKEND_SYCL
 #include <type_traits>
 #include <tuple>
+#include <functional>
 
 #include "../../iterator_impl.h"
 
@@ -590,6 +591,7 @@ template <::std::uint16_t _X, ::std::uint16_t... _Xs>
 class __static_monotonic_dispatcher<::std::integer_sequence<::std::uint16_t, _X, _Xs...>>
     _ExecutionPolicy __my_exec;
     _Event __my_event;
+    using ResPointer = ::std::unique_ptr<_Res, ResDeleter>;
     ResPointer __my_res;
         ::std::tuple_element<0, ::std::tuple<::std::integral_constant<::std::uint32_t, _Vals>...>>,
         ::std::integral_constant<::std::uint32_t, ::std::numeric_limits<::std::uint32_t>::max()>>::type;
@@ -597,7 +599,9 @@ class __static_monotonic_dispatcher<::std::integer_sequence<::std::uint16_t, _X,
 
     __reduce_future(_ExecutionPolicy&& __exec, _Event&& __e, _Res* __res)
         : __my_exec(::std::forward<_ExecutionPolicy>(__exec)), __my_event(::std::forward<_Event>(__e))
-    __dispatch(_F&& __f, ::std::uint16_t __x, _Args&&... args)
+          __my_res(__res, __my_exec.queue())
+        auto queue = __my_exec.queue();
+        __my_res = ResPointer(__res, [queue](_Res* __res) { ::sycl::free(__res, queue); });
     }
 
         auto queue = __my_exec.queue();

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -509,6 +509,17 @@ using __repacked_tuple_t = typename __repacked_tuple<T>::type;
 template <typename _ContainerOrIterable>
 using __value_t = typename __internal::__memobj_traits<_ContainerOrIterable>::value_type;
 
+    using __accessor_t = sycl::accessor<_T, 1, sycl::access::mode::read_write, __dpl_sycl::__target_device,
+                                        sycl::access::placeholder::false_t>;
+    _ExecutionPolicy m_exec;
+    __storage(_ExecutionPolicy& __exec, bool __usm, ::std::size_t __n) : m_usm(__usm)
+                __internal::__sycl_usm_alloc<_ExecutionPolicy, _T, sycl::usm::alloc::host>{__exec}(__n),
+                __internal::__sycl_usm_free<_ExecutionPolicy, _T>{__exec});
+    }
+    __storage(const __storage& __s) : m_usm(__s.m_usm), m_usm_buf(__s.m_usm_buf), m_sycl_buf(__s.m_sycl_buf)
+    {
+            acc.m_acc = sycl::accessor(*m_sycl_buf, __cgh, sycl::read_write, __dpl_sycl::__no_init{});
+            __cgh.require(acc.m_acc);
 //A contract for future class: <sycl::event or other event, a value or sycl::buffers...>
 //Impl details: inheretance (private) instead of aggregation for enabling the empty base optimization.
 template <typename _Event, typename... _Args>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -599,6 +599,7 @@ class __static_monotonic_dispatcher<::std::integer_sequence<::std::uint16_t, _X,
         : __my_exec(__exec), __my_event(__e), __my_res(__res)
     __dispatch(_F&& __f, ::std::uint16_t __x, _Args&&... args)
     }
+            sycl::free(*__my_res.get(), __my_exec.queue());
         return __my_event;
     void
 #if !ONEDPL_ALLOW_DEFERRED_WAITING
@@ -609,6 +610,7 @@ class __static_monotonic_dispatcher<::std::integer_sequence<::std::uint16_t, _X,
         using _Tp = typename ::std::remove_pointer<_Res>::type;
         _Tp __local_val = __my_res[0];
         sycl::free(__my_res, __my_exec.queue());
+        __my_event.wait_and_throw();
         return __my_res[0];
 } // namespace __par_backend_hetero
 } // namespace dpl

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -78,6 +78,14 @@
 #    define _ONEDPL_SYCL_REQD_SUB_GROUP_SIZE_IF_SUPPORTED(SIZE)
 #endif
 
+// The unified future supporting USM host memory and buffers is only supported by DPCPP 2023.1
+// and compilers starting from 20230820.
+#if (__SYCL_COMPILER_VERSION == 20230320 || __SYCL_COMPILER_VERSION >= 20230820)
+#    define _ONEDPL_SYCL_USM_HOST_PRESENT 1
+#else
+#    define _ONEDPL_SYCL_USM_HOST_PRESENT 0
+#endif
+
 namespace __dpl_sycl
 {
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -78,9 +78,9 @@
 #    define _ONEDPL_SYCL_REQD_SUB_GROUP_SIZE_IF_SUPPORTED(SIZE)
 #endif
 
-// The unified future supporting USM host memory and buffers is only supported by DPCPP 2023.1
-// and compilers starting from 20230820.
-#if (__SYCL_COMPILER_VERSION == 20230320 || __SYCL_COMPILER_VERSION >= 20230820)
+// The unified future supporting USM host memory and buffers is only supported after DPCPP 2023.1
+// but not by 2023.2.
+#if (_ONEDPL_LIBSYCL_VERSION >= 60100 && _ONEDPL_LIBSYCL_VERSION != 60200)
 #    define _ONEDPL_SYCL_USM_HOST_PRESENT 1
 #else
 #    define _ONEDPL_SYCL_USM_HOST_PRESENT 0

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -294,10 +294,4 @@
 #    define _ONEDPL_SYCL_INTEL_COMPILER 1
 #endif
 
-// The unified future supporting USM host memory and buffers is only supported by DPCPP 2023.1
-// and compilers starting from 20230820.
-#if (__SYCL_COMPILER_VERSION == 20230320 || __SYCL_COMPILER_VERSION >= 20230820)
-#    define _ONEDPL_USM_HOST_PRESENT 1
-#endif
-
 #endif // _ONEDPL_CONFIG_H

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -294,4 +294,10 @@
 #    define _ONEDPL_SYCL_INTEL_COMPILER 1
 #endif
 
+// The unified future supporting USM host memory and buffers is only supported by DPCPP 2023.1
+// and compilers starting from 20230820.
+#if (__SYCL_COMPILER_VERSION == 20230320 || __SYCL_COMPILER_VERSION >= 20230820)
+#    define _ONEDPL_USM_HOST_PRESENT 1
+#endif
+
 #endif // _ONEDPL_CONFIG_H


### PR DESCRIPTION
This patch aims at reducing the required transfer times in the family of reduce algorithms for copying the result back to the host.

The current mainline version uses a single value buffer that is wrapped in a future-like object. This patch introduces a future-like class for reduction results based on USM host memory. This eliminates the L0 call to `zeCommandListAppendMemoryCopy` and directly transfers the result instead. This improves the transfer times significantly with great runtime benefits for smaller input arrays.