### PR TITLE
[KT] Add int support for onesweep radix sort

### DIFF
--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
@@ -590,7 +590,7 @@ onesweep(_ExecutionPolicy&& __exec, _Range&& __rng, ::std::size_t __n)
     uint8_t *tmp_buffer = sycl::malloc_device<uint8_t>(temp_buffer_size, __exec.queue());
     auto p_global_offset = reinterpret_cast<uint32_t*>(tmp_buffer);
     auto p_sync_buffer = reinterpret_cast<uint32_t*>(tmp_buffer + GLOBAL_OFFSET_SIZE);
-    auto p_output = sycl::malloc_device<uint32_t>(__n, __exec.queue());
+    auto p_output = sycl::malloc_device<KeyT>(__n, __exec.queue());
     auto e_init = __exec.queue().memset(tmp_buffer, 0, temp_buffer_size);
 
     sycl::event event_chain = __radix_sort_onesweep_histogram_submitter<

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
@@ -87,7 +87,7 @@ void global_histogram(sycl::nd_item<1> idx, size_t __n, const InputT& input, uin
                 sycl::ext::intel::esimd::simd offset((read_addr + s + lane_id)*sizeof(KeyT));
                 simd<KeyT, 16> source = lsc_gather<KeyT, 1, lsc_data_size::default_size, cache_hint::cached, cache_hint::cached, 16>(input, offset, m);
 
-                keys.template select<16, 1>(s) = merge(source, simd<KeyT, 16>(-1), m);
+                keys.template select<16, 1>(s) = merge(source, simd<KeyT, 16>(utils::__sort_identity<KeyT, IsAscending>), m);
             }
         }
         #pragma unroll

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
@@ -548,7 +548,7 @@ struct __radix_sort_onesweep_submitter<KeyT, RADIX_BITS, THREAD_PER_TG, PROCESS_
 
 template <typename _ExecutionPolicy, typename KeyT, typename _Range, ::std::uint32_t RADIX_BITS,
           bool IsAscending, ::std::uint32_t PROCESS_SIZE>
