### PR TITLE
Improve reduce pattern performance with mid-sized inputs

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -153,7 +153,7 @@ struct __parallel_transform_reduce_mid_submitter<__work_group_size, __iters_per_
         _Size __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __size_per_work_group);
         _Size __n_items = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __iters_per_work_item1);
 
-        sycl::buffer<_Tp> __temp(sycl::range<1>(1 * __n_groups));
+        sycl::buffer<_Tp> __temp((sycl::range<1>(__n_groups)));
 
         sycl::event __reduce_event = __exec.queue().submit([&, __n, __n_items](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...); // get an access to data under SYCL buffer

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -359,7 +359,8 @@ struct __parallel_transform_reduce_impl
     }
 }; // struct __parallel_transform_reduce_impl
 
-// General version of parallel_transform_reduce. Processes elements in order to enable non-commutative algorithms.
+// General version of parallel_transform_reduce.
+// The binary operator must be associative but commutativity is not required since the elements are processed in order.
 // Each work item transforms and reduces __iters_per_work_item elements from global memory and stores the result in SLM.
 // 32 __iters_per_work_item was empirically found best for typical devices.
 // Each work group of size __work_group_size reduces the preliminary results of each work item in a group reduction

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -385,90 +385,89 @@ __parallel_transform_reduce(_ExecutionPolicy&& __exec, _ReduceOp __reduce_op, _T
     ::std::size_t __work_group_size = oneapi::dpl::__internal::__slm_adjusted_work_group_size(__exec, sizeof(_Tp) * 2);
 
     // Use single work group implementation if array < __work_group_size * __iters_per_work_item.
-    if (__n <= 256 && __work_group_size >= 256)
+    if (__work_group_size >= 256)
     {
-        return __parallel_transform_reduce_small_impl<256, 1, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                                   __reduce_op, __transform_op, __init,
-                                                                   ::std::forward<_Ranges>(__rngs)...);
-    }
-    else if (__n <= 512 && __work_group_size >= 256)
-    {
-        return __parallel_transform_reduce_small_impl<256, 2, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                                   __reduce_op, __transform_op, __init,
-                                                                   ::std::forward<_Ranges>(__rngs)...);
-    }
-    else if (__n <= 1024 && __work_group_size >= 256)
-    {
-        return __parallel_transform_reduce_small_impl<256, 4, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                                   __reduce_op, __transform_op, __init,
-                                                                   ::std::forward<_Ranges>(__rngs)...);
-    }
-    else if (__n <= 2048 && __work_group_size >= 256)
-    {
-        return __parallel_transform_reduce_small_impl<256, 8, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                                   __reduce_op, __transform_op, __init,
-                                                                   ::std::forward<_Ranges>(__rngs)...);
-    }
-    else if (__n <= 4096 && __work_group_size >= 256)
-    {
-        return __parallel_transform_reduce_small_impl<256, 16, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                                    __reduce_op, __transform_op, __init,
-                                                                    ::std::forward<_Ranges>(__rngs)...);
-    }
-    else if (__n <= 8192 && __work_group_size >= 256)
-    {
-        return __parallel_transform_reduce_small_impl<256, 32, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                                    __reduce_op, __transform_op, __init,
-                                                                    ::std::forward<_Ranges>(__rngs)...);
-    }
+        if (__n <= 256)
+        {
+            return __parallel_transform_reduce_small_impl<256, 1, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                       __reduce_op, __transform_op, __init,
+                                                                       ::std::forward<_Ranges>(__rngs)...);
+        }
+        else if (__n <= 512)
+        {
+            return __parallel_transform_reduce_small_impl<256, 2, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                       __reduce_op, __transform_op, __init,
+                                                                       ::std::forward<_Ranges>(__rngs)...);
+        }
+        else if (__n <= 1024)
+        {
+            return __parallel_transform_reduce_small_impl<256, 4, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                       __reduce_op, __transform_op, __init,
+                                                                       ::std::forward<_Ranges>(__rngs)...);
+        }
+        else if (__n <= 2048)
+        {
+            return __parallel_transform_reduce_small_impl<256, 8, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                       __reduce_op, __transform_op, __init,
+                                                                       ::std::forward<_Ranges>(__rngs)...);
+        }
+        else if (__n <= 4096)
+        {
+            return __parallel_transform_reduce_small_impl<256, 16, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                        __reduce_op, __transform_op, __init,
+                                                                        ::std::forward<_Ranges>(__rngs)...);
+        }
+        else if (__n <= 8192)
+        {
+            return __parallel_transform_reduce_small_impl<256, 32, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                        __reduce_op, __transform_op, __init,
+                                                                        ::std::forward<_Ranges>(__rngs)...);
+        }
 
-    // Use two-step tree reduction.
-    // First step reduces __work_group_size * __iters_per_work_item1 elements.
-    // Second step reduces __work_group_size * __iters_per_work_item2 elements.
-    else if (__n <= 2097152 && __work_group_size >= 256)
-    {
-        return __parallel_transform_reduce_mid_impl<256, 32, 1, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                                     __reduce_op, __transform_op, __init,
-                                                                     ::std::forward<_Ranges>(__rngs)...);
+        // Use two-step tree reduction.
+        // First step reduces __work_group_size * __iters_per_work_item1 elements.
+        // Second step reduces __work_group_size * __iters_per_work_item2 elements.
+        else if (__n <= 2097152)
+        {
+            return __parallel_transform_reduce_mid_impl<256, 32, 1, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                         __reduce_op, __transform_op, __init,
+                                                                         ::std::forward<_Ranges>(__rngs)...);
+        }
+        else if (__n <= 4194304)
+        {
+            return __parallel_transform_reduce_mid_impl<256, 32, 2, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                         __reduce_op, __transform_op, __init,
+                                                                         ::std::forward<_Ranges>(__rngs)...);
+        }
+        else if (__n <= 8388608)
+        {
+            return __parallel_transform_reduce_mid_impl<256, 32, 4, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                         __reduce_op, __transform_op, __init,
+                                                                         ::std::forward<_Ranges>(__rngs)...);
+        }
+        else if (__n <= 16777216)
+        {
+            return __parallel_transform_reduce_mid_impl<256, 32, 8, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                         __reduce_op, __transform_op, __init,
+                                                                         ::std::forward<_Ranges>(__rngs)...);
+        }
+        else if (__n <= 33554432)
+        {
+            return __parallel_transform_reduce_mid_impl<256, 32, 16, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                          __reduce_op, __transform_op, __init,
+                                                                          ::std::forward<_Ranges>(__rngs)...);
+        }
+        else if (__n <= 67108864)
+        {
+            return __parallel_transform_reduce_mid_impl<256, 32, 32, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                          __reduce_op, __transform_op, __init,
+                                                                          ::std::forward<_Ranges>(__rngs)...);
+        }
     }
-    else if (__n <= 4194304 && __work_group_size >= 256)
-    {
-        return __parallel_transform_reduce_mid_impl<256, 32, 2, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                                     __reduce_op, __transform_op, __init,
-                                                                     ::std::forward<_Ranges>(__rngs)...);
-    }
-    else if (__n <= 8388608 && __work_group_size >= 256)
-    {
-        return __parallel_transform_reduce_mid_impl<256, 32, 4, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                                     __reduce_op, __transform_op, __init,
-                                                                     ::std::forward<_Ranges>(__rngs)...);
-    }
-    else if (__n <= 16777216 && __work_group_size >= 256)
-    {
-        return __parallel_transform_reduce_mid_impl<256, 32, 8, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                                     __reduce_op, __transform_op, __init,
-                                                                     ::std::forward<_Ranges>(__rngs)...);
-    }
-    else if (__n <= 33554432 && __work_group_size >= 256)
-    {
-        return __parallel_transform_reduce_mid_impl<256, 32, 16, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                                      __reduce_op, __transform_op, __init,
-                                                                      ::std::forward<_Ranges>(__rngs)...);
-    }
-    else if (__n <= 67108864 && __work_group_size >= 256)
-    {
-        return __parallel_transform_reduce_mid_impl<256, 32, 32, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                                      __reduce_op, __transform_op, __init,
-                                                                      ::std::forward<_Ranges>(__rngs)...);
-    }
-    else
-    {
-
-        // Otherwise use a recursive tree reduction.
-        return __parallel_transform_reduce_impl<_Tp, 32>::submit(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                                 __work_group_size, __reduce_op, __transform_op, __init,
-                                                                 ::std::forward<_Ranges>(__rngs)...);
-    }
+    // Otherwise use a recursive tree reduction.
+    return __parallel_transform_reduce_impl<_Tp, 32>::submit(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                             __work_group_size, __reduce_op, __transform_op, __init,
+                                                             ::std::forward<_Ranges>(__rngs)...);
 }
 
 } // namespace __par_backend_hetero

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -141,8 +141,7 @@ __parallel_transform_reduce_small_impl(_ExecutionPolicy&& __exec, _Size __n, _Re
     using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
     using _CustomName = typename _Policy::kernel_name;
     using _ReduceKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
-        __reduce_small_kernel<::std::integral_constant<::std::uint16_t, __work_group_size>,
-                              ::std::integral_constant<::std::size_t, __iters_per_work_item>, _CustomName>>;
+        __reduce_small_kernel<::std::integral_constant<::std::size_t, __iters_per_work_item>, _CustomName>>;
 
     return __parallel_transform_reduce_small_submitter<__work_group_size, __iters_per_work_item, _Tp, _ReduceKernel>()(
         ::std::forward<_ExecutionPolicy>(__exec), __n, __reduce_op, __transform_op, __init,
@@ -179,8 +178,8 @@ struct __parallel_transform_reduce_mid_submitter<__work_group_size, __iters_per_
                 __reduce_op, _NoOpFunctor{}};
         auto __reduce_pattern = unseq_backend::reduce_over_group<_ExecutionPolicy, _ReduceOp, _Tp>{__reduce_op};
 
-        _Size __size_per_work_group =
-            __iters_per_work_item1 * __work_group_size; // number of buffer elements processed within workgroup
+        // number of buffer elements processed within workgroup
+        constexpr _Size __size_per_work_group = __iters_per_work_item1 * __work_group_size; 
         _Size __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __size_per_work_group);
         _Size __n_items = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __iters_per_work_item1);
 
