### PR TITLE
Implement & test esimd radix sort for int16_t and uint16_t

### DIFF
--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
@@ -168,10 +168,6 @@ void one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, uint32_t THREAD_PER_TG, con
                     keys.template select<16, 1>(s));
             }
             barrier();
-            //#pragma unroll
-            //for (uint32_t s = 0; s<PROCESS_SIZE; s+=64){
-            //    keys.template select<64, 1>(s) = lsc_slm_block_load<KeyT, 64>(slm_reorder_this_thread+s*sizeof(KeyT));
-            //}
             keys = utils::BlockLoad<KeyT, PROCESS_SIZE>(slm_reorder_this_thread);
         }
     }

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
@@ -168,10 +168,11 @@ void one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, uint32_t THREAD_PER_TG, con
                     keys.template select<16, 1>(s));
             }
             barrier();
-            #pragma unroll
-            for (uint32_t s = 0; s<PROCESS_SIZE; s+=64){
-                keys.template select<64, 1>(s) = lsc_slm_block_load<KeyT, 64>(slm_reorder_this_thread+s*sizeof(KeyT));
-            }
+            //#pragma unroll
+            //for (uint32_t s = 0; s<PROCESS_SIZE; s+=64){
+            //    keys.template select<64, 1>(s) = lsc_slm_block_load<KeyT, 64>(slm_reorder_this_thread+s*sizeof(KeyT));
+            //}
+            keys = utils::BlockLoad<KeyT, PROCESS_SIZE>(slm_reorder_this_thread);
         }
     }
     #pragma unroll

--- a/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
+++ b/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
@@ -310,6 +310,7 @@ int main()
         {
             test_usm<uint32_t>(size);
             test_usm<int>(size);
+            test_usm<int16_t>(size);
             test_usm<float>(size);
         }
         test_small_sizes();

--- a/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
+++ b/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
@@ -68,6 +68,13 @@ struct TypeInfo
     }
 
     template <>
+    const std::string& name<uint16_t>()
+    {
+        static const std::string kTypeName = "uint16_t";
+        return kTypeName;
+    }
+
+    template <>
     const std::string& name<uint32_t>()
     {
         static const std::string kTypeName = "uint32_t";
@@ -309,6 +316,7 @@ int main()
             test_general_cases<uint32_t>(size);
             test_general_cases<int>(size);
             test_general_cases<int16_t>(size);
+            test_general_cases<uint16_t>(size);
             test_general_cases<float>(size);
             // test_general_cases<double>(size);
         }
@@ -317,6 +325,7 @@ int main()
             test_general_cases<uint32_t>(size);
             test_general_cases<int>(size);
             test_general_cases<int16_t>(size);
+            test_general_cases<uint16_t>(size);
             test_general_cases<float>(size);
             // test_general_cases<double>(size);
         }
@@ -325,11 +334,13 @@ int main()
             test_usm<uint32_t>(size);
             test_usm<int>(size);
             test_usm<int16_t>(size);
+            test_usm<uint16_t>(size);
             test_usm<float>(size);
         }
         test_small_sizes<uint32_t>();
         test_small_sizes<int>();
         test_small_sizes<int16_t>();
+        test_small_sizes<uint16_t>();
     }
     catch (const ::std::exception& exc)
     {

--- a/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
+++ b/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
@@ -261,14 +261,19 @@ void test_sycl_iterators(std::size_t size)
     EXPECT_EQ_RANGES(ref, input, msg.c_str());
 }
 
+template <typename T>
 void test_small_sizes()
 {
+#ifdef LOG_TEST_INFO
+    std::cout << "\t\ttest_small_sizes<" << TypeInfo().name<T>() << ">();" << std::endl;
+#endif
+
     sycl::queue q = TestUtils::get_test_queue();
     auto policy = oneapi::dpl::execution::make_device_policy(q);
 
-    std::vector<uint32_t> input = {5, 11, 0, 17, 0};
+    std::vector<T> input = {5, 11, 0, 17, 0};
     generate_data(input.data(), input.size());
-    std::vector<uint32_t> ref(input);
+    std::vector<T> ref(input);
 
     oneapi::dpl::experimental::esimd::radix_sort<kWorkGroupSize,kDataPerWorkItem,Order>(policy, oneapi::dpl::begin(input), oneapi::dpl::begin(input));
     EXPECT_EQ_RANGES(ref, input, "sort modified input data when size == 0");
@@ -322,7 +327,9 @@ int main()
             test_usm<int16_t>(size);
             test_usm<float>(size);
         }
