### PR TITLE
Update software.intel.com URLs

### DIFF
--- a/documentation/CHANGES.rst
+++ b/documentation/CHANGES.rst
@@ -238,7 +238,7 @@ Known Issues and Limitations
   use ``std::array::operator[]`` instead.
 - ``std::array`` member function swap cannot be used in DPC++ kernels on Windows platform.
 - ``std::swap`` for ``std::array`` cannot work in DPC++ kernels on Windows platform.
-- Not all functions in <cmath> are supported currently, please refer to `DPC++ library guide <https://software.intel.com/content/www/us/en/develop/documentation/oneapi-dpcpp-library-guide/top.html>`_ guide for detail list.
+- Not all functions in <cmath> are supported currently, please refer to `DPC++ library guide <https://www.intel.com/content/www/us/en/docs/onedpl/developer-guide/current/overview.html>`_ guide for detail list.
 - Due to specifics of Microsoft Visual C++ implementation, some standard math functions for float
   (including: ``std::ldexp``, ``std::frexp``, ``std::sqrt(std::complex<float>)``) require device support
   for double precision.
@@ -281,7 +281,7 @@ Known Issues and Limitations
   use ``std::array::operator[]`` instead.
 - ``std::array`` member function swap cannot be used in DPC++ kernels on Windows platform.
 - ``std::swap`` for ``std::array`` cannot work in DPC++ kernels on Windows platform.
-- Not all functions in <cmath> are supported currently, please refer to `DPC++ library guide <https://software.intel.com/content/www/us/en/develop/documentation/oneapi-dpcpp-library-guide/top.html>`_ for detail list.
+- Not all functions in <cmath> are supported currently, please refer to `DPC++ library guide <https://www.intel.com/content/www/us/en/docs/onedpl/developer-guide/current/overview.html>`_ for detail list.
 - Due to specifics of Microsoft Visual C++ implementation, some standard math functions for float
   (including: ``std::ldexp``, ``std::frexp``, ``std::sqrt(std::complex<float>)``) require device support
   for double precision.
@@ -334,7 +334,7 @@ Known Issues and Limitations
   use ``std::array::operator[]`` instead.
 - ``std::array`` member function swap cannot be used in DPC++ kernels on Windows platform.
 - ``std::swap`` for ``std::array`` cannot work in DPC++ kernels on Windows platform.
-- Not all functions in <cmath> are supported currently, please refer to `DPC++ library guide <https://software.intel.com/content/www/us/en/develop/documentation/oneapi-dpcpp-library-guide/top.html>`_ for detail list.
+- Not all functions in <cmath> are supported currently, please refer to `DPC++ library guide <https://www.intel.com/content/www/us/en/docs/onedpl/developer-guide/current/overview.html>`_ for detail list.
 - Due to specifics of Microsoft Visual C++ implementation, some standard math functions for float
   (including: ``std::ldexp``, ``std::frexp``, ``std::sqrt(std::complex<float>)``) require device support
   for double precision.
@@ -407,7 +407,7 @@ Known Issues and Limitations
   use ``std::array::operator[]`` instead.
 - ``std::array`` member function swap cannot be used in DPC++ kernels on Windows platform.
 - ``std::swap`` for ``std::array`` cannot work in DPC++ kernels on Windows platform.
-- Not all functions in <cmath> are supported currently, please refer to `DPC++ library guide <https://software.intel.com/content/www/us/en/develop/documentation/oneapi-dpcpp-library-guide/top.html>`_ for detail list.
+- Not all functions in <cmath> are supported currently, please refer to `DPC++ library guide <https://www.intel.com/content/www/us/en/docs/onedpl/developer-guide/current/overview.html>`_ for detail list.
 - Due to specifics of Microsoft Visual C++ implementation, some standard math functions for float
   (including: ``std::ldexp``, ``std::frexp``, ``std::sqrt(std::complex<float>)``) require device support
   for double precision.
@@ -439,7 +439,7 @@ Known Issues and Limitations
 - ``std::array::at`` member function cannot be used in kernels because it may throw an exception; use ``std::array::operator[]`` instead.
 - ``std::array`` member function swap cannot be used in DPC++ kernels on Windows platform.
 - ``std::swap`` for ``std::array`` cannot work in DPC++ kernels on Windows platform.
