### PR TITLE
Updating CMake minimum required versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,13 @@
 #
 ##===----------------------------------------------------------------------===##
 
-cmake_minimum_required(VERSION 3.4.3)
+if (CMAKE_HOST_WIN32)
+    # Requires version 3.20 for baseline support of icx, icx-cl
+    cmake_minimum_required(VERSION 3.20)
+else()
+    # Requires version 3.11 for use of icpc with c++17 requirement
+    cmake_minimum_required(VERSION 3.11)
+endif()
 
 # oneDPL is a subproject only when PARENT_DIRECTORY is defined
 get_directory_property(_onedpl_is_subproject PARENT_DIRECTORY)

--- a/cmake/oneDPLWindowsIntelLLVMConfig.cmake
+++ b/cmake/oneDPLWindowsIntelLLVMConfig.cmake
@@ -12,7 +12,7 @@
 #
 ##===----------------------------------------------------------------------===##
 
-if(CMAKE_HOST_WIN32)
+if (CMAKE_HOST_WIN32)
     if (CMAKE_VERSION VERSION_LESS 3.20)
         set(REASON_FAILURE "oneDPLWindowsIntelLLVM requires CMake 3.20 or later on Windows.")
         set(oneDPLWindowsIntelLLVM_FOUND FALSE)

--- a/cmake/oneDPLWindowsIntelLLVMConfig.cmake
+++ b/cmake/oneDPLWindowsIntelLLVMConfig.cmake
@@ -11,7 +11,17 @@
 # See https://llvm.org/LICENSE.txt for license information.
 #
 ##===----------------------------------------------------------------------===##
-cmake_minimum_required(VERSION 3.15.0)
+
+if(CMAKE_HOST_WIN32)
+    if (CMAKE_VERSION VERSION_LESS 3.20)
+        set(REASON_FAILURE "oneDPLWindowsIntelLLVM requires CMake 3.20 or later on Windows.")
+        set(oneDPLWindowsIntelLLVM_FOUND FALSE)
+        return()
+    else()
+        # Requires version 3.20 for baseline support of icx, icx-cl
+        cmake_minimum_required(VERSION 3.20)
+    endif()
+endif()
 
 include(${CMAKE_ROOT}/Modules/FindPackageHandleStandardArgs.cmake)
 

--- a/cmake/templates/oneDPLConfig.cmake.in
+++ b/cmake/templates/oneDPLConfig.cmake.in
@@ -12,6 +12,24 @@
 #
 ##===----------------------------------------------------------------------===##
 
+if (CMAKE_HOST_WIN32 AND CMAKE_VERSION VERSION_LESS 3.20)
+    message(STATUS "oneDPL: requires CMake 3.20 or later on Windows")
+    set(oneDPL_FOUND FALSE)
+    return()
+elseif (NOT CMAKE_HOST_WIN32 AND CMAKE_VERSION VERSION_LESS 3.11)
+    message(STATUS "oneDPL: requires CMake 3.11 or later on Linux")
+    set(oneDPL_FOUND FALSE)
+    return()
+endif()
+
+if (CMAKE_HOST_WIN32)
+    # Requires version 3.20 for baseline support of icx, icx-cl
+    cmake_minimum_required(VERSION 3.20)
+else()
+    # Requires version 3.11 for use of icpc with c++17 requirement
+    cmake_minimum_required(VERSION 3.11)
+endif()
+
 # Installation path: <onedpl_root>/lib/cmake/oneDPL/
 get_filename_component(_onedpl_root "${CMAKE_CURRENT_LIST_DIR}" REALPATH)
 get_filename_component(_onedpl_root "${_onedpl_root}/../../../" ABSOLUTE)


### PR DESCRIPTION
Increasing minimum required CMake version:

- Windows: 3.20
  - Required for baseline CMake support for `icx`, `icx-cl` to allow workarounds to work 
- Linux: 3.11
  - Required for CMake support of `icpc` with required C++17 feature 

Adding in minimum CMake requirements for oneDPL via package inclusion (previously none).