### PR TITLE
Add checks for char8_t library support in numeric limits tests

### DIFF
--- a/test/support/test_macros.h
+++ b/test/support/test_macros.h
@@ -370,14 +370,8 @@ inline void DoNotOptimize(Tp const& value) {
 #  define TEST_HAS_NO_LOCALIZATION
 #endif
 
-#if TEST_STD_VER <= 17 || !defined(__cpp_char8_t)
+#if TEST_STD_VER <= 17 || !defined(__cpp_char8_t) || !defined(__cpp_lib_char8_t)
 #  define TEST_HAS_NO_CHAR8_T
-#endif
-
-#if TEST_STD_VER > 17 && defined(__cpp_char8_t) && defined(__cpp_lib_char8_t)
-#   define _ENABLE_CHAR8_T 1
-#else
-#   define _ENABLE_CHAR8_T 0
 #endif
 
 #if defined(_LIBCPP_HAS_NO_THREADS)

--- a/test/support/test_macros.h
+++ b/test/support/test_macros.h
@@ -374,6 +374,12 @@ inline void DoNotOptimize(Tp const& value) {
 #  define TEST_HAS_NO_CHAR8_T
 #endif
 
+#if TEST_STD_VER > 17 && defined(__cpp_char8_t) && defined(__cpp_lib_char8_t)
+#   define _ENABLE_CHAR8_T 1
+#else
+#   define _ENABLE_CHAR8_T 0
+#endif
+
 #if defined(_LIBCPP_HAS_NO_THREADS)
 #  define TEST_HAS_NO_THREADS
 #endif

--- a/test/xpu_api/language.support/support.limits/limits/infinity.pass.cpp
+++ b/test/xpu_api/language.support/support.limits/limits/infinity.pass.cpp
@@ -50,7 +50,7 @@ ONEDPL_TEST_NUM_MAIN
     test<signed char>(0);
     test<unsigned char>(0);
     test<wchar_t>(0);
-#if TEST_STD_VER > 17 && defined(__cpp_char8_t) && defined(__cpp_lib_char8_t)
+#if _ENABLE_CHAR8_T
     test<char8_t>(0);
 #endif
 #ifndef _LIBCPP_HAS_NO_UNICODE_CHARS

--- a/test/xpu_api/language.support/support.limits/limits/infinity.pass.cpp
+++ b/test/xpu_api/language.support/support.limits/limits/infinity.pass.cpp
@@ -50,7 +50,7 @@ ONEDPL_TEST_NUM_MAIN
     test<signed char>(0);
     test<unsigned char>(0);
     test<wchar_t>(0);
-#if _ENABLE_CHAR8_T
+#ifndef TEST_HAS_NO_CHAR8_T
     test<char8_t>(0);
 #endif
 #ifndef _LIBCPP_HAS_NO_UNICODE_CHARS

--- a/test/xpu_api/language.support/support.limits/limits/infinity.pass.cpp
+++ b/test/xpu_api/language.support/support.limits/limits/infinity.pass.cpp
@@ -50,7 +50,7 @@ ONEDPL_TEST_NUM_MAIN
     test<signed char>(0);
     test<unsigned char>(0);
     test<wchar_t>(0);
-#if TEST_STD_VER > 17 && defined(__cpp_char8_t)
+#if TEST_STD_VER > 17 && defined(__cpp_char8_t) && defined(__cpp_lib_char8_t)
     test<char8_t>(0);
 #endif
 #ifndef _LIBCPP_HAS_NO_UNICODE_CHARS

--- a/test/xpu_api/language.support/support.limits/limits/lowest.pass.cpp
+++ b/test/xpu_api/language.support/support.limits/limits/lowest.pass.cpp
@@ -52,7 +52,7 @@ ONEDPL_TEST_NUM_MAIN
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
     test<wchar_t>(WCHAR_MIN);
 #endif
-#if TEST_STD_VER > 17 && defined(__cpp_char8_t)
+#if TEST_STD_VER > 17 && defined(__cpp_char8_t) && defined(__cpp_lib_char8_t)
     test<char8_t>(0);
 #endif
 #ifndef _LIBCPP_HAS_NO_UNICODE_CHARS

--- a/test/xpu_api/language.support/support.limits/limits/lowest.pass.cpp
+++ b/test/xpu_api/language.support/support.limits/limits/lowest.pass.cpp
@@ -52,7 +52,7 @@ ONEDPL_TEST_NUM_MAIN
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
     test<wchar_t>(WCHAR_MIN);
 #endif
-#if TEST_STD_VER > 17 && defined(__cpp_char8_t) && defined(__cpp_lib_char8_t)
+#if _ENABLE_CHAR8_T
     test<char8_t>(0);
 #endif
 #ifndef _LIBCPP_HAS_NO_UNICODE_CHARS

--- a/test/xpu_api/language.support/support.limits/limits/lowest.pass.cpp
+++ b/test/xpu_api/language.support/support.limits/limits/lowest.pass.cpp
@@ -52,7 +52,7 @@ ONEDPL_TEST_NUM_MAIN
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
     test<wchar_t>(WCHAR_MIN);
 #endif
-#if _ENABLE_CHAR8_T
+#ifndef TEST_HAS_NO_CHAR8_T
     test<char8_t>(0);
 #endif
 #ifndef _LIBCPP_HAS_NO_UNICODE_CHARS

--- a/test/xpu_api/language.support/support.limits/limits/max1.pass.cpp
+++ b/test/xpu_api/language.support/support.limits/limits/max1.pass.cpp
@@ -52,7 +52,7 @@ ONEDPL_TEST_NUM_MAIN
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
     test<wchar_t>(WCHAR_MAX);
 #endif
-#if _ENABLE_CHAR8_T
+#ifndef TEST_HAS_NO_CHAR8_T
     test<char8_t>(UCHAR_MAX); // ??
 #endif
 #ifndef _LIBCPP_HAS_NO_UNICODE_CHARS

--- a/test/xpu_api/language.support/support.limits/limits/max1.pass.cpp
+++ b/test/xpu_api/language.support/support.limits/limits/max1.pass.cpp
@@ -52,7 +52,7 @@ ONEDPL_TEST_NUM_MAIN
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
     test<wchar_t>(WCHAR_MAX);
 #endif
-#if TEST_STD_VER > 17 && defined(__cpp_char8_t) && defined(__cpp_lib_char8_t)
+#if _ENABLE_CHAR8_T
     test<char8_t>(UCHAR_MAX); // ??
 #endif
 #ifndef _LIBCPP_HAS_NO_UNICODE_CHARS

--- a/test/xpu_api/language.support/support.limits/limits/max1.pass.cpp
+++ b/test/xpu_api/language.support/support.limits/limits/max1.pass.cpp
@@ -52,7 +52,7 @@ ONEDPL_TEST_NUM_MAIN
 #ifndef TEST_HAS_NO_WIDE_CHARACTERS
     test<wchar_t>(WCHAR_MAX);
 #endif
-#if TEST_STD_VER > 17 && defined(__cpp_char8_t)
+#if TEST_STD_VER > 17 && defined(__cpp_char8_t) && defined(__cpp_lib_char8_t)
     test<char8_t>(UCHAR_MAX); // ??
 #endif
 #ifndef _LIBCPP_HAS_NO_UNICODE_CHARS

--- a/test/xpu_api/language.support/support.limits/limits/quiet_NaN.pass.cpp
+++ b/test/xpu_api/language.support/support.limits/limits/quiet_NaN.pass.cpp
@@ -69,7 +69,7 @@ ONEDPL_TEST_NUM_MAIN
     test<signed char>();
     test<unsigned char>();
     test<wchar_t>();
-#if _ENABLE_CHAR8_T
+#ifndef TEST_HAS_NO_CHAR8_T
     test<char8_t>();
 #endif
 #ifndef _LIBCPP_HAS_NO_UNICODE_CHARS

--- a/test/xpu_api/language.support/support.limits/limits/quiet_NaN.pass.cpp
+++ b/test/xpu_api/language.support/support.limits/limits/quiet_NaN.pass.cpp
@@ -69,7 +69,7 @@ ONEDPL_TEST_NUM_MAIN
     test<signed char>();
     test<unsigned char>();
     test<wchar_t>();
-#if TEST_STD_VER > 17 && defined(__cpp_char8_t)
+#if TEST_STD_VER > 17 && defined(__cpp_char8_t) && defined(__cpp_lib_char8_t)
     test<char8_t>();
 #endif
 #ifndef _LIBCPP_HAS_NO_UNICODE_CHARS

--- a/test/xpu_api/language.support/support.limits/limits/quiet_NaN.pass.cpp
+++ b/test/xpu_api/language.support/support.limits/limits/quiet_NaN.pass.cpp
@@ -69,7 +69,7 @@ ONEDPL_TEST_NUM_MAIN
     test<signed char>();
     test<unsigned char>();
     test<wchar_t>();
-#if TEST_STD_VER > 17 && defined(__cpp_char8_t) && defined(__cpp_lib_char8_t)
+#if _ENABLE_CHAR8_T
     test<char8_t>();
 #endif
 #ifndef _LIBCPP_HAS_NO_UNICODE_CHARS


### PR DESCRIPTION
For the C++20 `char8_t` type, we only check for presence of the `char8_t` feature macro in our `std::numeric_limits` tests. However, it is necessary to also check for the presence of library support for `char8_t` to ensure that the `std::numeric_limits` specializations are implemented.