### PR TITLE
Disable checked iterators on Windows for tests which required onedpl backend

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -59,7 +59,10 @@ add_custom_target(run-onedpl-tests
 
 macro(onedpl_add_test test_source_file switch_off_checked_iterators)
 
-    string(TOLOWER "${CMAKE_BUILD_TYPE}" _build_type_in_lower)
+    set(_build_type_in_lower "unknown")
+    if (CMAKE_BUILD_TYPE)
+        string(TOLOWER "${CMAKE_BUILD_TYPE}" _build_type_in_lower)
+    endif()
 
     get_filename_component(_test_name ${test_source_file} NAME)
     string(REPLACE "\.cpp" "" _test_name ${_test_name})
@@ -75,11 +78,9 @@ macro(onedpl_add_test test_source_file switch_off_checked_iterators)
     #    https://learn.microsoft.com/en-us/cpp/standard-library/iterator-debug-level?view=msvc-170
     #    https://learn.microsoft.com/en-us/cpp/build/reference/md-mt-ld-use-run-time-library?view=msvc-170
     #    https://stackoverflow.com/questions/51494506/replacing-md-with-mt-in-cmake-is-not-possible-in-release-mode
-    if (WIN32 AND DEFINED _build_type_in_lower AND ${_build_type_in_lower} STREQUAL "debug")
-        if (${switch_off_checked_iterators})
-            target_compile_definitions(${_test_name} PRIVATE _ITERATOR_DEBUG_LEVEL=0)
-            target_compile_options(${_test_name} PRIVATE "/MD$<$<CONFIG:Debug>:>")
-        endif()
+    if (WIN32 AND ${_build_type_in_lower} STREQUAL "debug" AND ${switch_off_checked_iterators})
+        target_compile_definitions(${_test_name} PRIVATE _ITERATOR_DEBUG_LEVEL=0)
+        target_compile_options(${_test_name} PRIVATE "/MD$<$<CONFIG:Debug>:>")
     endif()
 
     # oneDPL test harness may initialize a C++ iterator using iterator with different type

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -57,7 +57,10 @@ add_custom_target(run-onedpl-tests
     DEPENDS build-onedpl-tests
     COMMENT "Build and run all oneDPL tests")
 
-macro(onedpl_add_test test_source_file)
+macro(onedpl_add_test test_source_file switch_off_checked_iterators)
+
+    string(TOLOWER "${CMAKE_BUILD_TYPE}" _build_type_in_lower)
+
     get_filename_component(_test_name ${test_source_file} NAME)
     string(REPLACE "\.cpp" "" _test_name ${_test_name})
 
@@ -65,6 +68,17 @@ macro(onedpl_add_test test_source_file)
     target_compile_definitions(${_test_name} PRIVATE _PSTL_TEST_SUCCESSFUL_KEYWORD=1)
     if (MSVC)
         target_compile_options(${_test_name} PRIVATE /bigobj)
+    endif()
+
+    # Disable checked iterators on Windows
+    # For details please see https://learn.microsoft.com/en-us/cpp/standard-library/iterator-debug-level?view=msvc-170
+    #                        https://learn.microsoft.com/en-us/cpp/build/reference/md-mt-ld-use-run-time-library?view=msvc-170
+    #                        https://stackoverflow.com/questions/51494506/replacing-md-with-mt-in-cmake-is-not-possible-in-release-mode
+    if (WIN32 AND ${_build_type_in_lower} STREQUAL "debug")
+        if (${switch_off_checked_iterators})
+            target_compile_definitions(${_test_name} PRIVATE _ITERATOR_DEBUG_LEVEL=0)
+            target_compile_options(${_test_name} PRIVATE "/MD$<$<CONFIG:Debug>:>")
+        endif()
     endif()
 
     # oneDPL test harness may initialize a C++ iterator using iterator with different type
@@ -79,7 +93,6 @@ macro(onedpl_add_test test_source_file)
 
     add_test(NAME ${_test_name} COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${_test_name})
 
-    string(TOLOWER "${CMAKE_BUILD_TYPE}" _build_type_in_lower)
     if (DEFINED ${_test_name}_timeout_${_build_type_in_lower})
         message(STATUS
         "Timeout for ${_test_name} is set to ${${_test_name}_timeout_${_build_type_in_lower}}, "
@@ -128,13 +141,20 @@ macro(onedpl_add_test test_source_file)
     add_dependencies(build-onedpl-tests ${_test_name})
 endmacro()
 
-set(_skip_regex_for_not_dpcpp "(xpu_api/algorithms|xpu_api/functional|xpu_api/numerics)")
+set(_regexp_dpcpp_backend_required "(xpu_api/algorithms|xpu_api/functional|xpu_api/numerics)")
 file(GLOB_RECURSE UNIT_TESTS "*.pass.cpp")
 foreach (_file IN LISTS UNIT_TESTS)
-    if (_file MATCHES "${_skip_regex_for_not_dpcpp}" AND NOT ONEDPL_BACKEND MATCHES "^(dpcpp|dpcpp_only)$")
-        message(STATUS "Skip test ${_file} as it requires DPC++ backend")
-        continue()
+
+    if (_file MATCHES "${_regexp_dpcpp_backend_required}")
+        if (ONEDPL_BACKEND MATCHES "^(dpcpp|dpcpp_only)$")
+            # Switch off checked iterators
+            onedpl_add_test(${_file} true)
+        else()
+            message(STATUS "Skip test ${_file} as it requires DPC++ backend")
+        endif()
+    else()
+        # Do not switch off checked iterators
+        onedpl_add_test(${_file} false)
     endif()
 
-        onedpl_add_test(${_file})
 endforeach()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -75,7 +75,7 @@ macro(onedpl_add_test test_source_file switch_off_checked_iterators)
     #    https://learn.microsoft.com/en-us/cpp/standard-library/iterator-debug-level?view=msvc-170
     #    https://learn.microsoft.com/en-us/cpp/build/reference/md-mt-ld-use-run-time-library?view=msvc-170
     #    https://stackoverflow.com/questions/51494506/replacing-md-with-mt-in-cmake-is-not-possible-in-release-mode
-    if (WIN32 AND DEFINED ${_build_type_in_lower} AND ${_build_type_in_lower} STREQUAL "debug")
+    if (WIN32 AND DEFINED _build_type_in_lower AND ${_build_type_in_lower} STREQUAL "debug")
         if (${switch_off_checked_iterators})
             target_compile_definitions(${_test_name} PRIVATE _ITERATOR_DEBUG_LEVEL=0)
             target_compile_options(${_test_name} PRIVATE "/MD$<$<CONFIG:Debug>:>")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -70,10 +70,11 @@ macro(onedpl_add_test test_source_file switch_off_checked_iterators)
         target_compile_options(${_test_name} PRIVATE /bigobj)
     endif()
 
-    # Disable checked iterators on Windows
-    # For details please see https://learn.microsoft.com/en-us/cpp/standard-library/iterator-debug-level?view=msvc-170
-    #                        https://learn.microsoft.com/en-us/cpp/build/reference/md-mt-ld-use-run-time-library?view=msvc-170
-    #                        https://stackoverflow.com/questions/51494506/replacing-md-with-mt-in-cmake-is-not-possible-in-release-mode
+    # Disable checked iterators on Windows for debug mode
+    # For details please see
+    #    https://learn.microsoft.com/en-us/cpp/standard-library/iterator-debug-level?view=msvc-170
+    #    https://learn.microsoft.com/en-us/cpp/build/reference/md-mt-ld-use-run-time-library?view=msvc-170
+    #    https://stackoverflow.com/questions/51494506/replacing-md-with-mt-in-cmake-is-not-possible-in-release-mode
     if (WIN32 AND ${_build_type_in_lower} STREQUAL "debug")
         if (${switch_off_checked_iterators})
             target_compile_definitions(${_test_name} PRIVATE _ITERATOR_DEBUG_LEVEL=0)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -75,7 +75,7 @@ macro(onedpl_add_test test_source_file switch_off_checked_iterators)
     #    https://learn.microsoft.com/en-us/cpp/standard-library/iterator-debug-level?view=msvc-170
     #    https://learn.microsoft.com/en-us/cpp/build/reference/md-mt-ld-use-run-time-library?view=msvc-170
     #    https://stackoverflow.com/questions/51494506/replacing-md-with-mt-in-cmake-is-not-possible-in-release-mode
-    if (WIN32 AND ${_build_type_in_lower} STREQUAL "debug")
+    if (WIN32 AND DEFINED ${_build_type_in_lower} AND ${_build_type_in_lower} STREQUAL "debug")
         if (${switch_off_checked_iterators})
             target_compile_definitions(${_test_name} PRIVATE _ITERATOR_DEBUG_LEVEL=0)
             target_compile_options(${_test_name} PRIVATE "/MD$<$<CONFIG:Debug>:>")


### PR DESCRIPTION
The goal of this PR is to avoid compile errors when we use checked iterators from MS STL library inside Kernel's code.
Previously we have compile errors in this situation like this:
```
In file included from test\xpu_api\numerics\numeric.ops\reduce\xpu_reduce.pass.cpp:17:
In file included from include\oneapi/dpl/numeric:21:
In file included from C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.34.31933\include\numeric:11:
C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.34.31933\include\xutility(868,5): error: SYCL kernel cannot call a variadic function
    _STL_VERIFY(_First <= _Last, "transposed pointer range");
    ^
C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.34.31933\include\yvals.h(190,13): note: expanded from macro '_STL_VERIFY'
            _STL_REPORT_ERROR(mesg);                                                       \
            ^
C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.34.31933\include\yvals.h(181,9): note: expanded from macro '_STL_REPORT_ERROR'
        _RPTF0(_CRT_ASSERT, mesg);               \
        ^
C:\Program Files (x86)\Windows Kits\10\include\10.0.22000.0\ucrt\crtdbg.h(764,37): note: expanded from macro '_RPTF0'
    #define _RPTF0(rptno, msg)      _RPT_BASE(rptno, __FILE__, __LINE__, NULL, "%s", msg)
                                    ^
C:\Program Files (x86)\Windows Kits\10\include\10.0.22000.0\ucrt\crtdbg.h(751,48): note: expanded from macro '_RPT_BASE'
        (void) ((1 != _CrtDbgReport(__VA_ARGS__)) || \
                                               ^
C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.34.31933\include\xutility(891,9): note: called by '_Adl_verify_range<const int *, const int *>'
        _Verify_range(_First, _Last);
        ^
C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.34.31933\include\numeric(73,5): note: called by 'reduce<const int *, int, std::plus<>>'
    _Adl_verify_range(_First, _Last);
    ^
C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.34.31933\include\numeric(102,17): note: called by 'reduce<const int *>'
    return _STD reduce(_First, _Last, _Iter_value_t<_InIt>{}, plus{});
                ^
test\xpu_api\numerics\numeric.ops\reduce\xpu_reduce.pass.cpp(54,39): note: called by 'operator()'
                        out[0] = dpl::reduce(Iter(&in[0]), Iter(&in[0]));
```

How we are doing this:
- define ```_ITERATOR_DEBUG_LEVEL``` as ```0```;
- use the multithread-specific and DLL-specific version of the run-time library: ```/MD```

When:
- on Windows for debug mode builds of out tests.

For which tests:
- for all tests which required **dpcpp** backend.

At this moment it's all tests from the next folders:
- test/xpu_api/algorithms;
- test/xpu_api/functional;
- test/xpu_api/numerics.

All details about ```_ITERATOR_DEBUG_LEVEL``` described at https://learn.microsoft.com/en-us/cpp/standard-library/iterator-debug-level?view=msvc-170

We already tried to solve this task in https://github.com/oneapi-src/oneDPL/pull/910, but as result - we had crashes on Windows in debug mode builds of tests.