### PR TITLE
Setup _ITERATOR_DEBUG_LEVEL to 0 on Windows for tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -57,6 +57,13 @@ add_custom_target(run-onedpl-tests
     DEPENDS build-onedpl-tests
     COMMENT "Build and run all oneDPL tests")
 
+# Disable iterators check under Intel LLVM-based compilers on Windows
+# For details please see https://learn.microsoft.com/en-us/cpp/standard-library/iterator-debug-level?view=msvc-170
+if (WIN32 AND INTEL_LLVM_COMPILER_GNU_LIKE)
+    add_definitions(-D_ITERATOR_DEBUG_LEVEL=0)
+    message(STATUS "Disable iterators check under Intel LLVM-based compilers on Windows : #define _ITERATOR_DEBUG_LEVEL 0")
+endif()
+
 macro(onedpl_add_test test_source_file)
     get_filename_component(_test_name ${test_source_file} NAME)
     string(REPLACE "\.cpp" "" _test_name ${_test_name})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -57,11 +57,11 @@ add_custom_target(run-onedpl-tests
     DEPENDS build-onedpl-tests
     COMMENT "Build and run all oneDPL tests")
 
-# Disable iterators check under Intel LLVM-based compilers on Windows
+# Disable iterators check on Windows
 # For details please see https://learn.microsoft.com/en-us/cpp/standard-library/iterator-debug-level?view=msvc-170
-if (WIN32 AND INTEL_LLVM_COMPILER_GNU_LIKE)
+if (WIN32)
     add_definitions(-D_ITERATOR_DEBUG_LEVEL=0)
-    message(STATUS "Disable iterators check under Intel LLVM-based compilers on Windows : #define _ITERATOR_DEBUG_LEVEL 0")
+    message(STATUS "Disable iterators check on Windows : #define _ITERATOR_DEBUG_LEVEL 0")
 endif()
 
 macro(onedpl_add_test test_source_file)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -57,11 +57,11 @@ add_custom_target(run-onedpl-tests
     DEPENDS build-onedpl-tests
     COMMENT "Build and run all oneDPL tests")
 
-# Disable iterators check on Windows
+# Disable checked iterators on Windows
 # For details please see https://learn.microsoft.com/en-us/cpp/standard-library/iterator-debug-level?view=msvc-170
 if (WIN32)
     add_definitions(-D_ITERATOR_DEBUG_LEVEL=0)
-    message(STATUS "Disable iterators check on Windows : #define _ITERATOR_DEBUG_LEVEL 0")
+    message(STATUS "Disable checked iterators on Windows : #define _ITERATOR_DEBUG_LEVEL 0")
 endif()
 
 macro(onedpl_add_test test_source_file)


### PR DESCRIPTION
In this PR we setup ```_ITERATOR_DEBUG_LEVEL``` to 0 on Windows for tests.

The goal of this change - to avoid compile error like the next one :
```
In file included from test\xpu_api\numerics\numeric.ops\reduce\xpu_reduce.pass.cpp:17:
In file included from include\oneapi/dpl/numeric:21:
In file included from C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.34.31933\include\numeric:11:
C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.34.31933\include\xutility(868,5): error: SYCL kernel cannot call a variadic function
    _STL_VERIFY(_First <= _Last, "transposed pointer range");
    ^
C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.34.31933\include\yvals.h(190,13): note: expanded from macro '_STL_VERIFY'
            _STL_REPORT_ERROR(mesg);                                                       \
            ^
C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.34.31933\include\yvals.h(181,9): note: expanded from macro '_STL_REPORT_ERROR'
        _RPTF0(_CRT_ASSERT, mesg);               \
        ^
C:\Program Files (x86)\Windows Kits\10\include\10.0.22000.0\ucrt\crtdbg.h(764,37): note: expanded from macro '_RPTF0'
    #define _RPTF0(rptno, msg)      _RPT_BASE(rptno, __FILE__, __LINE__, NULL, "%s", msg)
                                    ^
C:\Program Files (x86)\Windows Kits\10\include\10.0.22000.0\ucrt\crtdbg.h(751,48): note: expanded from macro '_RPT_BASE'
        (void) ((1 != _CrtDbgReport(__VA_ARGS__)) || \
                                               ^
C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.34.31933\include\xutility(891,9): note: called by '_Adl_verify_range<const int *, const int *>'
        _Verify_range(_First, _Last);
        ^
C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.34.31933\include\numeric(73,5): note: called by 'reduce<const int *, int, std::plus<>>'
    _Adl_verify_range(_First, _Last);
    ^
C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.34.31933\include\numeric(102,17): note: called by 'reduce<const int *>'
    return _STD reduce(_First, _Last, _Iter_value_t<_InIt>{}, plus{});
                ^
test\xpu_api\numerics\numeric.ops\reduce\xpu_reduce.pass.cpp(54,39): note: called by 'operator()'
                        out[0] = dpl::reduce(Iter(&in[0]), Iter(&in[0]));
```

All details about ```_ITERATOR_DEBUG_LEVEL``` described at https://learn.microsoft.com/en-us/cpp/standard-library/iterator-debug-level?view=msvc-170