### PR TITLE
Do not forward or move variables that are used later

### DIFF
--- a/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
@@ -61,7 +61,7 @@ inclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIter
 
     mask[0] = 1;
 
-    transform(::std::forward<Policy>(policy), first1, last1 - 1, first1 + 1, _mask.get() + 1,
+    transform(policy, first1, last1 - 1, first1 + 1, _mask.get() + 1,
               oneapi::dpl::__internal::__not_pred<BinaryPredicate>(binary_pred));
 
     typename internal::rebind_policy<policy_type, InclusiveScan1<policy_type>>::type policy1(policy);

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -946,8 +946,7 @@ __pattern_remove_if(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __la
     oneapi::dpl::__par_backend_hetero::__internal::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec,
                                                                                                 __last - __first);
     auto __copy_first = __buf.get();
-    auto __copy_last = __pattern_copy_if(__exec, __first, __last, __copy_first,
-                                         __not_pred<_Predicate>{__pred},
+    auto __copy_last = __pattern_copy_if(__exec, __first, __last, __copy_first, __not_pred<_Predicate>{__pred},
                                          /*vector=*/::std::true_type{}, /*parallel*/ ::std::true_type{});
 
     //TODO: optimize copy back depending on Iterator, i.e. set_final_data for host iterator/pointer
@@ -969,9 +968,8 @@ __pattern_unique(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last,
     oneapi::dpl::__par_backend_hetero::__internal::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec,
                                                                                                 __last - __first);
     auto __copy_first = __buf.get();
-    auto __copy_last =
-        __pattern_unique_copy(__exec, __first, __last, __copy_first, __pred,
-                              /*vector=*/::std::true_type{}, /*parallel*/ ::std::true_type{});
+    auto __copy_last = __pattern_unique_copy(__exec, __first, __last, __copy_first, __pred,
+                                             /*vector=*/::std::true_type{}, /*parallel*/ ::std::true_type{});
 
     //TODO: optimize copy back depending on Iterator, i.e. set_final_data for host iterator/pointer
     return __pattern_walk2</*_IsSync=*/::std::true_type, __par_backend_hetero::access_mode::read_write,
@@ -1157,8 +1155,7 @@ __pattern_inplace_merge(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator 
     auto __copy_first = __buf.get();
     auto __copy_last = __copy_first + __n;
 
-    __pattern_merge(__exec,
-                    __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first),
+    __pattern_merge(__exec, __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first),
                     __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__middle),
                     __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__middle),
                     __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__last),
@@ -1223,7 +1220,7 @@ __pattern_sort_by_key(_ExecutionPolicy&& __exec, _Iterator1 __keys_first, _Itera
     auto __beg = oneapi::dpl::make_zip_iterator(__keys_first, __values_first);
     auto __end = __beg + (__keys_last - __keys_first);
     __stable_sort_with_projection(::std::forward<_ExecutionPolicy>(__exec), __beg, __end, __comp,
-        [](const auto& __a) { return ::std::get<0>(__a); });
+                                  [](const auto& __a) { return ::std::get<0>(__a); });
 }
 
 
