### PR TITLE
Add a template variable for sorting identity; improve __get_bucket

### DIFF
--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -129,11 +129,11 @@ scan(sycl::ext::intel::esimd::simd<T, 16> src)
 }
 
 // get bits value (bucket) in a certain radix position
-template <::std::uint32_t __radix_mask, typename _T, int _N>
-sycl::ext::intel::esimd::simd<_T, _N>
+template <::std::uint16_t __radix_mask, typename _T, int _N>
+sycl::ext::intel::esimd::simd<::std::uint16_t, _N>
 __get_bucket(sycl::ext::intel::esimd::simd<_T, _N> __value, ::std::uint32_t __radix_offset)
 {
-    return (__value >> __radix_offset) & sycl::ext::intel::esimd::simd<_T, _N>(__radix_mask);
+    return sycl::ext::intel::esimd::simd<::std::uint16_t, _N>(__value >> __radix_offset) & __radix_mask;
 }
 
 template <bool __is_ascending, int _N>

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -135,7 +135,7 @@ scan(sycl::ext::intel::esimd::simd<T, 16> src)
 }
 
 // get bits value (bucket) in a certain radix position
-template <::std::uint16_t __radix_mask, typename _T, int _N>
+template <::std::uint16_t __radix_mask, typename _T, int _N, std::enable_if_t<::std::is_unsigned_v<_T>, int> = 0>
 sycl::ext::intel::esimd::simd<::std::uint16_t, _N>
 __get_bucket(sycl::ext::intel::esimd::simd<_T, _N> __value, ::std::uint32_t __radix_offset)
 {

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -10,6 +10,12 @@
 #ifndef _ONEDPL_KT_ESIMD_RADIX_SORT_UTILS_H
 #define _ONEDPL_KT_ESIMD_RADIX_SORT_UTILS_H
 
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
+#include <CL/sycl.hpp>
+#endif
+
 #include <ext/intel/esimd.hpp>
 #include <cstdint>
 #include <type_traits>
@@ -135,6 +141,10 @@ __get_bucket(sycl::ext::intel::esimd::simd<_T, _N> __value, ::std::uint32_t __ra
 {
     return sycl::ext::intel::esimd::simd<::std::uint16_t, _N>(__value >> __radix_offset) & __radix_mask;
 }
+
+template <typename T, bool __is_ascending>
+inline constexpr T __sort_identity =
+    __is_ascending? ::std::numeric_limits<T>::max() : ::std::numeric_limits<T>::lowest();
 
 template <bool __is_ascending, int _N>
 sycl::ext::intel::esimd::simd<bool, _N>


### PR DESCRIPTION
A couple of useful improvements from the work-in-progress branch; in particular, the sorting identity value for filling "useless" SIMD lanes at the end of the data.