### PR TITLE
Adding value_type to replicate_start_view_simple

### DIFF
--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -351,6 +351,8 @@ struct drop_view_simple
 template <typename _R, typename _Size>
 struct replicate_start_view_simple
 {
+    using value_type = typename ::std::decay_t<_R>::value_type;
+    
     _R __r;
     _Size __repl_count;
 

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -352,7 +352,7 @@ template <typename _R, typename _Size>
 struct replicate_start_view_simple
 {
     using value_type = typename ::std::decay_t<_R>::value_type;
-    
+
     _R __r;
     _Size __repl_count;
 


### PR DESCRIPTION
This adds the missing `value_type` to `replicate_start_view_simple` that became a requirement with changed introduced in #703.