### PR TITLE
Replace deprecated FPGA selector

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -94,9 +94,9 @@ class fpga_policy : public device_policy<KernelName>
     fpga_policy()
         : base(sycl::queue(
 #    if _ONEDPL_FPGA_EMU
-              __dpl_sycl::__fpga_emulator_selector {}
+              __dpl_sycl::__fpga_emulator_selector()
 #    else
-              __dpl_sycl::__fpga_selector {}
+              __dpl_sycl::__fpga_selector()
 #    endif // _ONEDPL_FPGA_EMU
               ))
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -212,27 +212,33 @@ __joint_inclusive_scan(_Args&&... __args)
 
 #if _ONEDPL_FPGA_DEVICE
 #    if _ONEDPL_LIBSYCL_VERSION >= 60100
-struct __fpga_emulator_selector
+inline auto __fpga_emulator_selector()
 {
-    int operator()(const sycl::device& d) const
-    {
-        return sycl::ext::intel::fpga_emulator_selector_v(d);
-    }
-};
+    return sycl::ext::intel::fpga_emulator_selector_v;
+}
+inline auto __fpga_selector()
+{
+    return sycl::ext::intel::fpga_selector_v;
+}
 
-struct __fpga_selector
-{
-    int operator()(const sycl::device& d) const
-    {
-        return sycl::ext::intel::fpga_selector_v(d);
-    }
-};
 #    elif _ONEDPL_LIBSYCL_VERSION >= 50300
-using __fpga_emulator_selector = sycl::ext::intel::fpga_emulator_selector;
-using __fpga_selector = sycl::ext::intel::fpga_selector;
+inline auto __fpga_emulator_selector()
+{
+    return sycl::ext::intel::fpga_emulator_selector{};
+}
+inline auto __fpga_selector()
+{
+    return sycl::ext::intel::fpga_selector{};
+}
 #    else
-using __fpga_emulator_selector = sycl::INTEL::fpga_emulator_selector;
-using __fpga_selector = sycl::INTEL::fpga_selector;
+inline auto __fpga_emulator_selector()
+{
+    return sycl::INTEL::fpga_emulator_selector{};
+}
+inline auto __fpga_selector()
+{
+    return sycl::INTEL::fpga_selector{};
+}
 #    endif
 #endif // _ONEDPL_FPGA_DEVICE
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -211,7 +211,23 @@ __joint_inclusive_scan(_Args&&... __args)
 }
 
 #if _ONEDPL_FPGA_DEVICE
-#    if _ONEDPL_LIBSYCL_VERSION >= 50300
+#    if _ONEDPL_LIBSYCL_VERSION >= 60100
+struct __fpga_emulator_selector
+{
+    int operator()(const sycl::device& d) const
+    {
+        return sycl::ext::intel::fpga_emulator_selector_v(d);
+    }
+};
+
+struct __fpga_selector
+{
+    int operator()(const sycl::device& d) const
+    {
+        return sycl::ext::intel::fpga_selector_v(d);
+    }
+};
+#    elif _ONEDPL_LIBSYCL_VERSION >= 50300
 using __fpga_emulator_selector = sycl::ext::intel::fpga_emulator_selector;
 using __fpga_selector = sycl::ext::intel::fpga_selector;
 #    else

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -107,9 +107,9 @@ make_new_policy(_Policy&& __policy)
 #if ONEDPL_FPGA_DEVICE
     auto default_selector =
 #    if ONEDPL_FPGA_EMULATOR
-        __dpl_sycl::__fpga_emulator_selector{};
+        __dpl_sycl::__fpga_emulator_selector();
 #    else
-        __dpl_sycl::__fpga_selector{};
+        __dpl_sycl::__fpga_selector();
 #    endif // ONEDPL_FPGA_EMULATOR
 
     auto&& default_dpcpp_policy =


### PR DESCRIPTION
In SYCL 2020, device selectors were changed to use a simpler API that utilized callables to rank devices as integers. It provided sensible defaults to replace the old selectors (e.g., `gpu_selector`) with a new version (e.g., `gpu_selector_v`). In oneDPL, we changed most of the selectors but we did not change the FPGA ones.

This PR replaces the old FPGA selectors with SYCL 2020 compliant versions.

I obtained the LIBSYCL version by finding the commit which deprecated the old FPGA selector https://github.com/intel/llvm/commit/0417651672159f821ba58eeb4b744d46661f867a and noting that the library version at that commit was 6.1.0.