### PR TITLE
Fix mangled Kernel names in tests

### DIFF
--- a/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
@@ -353,7 +353,7 @@ test_default_name_gen(Convert convert, size_t n)
 #endif //TEST_DPCPP_BACKEND_PRESENT
 
 
-template <typename T, typename Compare, typename Convert>
+template <::std::size_t CallNumber, typename T, typename Compare, typename Convert>
 void
 test_sort(Compare compare, Convert convert)
 {
@@ -366,12 +366,12 @@ test_sort(Compare compare, Convert convert)
         TestUtils::Sequence<T> expected(in);
         TestUtils::Sequence<T> tmp(in);
 #ifdef _PSTL_TEST_WITHOUT_PREDICATE
-        TestUtils::invoke_on_all_policies<0>()(test_sort_op<T>(), tmp.begin(), tmp.end(), expected.begin(),
-                                               expected.end(), in.begin(), in.end(), in.size());
+        TestUtils::invoke_on_all_policies<CallNumber>()(test_sort_op<T>(), tmp.begin(), tmp.end(), expected.begin(),
+                                                        expected.end(), in.begin(), in.end(), in.size());
 #endif // _PSTL_TEST_WITHOUT_PREDICATE
 #ifdef _PSTL_TEST_WITH_PREDICATE
-        TestUtils::invoke_on_all_policies<1>()(test_sort_op<T>(), tmp.begin(), tmp.end(), expected.begin(),
-                                               expected.end(), in.begin(), in.end(), in.size(), compare);
+        TestUtils::invoke_on_all_policies<CallNumber + 1>()(test_sort_op<T>(), tmp.begin(), tmp.end(), expected.begin(),
+                                                            expected.end(), in.begin(), in.end(), in.size(), compare);
 #endif // _PSTL_TEST_WITH_PREDICATE
     }
 }
@@ -419,25 +419,25 @@ main()
 
 #if !TEST_DPCPP_BACKEND_PRESENT
         // ParanoidKey has atomic increment in ctors. It's not allowed in kernel
-        test_sort<ParanoidKey>(KeyCompare(TestUtils::OddTag()),
-                               [](size_t k, size_t val) { return ParanoidKey(k, val, TestUtils::OddTag()); });
+        test_sort<0, ParanoidKey>(KeyCompare(TestUtils::OddTag()),
+                                  [](size_t k, size_t val) { return ParanoidKey(k, val, TestUtils::OddTag()); });
 #endif // !TEST_DPCPP_BACKEND_PRESENT
 
 #if !ONEDPL_FPGA_DEVICE
-        test_sort<TestUtils::float32_t>([](TestUtils::float32_t x, TestUtils::float32_t y) { return x < y; },
-                                        [](size_t k, size_t val) { return TestUtils::float32_t(val) * (k % 2 ? 1 : -1); });
+        test_sort<10, TestUtils::float32_t>([](TestUtils::float32_t x, TestUtils::float32_t y) { return x < y; },
+                                            [](size_t k, size_t val)
+                                            { return TestUtils::float32_t(val) * (k % 2 ? 1 : -1); });
 
-        test_sort<unsigned char>(
-            [](unsigned char x, unsigned char y) { return x > y; }, // Reversed so accidental use of < will be detected.
-            [](size_t k, size_t val) { return (unsigned char)val; });
+        test_sort<20, unsigned char>([](unsigned char x, unsigned char y)
+                                     { return x > y; }, // Reversed so accidental use of < will be detected.
+                                     [](size_t k, size_t val) { return (unsigned char)val; });
 
-        test_sort<unsigned char>(NonConstCmp{},
-            [](size_t k, size_t val) { return (unsigned char)val; });
+        test_sort<30, unsigned char>(NonConstCmp{}, [](size_t k, size_t val) { return (unsigned char)val; });
 
 #endif // !ONEDPL_FPGA_DEVICE
-        test_sort<std::int32_t>(
-            [](std::int32_t x, std::int32_t y) { return x > y; }, // Reversed so accidental use of < will be detected.
-            [](size_t k, size_t val) { return std::int32_t(val) * (k % 2 ? 1 : -1); });
+        test_sort<40, std::int32_t>([](std::int32_t x, std::int32_t y)
+                                    { return x > y; }, // Reversed so accidental use of < will be detected.
+                                    [](size_t k, size_t val) { return std::int32_t(val) * (k % 2 ? 1 : -1); });
     }
 
 #if TEST_DPCPP_BACKEND_PRESENT


### PR DESCRIPTION
In this PR we fix mangled Kernel names in tests:
- error was found at ```test_os=rhel8_compiler=dpcpp_backend=dpcpp_device_type=CPU_std=c++17_cfg=release_unnamed_lambda=OFF_compile_kernel=ON```
- ```cmake -DCMAKE_CXX_COMPILER=dpcpp -DCMAKE_CXX_STANDARD=17 -DONEDPL_BACKEND=dpcpp -DONEDPL_DEVICE_TYPE=CPU '-DCMAKE_CXX_FLAGS=-DTEST_LONG_RUN=1 ' -DCMAKE_BUILD_TYPE=release -DONEDPL_USE_UNNAMED_LAMBDA=OFF .```

Error: ```../include/sycl/handler.hpp:249:7: error: definition with same mangled name '_ZTSN4sycl3_V16detail19__pf_kernel_wrapperIN6oneapi3dpl20__par_backend_hetero18__sort_leaf_kernelIJN9TestUtils18unique_kernel_nameI12test_sort_opIhELm1EEEEEEEE' as another definition```