### PR TITLE
Allow sort to use non-const comparison functor

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1566,7 +1566,9 @@ template <
 auto
 __parallel_stable_sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp, _Proj __proj)
 {
-    auto __cmp_f = [__comp, __proj](const auto& __a, const auto& __b) mutable { return __comp(__proj(__a), __proj(__b)); };
+    auto __cmp_f = [__comp, __proj](const auto& __a, const auto& __b) mutable {
+        return __comp(__proj(__a), __proj(__b));
+    };
     return __parallel_sort_impl(::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range>(__rng),
                                 // Pass special tag to choose 'full' merge subroutine at compile-time
                                 __full_merge_kernel(), __cmp_f);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1566,7 +1566,7 @@ template <
 auto
 __parallel_stable_sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp, _Proj __proj)
 {
-    auto __cmp_f = [__comp, __proj](const auto& __a, const auto& __b) { return __comp(__proj(__a), __proj(__b)); };
+    auto __cmp_f = [__comp, __proj](const auto& __a, const auto& __b) mutable { return __comp(__proj(__a), __proj(__b)); };
     return __parallel_sort_impl(::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range>(__rng),
                                 // Pass special tag to choose 'full' merge subroutine at compile-time
                                 __full_merge_kernel(), __cmp_f);

--- a/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
@@ -392,6 +392,15 @@ struct test_non_const
     }
 };
 
+struct NonConstCmp
+{
+    template<typename T, typename U>
+    bool operator()(T x, U y)
+    {
+        return x < y;
+    }
+};
+
 int
 main()
 {
@@ -420,6 +429,9 @@ main()
 
         test_sort<unsigned char>(
             [](unsigned char x, unsigned char y) { return x > y; }, // Reversed so accidental use of < will be detected.
+            [](size_t k, size_t val) { return (unsigned char)val; });
+
+        test_sort<unsigned char>(NonConstCmp{},
             [](size_t k, size_t val) { return (unsigned char)val; });
 
 #endif // !ONEDPL_FPGA_DEVICE


### PR DESCRIPTION
The PR #859 accidentally introduced a change that required the comparison functor to provide a const `operator()`. This PR relaxes that requirement by changing the introduced lambda to be `mutable`.