### PR TITLE
[KT] Extend one workgroup implementation to sort signed integers & floats

### DIFF
--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort.h
@@ -54,24 +54,24 @@ radix_sort(_ExecutionPolicy&& __exec, _Range&& __rng)
 
     if (__n <= 16384)
     {
-        // TODO: allow differnt sorting orders
-        // TODO: allow diferent types
+        // TODO: allow different sorting orders
+        // TODO: support double
         // TODO: allow all RadixBits values (only 7 or 8 are currently supported)
         oneapi::dpl::experimental::esimd::impl::one_wg<_ExecutionPolicy, _KeyT, _Range, RadixBits, IsAscending>(
             ::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range>(__rng), __n);
     }
     else if (__n <= 262144)
     {
-        // TODO: allow differnt sorting orders
-        // TODO: allow diferent types
+        // TODO: allow different sorting orders
+        // TODO: allow different types
         oneapi::dpl::experimental::esimd::impl::cooperative<_ExecutionPolicy, _KeyT, _Range, RadixBits, IsAscending>(
             ::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range>(__rng), __n);
     }
     else
     {
-        // TODO: allow differnt sorting orders
-        // TODO: allow diferent types
-        // TODO: avoid kernel duplication (generate the output storate with the same type as input storatge and use swap)
+        // TODO: allow different sorting orders
+        // TODO: allow different types
+        // TODO: avoid kernel duplication (generate the output storage with the same type as input storage and use swap)
         // TODO: allow different RadixBits, make sure the data is in the input storage after the last stage
         // TODO: pass _ProcessSize according to __n
         // TODO: fix when compiled in -O0 mode: "esimd_radix_sort_one_wg.h : 54 : 5>: SLM init call is supported only in kernels"

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
@@ -67,7 +67,8 @@ void one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, uint32_t THREAD_PER_TG, con
     #pragma unroll
     for (uint32_t s = 0; s<PROCESS_SIZE; s+=16) {
         simd_mask<16> m = (io_offset+lane_id+s)<n;
-        keys.template select<16, 1>(s) = merge(utils::gather<KeyT, 16>(input, lane_id, io_offset + s, m), simd<KeyT, 16>(-1), m);
+        keys.template select<16, 1>(s) = merge(utils::gather<KeyT, 16>(input, lane_id, io_offset + s, m),
+                                               simd<KeyT, 16>(utils::__sort_identity<KeyT, IsAscending>), m);
     }
 
     for (uint32_t stage=0; stage < STAGES; stage++) {

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
@@ -177,7 +177,7 @@ void one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, uint32_t THREAD_PER_TG, con
     #pragma unroll
     for (uint32_t s = 0; s<PROCESS_SIZE; s+=16) {
         utils::scatter<KeyT, 16>(input, write_addr.template select<16, 1>(s), keys.template select<16, 1>(s),
-                                 (io_offset + lane_id + s) < n);
+                                 write_addr.template select<16, 1>(s) < n);
     }
 }
 

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
@@ -41,9 +41,10 @@ void one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, uint32_t THREAD_PER_TG, con
     constexpr uint32_t STAGES = oneapi::dpl::__internal::__dpl_ceiling_div(NBITS, RADIX_BITS);
     constexpr uint32_t MAX_THREAD_PER_TG = 64;
     constexpr bin_t MASK = BIN_COUNT - 1;
+    constexpr uint32_t HIST_STRIDE = sizeof(hist_t) * BIN_COUNT;
 
     constexpr uint32_t REORDER_SLM_SIZE = PROCESS_SIZE * sizeof(KeyT) * MAX_THREAD_PER_TG; // reorder buffer
-    constexpr uint32_t BIN_HIST_SLM_SIZE = BIN_COUNT * sizeof(hist_t) * MAX_THREAD_PER_TG;             // bin hist working buffer
+    constexpr uint32_t BIN_HIST_SLM_SIZE = HIST_STRIDE * MAX_THREAD_PER_TG;             // bin hist working buffer
     constexpr uint32_t INCOMING_OFFSET_SLM_SIZE = (BIN_COUNT+1)*sizeof(hist_t);                // incoming offset buffer
 
     // max SLM is 256 * 4 * 64 + 256 * 2 * 64 + 257*2, 97KB, when  PROCESS_SIZE = 256, BIN_COUNT = 256