@@ -245,11 +244,9 @@ __parallel_transform_reduce_mid_impl(_ExecutionPolicy&& __exec, _Size __n, _Redu
     using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
     using _CustomName = typename _Policy::kernel_name;
     using _ReduceMainKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
-        __reduce_mid_main_kernel<::std::integral_constant<::std::uint16_t, __work_group_size>,
-                                 ::std::integral_constant<::std::uint16_t, __iters_per_work_item1>, _CustomName>>;
+        __reduce_mid_main_kernel<::std::integral_constant<::std::uint16_t, __iters_per_work_item1>, _CustomName>>;
     using _ReduceLeafKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
-        __reduce_mid_leaf_kernel<::std::integral_constant<::std::uint16_t, __work_group_size>,
-                                 ::std::integral_constant<::std::uint16_t, __iters_per_work_item2>, _CustomName>>;
+        __reduce_mid_leaf_kernel<::std::integral_constant<::std::uint16_t, __iters_per_work_item2>, _CustomName>>;
 
     return __parallel_transform_reduce_mid_submitter<__work_group_size, __iters_per_work_item1, __iters_per_work_item2,
                                                      _Tp, _ReduceMainKernel, _ReduceLeafKernel>()(

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -34,71 +34,23 @@ namespace __par_backend_hetero
 {
 
 template <typename... _Name>
-class __reduce_seq_kernel;
-
-template <typename... _Name>
 class __reduce_small_kernel;
 
-template <bool _IsGPU, typename... _Name>
-class __reduce_kernel;
+template <typename... _Name>
+class __reduce_mid_main_kernel;
+
+template <typename... _Name>
+class __reduce_mid_leaf_kernel;
+
+template <typename... _Name>
+class __reduce_large_kernel;
 
 //------------------------------------------------------------------------
 // parallel_transform_reduce - async patterns
 // Please see the comment for __parallel_for_submitter for optional kernel name explanation
 //------------------------------------------------------------------------
 
-// Sequential parallel_transform_reduce used for small input sizes
-template <typename _Tp, typename _KernelName>
-struct __parallel_transform_reduce_seq_submitter;
-
-template <typename _Tp, typename... _Name>
-struct __parallel_transform_reduce_seq_submitter<_Tp, __internal::__optional_kernel_name<_Name...>>
-{
-    template <typename _ExecutionPolicy, typename _ReduceOp, typename _TransformOp, typename _Size, typename _InitType,
-              oneapi::dpl::__internal::__enable_if_device_execution_policy<_ExecutionPolicy, int> = 0,
-              typename... _Ranges>
-    auto
-    operator()(_ExecutionPolicy&& __exec, _Size __n, _ReduceOp __reduce_op, _TransformOp __transform_op,
-               _InitType __init, _Ranges&&... __rngs) const
-    {
-        auto __transform_pattern = unseq_backend::transform_reduce_seq<_ExecutionPolicy, _ReduceOp, _TransformOp, _Tp>{
-            __reduce_op, _TransformOp{__transform_op}};
-        auto __reduce_pattern = unseq_backend::reduce_over_group<_ExecutionPolicy, _ReduceOp, _Tp>{__reduce_op};
-
-        sycl::buffer<_Tp> __res(sycl::range<1>(1));
-
-        sycl::event __reduce_event = __exec.queue().submit([&, __n](sycl::handler& __cgh) {
-            oneapi::dpl::__ranges::__require_access(__cgh, __rngs...); // get an access to data under SYCL buffer
-            auto __res_acc = __res.template get_access<access_mode::write>(__cgh);
-            __cgh.single_task<_Name...>([=] {
-                _Tp __result = __transform_pattern(__n, __rngs...);
-                __reduce_pattern.apply_init(__init, __result);
-                __res_acc[0] = __result;
-            });
-        });
-
-        return __future(__reduce_event, __res);
-    }
-};
-
-template <typename _Tp, typename _ReduceOp, typename _TransformOp, typename _ExecutionPolicy, typename _Size,
-          typename _InitType, oneapi::dpl::__internal::__enable_if_device_execution_policy<_ExecutionPolicy, int> = 0,
-          typename... _Ranges>
-auto
-__parallel_transform_reduce_seq_impl(_ExecutionPolicy&& __exec, _Size __n, _ReduceOp __reduce_op,
-                                     _TransformOp __transform_op, _InitType __init, _Ranges&&... __rngs)
-{
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
-    using _CustomName = typename _Policy::kernel_name;
-    using _ReduceKernel =
-        oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<__reduce_seq_kernel<_CustomName>>;
-
-    return __parallel_transform_reduce_seq_submitter<_Tp, _ReduceKernel>()(::std::forward<_ExecutionPolicy>(__exec),
-                                                                           __n, __reduce_op, __transform_op, __init,
-                                                                           ::std::forward<_Ranges>(__rngs)...);
-}
-
-// Parallel_transform_reduce for a single work group
+// Parallel_transform_reduce for a small arrays using a single work group
 template <::std::uint16_t __work_group_size, ::std::size_t __iters_per_work_item, typename _Tp, typename _KernelName>
 struct __parallel_transform_reduce_small_submitter;
 
@@ -114,7 +66,7 @@ struct __parallel_transform_reduce_small_submitter<__work_group_size, __iters_pe
                _InitType __init, _Ranges&&... __rngs) const
     {
         auto __transform_pattern =
-            unseq_backend::transform_reduce_known<_ExecutionPolicy, __iters_per_work_item, _ReduceOp, _TransformOp>{
+            unseq_backend::transform_reduce<_ExecutionPolicy, __iters_per_work_item, _ReduceOp, _TransformOp>{
                 __reduce_op, _TransformOp{__transform_op}};
         auto __reduce_pattern = unseq_backend::reduce_over_group<_ExecutionPolicy, _ReduceOp, _Tp>{__reduce_op};
 
@@ -129,14 +81,12 @@ struct __parallel_transform_reduce_small_submitter<__work_group_size, __iters_pe
             __cgh.parallel_for<_Name...>(
                 sycl::nd_range<1>(sycl::range<1>(__work_group_size), sycl::range<1>(__work_group_size)),
                 [=](sycl::nd_item<1> __item_id) {
-                    ::std::size_t __global_idx = __item_id.get_global_id(0);
-                    ::std::uint16_t __local_idx = __item_id.get_local_id(0);
+                    auto __local_idx = __item_id.get_local_id(0);
                     // 1. Initialization (transform part). Fill local memory
-                    __transform_pattern(__local_idx, __n, __iters_per_work_item, __global_idx, /*global_offset*/ 0,
-                                        __temp_local, __rngs...);
+                    __transform_pattern(__item_id, __n, /*global_offset*/ 0, __temp_local, __rngs...);
                     __dpl_sycl::__group_barrier(__item_id);
                     // 2. Reduce within work group using local memory
-                    _Tp __result = __reduce_pattern(__item_id, __global_idx, __n_items, __temp_local);
+                    _Tp __result = __reduce_pattern(__item_id, __n_items, __temp_local);
                     if (__local_idx == 0)
                     {
                         __reduce_pattern.apply_init(__init, __result);
@@ -167,47 +117,139 @@ __parallel_transform_reduce_small_impl(_ExecutionPolicy&& __exec, _Size __n, _Re
         ::std::forward<_Ranges>(__rngs)...);
 }
 
-// General parallel_transform_reduce - uses a tree-based reduction
-template <typename _Tp, typename _IsGPU>
-struct __parallel_transform_reduce_impl
-{
-    template <typename... _Name>
-    using _KernelName = __reduce_kernel<_IsGPU{}, _Name...>;
+// Parallel_transform_reduce for a mid-sized arrays using two tree reductions
+template <::std::uint16_t __work_group_size, ::std::size_t __iters_per_work_item1, ::std::size_t __iters_per_work_item2,
+          typename _Tp, typename _MainName, typename _LeafName>
+struct __parallel_transform_reduce_mid_submitter;
 
-    template <typename _ExecutionPolicy, typename _Size, typename _ReduceOp, typename _TransformOp1,
-              typename _TransformOp2, typename _InitType,
+template <::std::uint16_t __work_group_size, ::std::size_t __iters_per_work_item1, ::std::size_t __iters_per_work_item2,
+          typename _Tp, typename... _MainName, typename... _LeafName>
+struct __parallel_transform_reduce_mid_submitter<__work_group_size, __iters_per_work_item1, __iters_per_work_item2, _Tp,
+                                                 __internal::__optional_kernel_name<_MainName...>,
+                                                 __internal::__optional_kernel_name<_LeafName...>>
+{
+    template <typename _ExecutionPolicy, typename _ReduceOp, typename _TransformOp, typename _Size, typename _InitType,
               oneapi::dpl::__internal::__enable_if_device_execution_policy<_ExecutionPolicy, int> = 0,
               typename... _Ranges>
-    static auto
-    submit(_ExecutionPolicy&& __exec, _Size __n, ::std::uint16_t __work_group_size, _ReduceOp __reduce_op,
-           _TransformOp1 __transform_op1, _TransformOp2 __transform_op2, _InitType __init, _Ranges&&... __rngs)
+    auto
+    operator()(_ExecutionPolicy&& __exec, _Size __n, _ReduceOp __reduce_op, _TransformOp __transform_op,
+               _InitType __init, _Ranges&&... __rngs) const
     {
-        using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
-        using _CustomName = typename _Policy::kernel_name;
-        using _ReduceKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<
-            _KernelName, _CustomName, _ReduceOp, _TransformOp1, _TransformOp2, _Ranges...>;
+        using _NoOpFunctor = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;
+        auto __transform_pattern1 =
+            unseq_backend::transform_reduce<_ExecutionPolicy, __iters_per_work_item1, _ReduceOp, _TransformOp>{
+                __reduce_op, _TransformOp{__transform_op}};
+        auto __transform_pattern2 =
+            unseq_backend::transform_reduce<_ExecutionPolicy, __iters_per_work_item2, _ReduceOp, _NoOpFunctor>{
+                __reduce_op, _NoOpFunctor{}};
+        auto __reduce_pattern = unseq_backend::reduce_over_group<_ExecutionPolicy, _ReduceOp, _Tp>{__reduce_op};
 
-#if _ONEDPL_COMPILE_KERNEL
-        auto __kernel = __internal::__kernel_compiler<_ReduceKernel>::__compile(__exec);
-        __work_group_size = ::std::min(
-            __work_group_size, (::std::uint16_t)oneapi::dpl::__internal::__kernel_work_group_size(__exec, __kernel));
-#endif
+        _Size __size_per_work_group =
+            __iters_per_work_item1 * __work_group_size; // number of buffer elements processed within workgroup
+        _Size __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __size_per_work_group);
+        _Size __n_items = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __iters_per_work_item1);
 
-        _Size __iters_per_work_item = 1;
-        if constexpr (_IsGPU{})
-        {
-            // empirically tested launch configuration
-            __iters_per_work_item = 32;
-            __work_group_size = ::std::min(__work_group_size, (::std::uint16_t)256);
-            _PRINT_INFO_IN_DEBUG_MODE(__exec, __work_group_size);
-        }
-        else
-        {
-            // distribution is ~1 work group per compute unit on CPU
-            auto __max_cu = oneapi::dpl::__internal::__max_compute_units(__exec);
-            __iters_per_work_item = oneapi::dpl::__internal::__dpl_ceiling_div(__n, (__max_cu * __work_group_size));
-            _PRINT_INFO_IN_DEBUG_MODE(__exec, __work_group_size, __max_cu);
-        }
+        sycl::buffer<_Tp> __temp(sycl::range<1>(1 * __n_groups));
+
+        sycl::event __reduce_event = __exec.queue().submit([&, __n, __n_items](sycl::handler& __cgh) {
+            oneapi::dpl::__ranges::__require_access(__cgh, __rngs...); // get an access to data under SYCL buffer
+            auto __temp_acc = __temp.template get_access<sycl::access_mode::write>(__cgh);
+            __dpl_sycl::__local_accessor<_Tp> __temp_local(sycl::range<1>(__work_group_size), __cgh);
+            __cgh.parallel_for<_MainName...>(
+                sycl::nd_range<1>(sycl::range<1>(__n_groups * __work_group_size), sycl::range<1>(__work_group_size)),
+                [=](sycl::nd_item<1> __item_id) {
+                    auto __local_idx = __item_id.get_local_id(0);
+                    auto __group_idx = __item_id.get_group(0);
+                    // 1. Initialization (transform part). Fill local memory
+                    __transform_pattern1(__item_id, __n, /*global_offset*/ 0, __temp_local, __rngs...);
+                    __dpl_sycl::__group_barrier(__item_id);
+                    // 2. Reduce within work group using local memory
+                    _Tp __result = __reduce_pattern(__item_id, __n_items, __temp_local);
+                    if (__local_idx == 0)
+                        __temp_acc[__group_idx] = __result;
+                });
+        });
+
+        __n = __n_groups;
+        __n_items = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __iters_per_work_item2);
+        __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __size_per_work_group);
+
+        sycl::buffer<_Tp> __res(sycl::range<1>(1));
+
+        __reduce_event = __exec.queue().submit([&, __n, __n_items](sycl::handler& __cgh) {
+            __cgh.depends_on(__reduce_event);
+
+            auto __temp_acc = __temp.template get_access<sycl::access_mode::read>(__cgh);
+            auto __res_acc = __res.template get_access<sycl::access_mode::write>(__cgh);
+            __dpl_sycl::__local_accessor<_Tp> __temp_local(sycl::range<1>(__work_group_size), __cgh);
+
+            __cgh.parallel_for<_LeafName...>(
+                sycl::nd_range<1>(sycl::range<1>(__work_group_size), sycl::range<1>(__work_group_size)),
+                [=](sycl::nd_item<1> __item_id) {
+                    auto __local_idx = __item_id.get_local_id(0);
+                    // 1. Initialization (transform part). Fill local memory
+                    __transform_pattern2(__item_id, __n, /*global_offset*/ 0, __temp_local, __temp_acc);
+                    __dpl_sycl::__group_barrier(__item_id);
+                    // 2. Reduce within work group using local memory
+                    _Tp __result = __reduce_pattern(__item_id, __n_items, __temp_local);
+                    if (__local_idx == 0)
+                    {
+                        __reduce_pattern.apply_init(__init, __result);
+                        __res_acc[0] = __result;
+                    }
+                });
+        });
+
+        return __future(__reduce_event, __res);
+    }
+}; // struct __parallel_transform_reduce_mid_submitter
+
+template <::std::uint16_t __work_group_size, ::std::size_t __iters_per_work_item1, ::std::size_t __iters_per_work_item2,
+          typename _Tp, typename _ReduceOp, typename _TransformOp, typename _ExecutionPolicy, typename _Size,
+          typename _InitType, oneapi::dpl::__internal::__enable_if_device_execution_policy<_ExecutionPolicy, int> = 0,
+          typename... _Ranges>
+auto
+__parallel_transform_reduce_mid_impl(_ExecutionPolicy&& __exec, _Size __n, _ReduceOp __reduce_op,
+                                     _TransformOp __transform_op, _InitType __init, _Ranges&&... __rngs)
+{
+    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _CustomName = typename _Policy::kernel_name;
+    using _ReduceMainKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
+        __reduce_mid_main_kernel<::std::integral_constant<::std::uint16_t, __work_group_size>,
+                                 ::std::integral_constant<::std::uint16_t, __iters_per_work_item1>, _CustomName>>;
+    using _ReduceLeafKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
+        __reduce_mid_leaf_kernel<::std::integral_constant<::std::uint16_t, __work_group_size>,
+                                 ::std::integral_constant<::std::uint16_t, __iters_per_work_item2>, _CustomName>>;
+
+    return __parallel_transform_reduce_mid_submitter<__work_group_size, __iters_per_work_item1, __iters_per_work_item2,
+                                                     _Tp, _ReduceMainKernel, _ReduceLeafKernel>()(
+        ::std::forward<_ExecutionPolicy>(__exec), __n, __reduce_op, __transform_op, __init,
+        ::std::forward<_Ranges>(__rngs)...);
+}
+
+// Parallel_transform_reduce for a large arrays using a recursive tree reduction
+template <::std::uint16_t __work_group_size, ::std::size_t __iters_per_work_item, typename _Tp, typename _KernelName>
+struct __parallel_transform_reduce_large_submitter;
+
+template <::std::uint16_t __work_group_size, ::std::size_t __iters_per_work_item, typename _Tp, typename... _Name>
+struct __parallel_transform_reduce_large_submitter<__work_group_size, __iters_per_work_item, _Tp,
+                                                   __internal::__optional_kernel_name<_Name...>>
+{
+    template <typename _ExecutionPolicy, typename _ReduceOp, typename _TransformOp, typename _Size, typename _InitType,
+              oneapi::dpl::__internal::__enable_if_device_execution_policy<_ExecutionPolicy, int> = 0,
+              typename... _Ranges>
+    auto
+    operator()(_ExecutionPolicy&& __exec, _Size __n, _ReduceOp __reduce_op, _TransformOp __transform_op,
+               _InitType __init, _Ranges&&... __rngs) const
+    {
+        using _NoOpFunctor = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;
+        auto __transform_pattern1 =
+            unseq_backend::transform_reduce<_ExecutionPolicy, __iters_per_work_item, _ReduceOp, _TransformOp>{
+                __reduce_op, _TransformOp{__transform_op}};
+        auto __transform_pattern2 =
+            unseq_backend::transform_reduce<_ExecutionPolicy, __iters_per_work_item, _ReduceOp, _NoOpFunctor>{
+                __reduce_op, _NoOpFunctor{}};
+        auto __reduce_pattern = unseq_backend::reduce_over_group<_ExecutionPolicy, _ReduceOp, _Tp>{__reduce_op};
 
         _Size __size_per_work_group =
             __iters_per_work_item * __work_group_size; // number of buffer elements processed within workgroup
@@ -221,58 +263,46 @@ struct __parallel_transform_reduce_impl
         // __is_first == false. Reduce between work groups
         bool __is_first = true;
 
-        // For memory utilization it's better to use one big buffer instead of two small because size of the buffer is close
-        // to a few MB
+        // For memory utilization it's better to use one big buffer instead of two small because size of the buffer is
+        // close to a few MB
         _Size __offset_1 = 0;
         _Size __offset_2 = __n_groups;
 
         sycl::event __reduce_event;
         do
         {
-            __reduce_event = __exec.queue().submit([&, __is_first, __offset_1, __offset_2, __n, __n_items, __n_groups,
-                                                    __iters_per_work_item](sycl::handler& __cgh) {
+            __reduce_event = __exec.queue().submit([&, __is_first, __offset_1, __offset_2, __n, __n_items, 
+                                                    __n_groups](sycl::handler& __cgh) {
                 __cgh.depends_on(__reduce_event);
 
                 oneapi::dpl::__ranges::__require_access(__cgh, __rngs...); // get an access to data under SYCL buffer
                 auto __temp_acc = __temp.template get_access<access_mode::read_write>(__cgh);
                 auto __res_acc = __res.template get_access<access_mode::write>(__cgh);
                 __dpl_sycl::__local_accessor<_Tp> __temp_local(sycl::range<1>(__work_group_size), __cgh);
-#if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
-                __cgh.use_kernel_bundle(__kernel.get_kernel_bundle());
-#endif
-                __cgh.parallel_for<_ReduceKernel>(
-#if _ONEDPL_COMPILE_KERNEL && !_ONEDPL_KERNEL_BUNDLE_PRESENT
-                    __kernel,
-#endif
+                __cgh.parallel_for<_Name...>(
                     sycl::nd_range<1>(sycl::range<1>(__n_groups * __work_group_size),
                                       sycl::range<1>(__work_group_size)),
                     [=](sycl::nd_item<1> __item_id) {
-                        ::std::size_t __global_idx = __item_id.get_global_id(0);
-                        ::std::uint16_t __local_idx = __item_id.get_local_id(0);
+                        auto __local_idx = __item_id.get_local_id(0);
+                        auto __group_idx = __item_id.get_group(0);
                         // 1. Initialization (transform part). Fill local memory
                         if (__is_first)
-                        {
-                            __transform_op1(__local_idx, __n, __iters_per_work_item, __global_idx,
-                                            /*global_offset*/ 0, __temp_local, __rngs...);
-                        }
+                            __transform_pattern1(__item_id, __n, /*global_offset*/ 0, __temp_local, __rngs...);
                         else
-                        {
-                            __transform_op2(__local_idx, __n, __iters_per_work_item, __global_idx, __offset_2,
-                                            __temp_local, __temp_acc);
-                        }
+                            __transform_pattern2(__item_id, __n,  __offset_2, __temp_local, __temp_acc);
                         __dpl_sycl::__group_barrier(__item_id);
                         // 2. Reduce within work group using local memory
-                        _Tp __result = __reduce_op(__item_id, __global_idx, __n_items, __temp_local);
+                        _Tp __result = __reduce_pattern(__item_id, __n_items, __temp_local);
                         if (__local_idx == 0)
                         {
                             // final reduction
                             if (__n_groups == 1)
                             {
-                                __reduce_op.apply_init(__init, __result);
+                                __reduce_pattern.apply_init(__init, __result);
                                 __res_acc[0] = __result;
                             }
 
-                            __temp_acc[__offset_1 + __item_id.get_group(0)] = __result;
+                            __temp_acc[__offset_1 + __group_idx] = __result;
                         }
                     });
             });
@@ -286,9 +316,35 @@ struct __parallel_transform_reduce_impl
 
         return __future(__reduce_event, __res);
     }
-}; // struct __parallel_transform_reduce_impl
+}; // struct __parallel_transform_reduce_large_submitter
 
-// General version of parallel_transform_reduce. Calls optimized kernels.
+template <::std::uint16_t __work_group_size, ::std::size_t __iters_per_work_item, typename _Tp, typename _ReduceOp,
+          typename _TransformOp, typename _ExecutionPolicy, typename _Size, typename _InitType,
+          oneapi::dpl::__internal::__enable_if_device_execution_policy<_ExecutionPolicy, int> = 0, typename... _Ranges>
+auto
+__parallel_transform_reduce_large_impl(_ExecutionPolicy&& __exec, _Size __n, _ReduceOp __reduce_op,
+                                       _TransformOp __transform_op, _InitType __init, _Ranges&&... __rngs)
+{
+    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _CustomName = typename _Policy::kernel_name;
+    using _ReduceKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
+        __reduce_large_kernel<::std::integral_constant<::std::uint16_t, __work_group_size>,
+                              ::std::integral_constant<::std::size_t, __iters_per_work_item>, _CustomName>>;
+
+    return __parallel_transform_reduce_large_submitter<__work_group_size, __iters_per_work_item, _Tp, _ReduceKernel>()(
+        ::std::forward<_ExecutionPolicy>(__exec), __n, __reduce_op, __transform_op, __init,
+        ::std::forward<_Ranges>(__rngs)...);
+}
+
+// General version of parallel_transform_reduce. Processes elements in order to enable non-commutative algorithms.
+// Each work item transforms and reduces __iters_per_work_item elements from global memory and stores the result in SLM.
+// 32 __iters_per_work_item was empirically found best for typical devices.
+// Each work group of size __work_group_size reduces the preliminary results of each work item in a group reduction
+// using SLM. 256 __work_group_size was empirically found best for typical devices.
+// A single-work group implementation is used for small arrays.
+// Mid-sized arrays use two tree reductions with independet __iters_per_work_item.
+// Big arrays are processed with a recursive tree reduction. __work_group_size * __iters_per_work_item elements are
+// reduced in each step.
 template <typename _Tp, typename _ReduceOp, typename _TransformOp, typename _ExecutionPolicy, typename _InitType,
           oneapi::dpl::__internal::__enable_if_device_execution_policy<_ExecutionPolicy, int> = 0, typename... _Ranges>
 auto
@@ -298,114 +354,112 @@ __parallel_transform_reduce(_ExecutionPolicy&& __exec, _ReduceOp __reduce_op, _T
     auto __n = oneapi::dpl::__ranges::__get_first_range_size(__rngs...);
     assert(__n > 0);
 
-    // Use a single-task sequential implementation for very small arrays.
-    if (__n <= 64)
-    {
-        return __parallel_transform_reduce_seq_impl<_Tp>(::std::forward<_ExecutionPolicy>(__exec), __n, __reduce_op,
-                                                         __transform_op, __init, ::std::forward<_Ranges>(__rngs)...);
-    }
-
-    // Use a single-pass tree reduction for medium-sized arrays with the following template parameters:
-    // __iters_per_work_item shows number of elements to reduce on global memory.
-    // __work_group_size shows number of elements to reduce on local memory.
-
-    // get the work group size adjusted to the local memory limit
-    // Pessimistically double the memory requirement to take into account memory used by compiled kernel
-    // TODO: find a way to generalize getting of reliable work-group size
+    // Get the work group size adjusted to the local memory limit.
+    // Pessimistically double the memory requirement to take into account memory used by compiled kernel.
+    // TODO: find a way to generalize getting of reliable work-group size.
     ::std::size_t __work_group_size = oneapi::dpl::__internal::__slm_adjusted_work_group_size(__exec, sizeof(_Tp) * 2);
 
-    if (__n <= 65536 && __work_group_size >= 512)
+    // Use single work group implementation if array < __work_group_size * __iters_per_work_item.
+    if (__n <= 256 && __work_group_size >= 256)
     {
-        if (__n <= 128)
-        {
-            return __parallel_transform_reduce_small_impl<128, 1, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                                       __reduce_op, __transform_op, __init,
-                                                                       ::std::forward<_Ranges>(__rngs)...);
-        }
-        else if (__n <= 256)
-        {
-            return __parallel_transform_reduce_small_impl<256, 1, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                                       __reduce_op, __transform_op, __init,
-                                                                       ::std::forward<_Ranges>(__rngs)...);
-        }
-        else if (__n <= 512)
-        {
-            return __parallel_transform_reduce_small_impl<512, 1, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                                       __reduce_op, __transform_op, __init,
-                                                                       ::std::forward<_Ranges>(__rngs)...);
-        }
-        else if (__n <= 1024)
-        {
-            return __parallel_transform_reduce_small_impl<512, 2, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                                       __reduce_op, __transform_op, __init,
-                                                                       ::std::forward<_Ranges>(__rngs)...);
-        }
-        else if (__n <= 2048)
-        {
-            return __parallel_transform_reduce_small_impl<512, 4, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                                       __reduce_op, __transform_op, __init,
-                                                                       ::std::forward<_Ranges>(__rngs)...);
-        }
-        else if (__n <= 4096)
-        {
-            return __parallel_transform_reduce_small_impl<512, 8, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                                       __reduce_op, __transform_op, __init,
-                                                                       ::std::forward<_Ranges>(__rngs)...);
-        }
-        else if (__n <= 8192)
-        {
-            return __parallel_transform_reduce_small_impl<512, 16, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                                        __reduce_op, __transform_op, __init,
-                                                                        ::std::forward<_Ranges>(__rngs)...);
-        }
-        else if (__n <= 16384)
-        {
-            return __parallel_transform_reduce_small_impl<512, 32, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                                        __reduce_op, __transform_op, __init,
-                                                                        ::std::forward<_Ranges>(__rngs)...);
-        }
-        else if (__n <= 32768)
-        {
-            return __parallel_transform_reduce_small_impl<512, 64, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                                        __reduce_op, __transform_op, __init,
-                                                                        ::std::forward<_Ranges>(__rngs)...);
-        }
-        else
-        {
-            return __parallel_transform_reduce_small_impl<512, 128, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                                         __reduce_op, __transform_op, __init,
-                                                                         ::std::forward<_Ranges>(__rngs)...);
-        }
+        return __parallel_transform_reduce_small_impl<256, 1, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                   __reduce_op, __transform_op, __init,
+                                                                   ::std::forward<_Ranges>(__rngs)...);
+    }
+    if (__n <= 512 && __work_group_size >= 256)
+    {
+        return __parallel_transform_reduce_small_impl<256, 2, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                   __reduce_op, __transform_op, __init,
+                                                                   ::std::forward<_Ranges>(__rngs)...);
+    }
+    if (__n <= 1024 && __work_group_size >= 256)
+    {
+        return __parallel_transform_reduce_small_impl<256, 4, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                   __reduce_op, __transform_op, __init,
+                                                                   ::std::forward<_Ranges>(__rngs)...);
+    }
+    if (__n <= 2048 && __work_group_size >= 256)
+    {
+        return __parallel_transform_reduce_small_impl<256, 8, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                   __reduce_op, __transform_op, __init,
+                                                                   ::std::forward<_Ranges>(__rngs)...);
+    }
+    if (__n <= 4096 && __work_group_size >= 256)
+    {
+        return __parallel_transform_reduce_small_impl<256, 16, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                    __reduce_op, __transform_op, __init,
+                                                                    ::std::forward<_Ranges>(__rngs)...);
+    }
+    if (__n <= 8192 && __work_group_size >= 256)
+    {
+        return __parallel_transform_reduce_small_impl<256, 32, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                    __reduce_op, __transform_op, __init,
+                                                                    ::std::forward<_Ranges>(__rngs)...);
     }
 