@@ -1249,8 +1246,7 @@ __pattern_stable_partition(_ExecutionPolicy&& __exec, _Iterator __first, _Iterat
     auto __true_result = __true_buf.get();
     auto __false_result = __false_buf.get();
 
-    auto copy_result = __pattern_partition_copy(__exec, __first, __last,
-                                                __true_result, __false_result, __pred,
+    auto copy_result = __pattern_partition_copy(__exec, __first, __last, __true_result, __false_result, __pred,
                                                 /*vector=*/::std::true_type{}, /*parallel*/ ::std::true_type{});
     auto true_count = copy_result.first - __true_result;
 
@@ -1439,8 +1435,8 @@ __pattern_partial_sort_copy(_ExecutionPolicy&& __exec, _InIterator __first, _InI
         // If our output buffer is larger than the input buffer, simply copy elements to the output and use
         // full sort on them.
         auto __out_end = __pattern_walk2</*_IsSync=*/::std::false_type>(
-            __par_backend_hetero::make_wrapped_policy<__initial_copy_1>(__exec),
-            __first, __last, __out_first, __brick_copy<_ExecutionPolicy>{}, ::std::true_type{}, ::std::true_type{});
+            __par_backend_hetero::make_wrapped_policy<__initial_copy_1>(__exec), __first, __last, __out_first,
+            __brick_copy<_ExecutionPolicy>{}, ::std::true_type{}, ::std::true_type{});
 
         // Use reqular sort as partial_sort isn't required to be stable
         __pattern_sort(
@@ -1459,8 +1455,8 @@ __pattern_partial_sort_copy(_ExecutionPolicy&& __exec, _InIterator __first, _InI
 
         auto __buf_first = __buf.get();
         auto __buf_last = __pattern_walk2</*_IsSync=*/::std::false_type>(
-            __par_backend_hetero::make_wrapped_policy<__initial_copy_2>(__exec),
-            __first, __last, __buf_first, __brick_copy<_ExecutionPolicy>{}, ::std::true_type{}, ::std::true_type{});
+            __par_backend_hetero::make_wrapped_policy<__initial_copy_2>(__exec), __first, __last, __buf_first,
+            __brick_copy<_ExecutionPolicy>{}, ::std::true_type{}, ::std::true_type{});
 
         auto __buf_mid = __buf_first + __out_size;
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -946,7 +946,7 @@ __pattern_remove_if(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __la
     oneapi::dpl::__par_backend_hetero::__internal::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec,
                                                                                                 __last - __first);
     auto __copy_first = __buf.get();
-    auto __copy_last = __pattern_copy_if(::std::forward<_ExecutionPolicy>(__exec), __first, __last, __copy_first,
+    auto __copy_last = __pattern_copy_if(__exec, __first, __last, __copy_first,
                                          __not_pred<_Predicate>{__pred},
                                          /*vector=*/::std::true_type{}, /*parallel*/ ::std::true_type{});
 
@@ -970,7 +970,7 @@ __pattern_unique(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last,
                                                                                                 __last - __first);
     auto __copy_first = __buf.get();
     auto __copy_last =
-        __pattern_unique_copy(::std::forward<_ExecutionPolicy>(__exec), __first, __last, __copy_first, __pred,
+        __pattern_unique_copy(__exec, __first, __last, __copy_first, __pred,
                               /*vector=*/::std::true_type{}, /*parallel*/ ::std::true_type{});
 
     //TODO: optimize copy back depending on Iterator, i.e. set_final_data for host iterator/pointer
@@ -1157,7 +1157,7 @@ __pattern_inplace_merge(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator 
     auto __copy_first = __buf.get();
     auto __copy_last = __copy_first + __n;
 
-    __pattern_merge(::std::forward<_ExecutionPolicy>(__exec),
+    __pattern_merge(__exec,
                     __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first),
                     __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__middle),
                     __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__middle),
@@ -1249,14 +1249,14 @@ __pattern_stable_partition(_ExecutionPolicy&& __exec, _Iterator __first, _Iterat
     auto __true_result = __true_buf.get();
     auto __false_result = __false_buf.get();
 
-    auto copy_result = __pattern_partition_copy(::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+    auto copy_result = __pattern_partition_copy(__exec, __first, __last,
                                                 __true_result, __false_result, __pred,
                                                 /*vector=*/::std::true_type{}, /*parallel*/ ::std::true_type{});
     auto true_count = copy_result.first - __true_result;
 
     //TODO: optimize copy back if possible (inplace, decrease number of submits)
     __pattern_walk2</*_IsSync=*/::std::false_type>(
-        __par_backend_hetero::make_wrapped_policy<copy_back_wrapper>(::std::forward<_ExecutionPolicy>(__exec)),
+        __par_backend_hetero::make_wrapped_policy<copy_back_wrapper>(__exec),
         __true_result, copy_result.first, __first, __brick_move<_ExecutionPolicy>{}, ::std::true_type{},
         ::std::true_type{});
     __pattern_walk2(
@@ -1439,7 +1439,7 @@ __pattern_partial_sort_copy(_ExecutionPolicy&& __exec, _InIterator __first, _InI
         // If our output buffer is larger than the input buffer, simply copy elements to the output and use
         // full sort on them.
         auto __out_end = __pattern_walk2</*_IsSync=*/::std::false_type>(
-            __par_backend_hetero::make_wrapped_policy<__initial_copy_1>(::std::forward<_ExecutionPolicy>(__exec)),
+            __par_backend_hetero::make_wrapped_policy<__initial_copy_1>(__exec),
             __first, __last, __out_first, __brick_copy<_ExecutionPolicy>{}, ::std::true_type{}, ::std::true_type{});
 
         // Use reqular sort as partial_sort isn't required to be stable
@@ -1459,13 +1459,13 @@ __pattern_partial_sort_copy(_ExecutionPolicy&& __exec, _InIterator __first, _InI
 
         auto __buf_first = __buf.get();
         auto __buf_last = __pattern_walk2</*_IsSync=*/::std::false_type>(
-            __par_backend_hetero::make_wrapped_policy<__initial_copy_2>(::std::forward<_ExecutionPolicy>(__exec)),
+            __par_backend_hetero::make_wrapped_policy<__initial_copy_2>(__exec),
             __first, __last, __buf_first, __brick_copy<_ExecutionPolicy>{}, ::std::true_type{}, ::std::true_type{});
 
         auto __buf_mid = __buf_first + __out_size;
 
         __par_backend_hetero::__parallel_partial_sort(
-            __par_backend_hetero::make_wrapped_policy<__partial_sort_2>(::std::forward<_ExecutionPolicy>(__exec)),
+            __par_backend_hetero::make_wrapped_policy<__partial_sort_2>(__exec),
             __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read_write>(__buf_first),
             __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read_write>(__buf_mid),
             __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read_write>(__buf_last), __comp);
@@ -1781,10 +1781,9 @@ __pattern_set_union(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _Forw
     auto __buf = __diff.get();
 
     //1. Calc difference {2} \ {1}
-    const auto __n_diff = oneapi::dpl::__internal::__pattern_hetero_set_op(::std::forward<_ExecutionPolicy>(__exec),
-                                                                           __first2, __last2, __first1, __last1, __buf,
-                                                                           __comp, unseq_backend::_DifferenceTag()) -
-                          __buf;
+    const auto __n_diff = oneapi::dpl::__internal::__pattern_hetero_set_op(__exec,__first2, __last2, __first1, __last1,
+                                                                           __buf,__comp, unseq_backend::_DifferenceTag()
+                                                                          ) - __buf;
     //2. Merge {1} and the difference
     return oneapi::dpl::__internal::__pattern_merge(
         oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__set_union_copy_case_2>(
@@ -1863,16 +1862,14 @@ __pattern_set_symmetric_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 
     //1. Calc difference {1} \ {2}
     const auto __n_diff_1 =
         oneapi::dpl::__internal::__pattern_hetero_set_op(
-            oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__set_symmetric_difference_phase_1>(
-                ::std::forward<_ExecutionPolicy>(__exec)),
+            oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__set_symmetric_difference_phase_1>(__exec),
             __first1, __last1, __first2, __last2, __buf_1, __comp, unseq_backend::_DifferenceTag()) -
         __buf_1;
 
     //2. Calc difference {2} \ {1}
     const auto __n_diff_2 =
         oneapi::dpl::__internal::__pattern_hetero_set_op(
-            oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__set_symmetric_difference_phase_2>(
-                ::std::forward<_ExecutionPolicy>(__exec)),
+            oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__set_symmetric_difference_phase_2>(__exec),
             __first2, __last2, __first1, __last1, __buf_2, __comp, unseq_backend::_DifferenceTag()) -
         __buf_2;
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -145,7 +145,7 @@ __pattern_find_end(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2
 
     if (__rng1.size() == __rng2.size())
     {
-        const bool __res = __pattern_equal(::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range1>(__rng1),
+        const bool __res = __pattern_equal(::std::forward<_ExecutionPolicy>(__exec), __rng1,
                                            ::std::forward<_Range2>(__rng2), __pred);
         return __res ? 0 : __rng1.size();
     }
@@ -224,7 +224,7 @@ __pattern_search(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, 
     {
         const bool __res = __pattern_equal(
             __par_backend_hetero::make_wrapped_policy<equal_wrapper>(::std::forward<_ExecutionPolicy>(__exec)),
-            ::std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2), __pred);
+            __rng1, ::std::forward<_Range2>(__rng2), __pred);
         return __res ? 0 : __rng1.size();
     }
 
@@ -408,7 +408,7 @@ __pattern_remove_if(_ExecutionPolicy&& __exec, _Range&& __rng, _Predicate __pred
     auto __copy_rng = oneapi::dpl::__ranges::views::all(__buf.get_buffer());
 
     auto __copy_last_id =
-        __pattern_copy_if(::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range>(__rng), __copy_rng,
+        __pattern_copy_if(__exec, __rng, __copy_rng,
                           __not_pred<_Predicate>{__pred}, oneapi::dpl::__internal::__pstl_assign());
     auto __copy_rng_truncated = __copy_rng | oneapi::dpl::experimental::ranges::views::take(__copy_last_id);
 
@@ -455,7 +455,7 @@ __pattern_unique(_ExecutionPolicy&& __exec, _Range&& __rng, _BinaryPredicate __p
 
     oneapi::dpl::__par_backend_hetero::__internal::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec, __rng.size());
     auto res_rng = oneapi::dpl::__ranges::views::all(__buf.get_buffer());
-    auto res = __pattern_unique_copy(::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range>(__rng), res_rng,
+    auto res = __pattern_unique_copy(__exec, __rng, res_rng,
                                      __pred, oneapi::dpl::__internal::__pstl_assign());
 
     __pattern_walk_n(::std::forward<_ExecutionPolicy>(__exec), __brick_copy<_ExecutionPolicy>{}, res_rng,
@@ -658,8 +658,7 @@ __pattern_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2
         __brick_copy<_ExecutionPolicy> __copy_range{};
 
         oneapi::dpl::__internal::__ranges::__pattern_walk_n(
-            oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__copy_keys_wrapper>(
-                ::std::forward<_ExecutionPolicy>(__exec)),
+            oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__copy_keys_wrapper>(__exec),
             __copy_range, ::std::forward<_Range1>(__keys), ::std::forward<_Range3>(__out_keys));
 
         oneapi::dpl::__internal::__ranges::__pattern_walk_n(
@@ -704,8 +703,7 @@ __pattern_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2
     // adjacent element (marks end of real segments)
     // TODO: replace wgroup size with segment size based on platform specifics.
     auto __intermediate_result_end =
-        __pattern_copy_if(oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__assign_key1_wrapper>(
-                              ::std::forward<_ExecutionPolicy>(__exec)),
+        __pattern_copy_if(oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__assign_key1_wrapper>(__exec),
                           __view1, __view2,
                           [__n, __binary_pred, __wgroup_size](const auto& __a) {
                               // The size of key range for the (i-1) view is one less, so for the 0th index we do
@@ -722,8 +720,7 @@ __pattern_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2
 
     //reduce by segment
     oneapi::dpl::__par_backend_hetero::__parallel_for(
-        oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__reduce1_wrapper>(
-            ::std::forward<_ExecutionPolicy>(__exec)),
+        oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__reduce1_wrapper>(__exec),
         unseq_backend::__brick_reduce_idx<_BinaryOperator, decltype(__n)>(__binary_op, __n), __intermediate_result_end,
         oneapi::dpl::__ranges::take_view_simple(experimental::ranges::views::all_read(__idx),
                                                 __intermediate_result_end),
@@ -752,8 +749,7 @@ __pattern_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2
     // element is copied if it is the 0th element (marks beginning of first segment), or has a key not equal to
     // the adjacent element (end of a segment). Artificial segments based on wg size are not created.
     auto __result_end =
-        __pattern_copy_if(oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__assign_key2_wrapper>(
-                              ::std::forward<_ExecutionPolicy>(__exec)),
+        __pattern_copy_if(oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__assign_key2_wrapper>(__exec),
                           __view3, __view4,
                           [__binary_pred](const auto& __a) {
                               // The size of key range for the (i-1) view is one less, so for the 0th index we do

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -232,8 +232,8 @@ __pattern_search(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, 
     using _TagType = oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_Range1>;
 
     return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
-        oneapi::dpl::__par_backend_hetero::make_wrapped_policy<
-            oneapi::dpl::__par_backend_hetero::__find_policy_wrapper>(::std::forward<_ExecutionPolicy>(__exec)),
+        oneapi::dpl::__par_backend_hetero::make_wrapped_policy<oneapi::dpl::__par_backend_hetero::__find_policy_wrapper>
+            (::std::forward<_ExecutionPolicy>(__exec)),
         _Predicate{__pred}, _TagType{}, ::std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2));
 }
 
@@ -407,9 +407,8 @@ __pattern_remove_if(_ExecutionPolicy&& __exec, _Range&& __rng, _Predicate __pred
     oneapi::dpl::__par_backend_hetero::__internal::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec, __rng.size());
     auto __copy_rng = oneapi::dpl::__ranges::views::all(__buf.get_buffer());
 
-    auto __copy_last_id =
-        __pattern_copy_if(__exec, __rng, __copy_rng,
-                          __not_pred<_Predicate>{__pred}, oneapi::dpl::__internal::__pstl_assign());
+    auto __copy_last_id = __pattern_copy_if(__exec, __rng, __copy_rng, __not_pred<_Predicate>{__pred},
+                                            oneapi::dpl::__internal::__pstl_assign());
     auto __copy_rng_truncated = __copy_rng | oneapi::dpl::experimental::ranges::views::take(__copy_last_id);
 
     oneapi::dpl::__internal::__ranges::__pattern_walk_n(::std::forward<_ExecutionPolicy>(__exec),
@@ -455,8 +454,7 @@ __pattern_unique(_ExecutionPolicy&& __exec, _Range&& __rng, _BinaryPredicate __p
 
     oneapi::dpl::__par_backend_hetero::__internal::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec, __rng.size());
     auto res_rng = oneapi::dpl::__ranges::views::all(__buf.get_buffer());
-    auto res = __pattern_unique_copy(__exec, __rng, res_rng,
-                                     __pred, oneapi::dpl::__internal::__pstl_assign());
+    auto res = __pattern_unique_copy(__exec, __rng, res_rng, __pred, oneapi::dpl::__internal::__pstl_assign());
 
     __pattern_walk_n(::std::forward<_ExecutionPolicy>(__exec), __brick_copy<_ExecutionPolicy>{}, res_rng,
                      ::std::forward<_Range>(__rng));
@@ -662,8 +660,8 @@ __pattern_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2
             __copy_range, ::std::forward<_Range1>(__keys), ::std::forward<_Range3>(__out_keys));
 
         oneapi::dpl::__internal::__ranges::__pattern_walk_n(
-            oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__copy_values_wrapper>(
-                ::std::forward<_ExecutionPolicy>(__exec)),
+            oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__copy_values_wrapper>
+                (::std::forward<_ExecutionPolicy>(__exec)),
             __copy_range, ::std::forward<_Range2>(__values), ::std::forward<_Range4>(__out_values));
 
         return 1;
@@ -702,21 +700,18 @@ __pattern_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2
     // evenly divisible by wg size (ensures segments are not long), or has a key not equal to the
     // adjacent element (marks end of real segments)
     // TODO: replace wgroup size with segment size based on platform specifics.
-    auto __intermediate_result_end =
-        __pattern_copy_if(oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__assign_key1_wrapper>(__exec),
-                          __view1, __view2,
-                          [__n, __binary_pred, __wgroup_size](const auto& __a) {
-                              // The size of key range for the (i-1) view is one less, so for the 0th index we do
-                              // not check the keys for (i-1), but we still need to get its key value as it is the
-                              // start of a segment
-                              const auto index = ::std::get<0>(__a);
-                              if (index == 0)
-                                  return true;
-
-                              return ::std::get<0>(__a) % __wgroup_size == 0 ||              // segment size
-                                     !__binary_pred(::std::get<1>(__a), ::std::get<2>(__a)); //keys comparison
-                          },
-                          unseq_backend::__brick_assign_key_position{});
+    auto __intermediate_result_end = __pattern_copy_if(
+        oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__assign_key1_wrapper>(__exec), __view1, __view2,
+        [__n, __binary_pred, __wgroup_size](const auto& __a) {
+            // The size of key range for the (i-1) view is one less, so for the 0th index we do not check the keys
+            // for (i-1), but we still need to get its key value as it is the start of a segment
+            const auto index = ::std::get<0>(__a);
+            if (index == 0)
+                return true;
+            return index % __wgroup_size == 0                                 // segment size
+                   || !__binary_pred(::std::get<1>(__a), ::std::get<2>(__a)); // key comparison
+        },
+        unseq_backend::__brick_assign_key_position{});
 
     //reduce by segment
     oneapi::dpl::__par_backend_hetero::__parallel_for(
@@ -748,20 +743,16 @@ __pattern_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2
 
     // element is copied if it is the 0th element (marks beginning of first segment), or has a key not equal to
     // the adjacent element (end of a segment). Artificial segments based on wg size are not created.
-    auto __result_end =
-        __pattern_copy_if(oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__assign_key2_wrapper>(__exec),
-                          __view3, __view4,
-                          [__binary_pred](const auto& __a) {
-                              // The size of key range for the (i-1) view is one less, so for the 0th index we do
-                              // not check the keys for (i-1), but we still need to get its key value as it is the
-                              // start of a segment
-                              const auto index = ::std::get<0>(__a);
-                              if (index == 0)
-                                  return true;
-
-                              return !__binary_pred(::std::get<1>(__a), ::std::get<2>(__a)); //keys comparison
-                          },
-                          unseq_backend::__brick_assign_key_position{});
+    auto __result_end = __pattern_copy_if(
+        oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__assign_key2_wrapper>(__exec), __view3, __view4,
+        [__binary_pred](const auto& __a) {
+            // The size of key range for the (i-1) view is one less, so for the 0th index we do not check the keys
+            // for (i-1), but we still need to get its key value as it is the start of a segment
+            if (::std::get<0>(__a) == 0)
+                return true;
+            return !__binary_pred(::std::get<1>(__a), ::std::get<2>(__a)); // keys comparison
+        },
+        unseq_backend::__brick_assign_key_position{});
 
     //reduce by segment
     oneapi::dpl::__par_backend_hetero::__parallel_for(

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -314,10 +314,8 @@ struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name
         auto __kernels = __internal::__kernel_compiler<_LocalScanKernel, _GroupScanKernel>::__compile(__exec);
         auto __kernel_1 = __kernels[0];
         auto __kernel_2 = __kernels[1];
-        auto __wgroup_size_kernel_1 =
-            oneapi::dpl::__internal::__kernel_work_group_size(__exec, __kernel_1);
-        auto __wgroup_size_kernel_2 =
-            oneapi::dpl::__internal::__kernel_work_group_size(__exec, __kernel_2);
+        auto __wgroup_size_kernel_1 = oneapi::dpl::__internal::__kernel_work_group_size(__exec, __kernel_1);
+        auto __wgroup_size_kernel_2 = oneapi::dpl::__internal::__kernel_work_group_size(__exec, __kernel_2);
         __wgroup_size = ::std::min({__wgroup_size, __wgroup_size_kernel_1, __wgroup_size_kernel_2});
 #endif
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -311,14 +311,13 @@ struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name
 
 #if _ONEDPL_COMPILE_KERNEL
         //Actually there is one kernel_bundle for the all kernels of the pattern.
-        auto __kernels = __internal::__kernel_compiler<_LocalScanKernel, _GroupScanKernel>::__compile(
-            ::std::forward<_ExecutionPolicy>(__exec));
+        auto __kernels = __internal::__kernel_compiler<_LocalScanKernel, _GroupScanKernel>::__compile(__exec);
         auto __kernel_1 = __kernels[0];
         auto __kernel_2 = __kernels[1];
         auto __wgroup_size_kernel_1 =
-            oneapi::dpl::__internal::__kernel_work_group_size(::std::forward<_ExecutionPolicy>(__exec), __kernel_1);
+            oneapi::dpl::__internal::__kernel_work_group_size(__exec, __kernel_1);
         auto __wgroup_size_kernel_2 =
-            oneapi::dpl::__internal::__kernel_work_group_size(::std::forward<_ExecutionPolicy>(__exec), __kernel_2);
+            oneapi::dpl::__internal::__kernel_work_group_size(__exec, __kernel_2);
         __wgroup_size = ::std::min({__wgroup_size, __wgroup_size_kernel_1, __wgroup_size_kernel_2});
 #endif
 
@@ -839,11 +838,10 @@ __parallel_find_or(_ExecutionPolicy&& __exec, _Brick __f, _BrickTag __brick_tag,
     assert(__rng_n > 0);
 
     // TODO: find a way to generalize getting of reliable work-group size
-    auto __wgroup_size = oneapi::dpl::__internal::__max_work_group_size(::std::forward<_ExecutionPolicy>(__exec));
+    auto __wgroup_size = oneapi::dpl::__internal::__max_work_group_size(__exec);
 #if _ONEDPL_COMPILE_KERNEL
-    auto __kernel = __internal::__kernel_compiler<_FindOrKernel>::__compile(::std::forward<_ExecutionPolicy>(__exec));
-    __wgroup_size = ::std::min(__wgroup_size, oneapi::dpl::__internal::__kernel_work_group_size(
-                                                  ::std::forward<_ExecutionPolicy>(__exec), __kernel));
+    auto __kernel = __internal::__kernel_compiler<_FindOrKernel>::__compile(__exec);
+    __wgroup_size = ::std::min(__wgroup_size, oneapi::dpl::__internal::__kernel_work_group_size(__exec, __kernel));
 #endif
     auto __max_cu = oneapi::dpl::__internal::__max_compute_units(__exec);
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -767,12 +767,12 @@ __parallel_radix_sort(_ExecutionPolicy&& __exec, _Range&& __in_rng, _Proj __proj
             // TODO: convert to ordered type once at the first iteration and convert back at the last one
             if (__radix_iter % 2 == 0)
                 __event = __parallel_radix_sort_iteration<__radix_bits, __is_ascending, /*even=*/true>::submit(
-                    ::std::forward<_ExecutionPolicy>(__exec), __segments, __radix_iter,
-                    ::std::forward<_Range>(__in_rng), __out_rng, __tmp_buf, __event, __proj);
+                    __exec, __segments, __radix_iter,
+                    __in_rng, __out_rng, __tmp_buf, __event, __proj);
             else //swap __in_rng and __out_rng
                 __event = __parallel_radix_sort_iteration<__radix_bits, __is_ascending, /*even=*/false>::submit(
-                    ::std::forward<_ExecutionPolicy>(__exec), __segments, __radix_iter, __out_rng,
-                    ::std::forward<_Range>(__in_rng), __tmp_buf, __event, __proj);
+                    __exec, __segments, __radix_iter, __out_rng,
+                    __in_rng, __tmp_buf, __event, __proj);
         }
     }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -140,8 +140,7 @@ class __radix_sort_reorder_kernel;
 template <typename _KernelName, ::std::uint32_t __radix_bits, bool __is_ascending, typename _ExecutionPolicy,
           typename _ValRange, typename _CountBuf, typename _Proj
 #if _ONEDPL_COMPILE_KERNEL
-          ,
-          typename _Kernel
+          , typename _Kernel
 #endif
           >
 sycl::event
@@ -149,8 +148,7 @@ __radix_sort_count_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments, :
                           ::std::uint32_t __radix_offset, _ValRange&& __val_rng, _CountBuf& __count_buf,
                           sycl::event __dependency_event, _Proj __proj
 #if _ONEDPL_COMPILE_KERNEL
-                          ,
-                          _Kernel& __kernel
+                          , _Kernel& __kernel
 #endif
 )
 {
@@ -240,16 +238,14 @@ __radix_sort_count_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments, :
 
 template <typename _KernelName, ::std::uint32_t __radix_bits, typename _ExecutionPolicy, typename _CountBuf
 #if _ONEDPL_COMPILE_KERNEL
-          ,
-          typename _Kernel
+          , typename _Kernel
 #endif
           >
 sycl::event
 __radix_sort_scan_submit(_ExecutionPolicy&& __exec, ::std::size_t __scan_wg_size, ::std::size_t __segments,
                          _CountBuf& __count_buf, sycl::event __dependency_event
 #if _ONEDPL_COMPILE_KERNEL
-                         ,
-                         _Kernel& __kernel
+                         , _Kernel& __kernel
 #endif
 )
 {
@@ -423,8 +419,7 @@ struct __peer_prefix_helper<_OffsetT, __peer_prefix_algo::subgroup_ballot>
 template <typename _KernelName, ::std::uint32_t __radix_bits, bool __is_ascending, __peer_prefix_algo _PeerAlgo,
           typename _ExecutionPolicy, typename _InRange, typename _OutRange, typename _OffsetBuf, typename _Proj
 #if _ONEDPL_COMPILE_KERNEL
-          ,
-          typename _Kernel
+          , typename _Kernel
 #endif
           >
 sycl::event
@@ -433,8 +428,7 @@ __radix_sort_reorder_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments,
                             _OutRange&& __output_rng, _OffsetBuf& __offset_buf, sycl::event __dependency_event,
                             _Proj __proj
 #if _ONEDPL_COMPILE_KERNEL
-                            ,
-                            _Kernel& __kernel
+                            , _Kernel& __kernel
 #endif
 )
 {
@@ -623,8 +617,7 @@ struct __parallel_radix_sort_iteration
         sycl::event __count_event = __radix_sort_count_submit<_RadixCountKernel, __radix_bits, __is_ascending>(
             __exec, __segments, __block_size, __radix_offset, __in_rng, __tmp_buf, __dependency_event, __proj
 #if _ONEDPL_COMPILE_KERNEL
-            ,
-            __count_kernel
+            , __count_kernel
 #endif
         );
 
@@ -632,8 +625,7 @@ struct __parallel_radix_sort_iteration
         sycl::event __scan_event = __radix_sort_scan_submit<_RadixLocalScanKernel, __radix_bits>(
             __exec, __scan_wg_size, __segments, __tmp_buf, __count_event
 #if _ONEDPL_COMPILE_KERNEL
-            ,
-            __local_scan_kernel
+            , __local_scan_kernel
 #endif
         );
 
@@ -654,8 +646,7 @@ struct __parallel_radix_sort_iteration
                 __exec, __segments, __block_size, __reorder_sg_size, __radix_offset, ::std::forward<_InRange>(__in_rng),
                 ::std::forward<_OutRange>(__out_rng), __tmp_buf, __scan_event, __proj
 #if _ONEDPL_COMPILE_KERNEL
-                    ,
-                    __reorder_peer_kernel
+                    , __reorder_peer_kernel
 #endif
                 );
         }
@@ -666,8 +657,7 @@ struct __parallel_radix_sort_iteration
                 __exec, __segments, __block_size, __reorder_sg_size, __radix_offset, ::std::forward<_InRange>(__in_rng),
                 ::std::forward<_OutRange>(__out_rng), __tmp_buf, __scan_event, __proj
 #if _ONEDPL_COMPILE_KERNEL
-                ,
-                __reorder_kernel
+                , __reorder_kernel
 #endif
             );
         }
@@ -756,7 +746,7 @@ __parallel_radix_sort(_ExecutionPolicy&& __exec, _Range&& __in_rng, _Proj __proj
         // memory for storing values sorted for an iteration
         __internal::__buffer<_DecExecutionPolicy, _ValueT> __out_buffer_holder{__exec, __n};
         __val_buf = __out_buffer_holder.get_buffer();
-        auto __out_rng = 
+        auto __out_rng =
             oneapi::dpl::__ranges::all_view<_ValueT, __par_backend_hetero::access_mode::read_write>(__val_buf);
 
         // iterations per each bucket
@@ -767,12 +757,10 @@ __parallel_radix_sort(_ExecutionPolicy&& __exec, _Range&& __in_rng, _Proj __proj
             // TODO: convert to ordered type once at the first iteration and convert back at the last one
             if (__radix_iter % 2 == 0)
                 __event = __parallel_radix_sort_iteration<__radix_bits, __is_ascending, /*even=*/true>::submit(
-                    __exec, __segments, __radix_iter,
-                    __in_rng, __out_rng, __tmp_buf, __event, __proj);
+                    __exec, __segments, __radix_iter, __in_rng, __out_rng, __tmp_buf, __event, __proj);
             else //swap __in_rng and __out_rng
                 __event = __parallel_radix_sort_iteration<__radix_bits, __is_ascending, /*even=*/false>::submit(
-                    __exec, __segments, __radix_iter, __out_rng,
-                    __in_rng, __tmp_buf, __event, __proj);
+                    __exec, __segments, __radix_iter, __out_rng, __in_rng, __tmp_buf, __event, __proj);
         }
     }
 

--- a/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
@@ -103,8 +103,7 @@ __pattern_transform_scan_base(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Rang
     _NoOpFunctor __get_data_op;
 
     oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(
-        ::std::forward<_ExecutionPolicy>(__exec), __rng1, ::std::forward<_Range2>(__rng2),
-        __binary_op, __init,
+        ::std::forward<_ExecutionPolicy>(__exec), __rng1, ::std::forward<_Range2>(__rng2), __binary_op, __init,
         // local scan
         unseq_backend::__scan<_Inclusive, _ExecutionPolicy, _BinaryOperation, _UnaryFunctor, _Assigner, _Assigner,
                               _NoOpFunctor, _InitType>{__binary_op, _UnaryFunctor{__unary_op}, __assign_op, __assign_op,

--- a/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
@@ -103,7 +103,7 @@ __pattern_transform_scan_base(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Rang
     _NoOpFunctor __get_data_op;
 
     oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(
-        ::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2),
+        ::std::forward<_ExecutionPolicy>(__exec), __rng1, ::std::forward<_Range2>(__rng2),
         __binary_op, __init,
         // local scan
         unseq_backend::__scan<_Inclusive, _ExecutionPolicy, _BinaryOperation, _UnaryFunctor, _Assigner, _Assigner,


### PR DESCRIPTION
Use of an object after it was forwarded or moved is incorrect, and is reported as an issue by static analysis tools.