### PR TITLE
Replace deprecated uses of host_buffer and get_access()

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -234,6 +234,13 @@ constexpr __target __target_device =
     __target::global_buffer;
 #endif
 
+constexpr __target __host_target =
+#if _ONEDPL_LIBSYCL_VERSION >= 60200
+    __target::host_task;
+#else
+    __target::host_buffer;
+#endif
+
 template <typename _DataT>
 using __buffer_allocator =
 #if _ONEDPL_LIBSYCL_VERSION >= 60000

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -130,7 +130,7 @@ inline constexpr all_view_fn<sycl::access::mode::read, __dpl_sycl::__target_devi
 inline constexpr all_view_fn<sycl::access::mode::write, __dpl_sycl::__target_device, sycl::access::placeholder::true_t>
     all_write;
 
-inline constexpr all_view_fn<sycl::access::mode::read_write, __dpl_sycl::__target::host_buffer,
+inline constexpr all_view_fn<sycl::access::mode::read_write, __dpl_sycl::__host_target,
                              sycl::access::placeholder::false_t>
     host_all;
 } // namespace views

--- a/test/parallel_api/experimental/asynch-scan.pass.cpp
+++ b/test/parallel_api/experimental/asynch-scan.pass.cpp
@@ -38,7 +38,7 @@ test_with_buffers()
 
         auto my_policy = TestUtils::make_device_policy<class Copy>(oneapi::dpl::execution::dpcpp_default);
         auto input = oneapi::dpl::counting_iterator<int>(0);
-        
+
         dpl::experimental::copy_async(my_policy, input, input+n, dpl::begin(x)).wait();
         const auto expected1 = ((n-1)*n)/2;
         const auto expected2 = expected1-n+1;
@@ -46,48 +46,48 @@ test_with_buffers()
         // transform inclusive (2 overloads)
         auto my_policy1 = TestUtils::make_device_policy<class Scan1>(my_policy);
         auto alpha = dpl::experimental::transform_inclusive_scan_async(my_policy1, dpl::begin(x), dpl::end(x), dpl::begin(y), std::plus<int>(), [](auto x) { return x * 10; });
-        auto result1 = alpha.get().get_buffer().get_access<sycl::access::mode::read>()[n-1]; 
+        auto result1 = alpha.get().get_buffer().get_host_access(sycl::read_only)[n-1];
         EXPECT_TRUE(result1 == (expected1 * 10), "wrong effect from async scan test (Ia) with sycl buffer");
 
         auto my_policy2 = TestUtils::make_device_policy<class Scan2>(my_policy);
         auto fut1b = dpl::experimental::transform_inclusive_scan_async(my_policy2, dpl::begin(x), dpl::end(x), dpl::begin(y), std::plus<int>(), [](auto x) { return x * 10; }, 1);
-        auto result1b = fut1b.get().get_buffer().get_access<sycl::access::mode::read>()[n-1];
+        auto result1b = fut1b.get().get_buffer().get_host_access(sycl::read_only)[n-1];
         EXPECT_TRUE(result1b == (expected1 * 10 + 1), "wrong effect from async scan test (Ib) with sycl buffer");
 
         // transform exclusive
         auto my_policy3 = TestUtils::make_device_policy<class Scan3>(my_policy);
         auto beta = dpl::experimental::transform_exclusive_scan_async(my_policy3, dpl::begin(x), dpl::end(x), dpl::begin(y), 0, std::plus<int>(), [](auto x) { return x * 10; });
-        auto result2 = beta.get().get_buffer().get_access<sycl::access::mode::read>()[n-1];
+        auto result2 = beta.get().get_buffer().get_host_access(sycl::read_only)[n-1];
         EXPECT_TRUE(result2 == expected2 * 10, "wrong effect from async scan test (II) with sycl buffer");
 
         // inclusive (3 overloads)
         auto my_policy4 = TestUtils::make_device_policy<class Scan4>(my_policy);
         auto gamma = dpl::experimental::inclusive_scan_async(my_policy4, dpl::begin(x), dpl::end(x), dpl::begin(y));
-        auto result3 = gamma.get().get_buffer().get_access<sycl::access::mode::read>()[n-1]; 
+        auto result3 = gamma.get().get_buffer().get_host_access(sycl::read_only)[n-1];
         EXPECT_TRUE(result3 == expected1, "wrong effect from async scan test (IIIa) with sycl buffer");
 
         auto my_policy5 = TestUtils::make_device_policy<class Scan5>(my_policy);
         auto fut3b = dpl::experimental::inclusive_scan_async(my_policy5, dpl::begin(x), dpl::end(x), dpl::begin(y), std::plus<int>(), gamma);
-        auto result3b = fut3b.get().get_buffer().get_access<sycl::access::mode::read>()[n-1];
+        auto result3b = fut3b.get().get_buffer().get_host_access(sycl::read_only)[n-1];
         EXPECT_TRUE(result3b == expected1, "wrong effect from async scan test (IIIb) with sycl buffer");
 
         auto my_policy6 = TestUtils::make_device_policy<class Scan6>(my_policy);
         auto fut3c = dpl::experimental::inclusive_scan_async(my_policy6, dpl::begin(x), dpl::end(x), dpl::begin(y), std::plus<int>(), 1, fut3b);
-        auto result3c = fut3c.get().get_buffer().get_access<sycl::access::mode::read>()[n-1];
+        auto result3c = fut3c.get().get_buffer().get_host_access(sycl::read_only)[n-1];
         EXPECT_TRUE(result3c == (expected1 + 1), "wrong effect from async scan test (IIIc) with sycl buffer");
 
         // exclusive (2 overloads)
         auto my_policy7 = TestUtils::make_device_policy<class Scan7>(my_policy);
         auto delta = dpl::experimental::exclusive_scan_async(my_policy7, dpl::begin(x), dpl::end(x), dpl::begin(y), 0);
-        auto result4 = delta.get().get_buffer().get_access<sycl::access::mode::read>()[n-1];
+        auto result4 = delta.get().get_buffer().get_host_access(sycl::read_only)[n-1];
         EXPECT_TRUE(result4 == expected2, "wrong effect from async scan test (IV) with sycl buffer");
 
         auto my_policy8 = TestUtils::make_device_policy<class Scan8>(my_policy);
         auto fut4b = dpl::experimental::exclusive_scan_async(my_policy8, dpl::begin(x), dpl::end(x), dpl::begin(y), 1, std::plus<int>(), delta);
-        auto result4b = fut4b.get().get_buffer().get_access<sycl::access::mode::read>()[n-1];
+        auto result4b = fut4b.get().get_buffer().get_host_access(sycl::read_only)[n-1];
         EXPECT_TRUE(result4b == (expected2 + 1), "wrong effect from async scan test (IV) with sycl buffer");
 
-        oneapi::dpl::experimental::wait_for_all(alpha,beta,gamma,delta);   
+        oneapi::dpl::experimental::wait_for_all(alpha,beta,gamma,delta); 
     }
 }
 #endif


### PR DESCRIPTION
When building tests with the latest compiler, we get the following warnings:

```
[...]/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h:133:84: warning: 'host_buffer' is deprecated: use 'host_accessor' instead [-Wdeprecated-declarations]
```
```
[...]/test/parallel_api/experimental/asynch-scan.pass.cpp:49:49: warning: 'get_access' is deprecated: get_access for host_accessor is deprecated, please use get_host_access instead [-Wdeprecated-declarations]
```

These are caused by deprecations in the SYCL spec for `host_buffer` and `get_access` for host access of buffers.