@@ -53,8 +54,8 @@ void one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, uint32_t THREAD_PER_TG, con
     uint32_t slm_bin_hist_start = 0;
     uint32_t slm_incoming_offset = slm_bin_hist_start + BIN_HIST_SLM_SIZE;
 
-    uint32_t slm_reorder = slm_reorder_start + local_tid * PROCESS_SIZE * sizeof(KeyT);
-    uint32_t slm_bin_hist_this_thread = slm_bin_hist_start + local_tid * BIN_COUNT * sizeof(hist_t);
+    uint32_t slm_reorder_this_thread = slm_reorder_start + local_tid * PROCESS_SIZE * sizeof(KeyT);
+    uint32_t slm_bin_hist_this_thread = slm_bin_hist_start + local_tid * HIST_STRIDE;
 
     simd<hist_t, BIN_COUNT> bin_offset;
     simd<device_addr_t, PROCESS_SIZE> write_addr;
@@ -90,7 +91,6 @@ void one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, uint32_t THREAD_PER_TG, con
         */
         {
             barrier();
-            constexpr uint32_t HIST_STRIDE = sizeof(hist_t)*BIN_COUNT;
             #pragma unroll
             for (uint32_t s = 0; s<BIN_COUNT; s+=128) {
                 lsc_slm_block_store<uint32_t, 64>(slm_bin_hist_this_thread + s*sizeof(hist_t), bin_offset.template select<128, 1>(s).template bit_cast_view<uint32_t>());
@@ -170,7 +170,7 @@ void one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, uint32_t THREAD_PER_TG, con
             barrier();
             #pragma unroll
             for (uint32_t s = 0; s<PROCESS_SIZE; s+=64){
-                keys.template select<64, 1>(s) = lsc_slm_block_load<KeyT, 64>(slm_reorder+s*sizeof(KeyT));
+                keys.template select<64, 1>(s) = lsc_slm_block_load<KeyT, 64>(slm_reorder_this_thread+s*sizeof(KeyT));
             }
         }
     }
