### PR TITLE
Put _impl classes in the right namespaces

### DIFF
--- a/include/oneapi/dpl/dynamic_selection
+++ b/include/oneapi/dpl/dynamic_selection
@@ -29,12 +29,12 @@ namespace dpl {
 namespace experimental {
 
 #if _DS_BACKEND_SYCL != 0
-  using static_policy = policy<static_policy_impl<sycl_scheduler>>;
-  using round_robin_policy = policy<round_robin_policy_impl<sycl_scheduler>>;
+  using static_policy = policy<ds_impl::static_policy_impl<ds_impl::sycl_scheduler>>;
+  using round_robin_policy = policy<ds_impl::round_robin_policy_impl<ds_impl::sycl_scheduler>>;
   inline static_policy default_policy;
 #endif
-  template<typename S> using static_policy_t = policy<static_policy_impl<S>>;
-  template<typename S> using round_robin_policy_t = policy<round_robin_policy_impl<S>>;
+  template<typename S> using static_policy_t = policy<ds_impl::static_policy_impl<S>>;
+  template<typename S> using round_robin_policy_t = policy<ds_impl::round_robin_policy_impl<S>>;
 } //namespace experimental
 } //namespace dpl
 } //namespace oneapi

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/concurrent_queue.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/concurrent_queue.h
@@ -19,6 +19,7 @@
 namespace oneapi {
 namespace dpl{
 namespace experimental{
+namespace ds_impl{
 namespace util{
     template <typename T>
     class concurrent_queue
@@ -69,6 +70,7 @@ namespace util{
         std::condition_variable cond_;
     };
 } // namespace util
+} // namespace ds_impl
 } // namespace experimental
 } // namespace dpl
 } // namespace oneapi

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/round_robin_policy_impl.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/round_robin_policy_impl.h
@@ -16,6 +16,7 @@
 namespace oneapi {
 namespace dpl{
 namespace experimental{
+namespace ds_impl {
 
   template <typename Scheduler>
   struct round_robin_policy_impl {
@@ -24,7 +25,7 @@ namespace experimental{
     using execution_resource_t = typename scheduler_t::execution_resource_t;
     using native_sync_t = typename scheduler_t::native_sync_t;
     using universe_container_t = typename scheduler_t::universe_container_t;
-    using selection_handle_t = oneapi::dpl::experimental::basic_selection_handle_t<execution_resource_t>;
+    using selection_handle_t = oneapi::dpl::experimental::ds_impl::basic_selection_handle_t<execution_resource_t>;
     using universe_container_size_t = typename universe_container_t::size_type;
 
     std::shared_ptr<scheduler_t> sched_;
@@ -100,6 +101,8 @@ namespace experimental{
       sched_->wait();
     }
   };
+} //namespce ds_impl
+
 } // namespace experimental
 
 } // namespace dpl

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/scheduler_defs.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/scheduler_defs.h
@@ -13,7 +13,7 @@
 namespace oneapi {
 namespace dpl{
 namespace experimental{
-
+namespace ds_impl {
   template<typename NativeContext>
   struct basic_execution_resource_t {
     using native_resource_t = NativeContext;
@@ -28,6 +28,8 @@ namespace experimental{
       return native_resource_ == e;
     }
   };
+
+} // namespace ds_impl
 
 } // namespace experimental
 

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/scoring_policy_defs.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/scoring_policy_defs.h
@@ -13,6 +13,7 @@
 namespace oneapi {
 namespace dpl {
 namespace experimental {
+namespace ds_impl {
   struct basic_property_handle_t {
     static constexpr bool should_report_task_submission = false;
     static constexpr bool should_report_task_completion = false;
@@ -28,14 +29,15 @@ namespace experimental {
   class basic_selection_handle_t {
     ExecutionContext e_;
   public:
-    using property_handle_t = oneapi::dpl::experimental::basic_property_handle_t;
+    using property_handle_t = oneapi::dpl::experimental::ds_impl::basic_property_handle_t;
     using execution_resource_t = ExecutionContext;
     using native_resource_t = typename execution_resource_t::native_resource_t;
 
     explicit basic_selection_handle_t(execution_resource_t e = execution_resource_t{}) : e_(e) {}
     native_resource_t get_native() { return e_.get_native(); }
-    property_handle_t get_property_handle() { return oneapi::dpl::experimental::basic_property_handle; }
+    property_handle_t get_property_handle() { return oneapi::dpl::experimental::ds_impl::basic_property_handle; }
   };
+} // namespace ds_impl
 
 } // namespace experimental
 

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/static_policy_impl.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/static_policy_impl.h
@@ -15,6 +15,7 @@
 namespace oneapi {
 namespace dpl {
 namespace experimental {
+namespace ds_impl {
 
   template <typename Scheduler>
   struct static_policy_impl {
@@ -23,7 +24,7 @@ namespace experimental {
     using execution_resource_t = typename scheduler_t::execution_resource_t;
     using native_sync_t = typename scheduler_t::native_sync_t;
     using universe_container_t = typename scheduler_t::universe_container_t;
-    using selection_handle_t = oneapi::dpl::experimental::basic_selection_handle_t<execution_resource_t>;
+    using selection_handle_t = oneapi::dpl::experimental::ds_impl::basic_selection_handle_t<execution_resource_t>;
 
     std::shared_ptr<scheduler_t> sched_;
     universe_container_t universe_;
@@ -91,6 +92,7 @@ namespace experimental {
       sched_->wait();
     }
   };
+} //namespace ds_impl
 } //namespace experimental
 } //namespace dpl
 } //namespace oneapi

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/sycl_scheduler.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/sycl_scheduler.h
@@ -24,12 +24,13 @@
 namespace oneapi {
 namespace dpl {
 namespace experimental {
+namespace ds_impl {
 
   struct sycl_scheduler {
 
     using native_resource_t = sycl::queue;
     using native_sync_t = sycl::event;
-    using execution_resource_t = oneapi::dpl::experimental::basic_execution_resource_t<native_resource_t>;
+    using execution_resource_t = oneapi::dpl::experimental::ds_impl::basic_execution_resource_t<native_resource_t>;
     using universe_container_t = std::vector<execution_resource_t>;
 
     class async_wait_t {
@@ -134,7 +135,7 @@ namespace experimental {
     }
 
   };
-
+} //namespace ds_impl
 } //namespace experimental
 } //namespace dpl
 } //namespace oneapi

--- a/test/parallel_api/dynamic_selection/sycl/test_internal_sycl_scheduler.pass.cpp
+++ b/test/parallel_api/dynamic_selection/sycl/test_internal_sycl_scheduler.pass.cpp
@@ -16,23 +16,23 @@
 class fake_selection_handle_t {
   sycl::queue q_;
 public:
-  using property_handle_t = oneapi::dpl::experimental::basic_property_handle_t;
+  using property_handle_t = oneapi::dpl::experimental::ds_impl::basic_property_handle_t;
   using native_context_t = sycl::queue;
 
   fake_selection_handle_t(native_context_t q = sycl::queue(sycl::default_selector{})) : q_(q) {}
   native_context_t get_native() { return q_; }
-  property_handle_t get_property_handle() { return oneapi::dpl::experimental::basic_property_handle; }
+  property_handle_t get_property_handle() { return oneapi::dpl::experimental::ds_impl::basic_property_handle; }
 };
 
 int test_cout() {
-  oneapi::dpl::experimental::sycl_scheduler s;
-  oneapi::dpl::experimental::sycl_scheduler::execution_resource_t e;
+  oneapi::dpl::experimental::ds_impl::sycl_scheduler s;
+  oneapi::dpl::experimental::ds_impl::sycl_scheduler::execution_resource_t e;
   return 0;
 }
 
 int test_submit_and_wait_on_scheduler() {
   const int N = 100;
-  oneapi::dpl::experimental::sycl_scheduler s;
+  oneapi::dpl::experimental::ds_impl::sycl_scheduler s;
   fake_selection_handle_t h;
 
   std::atomic<int> ecount = 0;
@@ -56,7 +56,7 @@ int test_submit_and_wait_on_scheduler() {
 
 int test_submit_and_wait_on_scheduler_single_element() {
   const int N = 1;
-  oneapi::dpl::experimental::sycl_scheduler s;
+  oneapi::dpl::experimental::ds_impl::sycl_scheduler s;
   fake_selection_handle_t h;
 
   std::atomic<int> ecount = 0;
@@ -80,7 +80,7 @@ int test_submit_and_wait_on_scheduler_single_element() {
 
 int test_submit_and_wait_on_scheduler_empty() {
   const int N = 0;
-  oneapi::dpl::experimental::sycl_scheduler s;
+  oneapi::dpl::experimental::ds_impl::sycl_scheduler s;
   fake_selection_handle_t h;
 
   std::atomic<int> ecount = 0;
@@ -104,7 +104,7 @@ int test_submit_and_wait_on_scheduler_empty() {
 
 int test_submit_and_wait_on_sync() {
   const int N = 100;
-  oneapi::dpl::experimental::sycl_scheduler s;
+  oneapi::dpl::experimental::ds_impl::sycl_scheduler s;
   fake_selection_handle_t h;
 
   std::atomic<int> ecount = 0;
@@ -129,7 +129,7 @@ int test_submit_and_wait_on_sync() {
 
 int test_submit_and_wait_on_sync_single_element() {
   const int N = 1;
-  oneapi::dpl::experimental::sycl_scheduler s;
+  oneapi::dpl::experimental::ds_impl::sycl_scheduler s;
   fake_selection_handle_t h;
 
   std::atomic<int> ecount = 0;
@@ -154,7 +154,7 @@ int test_submit_and_wait_on_sync_single_element() {
 
 int test_submit_and_wait_on_sync_empty() {
   const int N = 0;
-  oneapi::dpl::experimental::sycl_scheduler s;
+  oneapi::dpl::experimental::ds_impl::sycl_scheduler s;
   fake_selection_handle_t h;
 
   std::atomic<int> ecount = 0;
@@ -178,8 +178,8 @@ int test_submit_and_wait_on_sync_empty() {
 }
 
 int test_properties() {
-  oneapi::dpl::experimental::sycl_scheduler s;
-  oneapi::dpl::experimental::sycl_scheduler::universe_container_t v;
+  oneapi::dpl::experimental::ds_impl::sycl_scheduler s;
+  oneapi::dpl::experimental::ds_impl::sycl_scheduler::universe_container_t v;
   //= { sycl::queue(sycl::cpu_selector{}), sycl::queue(sycl::gpu_selector{}) };
   try {
     sycl::cpu_selector ds_cpu;

--- a/test/parallel_api/dynamic_selection/test_internal_inline_scheduler.pass.cpp
+++ b/test/parallel_api/dynamic_selection/test_internal_inline_scheduler.pass.cpp
@@ -18,12 +18,12 @@
 class fake_selection_handle_t {
   int  q_;
 public:
-  using property_handle_t = oneapi::dpl::experimental::basic_property_handle_t;
+  using property_handle_t = oneapi::dpl::experimental::ds_impl::basic_property_handle_t;
   using native_context_t = int;
 
   fake_selection_handle_t(native_context_t q = 0) : q_(q) {}
   native_context_t get_native() { return q_; }
-  property_handle_t get_property_handle() { return oneapi::dpl::experimental::basic_property_handle; }
+  property_handle_t get_property_handle() { return oneapi::dpl::experimental::ds_impl::basic_property_handle; }
 };
 
 int test_cout() {

--- a/test/support/inline_scheduler.h
+++ b/test/support/inline_scheduler.h
@@ -21,7 +21,7 @@ namespace TestUtils {
 struct int_inline_scheduler_t {
   using native_resource_t = int;
   using native_sync_t = int;
-  using execution_resource_t = oneapi::dpl::experimental::basic_execution_resource_t<native_resource_t>;
+  using execution_resource_t = oneapi::dpl::experimental::ds_impl::basic_execution_resource_t<native_resource_t>;
   using native_universe_container_t = std::vector<native_resource_t>;
   using universe_container_t = std::vector<execution_resource_t>;
 


### PR DESCRIPTION
Added an new nampespace oneapi::dpl::experimental::ds_impl for dynamic selection impl classes. 