### PR TITLE
Define missed variables in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,13 +32,17 @@ string(REGEX REPLACE ".*#define ONEDPL_VERSION_MAJOR ([0-9]+).*" "\\1" _onedpl_v
 string(REGEX REPLACE ".*#define ONEDPL_VERSION_MINOR ([0-9]+).*" "\\1" _onedpl_ver_minor "${_onedpl_version_info}")
 string(REGEX REPLACE ".*#define ONEDPL_VERSION_PATCH ([0-9]+).*" "\\1" _onedpl_ver_patch "${_onedpl_version_info}")
 
-if (CMAKE_CXX_COMPILER MATCHES ".*(dpcpp-cl|icx-cl|icx)(.exe)?$")
-    set(INTEL_LLVM_COMPILER_MSVC_LIKE TRUE)
-elseif(CMAKE_CXX_COMPILER MATCHES ".*(dpcpp|icpx)(.exe)?$")
-    set(INTEL_LLVM_COMPILER_GNU_LIKE TRUE)
+# CMAKE_CXX_COMPILER_ID and CMAKE_CXX_COMPILER_VERSION_ID cannot be used because
+# CMake 3.19 and older will detect IntelLLVM compiler as CLang with CLang-specific version, see https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER_ID.html
+if (CMAKE_CXX_COMPILER MATCHES ".*(dpcpp-cl|dpcpp|icx-cl|icpx|icx)(.exe)?$")
+    set(INTEL_LLVM_COMPILER TRUE)
+    execute_process(COMMAND ${CMAKE_CXX_COMPILER} --version OUTPUT_VARIABLE INTEL_LLVM_COMPILER_VERSION_RAW)
+    string(REGEX MATCH "[0-9][0-9][0-9][0-9]\\.[0-9]\\.[0-9]" INTEL_LLVM_COMPILER_VERSION ${INTEL_LLVM_COMPILER_VERSION_RAW})
+else()
+    set(INTEL_LLVM_COMPILER FALSE)
 endif()
 
-if (CMAKE_HOST_WIN32 AND (INTEL_LLVM_COMPILER_MSVC_LIKE OR INTEL_LLVM_COMPILER_GNU_LIKE))
+if (CMAKE_HOST_WIN32 AND INTEL_LLVM_COMPILER)
     if (_onedpl_is_subproject)
         # If oneDPL is a subproject, warn if workarounds are not included
         if (NOT oneDPLWindowsIntelLLVM_FOUND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ string(REGEX REPLACE ".*#define ONEDPL_VERSION_MAJOR ([0-9]+).*" "\\1" _onedpl_v
 string(REGEX REPLACE ".*#define ONEDPL_VERSION_MINOR ([0-9]+).*" "\\1" _onedpl_ver_minor "${_onedpl_version_info}")
 string(REGEX REPLACE ".*#define ONEDPL_VERSION_PATCH ([0-9]+).*" "\\1" _onedpl_ver_patch "${_onedpl_version_info}")
 
-# CMAKE_CXX_COMPILER_ID and CMAKE_CXX_COMPILER_VERSION_ID cannot be used because
+# CMAKE_CXX_COMPILER_ID and CMAKE_CXX_COMPILER_VERSION cannot be used because
 # CMake 3.19 and older will detect IntelLLVM compiler as CLang with CLang-specific version, see https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER_ID.html
 if (CMAKE_CXX_COMPILER MATCHES ".*(dpcpp-cl|dpcpp|icx-cl|icpx|icx)(.exe)?$")
     set(INTEL_LLVM_COMPILER TRUE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ include(CMakeDependentOption)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 option(ONEDPL_FPGA_STATIC_REPORT "Enable the static report generation for the FPGA device" OFF)
-option(ONEDPL_USE_AOT_COMPILATION "Enable the ahead of time compilation via OCLOC compiler" OFF)
+option(ONEDPL_USE_AOT_COMPILATION "Enable the ahead of time compilation" OFF)
 option(ONEDPL_ENABLE_SIMD "Enable SIMD vectorization by passing an OpenMP SIMD flag to the compiler if supported" ON)
 cmake_dependent_option(ONEDPL_TEST_WIN_ICX_FIXES "Enable icx workarounds for Windows" ON "CMAKE_HOST_WIN32;NOT _onedpl_is_subproject" OFF)
 

--- a/cmake/oneDPLWindowsIntelLLVMConfig.cmake
+++ b/cmake/oneDPLWindowsIntelLLVMConfig.cmake
@@ -21,7 +21,7 @@ if (DEFINED CMAKE_PROJECT_NAME AND (NOT DEFINED oneDPLWindowsIntelLLVM_DIR))
     set(REASON_FAILURE "oneDPLWindowsIntelLLVM package must be included before the project() call!")
 else()
 
-    # CMAKE_CXX_COMPILER and CMAKE_CXX_COMPILER_VERSION cannot be used because
+    # CMAKE_CXX_COMPILER_ID and CMAKE_CXX_COMPILER_VERSION_ID cannot be used because
     # CMake 3.19 and older will detect IntelLLVM compiler as CLang with CLang-specific version, see https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER_ID.html
     if (CMAKE_CXX_COMPILER MATCHES ".*(dpcpp-cl|dpcpp|icx-cl|icpx|icx)(.exe)?$")
         set(INTEL_LLVM_COMPILER TRUE)
@@ -77,7 +77,7 @@ else()
 
     # The following are planned workarounds to be applied after project() by oneDPL CMake files
     if (CMAKE_HOST_WIN32 AND INTEL_LLVM_COMPILER_MSVC_LIKE)
-        # Fix std compiler options for icx, icx-cl 
+        # Fix std compiler options for icx, icx-cl
         # Adapted from fix in CMake 3.26: https://github.com/Kitware/CMake/commit/42ca6416afeabd445bc6c19749e68604c9c2d733
         if (${CMAKE_VERSION} VERSION_LESS "3.26")
             set(INTELLLVM_MSVC_WIN_STDOPTION_FIX TRUE)
@@ -105,7 +105,7 @@ else()
     endif()
 endif()
 
-find_package_handle_standard_args(oneDPLWindowsIntelLLVM 
+find_package_handle_standard_args(oneDPLWindowsIntelLLVM
     FOUND_VAR oneDPLWindowsIntelLLVM_FOUND
     REQUIRED_VARS INTEL_LLVM_COMPILER
     REASON_FAILURE_MESSAGE "${REASON_FAILURE}")

--- a/cmake/oneDPLWindowsIntelLLVMConfig.cmake
+++ b/cmake/oneDPLWindowsIntelLLVMConfig.cmake
@@ -21,7 +21,7 @@ if (DEFINED CMAKE_PROJECT_NAME AND (NOT DEFINED oneDPLWindowsIntelLLVM_DIR))
     set(REASON_FAILURE "oneDPLWindowsIntelLLVM package must be included before the project() call!")
 else()
 
-    # CMAKE_CXX_COMPILER_ID and CMAKE_CXX_COMPILER_VERSION_ID cannot be used because
+    # CMAKE_CXX_COMPILER_ID and CMAKE_CXX_COMPILER_VERSION cannot be used because
     # CMake 3.19 and older will detect IntelLLVM compiler as CLang with CLang-specific version, see https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER_ID.html
     if (CMAKE_CXX_COMPILER MATCHES ".*(dpcpp-cl|dpcpp|icx-cl|icpx|icx)(.exe)?$")
         set(INTEL_LLVM_COMPILER TRUE)


### PR DESCRIPTION
CMakeLists relies on `INTEL_LLVM_COMPILER` and `INTEL_LLVM_COMPILER_VERSION` variables. Currently, they are not defined unless `ONEDPL_TEST_WIN_ICX_FIXES` is on.

A side effect of the change is that when `ONEDPL_TEST_WIN_ICX_FIXES` is on and this `CMakeLists` is used, these variables are set again inside `oneDPLWindowsIntelLLVMConfig.cmake` and have the same values. This does not change CMake behavior.

I additionally corrected a message for `ONEDPL_USE_AOT_COMPILATION`, because AOT compilation does not depend on OCLOC compiler (only) since #794.