@@ -219,7 +219,6 @@ void one_wg(_ExecutionPolicy&& __exec, _Range&& __rng, ::std::size_t __n) {
     using namespace sycl;
     using namespace __ESIMD_NS;
 
-    constexpr uint32_t BINCOUNT = 1 << RADIX_BITS;
     constexpr uint32_t MAX_TG_COUNT = 64;
     constexpr uint32_t MIN_TG_COUNT = 8;
     uint32_t PROCESS_SIZE = 64;

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
@@ -573,7 +573,16 @@ struct __radix_sort_onesweep_submitter<KeyT, RADIX_BITS, THREAD_PER_TG, PROCESS_
 
 template <typename _ExecutionPolicy, typename KeyT, typename _Range, ::std::uint32_t RADIX_BITS,
           bool IsAscending, ::std::uint32_t PROCESS_SIZE>
-void onesweep(_ExecutionPolicy&& __exec, _Range&& __rng, ::std::size_t __n)
+std::enable_if_t<!::std::is_unsigned_v<KeyT>, void>
+onesweep(_ExecutionPolicy&& __exec, _Range&& __rng, ::std::size_t __n)
+{
+    // TODO: remove this when the implementation below can compile for other data types
+}
+
+template <typename _ExecutionPolicy, typename KeyT, typename _Range, ::std::uint32_t RADIX_BITS,
+          bool IsAscending, ::std::uint32_t PROCESS_SIZE>
+std::enable_if_t<::std::is_unsigned_v<KeyT>, void>
+onesweep(_ExecutionPolicy&& __exec, _Range&& __rng, ::std::size_t __n)
 {
     using namespace sycl;
     using namespace __ESIMD_NS;

--- a/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
+++ b/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
@@ -33,6 +33,8 @@
 #include <random>
 #include <string>
 #include <iostream>
+#include <cmath>
+#include <limits>
 
 template <typename T>
 typename ::std::enable_if_t<std::is_arithmetic_v<T>, void>

--- a/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
+++ b/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
@@ -183,9 +183,9 @@ void test_general_cases(std::size_t size)
 int main()
 {
 #if TEST_DPCPP_BACKEND_PRESENT
-    const std::vector<std::size_t> onewg_sizes = { 6, 16, 43, 256, 316, 2048, 5072, 8192, 14001, 2<<14 };
-    const std::vector<std::size_t> coop_sizes = { (2<<14)+1, 50000, 67543, 100'000, 2<<17, 179'581, 250'000, 2<<18 };
-    const std::vector<std::size_t> onesweep_sizes = { (2<<18)+1, 500'000, 888'235, 1'000'000, 2<<20, 10'000'000 };
+    const std::vector<std::size_t> onewg_sizes = { 6, 16, 43, 256, 316, 2048, 5072, 8192, 14001, 1<<14 };
+    const std::vector<std::size_t> coop_sizes = { (1<<14)+1, 50000, 67543, 100'000, 1<<17, 179'581, 250'000, 1<<18 };
+    const std::vector<std::size_t> onesweep_sizes = { (1<<18)+1, 500'000, 888'235, 1'000'000, 1<<20, 10'000'000 };
 
     try
     {

--- a/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
+++ b/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
@@ -183,15 +183,20 @@ void test_general_cases(std::size_t size)
 int main()
 {
 #if TEST_DPCPP_BACKEND_PRESENT
-    const std::vector<std::size_t> sizes = {
-        6, 16, 42, 256, 316, 2048, 5072, 8192, 14001,                        // one work-group
-        2<<14, 50000, 67543, 100'000, 2<<17, 179'581, 250'000                // cooperative
-    };
-    const std::vector<std::size_t> onesweep_sizes = {2<<18, 500'000, 888'235, 1'000'000, 2<<20, 10'000'000};
+    const std::vector<std::size_t> onewg_sizes = { 6, 16, 43, 256, 316, 2048, 5072, 8192, 14001, 2<<14 };
+    const std::vector<std::size_t> coop_sizes = { 2<<14+1, 50000, 67543, 100'000, 2<<17, 179'581, 250'000, 2<<18 };
+    const std::vector<std::size_t> onesweep_sizes = {2<<18+1, 500'000, 888'235, 1'000'000, 2<<20, 10'000'000};
 
     try
     {
-        for(auto size: sizes)
+        for(auto size: onewg_sizes)
+        {
+            test_general_cases<uint32_t>(size);
+            test_general_cases<int>(size);
+            test_general_cases<float>(size);
+            // test_general_cases<double>(size);
+        }
+        for(auto size: coop_sizes)
         {
             test_general_cases<uint32_t>(size);
             // test_general_cases<int>(size);

--- a/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
+++ b/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
@@ -184,8 +184,8 @@ int main()
 {
 #if TEST_DPCPP_BACKEND_PRESENT
     const std::vector<std::size_t> onewg_sizes = { 6, 16, 43, 256, 316, 2048, 5072, 8192, 14001, 2<<14 };
-    const std::vector<std::size_t> coop_sizes = { 2<<14+1, 50000, 67543, 100'000, 2<<17, 179'581, 250'000, 2<<18 };
-    const std::vector<std::size_t> onesweep_sizes = {2<<18+1, 500'000, 888'235, 1'000'000, 2<<20, 10'000'000};
+    const std::vector<std::size_t> coop_sizes = { (2<<14)+1, 50000, 67543, 100'000, 2<<17, 179'581, 250'000, 2<<18 };
+    const std::vector<std::size_t> onesweep_sizes = { (2<<18)+1, 500'000, 888'235, 1'000'000, 2<<20, 10'000'000 };
 
     try
     {


### PR DESCRIPTION
Key changes: Use the sort identity for filling in extra vector lanes, and fix the scatter mask when writing the results back. Also there are some cosmetic improvements, and the test is updated.