-    // Use a recursive tree reduction for large arrays.
-    // A fixed __iters_per_work_item is used for on GPUs to achieve high memory throughputs.
-    // CPUs use a dynamic __iters_per_work_item that distributes ~1 work group on each compute unit.
-    using _NoOpFunctor = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;
-    if (__exec.queue().get_device().is_gpu())
+    // Use two step tree reduction.
+    // First step reduces __work_group_size * __iters_per_work_item1 elements.
+    // Second step reduces __work_group_size * __iters_per_work_item2 elements.
+    if (__n <= 2097152 && __work_group_size >= 256)
     {
-        auto __transform_pattern1 =
-            unseq_backend::transform_reduce_known<_ExecutionPolicy, 32, _ReduceOp, _TransformOp>{
-                __reduce_op, _TransformOp{__transform_op}};
-        auto __transform_pattern2 =
-            unseq_backend::transform_reduce_known<_ExecutionPolicy, 32, _ReduceOp, _NoOpFunctor>{__reduce_op,
-                                                                                                 _NoOpFunctor{}};
-        auto __reduce_pattern = unseq_backend::reduce_over_group<_ExecutionPolicy, _ReduceOp, _Tp>{__reduce_op};
-        return __parallel_transform_reduce_impl<_Tp, ::std::true_type>::submit(
-            ::std::forward<_ExecutionPolicy>(__exec), __n, __work_group_size, __reduce_pattern, __transform_pattern1,
-            __transform_pattern2, __init, ::std::forward<_Ranges>(__rngs)...);
+        return __parallel_transform_reduce_mid_impl<256, 32, 1, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                     __reduce_op, __transform_op, __init,
+                                                                     ::std::forward<_Ranges>(__rngs)...);
     }
