### PR TITLE
Ensure absence of overflow due to unintentional use of 32-bit arithmetic

### DIFF
--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -613,7 +613,7 @@ __dpl_bit_floor(_T __x) noexcept
     return ::std::bit_floor(__x);
 #elif _ONEDPL_BACKEND_SYCL
     // Use the count-leading-zeros function
-    return 1 << (sizeof(_T) * CHAR_BIT - sycl::clz(__x) - 1);
+    return _T{1} << (sizeof(_T) * CHAR_BIT - sycl::clz(__x) - 1);
 #else
     // Fill all the lower bits with 1s
     __x |= (__x >> 1);
@@ -623,7 +623,7 @@ __dpl_bit_floor(_T __x) noexcept
     if constexpr (sizeof(_T) > 2) __x |= (__x >> 16);
     if constexpr (sizeof(_T) > 4) __x |= (__x >> 32);
     __x += 1; // Now it equals to the next greater power of 2, or 0 in case of wraparound
-    return (__x == 0) ? 1 << (sizeof(_T) * CHAR_BIT - 1) : __x >> 1;
+    return (__x == 0) ? _T{1} << (sizeof(_T) * CHAR_BIT - 1) : __x >> 1;
 #endif
 }
 

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
@@ -63,8 +63,8 @@ DEFINE_TEST(test_exclusive_scan_by_segment)
         //T vals[n1] = { 1, 1, 1, 1, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 3, ...};
 
         assert(init == 0 || init == 1);
-        int segment_length = 1;
-        auto expected_segment_sum = init;
+        T segment_length = 1;
+        T expected_segment_sum = init;
         auto current_key = host_keys[0];
         typename std::decay<decltype(val_res[0])>::type current_sum = 0;
         for (int i = 0; i != n; ++i)
@@ -78,7 +78,8 @@ DEFINE_TEST(test_exclusive_scan_by_segment)
                 current_key = host_keys[i];
                 if (current_key == 1) {
                     ++segment_length;
-                    expected_segment_sum = init == 1 ? segment_length * (segment_length + 1) / 2 : segment_length * (segment_length - 1) / 2;
+                    expected_segment_sum = (init == 1) ? segment_length * (segment_length + 1) / 2
+                                                       : segment_length * (segment_length - 1) / 2;
                 }
             }
         }


### PR DESCRIPTION
Address another potential issue found by static code analysis: intermediate computations are done in 32 bit while the result is then assigned to 64-bit variables