### PR TITLE
Correct radix sort's order preserving cast for descending sort

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -62,7 +62,8 @@ __order_preserving_cast(_Int __val)
 {
     using _UInt = ::std::make_unsigned_t<_Int>;
     // mask: 100..0 for ascending, 011..1 for descending
-    constexpr _UInt __mask = (__is_ascending) ? _UInt(1) << ::std::numeric_limits<_Int>::digits : _UInt(~_UInt(0)) >> 1;
+    constexpr _UInt __mask =
+        (__is_ascending) ? _UInt(1) << ::std::numeric_limits<_Int>::digits : ::std::numeric_limits<_UInt>::max() >> 1;
     return __val ^ __mask;
 }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -62,7 +62,7 @@ __order_preserving_cast(_Int __val)
 {
     using _UInt = ::std::make_unsigned_t<_Int>;
     // mask: 100..0 for ascending, 011..1 for descending
-    constexpr _UInt __mask = (__is_ascending) ? _UInt(1) << ::std::numeric_limits<_Int>::digits : ~_UInt(0) >> 1;
+    constexpr _UInt __mask = (__is_ascending) ? _UInt(1) << ::std::numeric_limits<_Int>::digits : _UInt(~_UInt(0)) >> 1;
     return __val ^ __mask;
 }
 

--- a/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
@@ -438,6 +438,11 @@ main()
         test_sort<40, std::int32_t>([](std::int32_t x, std::int32_t y)
                                     { return x > y; }, // Reversed so accidental use of < will be detected.
                                     [](size_t k, size_t val) { return std::int32_t(val) * (k % 2 ? 1 : -1); });
+
+        test_sort<50, std::int16_t>(
+            std::greater<std::int16_t>(),
+            [](size_t k, size_t val) {
+            return std::int16_t(val) * (k % 2 ? 1 : -1); });
     }
 
 #if TEST_DPCPP_BACKEND_PRESENT


### PR DESCRIPTION
Our radix sort implementation has been observed to produce incorrect results when performing a descending sort of `int16_t` numbers containing negative values.

The bitwise complement operation adheres to integral promotion rules. In `__order_preserving_cast` of our radix sort, we require a mask of the form 011..11 for the descending case. In order to ensure this, we need the right shift operator to pad with zeros which is only guaranteed when shifting unsigned types. We must add an additional cast to ensure that we are right-shifting an 
unsigned type. This change corrects the observed sorting bug.