-    else
+    if (__n <= 4194304 && __work_group_size >= 256)
     {
-        auto __transform_pattern1 = unseq_backend::transform_reduce_unknown<_ExecutionPolicy, _ReduceOp, _TransformOp>{
-            __reduce_op, _TransformOp{__transform_op}};
-        auto __transform_pattern2 = unseq_backend::transform_reduce_unknown<_ExecutionPolicy, _ReduceOp, _NoOpFunctor>{
-            __reduce_op, _NoOpFunctor{}};
-        auto __reduce_pattern = unseq_backend::reduce_over_group<_ExecutionPolicy, _ReduceOp, _Tp>{__reduce_op};
-        return __parallel_transform_reduce_impl<_Tp, ::std::false_type>::submit(
-            ::std::forward<_ExecutionPolicy>(__exec), __n, __work_group_size, __reduce_pattern, __transform_pattern1,
-            __transform_pattern2, __init, ::std::forward<_Ranges>(__rngs)...);
+        return __parallel_transform_reduce_mid_impl<256, 32, 2, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                     __reduce_op, __transform_op, __init,
+                                                                     ::std::forward<_Ranges>(__rngs)...);
     }
+    if (__n <= 8388608 && __work_group_size >= 256)
+    {
+        return __parallel_transform_reduce_mid_impl<256, 32, 4, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                     __reduce_op, __transform_op, __init,
+                                                                     ::std::forward<_Ranges>(__rngs)...);
+    }
+    if (__n <= 16777216 && __work_group_size >= 256)
+    {
+        return __parallel_transform_reduce_mid_impl<256, 32, 8, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                     __reduce_op, __transform_op, __init,
+                                                                     ::std::forward<_Ranges>(__rngs)...);
+    }
+    if (__n <= 33554432 && __work_group_size >= 256)
+    {
+        return __parallel_transform_reduce_mid_impl<256, 32, 16, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                      __reduce_op, __transform_op, __init,
+                                                                      ::std::forward<_Ranges>(__rngs)...);
+    }
+    if (__n <= 67108864 && __work_group_size >= 256)
+    {
+        return __parallel_transform_reduce_mid_impl<256, 32, 32, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                      __reduce_op, __transform_op, __init,
+                                                                      ::std::forward<_Ranges>(__rngs)...);
+    }
+
+    // Else use a recursive tree reduction.
+    if (__work_group_size >= 256)
+    {
+        return __parallel_transform_reduce_large_impl<256, 32, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                    __reduce_op, __transform_op, __init,
+                                                                    ::std::forward<_Ranges>(__rngs)...);
+    }
+    if (__work_group_size >= 128)
+    {
+        return __parallel_transform_reduce_large_impl<128, 32, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                    __reduce_op, __transform_op, __init,
+                                                                    ::std::forward<_Ranges>(__rngs)...);
+    }
+    if (__work_group_size >= 64)
+    {
+        return __parallel_transform_reduce_large_impl<64, 32, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                   __reduce_op, __transform_op, __init,
+                                                                   ::std::forward<_Ranges>(__rngs)...);
+    }
+    assert("Work group sizes of at least 32 are required." && __work_group_size >= 32);
+    return __parallel_transform_reduce_large_impl<32, 32, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                               __reduce_op, __transform_op, __init,
+                                                               ::std::forward<_Ranges>(__rngs)...);
 }
 
 } // namespace __par_backend_hetero

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -122,7 +122,7 @@ struct __parallel_transform_reduce_small_submitter<__work_group_size, __iters_pe
             __cgh.parallel_for<_Name...>(
                 sycl::nd_range<1>(sycl::range<1>(__work_group_size), sycl::range<1>(__work_group_size)),
                 [=](sycl::nd_item<1> __item_id) {
-                    __work_group_reduce_kernel<_Tp>(__item_id, __n, __n_items, __transform_pattern, __reduce_pattern, 
+                    __work_group_reduce_kernel<_Tp>(__item_id, __n, __n_items, __transform_pattern, __reduce_pattern,
                                                     __init, __temp_local, __res_acc, __rngs...);
                 });
         });
