### PR TITLE
[Tests] Fix UB in the tests (may happen with multiple TUs)

### DIFF
--- a/test/support/utils_invoke.h
+++ b/test/support/utils_invoke.h
@@ -107,7 +107,7 @@ struct invoke_on_all_host_policies
 #if TEST_DPCPP_BACKEND_PRESENT
 
 // Implemented in utils_sycl.h, required to include this file.
-sycl::queue& get_test_queue();
+sycl::queue get_test_queue();
 
 ////////////////////////////////////////////////////////////////////////////////
 // check fp16/fp64 support by a device

--- a/test/support/utils_invoke.h
+++ b/test/support/utils_invoke.h
@@ -107,7 +107,7 @@ struct invoke_on_all_host_policies
 #if TEST_DPCPP_BACKEND_PRESENT
 
 // Implemented in utils_sycl.h, required to include this file.
-sycl::queue get_test_queue();
+sycl::queue& get_test_queue();
 
 ////////////////////////////////////////////////////////////////////////////////
 // check fp16/fp64 support by a device

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -134,7 +134,7 @@ make_new_policy(_Policy&& __policy)
 #endif     // ONEDPL_FPGA_DEVICE
 
 // create the queue with custom asynchronous exceptions handler
-static auto my_queue = sycl::queue(default_selector, async_handler);
+inline auto my_queue = sycl::queue(default_selector, async_handler);
 
 inline
 sycl::queue get_test_queue()

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -134,7 +134,7 @@ make_new_policy(_Policy&& __policy)
 #endif     // ONEDPL_FPGA_DEVICE
 
 inline
-sycl::queue& get_test_queue()
+sycl::queue get_test_queue()
 {
     // create the queue with custom asynchronous exceptions handler
     static sycl::queue my_queue(default_selector, async_handler);

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -133,12 +133,11 @@ make_new_policy(_Policy&& __policy)
 #    endif // ONEDPL_USE_PREDEFINED_POLICIES
 #endif     // ONEDPL_FPGA_DEVICE
 
-// create the queue with custom asynchronous exceptions handler
-inline auto my_queue = sycl::queue(default_selector, async_handler);
-
 inline
-sycl::queue get_test_queue()
+sycl::queue& get_test_queue()
 {
+    // create the queue with custom asynchronous exceptions handler
+    static sycl::queue my_queue(default_selector, async_handler);
     return my_queue;
 }
 


### PR DESCRIPTION
C++ specification says:
> If an inline function or variable (since C++17) with external linkage is defined differently in different translation units, the behavior is undefined.

`get_test_queue()` uses `my_queue`, which is linked internally and thus has different addresses in each TU.