### PR TITLE
Using custom deleter in __reduce_future::__my_res shared pointer

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -76,7 +76,8 @@ struct __parallel_transform_reduce_seq_submitter<_Tp, __internal::__optional_ker
             });
         });
 
-        return __reduce_future(::std::forward<_ExecutionPolicy>(__exec), __reduce_event, __res);
+        return __reduce_future<_ExecutionPolicy, sycl::event, _Tp>(::std::forward<_ExecutionPolicy>(__exec),
+                                                                   ::std::move(__reduce_event), __res);
     }
 };
 
@@ -143,7 +144,8 @@ struct __parallel_transform_reduce_small_submitter<__work_group_size, __iters_pe
                 });
         });
 
-        return __reduce_future(::std::forward<_ExecutionPolicy>(__exec), __reduce_event, __res);
+        return __reduce_future<_ExecutionPolicy, sycl::event, _Tp>(::std::forward<_ExecutionPolicy>(__exec),
+                                                                   ::std::move(__reduce_event), __res);
     }
 }; // struct __parallel_transform_reduce_small_submitter
 
@@ -281,7 +283,8 @@ struct __parallel_transform_reduce_impl
             __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __size_per_work_group);
         } while (__n > 1);
 
-        return __reduce_future(::std::forward<_ExecutionPolicy>(__exec), __reduce_event, __res);
+        return __reduce_future<_ExecutionPolicy, sycl::event, _Tp>(::std::forward<_ExecutionPolicy>(__exec),
+                                                                   ::std::move(__reduce_event), __res);
     }
 }; // struct __parallel_transform_reduce_impl
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -20,6 +20,7 @@
 #include <memory>
 #include <type_traits>
 #include <tuple>
+#include <functional>
 
 #include "../../iterator_impl.h"
 
@@ -580,14 +581,15 @@ class __reduce_future
 {
     _ExecutionPolicy __my_exec;
     _Event __my_event;
-    ::std::shared_ptr<_Res> __my_res;
+    using ResPointer = ::std::unique_ptr<_Res, ::std::function<void(_Res*)>>;
+    ResPointer __my_res;
 
   public:
     __reduce_future(_ExecutionPolicy&& __exec, _Event&& __e, _Res* __res)
         : __my_exec(::std::forward<_ExecutionPolicy>(__exec)), __my_event(::std::forward<_Event>(__e))
     {
         auto queue = __my_exec.queue();
-        __my_res.reset(__res, [queue](_Res* __res) { ::sycl::free(__res, queue); });
+        __my_res = ResPointer(__res, [queue](_Res* __res) { ::sycl::free(__res, queue); });
     }
 
     auto

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -590,12 +590,6 @@ class __reduce_future
         __my_res.reset(__res, [queue](_Res* __res) { ::sycl::free(__res, queue); });
     }
 
-    ~__reduce_future()
-    {
-        if (__my_res.use_count() == 1)
-            sycl::free(*__my_res.get(), __my_exec.queue());
-    }
-
     auto
     event() const
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -612,7 +612,7 @@ class __reduce_future
     get()
     {
         __my_event.wait_and_throw();
-        return *__my_res.get()[0];
+        return *__my_res.get();
     }
 };
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -583,7 +583,7 @@ class __reduce_future
     ::std::shared_ptr<_Res> __my_res;
 
   public:
-    __reduce_future(const _ExecutionPolicy& __exec, _Event __e, _Res __res)
+    __reduce_future(const _ExecutionPolicy& __exec, _Event __e, _Res* __res)
         : __my_exec(__exec), __my_event(__e), __my_res(::std::make_shared<_Res>(__res))
     {
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -584,8 +584,10 @@ class __reduce_future
 
   public:
     __reduce_future(const _ExecutionPolicy& __exec, _Event __e, _Res* __res)
-        : __my_exec(__exec), __my_event(__e), __my_res(::std::make_shared<_Res>(__res))
+        : __my_exec(__exec), __my_event(__e)
     {
+        auto queue = __my_exec.queue();
+        __my_res.reset(__res, [queue](_Res* __res) { ::sycl::free(__res, queue); });
     }
 
     ~__reduce_future()

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -583,8 +583,8 @@ class __reduce_future
     ::std::shared_ptr<_Res> __my_res;
 
   public:
-    __reduce_future(const _ExecutionPolicy& __exec, _Event __e, _Res* __res)
-        : __my_exec(__exec), __my_event(__e)
+    __reduce_future(_ExecutionPolicy&& __exec, _Event&& __e, _Res* __res)
+        : __my_exec(::std::forward<_ExecutionPolicy>(__exec)), __my_event(::std::forward<_Event>(__e))
     {
         auto queue = __my_exec.queue();
         __my_res.reset(__res, [queue](_Res* __res) { ::sycl::free(__res, queue); });


### PR DESCRIPTION
1) Using custom deleter in __reduce_future::__my_res shared pointer
2) Fix some compile errors
3) Using move semantic in params of the __reduce_future constructor