@@ -193,7 +193,7 @@ struct __parallel_transform_reduce_mid_submitter<__work_group_size, __iters_per_
             __cgh.parallel_for<_MainName...>(
                 sycl::nd_range<1>(sycl::range<1>(__n_groups * __work_group_size), sycl::range<1>(__work_group_size)),
                 [=](sycl::nd_item<1> __item_id) {
-                    __device_reduce_kernel<_Tp>(__item_id, __n, __n_items, __transform_pattern1, __reduce_pattern, 
+                    __device_reduce_kernel<_Tp>(__item_id, __n, __n_items, __transform_pattern1, __reduce_pattern,
                                                 __init, __temp_local, __temp_acc, __rngs...);
                 });
         });
@@ -225,7 +225,7 @@ struct __parallel_transform_reduce_mid_submitter<__work_group_size, __iters_per_
             __cgh.parallel_for<_LeafName...>(
                 sycl::nd_range<1>(sycl::range<1>(__work_group_size2), sycl::range<1>(__work_group_size2)),
                 [=](sycl::nd_item<1> __item_id) {
-                    __work_group_reduce_kernel<_Tp>(__item_id, __n, __n_items, __transform_pattern2, __reduce_pattern, 
+                    __work_group_reduce_kernel<_Tp>(__item_id, __n, __n_items, __transform_pattern2, __reduce_pattern,
                                                     __init, __temp_local, __res_acc, __temp_acc);
                 });
         });

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -152,12 +152,12 @@ __parallel_transform_reduce_small_impl(_ExecutionPolicy&& __exec, _Size __n, _Re
 // First: __work_group_size * __iters_per_work_item1 elements are transformed and reduced to a single partial result by
 // each work group.
 // Second: __work_group_size * __iters_per_work_item2 elements are reduced to the single result.
-template <::std::uint16_t __work_group_size, ::std::uint8_t __iters_per_work_item1, ::std::uint8_t __iters_per_work_item2,
-          typename _Tp, typename _MainName, typename _LeafName>
+template <::std::uint16_t __work_group_size, ::std::uint8_t __iters_per_work_item1,
+          ::std::uint8_t __iters_per_work_item2, typename _Tp, typename _MainName, typename _LeafName>
 struct __parallel_transform_reduce_mid_submitter;
 
-template <::std::uint16_t __work_group_size, ::std::uint8_t __iters_per_work_item1, ::std::uint8_t __iters_per_work_item2,
-          typename _Tp, typename... _MainName, typename... _LeafName>
+template <::std::uint16_t __work_group_size, ::std::uint8_t __iters_per_work_item1,
+          ::std::uint8_t __iters_per_work_item2, typename _Tp, typename... _MainName, typename... _LeafName>
 struct __parallel_transform_reduce_mid_submitter<__work_group_size, __iters_per_work_item1, __iters_per_work_item2, _Tp,
                                                  __internal::__optional_kernel_name<_MainName...>,
                                                  __internal::__optional_kernel_name<_LeafName...>>
@@ -233,10 +233,10 @@ struct __parallel_transform_reduce_mid_submitter<__work_group_size, __iters_per_
     }
 }; // struct __parallel_transform_reduce_mid_submitter
 