-std::enable_if_t<!::std::is_unsigned_v<KeyT>, void>
+std::enable_if_t<!::std::is_unsigned_v<KeyT> && !::std::is_signed_v<KeyT>, void>
 onesweep(_ExecutionPolicy&& __exec, _Range&& __rng, ::std::size_t __n)
 {
     // TODO: remove this when the implementation below can compile for other data types
@@ -556,7 +556,7 @@ onesweep(_ExecutionPolicy&& __exec, _Range&& __rng, ::std::size_t __n)
 
 template <typename _ExecutionPolicy, typename KeyT, typename _Range, ::std::uint32_t RADIX_BITS,
           bool IsAscending, ::std::uint32_t PROCESS_SIZE>
-std::enable_if_t<::std::is_unsigned_v<KeyT>, void>
+std::enable_if_t<::std::is_unsigned_v<KeyT> || ::std::is_signed_v<KeyT>, void>
 onesweep(_ExecutionPolicy&& __exec, _Range&& __rng, ::std::size_t __n)
 {
     using namespace sycl;

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
@@ -548,7 +548,7 @@ struct __radix_sort_onesweep_submitter<KeyT, RADIX_BITS, THREAD_PER_TG, PROCESS_
 
 template <typename _ExecutionPolicy, typename KeyT, typename _Range, ::std::uint32_t RADIX_BITS,
           bool IsAscending, ::std::uint32_t PROCESS_SIZE>
-std::enable_if_t<!::std::is_unsigned_v<KeyT> && !::std::is_signed_v<KeyT>, void>
+std::enable_if_t<!::std::is_integral_v<KeyT>, void>
 onesweep(_ExecutionPolicy&& __exec, _Range&& __rng, ::std::size_t __n)
 {
     // TODO: remove this when the implementation below can compile for other data types
@@ -556,7 +556,7 @@ onesweep(_ExecutionPolicy&& __exec, _Range&& __rng, ::std::size_t __n)
 
 template <typename _ExecutionPolicy, typename KeyT, typename _Range, ::std::uint32_t RADIX_BITS,
           bool IsAscending, ::std::uint32_t PROCESS_SIZE>
-std::enable_if_t<::std::is_unsigned_v<KeyT> || ::std::is_signed_v<KeyT>, void>
+std::enable_if_t<::std::is_integral_v<KeyT>, void>
 onesweep(_ExecutionPolicy&& __exec, _Range&& __rng, ::std::size_t __n)
 {
     using namespace sycl;

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
@@ -165,7 +165,7 @@ struct slm_lookup_t {
     }
 };
 
-template <typename KeyT, typename InputT, typename OutputT, uint32_t RADIX_BITS, uint32_t SG_PER_WG, uint32_t PROCESS_SIZE>
+template <typename KeyT, typename InputT, typename OutputT, uint32_t RADIX_BITS, uint32_t SG_PER_WG, uint32_t PROCESS_SIZE, bool IsAscending>
 struct radix_sort_onesweep_slm_reorder_kernel {
     using bin_t = uint16_t;
     using hist_t = uint16_t;
@@ -527,7 +527,7 @@ struct __radix_sort_onesweep_submitter<KeyT, RADIX_BITS, THREAD_PER_TG, PROCESS_
                 oneapi::dpl::__ranges::__require_access(__cgh, __rng);
                 auto __data = __rng.data();
                 __cgh.depends_on(__e);
-                radix_sort_onesweep_slm_reorder_kernel<KeyT, decltype(__data), _Output, RADIX_BITS, THREAD_PER_TG, PROCESS_SIZE>
+                radix_sort_onesweep_slm_reorder_kernel<KeyT, decltype(__data), _Output, RADIX_BITS, THREAD_PER_TG, PROCESS_SIZE, IsAscending>
                     K(__n, __stage, __data, __output, __tmp_data);
                 __cgh.parallel_for<_Name...>(__nd_range, K);
             });
@@ -538,7 +538,7 @@ struct __radix_sort_onesweep_submitter<KeyT, RADIX_BITS, THREAD_PER_TG, PROCESS_
                 oneapi::dpl::__ranges::__require_access(__cgh, __rng);
                 auto __data = __rng.data();
                 __cgh.depends_on(__e);
-                radix_sort_onesweep_slm_reorder_kernel<KeyT, _Output, decltype(__data), RADIX_BITS, THREAD_PER_TG, PROCESS_SIZE>
+                radix_sort_onesweep_slm_reorder_kernel<KeyT, _Output, decltype(__data), RADIX_BITS, THREAD_PER_TG, PROCESS_SIZE, IsAscending>
                     K(__n, __stage, __output, __data, __tmp_data);
                 __cgh.parallel_for<_Name...>(__nd_range, K);
             });

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
@@ -370,7 +370,7 @@ struct radix_sort_onesweep_slm_reorder_kernel {
         simd<device_addr_t, 16> lane_id(0, 1);
 
         device_addr_t io_offset = PROCESS_SIZE * (wg_id*wg_size+local_tid);
-        constexpr KeyT default_key = -1;
+        constexpr KeyT default_key = utils::__sort_identity<KeyT, IsAscending>;
 
         LoadKeys<16>(io_offset, keys, default_key);
 

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -289,12 +289,12 @@ template <typename T, int VSize, int LANES,
     __ESIMD_ENS::cache_hint H1 = __ESIMD_ENS::cache_hint::none,
     __ESIMD_ENS::cache_hint H3 = __ESIMD_ENS::cache_hint::none>
 inline std::enable_if_t<(VSize <= 4 && LANES <= 32), void>
-VectorStore(T* src,
+VectorStore(T* dest,
             __ESIMD_NS::simd<uint32_t, LANES> offset,
             __ESIMD_NS::simd<T, VSize * LANES> data,
             __ESIMD_NS::simd_mask<LANES> mask = 1)
 {
-    __ESIMD_ENS::lsc_scatter<T, VSize, __ESIMD_ENS::lsc_data_size::default_size, H1, H3, LANES>(src, offset, data, mask);
+    __ESIMD_ENS::lsc_scatter<T, VSize, __ESIMD_ENS::lsc_data_size::default_size, H1, H3, LANES>(dest, offset, data, mask);
 }
 
 template <typename T, int VSize, int LANES, typename AccessorTy,
@@ -314,13 +314,13 @@ template <typename T, int VSize, int LANES,
     __ESIMD_ENS::cache_hint H1 = __ESIMD_ENS::cache_hint::none,
     __ESIMD_ENS::cache_hint H3 = __ESIMD_ENS::cache_hint::none>
 inline std::enable_if_t<(LANES > 32), void>
-VectorStore(T* src,
+VectorStore(T* dest,
             __ESIMD_NS::simd<uint32_t, LANES> offset,
             __ESIMD_NS::simd<T, VSize * LANES> data,
             __ESIMD_NS::simd_mask<LANES> mask = 1)
 {
-    VectorStore<T, VSize, 32>(src, offset.template select<32, 1>(0), data.template select<VSize*32, 1>(0), mask.template select<32, 1>(0));
-    VectorStore<T, VSize, LANES - 32>(src, offset.template select<LANES - 32, 1>(32), data.template select<VSize * (LANES - 32), 1>(32), mask.template select<LANES-32, 1>(32));
+    VectorStore<T, VSize, 32>(dest, offset.template select<32, 1>(0), data.template select<VSize*32, 1>(0), mask.template select<32, 1>(0));
+    VectorStore<T, VSize, LANES - 32>(dest, offset.template select<LANES - 32, 1>(32), data.template select<VSize * (LANES - 32), 1>(32), mask.template select<LANES-32, 1>(32));
 }
 
 template <typename T, int VSize, int LANES, typename AccessorTy,
@@ -343,13 +343,13 @@ template <typename T, int VSize, int LANES,
     __ESIMD_ENS::cache_hint H1 = __ESIMD_ENS::cache_hint::none,
     __ESIMD_ENS::cache_hint H3 = __ESIMD_ENS::cache_hint::none>
 inline std::enable_if_t<(VSize > 4 && LANES <= 32), void>
-VectorStore(T* src,
+VectorStore(T* dest,
             __ESIMD_NS::simd<uint32_t, LANES> offset,
             __ESIMD_NS::simd<T, VSize * LANES> data,
             __ESIMD_NS::simd_mask<LANES> mask = 1)
 {
-    VectorStore<T, 4, LANES>(src, offset, data.template select<4*LANES, 1>(0), mask);
-    VectorStore<T, VSize-4, LANES>(src, offset+4*sizeof(T), data.template select<(VSize-4)*LANES, 1>(4*LANES), mask);
+    VectorStore<T, 4, LANES>(dest, offset, data.template select<4*LANES, 1>(0), mask);
+    VectorStore<T, VSize-4, LANES>(dest, offset+4*sizeof(T), data.template select<(VSize-4)*LANES, 1>(4*LANES), mask);
 }
 
 template <typename T, int VSize, int LANES, typename AccessorTy,
@@ -372,13 +372,13 @@ template <typename T, int VSize, int LANES,
     __ESIMD_ENS::cache_hint H1 = __ESIMD_ENS::cache_hint::none,
     __ESIMD_ENS::cache_hint H3 = __ESIMD_ENS::cache_hint::none>
 inline void
-VectorStore(T* src,
+VectorStore(T* dest,
             uint32_t offset,
             __ESIMD_NS::simd<T, VSize * LANES> data,
             __ESIMD_NS::simd_mask<LANES> mask = 1)
 {
     // optimization needed here, hard for compiler to optimize the offset vector calculation
-    VectorStore<T, VSize, LANES, H1, H3>(src, {offset, LaneStride*sizeof(T)}, data, mask);
+    VectorStore<T, VSize, LANES, H1, H3>(dest, {offset, LaneStride*sizeof(T)}, data, mask);
 }
 
 template <typename T, int VSize, int LANES, typename AccessorTy,

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -294,7 +294,7 @@ VectorStore(T* src,
             __ESIMD_NS::simd<T, VSize * LANES> data,
             __ESIMD_NS::simd_mask<LANES> mask = 1)
 {
-    return __ESIMD_ENS::lsc_scatter<T, VSize, __ESIMD_ENS::lsc_data_size::default_size, H1, H3, LANES>(src, offset, data, mask);
+    __ESIMD_ENS::lsc_scatter<T, VSize, __ESIMD_ENS::lsc_data_size::default_size, H1, H3, LANES>(src, offset, data, mask);
 }
 
 template <typename T, int VSize, int LANES, typename AccessorTy,
@@ -306,7 +306,7 @@ VectorStore(AccessorTy acc,
             __ESIMD_NS::simd<T, VSize * LANES> data,
             __ESIMD_NS::simd_mask<LANES> mask = 1)
 {
-    return __ESIMD_ENS::lsc_scatter<T, VSize, __ESIMD_ENS::lsc_data_size::default_size, H1, H3, LANES>(acc, offset, data, mask);
+    __ESIMD_ENS::lsc_scatter<T, VSize, __ESIMD_ENS::lsc_data_size::default_size, H1, H3, LANES>(acc, offset, data, mask);
 }
 
 
@@ -378,7 +378,7 @@ VectorStore(T* src,
             __ESIMD_NS::simd_mask<LANES> mask = 1)
 {
     // optimization needed here, hard for compiler to optimize the offset vector calculation
-    return VectorStore<T, VSize, LANES, H1, H3>(src, {offset, LaneStride*sizeof(T)}, data, mask);
+    VectorStore<T, VSize, LANES, H1, H3>(src, {offset, LaneStride*sizeof(T)}, data, mask);
 }
 
 template <typename T, int VSize, int LANES, typename AccessorTy,
@@ -392,7 +392,7 @@ VectorStore(AccessorTy acc,
             __ESIMD_NS::simd_mask<LANES> mask = 1)
 {
     // optimization needed here, hard for compiler to optimize the offset vector calculation
-    return VectorStore<T, VSize, LANES, H1, H3>(acc, {offset, LaneStride*sizeof(T)}, data, mask);
+    VectorStore<T, VSize, LANES, H1, H3>(acc, {offset, LaneStride*sizeof(T)}, data, mask);
 }
 
 template <typename T, int VSize, int LANES>

--- a/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
+++ b/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
@@ -234,9 +234,9 @@ int main()
         {
             test_usm<uint32_t, sycl::usm::alloc::shared>(size);
             test_usm<uint32_t, sycl::usm::alloc::device>(size);
-            
-            test_usm<int32_t, sycl::usm::alloc::shared>(size);
-            test_usm<int32_t, sycl::usm::alloc::device>(size);
+
+            test_usm<int, sycl::usm::alloc::shared>(size);
+            test_usm<int, sycl::usm::alloc::device>(size);
         }
         test_small_sizes();
     }

--- a/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
+++ b/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
@@ -234,6 +234,9 @@ int main()
         {
             test_usm<uint32_t, sycl::usm::alloc::shared>(size);
             test_usm<uint32_t, sycl::usm::alloc::device>(size);
+            
+            test_usm<int32_t, sycl::usm::alloc::shared>(size);
+            test_usm<int32_t, sycl::usm::alloc::device>(size);
         }
         test_small_sizes();
     }


### PR DESCRIPTION
What's done:
- fixed compile error for onesweep radix sort for non uint32_t types in the file [esimd_radix_sort_onesweep.h](https://github.com/oneapi-src/oneDPL/pull/947/files#diff-e1ae92ade037e076287bd65fc13b927416746cfda57f50e38ac3161f9dcde285)
```auto p_output = sycl::malloc_device<uint32_t>(__n, __exec.queue());```
    -> ```auto p_output = sycl::malloc_device<KeyT>(__n, __exec.queue());```
- added support of all types into onesweep like as ```::std::is_integral_v<KeyT>```
- changed initial value from '''-1''' to ```utils::__sort_identity<KeyT, IsAscending>)```
- renamed some params in ```VectorStore``` functions: ```src``` -> ```dest```
- added test on onesweep sort for ```int``` type on USM shared/device memory