### PR TITLE
[KT] Support for descending sort order

### DIFF
--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort.h
@@ -54,23 +54,20 @@ radix_sort(_ExecutionPolicy&& __exec, _Range&& __rng)
 
     if (__n <= 16384)
     {
-        // TODO: allow different sorting orders
-        // TODO: support double
+        // TODO: support double and small-size integers
         // TODO: allow all RadixBits values (only 7 or 8 are currently supported)
         oneapi::dpl::experimental::esimd::impl::one_wg<_ExecutionPolicy, _KeyT, _Range, RadixBits, IsAscending>(
             ::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range>(__rng), __n);
     }
     else if (__n <= 262144)
     {
-        // TODO: allow different sorting orders
-        // TODO: allow different types
+        // TODO: support double and small-size integers
         oneapi::dpl::experimental::esimd::impl::cooperative<_ExecutionPolicy, _KeyT, _Range, RadixBits, IsAscending>(
             ::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range>(__rng), __n);
     }
     else
     {
-        // TODO: allow different sorting orders
-        // TODO: allow different types
+        // TODO: support floating point types and small-size integers
         // TODO: avoid kernel duplication (generate the output storage with the same type as input storage and use swap)
         // TODO: allow different RadixBits, make sure the data is in the input storage after the last stage
         // TODO: pass _ProcessSize according to __n

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
@@ -375,7 +375,7 @@ struct radix_sort_onesweep_slm_reorder_kernel {
         LoadKeys<16>(io_offset, keys, default_key);
 
         // bins = (keys >> (stage * RADIX_BITS)) & MASK;
-        bins = utils::__get_bucket<MASK>(utils::__order_preserving_cast</*IsAscending*/ true>(keys), stage * RADIX_BITS);
+        bins = utils::__get_bucket<MASK>(utils::__order_preserving_cast<IsAscending>(keys), stage * RADIX_BITS);
 
         ResetBinCounters(slm_bin_hist_this_thread);
 
@@ -403,7 +403,7 @@ struct radix_sort_onesweep_slm_reorder_kernel {
         {
 
             //bins = (keys >> (stage * RADIX_BITS)) & MASK;
-            bins = utils::__get_bucket<MASK>(utils::__order_preserving_cast</*IsAscending*/ true>(keys), stage * RADIX_BITS);
+            bins = utils::__get_bucket<MASK>(utils::__order_preserving_cast<IsAscending>(keys), stage * RADIX_BITS);
 
             slm_lookup_t<hist_t> subgroup_lookup(slm_lookup_subgroup);
             simd<hist_t, PROCESS_SIZE> wg_offset = ranks + subgroup_lookup.template lookup<PROCESS_SIZE>(subgroup_offset, bins);
@@ -421,7 +421,7 @@ struct radix_sort_onesweep_slm_reorder_kernel {
             keys = utils::BlockLoad<KeyT, PROCESS_SIZE>(local_tid * PROCESS_SIZE * sizeof(KeyT));
 
             // bins = (keys >> (stage * RADIX_BITS)) & MASK;
-            bins = utils::__get_bucket<MASK>(utils::__order_preserving_cast</*IsAscending*/ true>(keys), stage * RADIX_BITS);
+            bins = utils::__get_bucket<MASK>(utils::__order_preserving_cast<IsAscending>(keys), stage * RADIX_BITS);
 
             simd<hist_t, PROCESS_SIZE> group_offset = utils::create_simd<hist_t, PROCESS_SIZE>(local_tid*PROCESS_SIZE, 1);
 

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -179,7 +179,8 @@ __order_preserving_cast(sycl::ext::intel::esimd::simd<_Int, _N> __src)
 {
     using _UInt = ::std::make_unsigned_t<_Int>;
     // mask: 100..0 for ascending, 011..1 for descending
-    constexpr _UInt __mask = (__is_ascending) ? _UInt(1) << ::std::numeric_limits<_Int>::digits : ~_UInt(0) >> 1;
+    constexpr _UInt __mask = (__is_ascending) ? _UInt(1) << ::std::numeric_limits<_Int>::digits 
+                                              : ::std::numeric_limits<_UInt>::max() >> 1;
     return __src.template bit_cast_view<_UInt>() ^ __mask;
 }
 

--- a/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
+++ b/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
@@ -86,7 +86,7 @@ void print_data(const Container1& expected, const Container2& actual, std::size_
         std::cout << std::hexfloat;
     else
         std::cout << std::hex;
-    
+
     for (std::size_t i=first; i < first+n; ++i)
     {
         std::cout << actual[i] << " --- " << expected[i] << std::endl;

--- a/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
+++ b/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
@@ -38,15 +38,15 @@
 #include <cmath>
 #include <limits>
 
+constexpr bool Ascending = true;
+template <bool = Ascending>
+struct Compare : public std::less<void> {};
+template <>
+struct Compare<!Ascending> : public std::greater<void> {};
+
 constexpr ::std::uint16_t kWorkGroupSize = 256;
 constexpr ::std::uint16_t kDataPerWorkItem = 16;
-
-constexpr bool Ascending = true;
 constexpr bool Order = Ascending;
-template <bool = Ascending>
-using Compare = std::less<void>;
-template <>
-using Compare<!Ascending> = std::greater<void>;
 
 template <typename T>
 typename ::std::enable_if_t<std::is_arithmetic_v<T>, void>


### PR DESCRIPTION
No implementation changes appear necessary, except for onesweep to use the order as designed.

In the test, I enable the possibility to test everything in descending order, off by default. It's similar to other template parameters - WG size, etc. We will need to find out how to test for different parameter values without сombinatorial explosion.