-        test_small_sizes();
+        test_small_sizes<uint32_t>();
+        test_small_sizes<int>();
+        test_small_sizes<int16_t>();
     }
     catch (const ::std::exception& exc)
     {

--- a/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
+++ b/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
@@ -268,19 +268,14 @@ void test_sycl_iterators(std::size_t size)
     EXPECT_EQ_RANGES(ref, input, msg.c_str());
 }
 
-template <typename T>
 void test_small_sizes()
 {
-#ifdef LOG_TEST_INFO
-    std::cout << "\t\ttest_small_sizes<" << TypeInfo().name<T>() << ">();" << std::endl;
-#endif
-
     sycl::queue q = TestUtils::get_test_queue();
     auto policy = oneapi::dpl::execution::make_device_policy(q);
 
-    std::vector<T> input = {5, 11, 0, 17, 0};
+    std::vector<uint32_t> input = {5, 11, 0, 17, 0};
     generate_data(input.data(), input.size());
-    std::vector<T> ref(input);
+    std::vector<uint32_t> ref(input);
 
     oneapi::dpl::experimental::esimd::radix_sort<kWorkGroupSize,kDataPerWorkItem,Order>(policy, oneapi::dpl::begin(input), oneapi::dpl::begin(input));
     EXPECT_EQ_RANGES(ref, input, "sort modified input data when size == 0");
@@ -337,10 +332,7 @@ int main()
             test_usm<uint16_t>(size);
             test_usm<float>(size);
         }
-        test_small_sizes<uint32_t>();
-        test_small_sizes<int>();
-        test_small_sizes<int16_t>();
-        test_small_sizes<uint16_t>();
+        test_small_sizes();
     }
     catch (const ::std::exception& exc)
     {

--- a/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
+++ b/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
@@ -61,6 +61,13 @@ struct TypeInfo
     }
 
     template <>
+    const std::string& name<int16_t>()
+    {
+        static const std::string kTypeName = "int16_t";
+        return kTypeName;
+    }
+
+    template <>
     const std::string& name<uint32_t>()
     {
         static const std::string kTypeName = "uint32_t";

--- a/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
+++ b/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
@@ -303,6 +303,7 @@ int main()
         {
             test_general_cases<uint32_t>(size);
             test_general_cases<int>(size);
+            test_general_cases<int16_t>(size);
             test_general_cases<float>(size);
             // test_general_cases<double>(size);
         }
@@ -310,6 +311,7 @@ int main()
         {
             test_general_cases<uint32_t>(size);
             test_general_cases<int>(size);
+            test_general_cases<int16_t>(size);
             test_general_cases<float>(size);
             // test_general_cases<double>(size);
         }


### PR DESCRIPTION
In this PR we add support of ```int16_t``` and ```uint16_t``` into esimd radix sort.

For that we made change in ```one_wg_kernel``` function:
- we replace block of code
```
            #pragma unroll
            for (uint32_t s = 0; s<PROCESS_SIZE; s+=64){
                keys.template select<64, 1>(s) = lsc_slm_block_load<KeyT, 64>(slm_reorder_this_thread+s*sizeof(KeyT));
            }
```
to
```
            keys = utils::BlockLoad<KeyT, PROCESS_SIZE>(slm_reorder_this_thread);
```
to avoid compile error:
```
../include/sycl/ext/intel/experimental/esimd/memory.hpp:381:3: error: static assertion failed due to requirement '_DS == lsc_data_size::u32 || _DS == lsc_data_size::u64': Transposed load is supported only for data size u32 or u64
```