### PR TITLE
Support creating a view over an entire range with take_view_simple

### DIFF
--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -281,7 +281,7 @@ struct take_view_simple
     _R __r;
     _Size __n;
 
-    take_view_simple(_R __rng, _Size __size) : __r(__rng), __n(__size) { assert(__n >= 0 && __n < __r.size()); }
+    take_view_simple(_R __rng, _Size __size) : __r(__rng), __n(__size) { assert(__n >= 0 && __n <= __r.size()); }
 
     //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range
     template <typename Idx>

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -281,7 +281,10 @@ struct take_view_simple
     _R __r;
     _Size __n;
 
-    take_view_simple(_R __rng, _Size __size) : __r(__rng), __n(__size) { assert(__n >= 0 && __n <= __r.size()); }
+    take_view_simple(_R __rng, _Size __size) : __r(__rng), __n(::std::min(__size, _Size(__r.size())))
+    {
+        assert(__n >= 0);
+    }
 
     //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range
     template <typename Idx>
@@ -318,7 +321,10 @@ struct drop_view_simple
     _R __r;
     _Size __n;
 
-    drop_view_simple(_R __rng, _Size __size) : __r(__rng), __n(__size) { assert(__n >= 0 && __n < __r.size()); }
+    drop_view_simple(_R __rng, _Size __size) : __r(__rng), __n(::std::min(__size, _Size(__r.size())))
+    {
+        assert(__n >= 0);
+    }
 
     //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range
     template <typename Idx>

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -272,7 +272,8 @@ struct reverse_view_simple
     }
 };
 
-//It is kind of pseudo-view for take_view support.
+//It is kind of pseudo-view for take_view support. We assume that the underlying range will not shrink
+//after creation of the view to favor performance.
 template <typename _R, typename _Size>
 struct take_view_simple
 {
@@ -281,7 +282,7 @@ struct take_view_simple
     _R __r;
     _Size __n;
 
-    take_view_simple(_R __rng, _Size __size) : __r(__rng), __n(__size) { assert(__n >= 0); }
+    take_view_simple(_R __rng, _Size __size) : __r(__rng), __n(__size) { assert(__n >= 0 && __n <= __r.size()); }
 
     //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range
     template <typename Idx>
@@ -293,7 +294,7 @@ struct take_view_simple
     _Size
     size() const
     {
-        return ::std::min(_Size(__r.size()), __n);
+        return __n;
     }
 
     bool
@@ -309,7 +310,8 @@ struct take_view_simple
     }
 };
 
-//It is kind of pseudo-view for drop_view support.
+//It is kind of pseudo-view for drop_view support. We assume that the underlying range will not shrink
+//after creation of the view to favor performance.
 template <typename _R, typename _Size>
 struct drop_view_simple
 {
@@ -318,7 +320,7 @@ struct drop_view_simple
     _R __r;
     _Size __n;
 
-    drop_view_simple(_R __rng, _Size __size) : __r(__rng), __n(__size) { assert(__n >= 0); }
+    drop_view_simple(_R __rng, _Size __size) : __r(__rng), __n(__size) { assert(__n >= 0 && __n <= __r.size()); }
 
     //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range
     template <typename Idx>
@@ -330,7 +332,7 @@ struct drop_view_simple
     _Size
     size() const
     {
-        return __r.size() - ::std::min(_Size(__r.size()), __n);
+        return __r.size() - __n;
     }
 
     bool

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -281,10 +281,7 @@ struct take_view_simple
     _R __r;
     _Size __n;
 
-    take_view_simple(_R __rng, _Size __size) : __r(__rng), __n(::std::min(__size, _Size(__r.size())))
-    {
-        assert(__n >= 0);
-    }
+    take_view_simple(_R __rng, _Size __size) : __r(__rng), __n(__size) { assert(__n >= 0); }
 
     //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range
     template <typename Idx>
@@ -296,7 +293,7 @@ struct take_view_simple
     _Size
     size() const
     {
-        return __n;
+        return ::std::min(_Size(__r.size()), __n);
     }
 
     bool
@@ -321,10 +318,7 @@ struct drop_view_simple
     _R __r;
     _Size __n;
 
-    drop_view_simple(_R __rng, _Size __size) : __r(__rng), __n(::std::min(__size, _Size(__r.size())))
-    {
-        assert(__n >= 0);
-    }
+    drop_view_simple(_R __rng, _Size __size) : __r(__rng), __n(__size) { assert(__n >= 0); }
 
     //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range
     template <typename Idx>
@@ -336,7 +330,7 @@ struct drop_view_simple
     _Size
     size() const
     {
-        return __r.size() - __n;
+        return __r.size() - ::std::min(_Size(__r.size()), __n);
     }
 
     bool


### PR DESCRIPTION
Currently, take_view_simple can only create a view up to the first `n - 1` elements of the range. We are extending this to support creating a view over all `n` elements which is consistent with the behavior of `std::ranges::take_view` in C++20.

This PR was identified by and fixes a bug in `reduce_by_segment` where the modified assertion fails when each segment is of size `1`.