-- Not all functions in <cmath> are supported currently, please refer to `DPC++ library guide <https://software.intel.com/content/www/us/en/develop/documentation/oneapi-dpcpp-library-guide/top.html>`_ for detail list.
+- Not all functions in <cmath> are supported currently, please refer to `DPC++ library guide <https://www.intel.com/content/www/us/en/docs/onedpl/developer-guide/current/overview.html>`_ for detail list.
 - Due to specifics of Microsoft Visual C++ implementation, some standard math functions for float (including: ``std::ldexp``, ``std::frexp``, ``std::sqrt(std::complex<float>)``) require device support for double precision.
 - There is a known issue on Windows platform with trying to use clGetPlatformInfo and ClGetDeviceInfo when using a graphics driver older than 27.20.100.8280.
   If you run into this issue, please upgrade to the latest driver of at least version 27.20.100.8280 from the `Download Center <https://downloadcenter.intel.com/product/80939/Graphics>`_.
@@ -473,7 +473,7 @@ Known Issues and Limitations
 - ``std::array::at`` member function cannot be used in kernels because it may throw an exception; use ``std::array::operator[]`` instead.
 - ``std::array`` member function swap cannot be used in DPC++ kernels on Windows platform.
 - ``std::swap`` for ``std::array`` cannot work in DPC++ kernels on Windows platform.
-- Not all functions in <cmath> are supported currently, please refer to `DPC++ library guide <https://software.intel.com/content/www/us/en/develop/documentation/oneapi-dpcpp-library-guide/top.html>`_ for detail list.
+- Not all functions in <cmath> are supported currently, please refer to `DPC++ library guide <https://www.intel.com/content/www/us/en/docs/onedpl/developer-guide/current/overview.html>`_ for detail list.
 - ``std::complex`` division may fail in kernel code on some CPU platform.
 
 New in 2021.1-beta05
@@ -498,7 +498,7 @@ Known Issues and Limitations
 - ``std::array::at`` member function cannot be used in kernels because it may throw an exception; use ``std::array::operator[]`` instead.
 - ``std::array`` member function swap cannot be used in DPC++ kernels on Windows platform.
 - ``std::swap`` for ``std::array`` cannot work in DPC++ kernels on Windows platform.
-- Not all functions in <cmath> are supported currently, please refer to `DPC++ library guide <https://software.intel.com/content/www/us/en/develop/documentation/oneapi-dpcpp-library-guide/top.html>`_ for detail list.
+- Not all functions in <cmath> are supported currently, please refer to `DPC++ library guide <https://www.intel.com/content/www/us/en/docs/onedpl/developer-guide/current/overview.html>`_ for detail list.
 - ``std::complex`` division may fail in kernel code on some CPU platform.
 
 New in 2021.1-beta04
@@ -539,7 +539,7 @@ Known Issues and Limitations
 - ``std::array::at`` member function cannot be used in kernels because it may throw an exception; use ``std::array::operator[]`` instead.
 - ``std::array`` member function swap cannot be used in DPC++ kernels on Windows platform.
 - ``std::swap`` for ``std::array`` cannot work in DPC++ kernels on Windows platform.
-- Not all functions in <cmath> are supported currently, please refer to `DPC++ library guide <https://software.intel.com/content/www/us/en/develop/documentation/oneapi-dpcpp-library-guide/top.html>`_ for detail list.
+- Not all functions in <cmath> are supported currently, please refer to `DPC++ library guide <https://www.intel.com/content/www/us/en/docs/onedpl/developer-guide/current/overview.html>`_ for detail list.
 - ``std::complex`` division may fail in kernel code on some CPU platform.
 
 New in 2021.1-beta03
