### PR TITLE
Adding sycl header check

### DIFF
--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -246,7 +246,8 @@
 // Check the user-defined macro for parallel policies
 // define _ONEDPL_BACKEND_SYCL 1 when we compile with the Compiler that supports SYCL
 #if !defined(_ONEDPL_BACKEND_SYCL)
-#    if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION))
+#    if ((defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) &&                                      \
+         (__has_include(<sycl/sycl.hpp>) || __has_include(<CL/sycl.hpp>)))
 #        define _ONEDPL_BACKEND_SYCL 1
 #    else
 #        define _ONEDPL_BACKEND_SYCL 0

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -58,7 +58,9 @@
 #define _PSTL_SYCL_TEST_USM 1
 
 // Enable test when the DPC++ backend is available
-#if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && (!defined(ONEDPL_USE_DPCPP_BACKEND) || ONEDPL_USE_DPCPP_BACKEND != 0)
+#if ((defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) &&                                         \
+     (__has_include(<sycl/sycl.hpp>) || __has_include(<CL/sycl.hpp>))) &&                                             \
+    (!defined(ONEDPL_USE_DPCPP_BACKEND) || ONEDPL_USE_DPCPP_BACKEND != 0)
 #define TEST_DPCPP_BACKEND_PRESENT 1
 #else
 #define TEST_DPCPP_BACKEND_PRESENT 0


### PR DESCRIPTION
Adding commit b6ea2df988fd0f5f4ea02b9abc38b42f181a9a11 from #906 into dynamic_selection branch:

Adding checks for the presence of sycl headers prior to enabling sycl backend.
This is required when compilers support -fsycl option and define SYCL_LANGUAGE_VERSION, without making SYCL implementation available in practice.