-template <::std::uint16_t __work_group_size, ::std::uint8_t __iters_per_work_item1, ::std::uint8_t __iters_per_work_item2,
-          typename _Tp, typename _ReduceOp, typename _TransformOp, typename _ExecutionPolicy, typename _Size,
-          typename _InitType, oneapi::dpl::__internal::__enable_if_device_execution_policy<_ExecutionPolicy, int> = 0,
-          typename... _Ranges>
+template <::std::uint16_t __work_group_size, ::std::uint8_t __iters_per_work_item1,
+          ::std::uint8_t __iters_per_work_item2, typename _Tp, typename _ReduceOp, typename _TransformOp,
+          typename _ExecutionPolicy, typename _Size, typename _InitType,
+          oneapi::dpl::__internal::__enable_if_device_execution_policy<_ExecutionPolicy, int> = 0, typename... _Ranges>
 auto
 __parallel_transform_reduce_mid_impl(_ExecutionPolicy&& __exec, _Size __n, _ReduceOp __reduce_op,
                                      _TransformOp __transform_op, _InitType __init, _Ranges&&... __rngs)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -119,7 +119,7 @@ __parallel_transform_reduce_small_impl(_ExecutionPolicy&& __exec, _Size __n, _Re
 }
 
 // Parallel_transform_reduce for a mid-sized arrays using two reduction steps.
-// First: __work_group_size * __iters_per_work_item1 elements are transformed and reduced to a single partial result by 
+// First: __work_group_size * __iters_per_work_item1 elements are transformed and reduced to a single partial result by
 // each work group.
 // Second: __work_group_size * __iters_per_work_item2 elements are reduced to the single result.
 template <::std::uint16_t __work_group_size, ::std::size_t __iters_per_work_item1, ::std::size_t __iters_per_work_item2,
@@ -293,7 +293,7 @@ struct __parallel_transform_reduce_impl
         sycl::event __reduce_event;
         do
         {
-            __reduce_event = __exec.queue().submit([&, __is_first, __offset_1, __offset_2, __n, __n_items, 
+            __reduce_event = __exec.queue().submit([&, __is_first, __offset_1, __offset_2, __n, __n_items,
                                                     __n_groups](sycl::handler& __cgh) {
                 __cgh.depends_on(__reduce_event);
 
@@ -352,7 +352,7 @@ struct __parallel_transform_reduce_impl
 // Each work group of size __work_group_size reduces the preliminary results of each work item in a group reduction
 // using SLM. 256 __work_group_size was empirically found best for typical devices.
 // A single-work group implementation is used for small arrays.
-// Mid-sized arrays use two tree reductions with independet __iters_per_work_item.
+// Mid-sized arrays use two tree reductions with independent __iters_per_work_item.
 // Big arrays are processed with a recursive tree reduction. __work_group_size * __iters_per_work_item elements are
 // reduced in each step.
 template <typename _Tp, typename _ReduceOp, typename _TransformOp, typename _ExecutionPolicy, typename _InitType,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -179,7 +179,7 @@ struct __parallel_transform_reduce_mid_submitter<__work_group_size, __iters_per_
         auto __reduce_pattern = unseq_backend::reduce_over_group<_ExecutionPolicy, _ReduceOp, _Tp>{__reduce_op};
 
         // number of buffer elements processed within workgroup
-        constexpr _Size __size_per_work_group = __iters_per_work_item1 * __work_group_size; 
+        constexpr _Size __size_per_work_group = __iters_per_work_item1 * __work_group_size;
         _Size __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __size_per_work_group);
         _Size __n_items = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __iters_per_work_item1);
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -391,31 +391,31 @@ __parallel_transform_reduce(_ExecutionPolicy&& __exec, _ReduceOp __reduce_op, _T
                                                                    __reduce_op, __transform_op, __init,
                                                                    ::std::forward<_Ranges>(__rngs)...);
     }
-    if (__n <= 512 && __work_group_size >= 256)
+    else if (__n <= 512 && __work_group_size >= 256)
     {
         return __parallel_transform_reduce_small_impl<256, 2, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
                                                                    __reduce_op, __transform_op, __init,
                                                                    ::std::forward<_Ranges>(__rngs)...);
     }
-    if (__n <= 1024 && __work_group_size >= 256)
+    else if (__n <= 1024 && __work_group_size >= 256)
     {
         return __parallel_transform_reduce_small_impl<256, 4, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
                                                                    __reduce_op, __transform_op, __init,
                                                                    ::std::forward<_Ranges>(__rngs)...);
     }