@@ -577,7 +577,7 @@ Known Issues and Limitations
 .. [#fnote1] The sorting algorithms in oneDPL use Radix sort for arithmetic data types compared with
    ``std::less`` or ``std::greater``, otherwise Merge sort.
 .. _`the oneDPL Specification`: https://spec.oneapi.com/versions/latest/elements/oneDPL/source/index.html
-.. _`Intel® oneAPI Threading Building Blocks (oneTBB) Release Notes`: https://software.intel.com/content/www/us/en/develop/articles/intel-oneapi-threading-building-blocks-release-notes.html
+.. _`Intel® oneAPI Threading Building Blocks (oneTBB) Release Notes`: https://www.intel.com/content/www/us/en/developer/articles/release-notes/intel-oneapi-threading-building-blocks-release-notes.html
 .. _`oneDPL Guide`: https://oneapi-src.github.io/oneDPL/index.html
 .. _`Tested Standard C++ API`: https://oneapi-src.github.io/oneDPL/api_for_dpcpp_kernels/tested_standard_cpp_api.html#tested-standard-c-api-reference
 .. _`Macros`: https://oneapi-src.github.io/oneDPL/macros.html

--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -6,16 +6,16 @@ Policies <https://en.cppreference.com/w/cpp/algorithm/execution_policy_tag_t>`_
 to enable parallelism on the host.
 
 The |onedpl_long| (|onedpl_short|) is implemented in accordance with the `oneDPL
-Specification <https://spec.oneapi.com/versions/latest/elements/oneDPL/source/index.html>`_.
+Specification <https://spec.oneapi.io/versions/latest/elements/oneDPL/source/index.html>`_.
 
 To support heterogeneity, |onedpl_short| works with the DPC++ API. More information can be found in the
-`DPC++ Specification <https://spec.oneapi.com/versions/latest/elements/dpcpp/source/index.html#dpc>`_.
+`oneAPI Specification <https://spec.oneapi.io/versions/latest/elements/sycl/source/index.html>`_.
 
 Before You Begin
 ================
 
 Visit the |onedpl_short| `Release Notes
-<https://software.intel.com/content/www/us/en/develop/articles/intel-oneapi-dpcpp-library-release-notes.html>`_
+<https://www.intel.com/content/www/us/en/developer/articles/release-notes/intel-oneapi-dpcpp-library-release-notes.html>`_
 page for:
 
 * Where to Find the Release
@@ -26,7 +26,7 @@ page for:
 * Known Issues and Limitations
 * Previous Release Notes 
 
-Install the `Intel® oneAPI Base Toolkit (Base Kit) <https://software.intel.com/en-us/oneapi/base-kit>`_
+Install the `Intel® oneAPI Base Toolkit (Base Kit) <https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit.html#gs.xaontv>`_
 to use |onedpl_short|.
 
 All |onedpl_short| header files are in the ``oneapi/dpl`` directory. To use the |onedpl_short| API,
@@ -132,7 +132,7 @@ Build Your Code with |onedpl_short|
 Follow the steps below to build your code with |onedpl_short|:
 
 #. To build with the |dpcpp_cpp|, see the `Get Started with the Intel® oneAPI DPC++/C++ Compiler
-   <https://software.intel.com/content/www/us/en/develop/documentation/get-started-with-dpcpp-compiler/top.html>`_
+   <https://www.intel.com/content/www/us/en/docs/dpcpp-cpp-compiler/get-started-guide/current/overview.html>`_
    for details.
 #. Set the environment variables for |onedpl_short| and |onetbb_short|.
 #. To avoid naming device policy objects explicitly, add the ``-fsycl-unnamed-lambda`` option.
@@ -144,4 +144,4 @@ Below is an example of a command line used to compile code that contains
 
   dpcpp [-fsycl-unnamed-lambda] test.cpp [-ltbb|-fopenmp] -o test
 
-.. _`Intel® oneAPI Threading Building Blocks (oneTBB) Release Notes`: https://software.intel.com/content/www/us/en/develop/articles/intel-oneapi-threading-building-blocks-release-notes.html
+.. _`Intel® oneAPI Threading Building Blocks (oneTBB) Release Notes`: https://www.intel.com/content/www/us/en/developer/articles/release-notes/intel-oneapi-threading-building-blocks-release-notes.html

--- a/documentation/library_guide/macros.rst
+++ b/documentation/library_guide/macros.rst
@@ -40,11 +40,7 @@ Macro                              Description
                                    are executed with unsequenced policies.
                                    For further details about the pragma,
                                    see the `vector page in the Intel® oneAPI DPC++/C++ Compiler Developer Guide and Reference
-                                   <https://software.intel.com/
-                                   content/www/us/en/develop/documentation/
-                                   oneapi-dpcpp-cpp-compiler-dev-guide-and-reference/top/
-                                   compiler-reference/pragmas/
-                                   intel-specific-pragma-reference/vector.html>`_.
+                                   <https://www.intel.com/content/www/us/en/docs/dpcpp-cpp-compiler/developer-guide-reference/current/vector.html>`_.
                                    If the macro evaluates to a non-zero value,
                                    the use of ``#pragma vector nontemporal`` is enabled.
                                    By default, the macro is not defined.

--- a/documentation/library_guide/onedpl_gsg.rst
+++ b/documentation/library_guide/onedpl_gsg.rst
@@ -2,7 +2,7 @@ Get Started with the |onedpl_long|
 ##################################
 
 |onedpl_long| (|onedpl_short|) works with the
-`Intel® oneAPI DPC++/C++ Compiler <https://software.intel.com/content/www/us/en/develop/documentation/get-started-with-dpcpp-compiler/top.html>`_
+`Intel® oneAPI DPC++/C++ Compiler <https://www.intel.com/content/www/us/en/docs/dpcpp-cpp-compiler/get-started-guide/current/overview.html>`_
 to provide high-productivity APIs to developers, which can minimize SYCL*
 programming efforts across devices for high performance parallel applications.
 
@@ -14,8 +14,8 @@ programming efforts across devices for high performance parallel applications.
 
 
 For general information about |onedpl_short|, visit the `oneDPL GitHub* repository <https://github.com/oneapi-src/oneDPL>`_,
-or visit the `Intel® oneAPI DPC++ Library Guide <https://software.intel.com/content/www/us/en/develop/documentation/oneapi-dpcpp-library-guide/top.html>`_
-and the `Intel® oneAPI DPC++ Library main page <https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/dpc-library.html>`_.
+or visit the `Intel® oneAPI DPC++ Library Guide <https://www.intel.com/content/www/us/en/docs/onedpl/developer-guide/current/overview.html>`_
+and the `Intel® oneAPI DPC++ Library main page <https://www.intel.com/content/www/us/en/developer/tools/oneapi/dpc-library.html>`_.
 
 Quick Start
 ===========
@@ -24,7 +24,7 @@ Installation
 ------------
 
 Visit the |onedpl_short| `Release Notes
-<https://software.intel.com/content/www/us/en/develop/articles/intel-oneapi-dpcpp-library-release-notes.html>`_
+<https://www.intel.com/content/www/us/en/developer/articles/release-notes/intel-oneapi-dpcpp-library-release-notes.html>`_
 page for:
 
 * Where to Find the Release
@@ -33,7 +33,7 @@ page for:
 * Fixed Issues
 * Known Issues and Limitations
 
-Install the `Intel® oneAPI Base Toolkit (Base Kit) <https://software.intel.com/en-us/oneapi/base-kit>`_
+Install the `Intel® oneAPI Base Toolkit (Base Kit) <https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit.html>`_
 to use |onedpl_short|.
 
 To use Parallel API, include the corresponding header files in your source code.
@@ -165,13 +165,13 @@ Find More
 
    * - Resource Link
      - Description
-   * - `Intel® oneAPI DPC++ Library Guide <https://software.intel.com/content/www/us/en/develop/documentation/oneapi-dpcpp-library-guide/top.html>`_
+   * - `Intel® oneAPI DPC++ Library Guide <https://www.intel.com/content/www/us/en/docs/onedpl/developer-guide/current/overview.html>`_
      - Refer to the |onedpl_short| guide for  more in depth information.
-   * - `System Requirements <https://software.intel.com/content/www/us/en/develop/articles/intel-oneapi-dpcpp-system-requirements.html>`_
+   * - `System Requirements <https://www.intel.com/content/www/us/en/developer/articles/system-requirements/intel-oneapi-dpcpp-system-requirements.html>`_
      - Check system requirements before you install |onedpl_short|.
-   * - `Intel® oneAPI DPC++ Library Release Notes <https://software.intel.com/content/www/us/en/develop/articles/intel-oneapi-dpcpp-library-release-notes.html>`_
+   * - `Intel® oneAPI DPC++ Library Release Notes <https://www.intel.com/content/www/us/en/developer/articles/release-notes/intel-oneapi-dpcpp-library-release-notes.html>`_
      - Check the release notes to learn about updates in the latest release.
    * - `oneDPL Samples <https://github.com/oneapi-src/oneAPI-samples/tree/master/Libraries/oneDPL>`_
      - Learn how to use |onedpl_short| with samples.
-   * - `Layers for Yocto* Project <https://www.intel.com/content/www/us/en/develop/documentation/get-started-with-intel-oneapi-iot-linux/top/adding-oneapi-components-to-yocto-project-builds.html>`_
+   * - `Layers for Yocto* Project <https://www.intel.com/content/www/us/en/docs/oneapi-iot-toolkit/get-started-guide-linux/current/adding-oneapi-components-to-yocto-project-builds.html>`_
      - Add oneAPI components to a Yocto project build using the meta-intel layers.

--- a/documentation/library_guide/parallel_api/execution_policies.rst
+++ b/documentation/library_guide/parallel_api/execution_policies.rst
@@ -4,7 +4,7 @@ Execution Policies
 The implementation supports the device execution policies used to run the massive parallel
 computational model for heterogeneous systems. The policies are specified in
 the |onedpl_long| (|onedpl_short|) section of the `oneAPI Specification
-<https://spec.oneapi.com/versions/latest/elements/oneDPL/source/pstl.html#dpc-execution-policy>`_.
+<https://spec.oneapi.io/versions/latest/elements/oneDPL/source/parallel_api.html#dpc-execution-policy>`_.
 
 For any of the implemented algorithms, pass one of the execution policy objects as the first
 argument in a call to specify the desired execution behavior. The policies have
@@ -175,10 +175,10 @@ Use it to create customized policy objects or pass directly when invoking an alg
 
    Specifying the unroll factor for a policy enables loop unrolling in the implementation of
    your algorithms. The default value is 1.
-   To find out how to choose a more precise value, refer to the `unroll Pragma <https://software.intel.com/content/www/us/en/develop/documentation/oneapi-fpga-optimization-guide/top/fpga-optimization-flags-attributes-pragmas-and-extensions/loop-directives/unroll-pragma.html>`_
-   and `Loop Analysis <https://software.intel.com/content/www/us/en/develop/documentation/oneapi-fpga-optimization-guide/top/analyze-your-design/analyze-the-fpga-early-image/review-the-report-html-file/loop-analysis.html>`_ chapters of
+   To find out how to choose a more precise value, refer to the `unroll Pragma <https://www.intel.com/content/www/us/en/docs/oneapi-fpga-add-on/optimization-guide/current/unroll-pragma.html>`_
+   and `Loop Analysis <https://www.intel.com/content/www/us/en/docs/oneapi-fpga-add-on/optimization-guide/current/loop-analysis.html>`_ chapters of
    the `Intel® oneAPI DPC++ FPGA Optimization Guide
-   <https://software.intel.com/content/www/us/en/develop/documentation/oneapi-fpga-optimization-guide/top.html>`_.
+   <https://www.intel.com/content/www/us/en/docs/oneapi-fpga-add-on/optimization-guide/current/overview.html>`_.
 
 The ``make_fpga_policy`` function templates simplify ``fpga_policy`` creation.
 

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -453,7 +453,7 @@ Known Issues and Limitations
    ``std::less`` or ``std::greater``, otherwise Merge sort.
 .. _`the oneDPL Specification`: https://spec.oneapi.com/versions/latest/elements/oneDPL/source/index.html
 .. _`oneDPL Guide`: https://oneapi-src.github.io/oneDPL/index.html
-.. _`Intel® oneAPI Threading Building Blocks (oneTBB) Release Notes`: https://software.intel.com/content/www/us/en/develop/articles/intel-oneapi-threading-building-blocks-release-notes.html
+.. _`Intel® oneAPI Threading Building Blocks (oneTBB) Release Notes`: https://www.intel.com/content/www/us/en/developer/articles/release-notes/intel-oneapi-threading-building-blocks-release-notes.html
 .. _`restrictions and known limitations`: https://oneapi-src.github.io/oneDPL/overview.html#restrictions
 .. _`Tested Standard C++ API`: https://oneapi-src.github.io/oneDPL/api_for_sycl_kernels/tested_standard_cpp_api.html#tested-standard-c-api-reference
 .. _`Macros`: https://oneapi-src.github.io/oneDPL/macros.html


### PR DESCRIPTION
Updated all URLs with the old schema software.intel.com and updated some URLs that were resulting in a 404.