### PR TITLE
Remove unnecessary comparisons in minmax_element

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/utils_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/utils_hetero.h
@@ -116,13 +116,11 @@ struct __identity_reduce_fn
     {
         using ::std::get;
         auto __chosen_for_min = __a;
-        auto __chosen_for_max = __b;
-        // if b "<" a or if b "==" a and b_index < a_index
-        if (__comp(get<2>(__b), get<2>(__a)) || (!__comp(get<2>(__a), get<2>(__b)) && get<0>(__b) < get<0>(__a)))
+        auto __chosen_for_max = __a;
+        if (__comp(get<2>(__b), get<2>(__a)))
             __chosen_for_min = __b;
-        // if a ">" b or if a "==" b and a_index > b_index
-        if (__comp(get<3>(__b), get<3>(__a)) || (!__comp(get<3>(__a), get<3>(__b)) && get<1>(__b) < get<1>(__a)))
-            __chosen_for_max = __a;
+        if (!__comp(get<3>(__b), get<3>(__a)))
+            __chosen_for_max = __b;
         auto __result = _ReduceValueType{get<0>(__chosen_for_min), get<1>(__chosen_for_max), get<2>(__chosen_for_min),
                                          get<3>(__chosen_for_max)};
 


### PR DESCRIPTION
This PR removes array index comparisons from the `minmax_element` algorithm which I believe are unnecessary. As with the `min_element` algorithm, I think we assume that the array position of `__a` is always lower than that of `__b`.

I believe this fixes #873. I ran the benchmark mentioned in that issue & recovered the performance:

```
Total number of points: 264708400
Average execution time of onedpl:min() and onedpl:max(): 21960.263672 (us)
Average execution time of onedpl:min_max(): 16694.007812 (us)
PASS
```
running on RTX 3060.

Note: I tried swapping the initial value & logic of `__chosen_for_max` as I thought it might improve performance but actually it got slightly slower.