-    if (__n <= 2048 && __work_group_size >= 256)
+    else if (__n <= 2048 && __work_group_size >= 256)
     {
         return __parallel_transform_reduce_small_impl<256, 8, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
                                                                    __reduce_op, __transform_op, __init,
                                                                    ::std::forward<_Ranges>(__rngs)...);
     }
-    if (__n <= 4096 && __work_group_size >= 256)
+    else if (__n <= 4096 && __work_group_size >= 256)
     {
         return __parallel_transform_reduce_small_impl<256, 16, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
                                                                     __reduce_op, __transform_op, __init,
                                                                     ::std::forward<_Ranges>(__rngs)...);
     }
-    if (__n <= 8192 && __work_group_size >= 256)
+    else if (__n <= 8192 && __work_group_size >= 256)
     {
         return __parallel_transform_reduce_small_impl<256, 32, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
                                                                     __reduce_op, __transform_op, __init,
@@ -425,47 +425,50 @@ __parallel_transform_reduce(_ExecutionPolicy&& __exec, _ReduceOp __reduce_op, _T
     // Use two-step tree reduction.
     // First step reduces __work_group_size * __iters_per_work_item1 elements.
     // Second step reduces __work_group_size * __iters_per_work_item2 elements.
-    if (__n <= 2097152 && __work_group_size >= 256)
+    else if (__n <= 2097152 && __work_group_size >= 256)
     {
         return __parallel_transform_reduce_mid_impl<256, 32, 1, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
                                                                      __reduce_op, __transform_op, __init,
                                                                      ::std::forward<_Ranges>(__rngs)...);
     }
-    if (__n <= 4194304 && __work_group_size >= 256)
+    else if (__n <= 4194304 && __work_group_size >= 256)
     {
         return __parallel_transform_reduce_mid_impl<256, 32, 2, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
                                                                      __reduce_op, __transform_op, __init,
                                                                      ::std::forward<_Ranges>(__rngs)...);
     }
-    if (__n <= 8388608 && __work_group_size >= 256)
+    else if (__n <= 8388608 && __work_group_size >= 256)
     {
         return __parallel_transform_reduce_mid_impl<256, 32, 4, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
                                                                      __reduce_op, __transform_op, __init,
                                                                      ::std::forward<_Ranges>(__rngs)...);
     }
-    if (__n <= 16777216 && __work_group_size >= 256)
+    else if (__n <= 16777216 && __work_group_size >= 256)
     {
         return __parallel_transform_reduce_mid_impl<256, 32, 8, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
                                                                      __reduce_op, __transform_op, __init,
                                                                      ::std::forward<_Ranges>(__rngs)...);
     }
-    if (__n <= 33554432 && __work_group_size >= 256)
+    else if (__n <= 33554432 && __work_group_size >= 256)
     {
         return __parallel_transform_reduce_mid_impl<256, 32, 16, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
                                                                       __reduce_op, __transform_op, __init,
                                                                       ::std::forward<_Ranges>(__rngs)...);
     }
-    if (__n <= 67108864 && __work_group_size >= 256)
+    else if (__n <= 67108864 && __work_group_size >= 256)
     {
         return __parallel_transform_reduce_mid_impl<256, 32, 32, _Tp>(::std::forward<_ExecutionPolicy>(__exec), __n,
                                                                       __reduce_op, __transform_op, __init,
                                                                       ::std::forward<_Ranges>(__rngs)...);
     }
+    else
+    {
 
-    // Otherwise use a recursive tree reduction.
-    return __parallel_transform_reduce_impl<_Tp, 32>::submit(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                             __work_group_size, __reduce_op, __transform_op, __init,
-                                                             ::std::forward<_Ranges>(__rngs)...);
+        // Otherwise use a recursive tree reduction.
+        return __parallel_transform_reduce_impl<_Tp, 32>::submit(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                 __work_group_size, __reduce_op, __transform_op, __init,
+                                                                 ::std::forward<_Ranges>(__rngs)...);
+    }
 }
 
 } // namespace __par_backend_hetero

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -141,7 +141,7 @@ __parallel_transform_reduce_small_impl(_ExecutionPolicy&& __exec, _Size __n, _Re
     using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
     using _CustomName = typename _Policy::kernel_name;
     using _ReduceKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
-        __reduce_small_kernel<::std::integral_constant<::std::size_t, __iters_per_work_item>, _CustomName>>;
+        __reduce_small_kernel<::std::integral_constant<::std::uint8_t, __iters_per_work_item>, _CustomName>>;
 
     return __parallel_transform_reduce_small_submitter<__work_group_size, __iters_per_work_item, _Tp, _ReduceKernel>()(
         ::std::forward<_ExecutionPolicy>(__exec), __n, __reduce_op, __transform_op, __init,
@@ -244,9 +244,9 @@ __parallel_transform_reduce_mid_impl(_ExecutionPolicy&& __exec, _Size __n, _Redu
     using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
     using _CustomName = typename _Policy::kernel_name;
     using _ReduceMainKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
-        __reduce_mid_main_kernel<::std::integral_constant<::std::uint16_t, __iters_per_work_item1>, _CustomName>>;
+        __reduce_mid_main_kernel<::std::integral_constant<::std::uint8_t, __iters_per_work_item1>, _CustomName>>;
     using _ReduceLeafKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
-        __reduce_mid_leaf_kernel<::std::integral_constant<::std::uint16_t, __iters_per_work_item2>, _CustomName>>;
+        __reduce_mid_leaf_kernel<::std::integral_constant<::std::uint8_t, __iters_per_work_item2>, _CustomName>>;
 
     return __parallel_transform_reduce_mid_submitter<__work_group_size, __iters_per_work_item1, __iters_per_work_item2,
                                                      _Tp, _ReduceMainKernel, _ReduceLeafKernel>()(

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -237,9 +237,8 @@ struct reduce_over_group
     reduce_impl(const _NDItemId __item_id, const _Size __n, _AccLocal& __local_mem,
                 std::true_type /*has_known_identity*/) const
     {
-        auto __local_id = __item_id.get_local_id(0);
-        auto __global_idx = __item_id.get_global_id(0);
         auto __local_idx = __item_id.get_local_id(0);
+        auto __global_idx = __item_id.get_global_id(0);
         if (__global_idx >= __n)
         {
             // Fill the rest of local buffer with init elements so each of inclusive_scan method could correctly work

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -184,38 +184,22 @@ struct __init_processing
 // transform_reduce
 //------------------------------------------------------------------------
 
-// TODO: Think about unifying "transform_reduce" structures since their code is very similar.
-template <typename _ExecutionPolicy, typename _Operation1, typename _Operation2, typename _Tp>
-struct transform_reduce_seq
-{
-    _Operation1 __binary_op;
-    _Operation2 __unary_op;
-
-    template <typename _Size, typename... _Acc>
-    _Tp
-    operator()(const _Size __n, const _Acc&... __acc) const
-    {
-        _Tp __result = __unary_op(0, __acc...);
-        // Add neighbour to the current __result
-        for (_Size __i = 1; __i < __n; ++__i)
-            __result = __binary_op(__result, __unary_op(__i, __acc...));
-        return __result;
-    }
-};
-
+// Load elements consecutively from global memory, transform them, and apply a local reduction. Each local result is
+// stored in local memory.
 template <typename _ExecutionPolicy, ::std::size_t __iters_per_work_item, typename _Operation1, typename _Operation2>
-struct transform_reduce_known
+struct transform_reduce
 {
     _Operation1 __binary_op;
     _Operation2 __unary_op;
 
-    template <typename _Size, typename _AccLocal, typename... _Acc>
+    template <typename _NDItemId, typename _Size, typename _AccLocal, typename... _Acc>
     void
-    operator()(const ::std::uint16_t __local_id, const _Size __n,
-               const ::std::size_t /* unused __iters_per_work_item */, const ::std::size_t __global_id,
-               const ::std::size_t __global_offset, _AccLocal& __local_mem, const _Acc&... __acc) const
+    operator()(const _NDItemId __item_id, const _Size __n, const ::std::size_t __global_offset, _AccLocal& __local_mem,
+               const _Acc&... __acc) const
     {
-        const _Size __adjusted_global_id = __global_offset + __iters_per_work_item * __global_id;
+        auto __global_idx = __item_id.get_global_id(0);
+        auto __local_idx = __item_id.get_local_id(0);
+        const _Size __adjusted_global_id = __global_offset + __iters_per_work_item * __global_idx;
         const _Size __adjusted_n = __global_offset + __n;
         // Add neighbour to the current __local_mem
         if (__adjusted_global_id + __iters_per_work_item < __adjusted_n)
@@ -225,7 +209,7 @@ struct transform_reduce_known
             _ONEDPL_PRAGMA_UNROLL
             for (_Size __i = 1; __i < __iters_per_work_item; ++__i)
                 __res = __binary_op(__res, __unary_op(__adjusted_global_id + __i, __acc...));
-            __local_mem[__local_id] = __res;
+            __local_mem[__local_idx] = __res;
         }
         else if (__adjusted_global_id < __adjusted_n)
         {
@@ -234,68 +218,44 @@ struct transform_reduce_known
             typename _AccLocal::value_type __res = __unary_op(__adjusted_global_id, __acc...);
             for (_Size __i = 1; __i < __items_to_process; ++__i)
                 __res = __binary_op(__res, __unary_op(__adjusted_global_id + __i, __acc...));
-            __local_mem[__local_id] = __res;
+            __local_mem[__local_idx] = __res;
         }
     }
 };
 
-template <typename _ExecutionPolicy, typename _Operation1, typename _Operation2>
-struct transform_reduce_unknown
-{
-    _Operation1 __binary_op;
-    _Operation2 __unary_op;
-
-    template <typename _Size, typename _AccLocal, typename... _Acc>
-    void
-    operator()(const ::std::uint16_t __local_id, const _Size __n, const ::std::size_t __iters_per_work_item,
-               const ::std::size_t __global_id, const ::std::size_t __global_offset, _AccLocal& __local_mem,
-               const _Acc&... __acc) const
-    {
-        ::std::size_t __adjusted_global_id = __global_offset + __iters_per_work_item * __global_id;
-        _Size __adjusted_n = __global_offset + __n;
-        if (__adjusted_global_id < __adjusted_n)
-        {
-            typename _AccLocal::value_type __res = __unary_op(__adjusted_global_id, __acc...);
-            // Add neighbour to the current __local_mem
-            for (_Size __i = 1; __i < __iters_per_work_item; ++__i)
-            {
-                ::std::size_t __shifted_id = __adjusted_global_id + __i;
-                if (__shifted_id < __adjusted_n)
-                    __res = __binary_op(__res, __unary_op(__shifted_id, __acc...));
-            }
-            __local_mem[__local_id] = __res;
-        }
-    }
-};
-
-// Reduce on local memory
+// Reduce local reductions of each work item to a single reduced element per work group. The local reductions are held
+// in local memory. sycl::reduce_over_group is used for supported data types and operations. All other operations are
+// processed in order and without a known identity.
 template <typename _ExecutionPolicy, typename _BinaryOperation1, typename _Tp>
 struct reduce_over_group
 {
     _BinaryOperation1 __bin_op1;
 
     // Reduce on local memory with subgroups
-    template <typename _NDItemId, typename _GlobalIdx, typename _Size, typename _AccLocal>
+    template <typename _NDItemId, typename _Size, typename _AccLocal>
     _Tp
-    reduce_impl(const _NDItemId __item_id, const _GlobalIdx __global_idx, const _Size __n, _AccLocal& __local_mem,
+    reduce_impl(const _NDItemId __item_id, const _Size __n, _AccLocal& __local_mem,
                 std::true_type /*has_known_identity*/) const
     {
         auto __local_id = __item_id.get_local_id(0);
+        auto __global_idx = __item_id.get_global_id(0);
+        auto __local_idx = __item_id.get_local_id(0);
         if (__global_idx >= __n)
         {
             // Fill the rest of local buffer with init elements so each of inclusive_scan method could correctly work
             // for each work-item in sub-group
-            __local_mem[__local_id] = __known_identity<_BinaryOperation1, _Tp>;
+            __local_mem[__local_idx] = __known_identity<_BinaryOperation1, _Tp>;
         }
-        return __dpl_sycl::__reduce_over_group(__item_id.get_group(), __local_mem[__local_id], __bin_op1);
+        return __dpl_sycl::__reduce_over_group(__item_id.get_group(), __local_mem[__local_idx], __bin_op1);
     }
 
-    template <typename _NDItemId, typename _GlobalIdx, typename _Size, typename _AccLocal>
+    template <typename _NDItemId, typename _Size, typename _AccLocal>
     _Tp
-    reduce_impl(const _NDItemId __item_id, const _GlobalIdx __global_idx, const _Size __n, _AccLocal& __local_mem,
+    reduce_impl(const _NDItemId __item_id, const _Size __n, _AccLocal& __local_mem,
                 std::false_type /*has_known_identity*/) const
     {
         auto __local_idx = __item_id.get_local_id(0);
+        auto __global_idx = __item_id.get_global_id(0);
         auto __group_size = __item_id.get_local_range().size();
 
         for (::std::uint32_t __power_2 = 1; __power_2 < __group_size; __power_2 *= 2)
@@ -310,11 +270,11 @@ struct reduce_over_group
         return __local_mem[__local_idx];
     }
 
-    template <typename _NDItemId, typename _GlobalIdx, typename _Size, typename _AccLocal>
+    template <typename _NDItemId, typename _Size, typename _AccLocal>
     _Tp
-    operator()(const _NDItemId __item_id, const _GlobalIdx __global_idx, const _Size __n, _AccLocal& __local_mem) const
+    operator()(const _NDItemId __item_id, const _Size __n, _AccLocal& __local_mem) const
     {
-        return reduce_impl(__item_id, __global_idx, __n, __local_mem, __has_known_identity<_BinaryOperation1, _Tp>{});
+        return reduce_impl(__item_id, __n, __local_mem, __has_known_identity<_BinaryOperation1, _Tp>{});
     }
 
     template <typename _InitType, typename _Result>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -186,7 +186,7 @@ struct __init_processing
 
 // Load elements consecutively from global memory, transform them, and apply a local reduction. Each local result is
 // stored in local memory.
-template <typename _ExecutionPolicy, ::std::size_t __iters_per_work_item, typename _Operation1, typename _Operation2>
+template <typename _ExecutionPolicy, ::std::uint8_t __iters_per_work_item, typename _Operation1, typename _Operation2>
 struct transform_reduce
 {
     _Operation1 __binary_op;
@@ -194,7 +194,7 @@ struct transform_reduce
 
     template <typename _NDItemId, typename _Size, typename _AccLocal, typename... _Acc>
     void
-    operator()(const _NDItemId __item_id, const _Size __n, const ::std::size_t __global_offset, _AccLocal& __local_mem,
+    operator()(const _NDItemId __item_id, const _Size __n, const _Size __global_offset, const _AccLocal& __local_mem,
                const _Acc&... __acc) const
     {
         auto __global_idx = __item_id.get_global_id(0);
@@ -234,7 +234,7 @@ struct reduce_over_group
     // Reduce on local memory with subgroups
     template <typename _NDItemId, typename _Size, typename _AccLocal>
     _Tp
-    reduce_impl(const _NDItemId __item_id, const _Size __n, _AccLocal& __local_mem,
+    reduce_impl(const _NDItemId __item_id, const _Size __n, const _AccLocal& __local_mem,
                 std::true_type /*has_known_identity*/) const
     {
         auto __local_idx = __item_id.get_local_id(0);
@@ -250,7 +250,7 @@ struct reduce_over_group
 
     template <typename _NDItemId, typename _Size, typename _AccLocal>
     _Tp
-    reduce_impl(const _NDItemId __item_id, const _Size __n, _AccLocal& __local_mem,
+    reduce_impl(const _NDItemId __item_id, const _Size __n, const _AccLocal& __local_mem,
                 std::false_type /*has_known_identity*/) const
     {
         auto __local_idx = __item_id.get_local_id(0);
@@ -271,7 +271,7 @@ struct reduce_over_group
 
     template <typename _NDItemId, typename _Size, typename _AccLocal>
     _Tp
-    operator()(const _NDItemId __item_id, const _Size __n, _AccLocal& __local_mem) const
+    operator()(const _NDItemId __item_id, const _Size __n, const _AccLocal& __local_mem) const
     {
         return reduce_impl(__item_id, __n, __local_mem, __has_known_identity<_BinaryOperation1, _Tp>{});
     }


### PR DESCRIPTION
This patch refactors the reduce pattern by:
- Fixed numbers of `__iters_per_work_item` are used independent of the device. This unifies the similar `transform_reduce_known` and `transform_reduce_unknown` structs.
- The sequential kernel was removed since it does not provide significant performance improvements.
- The performance of mid-sized arrays is improved by reducing the `__iters_per_work_item` for the second kernel to the lowest value needed. This better balances the work across work items. If each work item has less than one element to work on, the work group size is further reduced if possible. This lowers the complexity of the work group reduction.
- Improved documentation and naming.