### PR TITLE
Modernize OpenMP CMake inclusion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,7 +285,7 @@ elseif(ONEDPL_BACKEND MATCHES "^(serial)$")
     message(STATUS "Compilation for the host due to serial backend")
 
 elseif(ONEDPL_BACKEND MATCHES "^(omp)$")
-    find_package(OpenMP REQUIRED)
+    find_package(OpenMP)
     if (OpenMP_CXX_FOUND)
         message(STATUS "Compilation for the host due to OpenMP backend.")
         target_link_libraries(oneDPL INTERFACE OpenMP::OpenMP_CXX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,32 +285,17 @@ elseif(ONEDPL_BACKEND MATCHES "^(serial)$")
     message(STATUS "Compilation for the host due to serial backend")
 
 elseif(ONEDPL_BACKEND MATCHES "^(omp)$")
-
-    foreach(_openmp_flag -fopenmp /Qopenmp -qopenmp -openmp)
-        #set(_cmake_required_libraries ${CMAKE_REQUIRED_LIBRARIES})
-        #set(CMAKE_REQUIRED_LIBRARIES _openmp_flag)
-
-        string(MAKE_C_IDENTIFIER ${_openmp_flag} FLAG_DISPLAY_NAME)
-        check_cxx_compiler_flag(${_openmp_flag} ${FLAG_DISPLAY_NAME}_option)
-        #set(CMAKE_REQUIRED_LIBRARIES ${_cmake_required_libraries})
-
-        if (${FLAG_DISPLAY_NAME}_option)
-            target_compile_options(oneDPL INTERFACE ${_openmp_flag})
-            target_link_libraries(oneDPL INTERFACE ${_openmp_flag})
-            set(_openmp_enabled_flag ${_openmp_flag})
-            target_compile_definitions(oneDPL INTERFACE
-                ONEDPL_USE_TBB_BACKEND=0
-                ONEDPL_USE_DPCPP_BACKEND=0
-                ONEDPL_USE_OPENMP_BACKEND=1
-                )
-            break()
-        endif()
-    endforeach()
-
-    if (_openmp_enabled_flag)
-        message(STATUS "Compilation for the host due to OpenMP backend by passing ${_openmp_enabled_flag} to compiler")
+    find_package(OpenMP REQUIRED)
+    if (OpenMP_CXX_FOUND)
+        message(STATUS "Compilation for the host due to OpenMP backend.")
+        target_link_libraries(oneDPL INTERFACE OpenMP::OpenMP_CXX)
+        target_compile_definitions(oneDPL INTERFACE
+            ONEDPL_USE_TBB_BACKEND=0
+            ONEDPL_USE_DPCPP_BACKEND=0
+            ONEDPL_USE_OPENMP_BACKEND=1
+            )
     else()
-        message(FATAL_ERROR "${CMAKE_CXX_COMPILER} doesn't support any known OpenMP option.\n"
+        message(FATAL_ERROR "${CMAKE_CXX_COMPILER} doesn't support OpenMP.\n"
             "It is required if ONEDPL_BACKEND=${ONEDPL_BACKEND}")
     endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,28 +285,34 @@ elseif(ONEDPL_BACKEND MATCHES "^(serial)$")
     message(STATUS "Compilation for the host due to serial backend")
 
 elseif(ONEDPL_BACKEND MATCHES "^(omp)$")
-    if(UNIX)
-        set(_openmp_flag "-fopenmp")
+
+    foreach(_openmp_flag -fopenmp /Qopenmp -qopenmp -openmp)
+        #set(_cmake_required_libraries ${CMAKE_REQUIRED_LIBRARIES})
+        #set(CMAKE_REQUIRED_LIBRARIES _openmp_flag)
+
+        string(MAKE_C_IDENTIFIER ${_openmp_flag} FLAG_DISPLAY_NAME)
+        check_cxx_compiler_flag(${_openmp_flag} ${FLAG_DISPLAY_NAME}_option)
+        #set(CMAKE_REQUIRED_LIBRARIES ${_cmake_required_libraries})
+
+        if (${FLAG_DISPLAY_NAME}_option)
+            target_compile_options(oneDPL INTERFACE ${_openmp_flag})
+            target_link_libraries(oneDPL INTERFACE ${_openmp_flag})
+            set(_openmp_enabled_flag ${_openmp_flag})
+            target_compile_definitions(oneDPL INTERFACE
+                ONEDPL_USE_TBB_BACKEND=0
+                ONEDPL_USE_DPCPP_BACKEND=0
+                ONEDPL_USE_OPENMP_BACKEND=1
+                )
+            break()
+        endif()
+    endforeach()
+
+    if (_openmp_enabled_flag)
+        message(STATUS "Compilation for the host due to OpenMP backend by passing ${_openmp_enabled_flag} to compiler")
     else()
-        set(_openmp_flag "-Qopenmp")
-    endif()
-    set(_cmake_required_libraries ${CMAKE_REQUIRED_LIBRARIES})
-    set(CMAKE_REQUIRED_LIBRARIES ${_openmp_flag})
-    check_cxx_compiler_flag(${_openmp_flag} _openmp_option)
-    if (_openmp_option)
-        target_compile_options(oneDPL INTERFACE ${_openmp_flag})
-        target_link_libraries(oneDPL INTERFACE ${_openmp_flag})
-        target_compile_definitions(oneDPL INTERFACE
-            ONEDPL_USE_TBB_BACKEND=0
-            ONEDPL_USE_DPCPP_BACKEND=0
-            ONEDPL_USE_OPENMP_BACKEND=1
-            )
-        message(STATUS "Compilation for the host due to OpenMP backend")
-    else()
-        message(FATAL_ERROR "${CMAKE_CXX_COMPILER} doesn't support ${_openmp_flag} option.\n"
+        message(FATAL_ERROR "${CMAKE_CXX_COMPILER} doesn't support any known OpenMP option.\n"
             "It is required if ONEDPL_BACKEND=${ONEDPL_BACKEND}")
     endif()
-    set(CMAKE_REQUIRED_LIBRARIES ${_cmake_required_libraries})
 
 else()
     message(STATUS "Using Parallel Policies, but not oneTBB/DPC++")

--- a/cmake/templates/oneDPLConfig.cmake.in
+++ b/cmake/templates/oneDPLConfig.cmake.in
@@ -74,28 +74,15 @@ if (EXISTS "${_onedpl_headers}")
         endif()
 
         if (NOT ONEDPL_PAR_BACKEND OR ONEDPL_PAR_BACKEND STREQUAL "openmp")  # Handle OpenMP backend
-            if (UNIX)
-                set(_openmp_flag "-fopenmp")
-            else()
-                set(_openmp_flag "-Qopenmp")
-            endif()
-
-            # Some compilers may fail if _openmp_flag is not in CMAKE_REQUIRED_LIBRARIES.
-            set(_onedpl_saved_required_libs ${CMAKE_REQUIRED_LIBRARIES})
-            set(CMAKE_REQUIRED_LIBRARIES ${_openmp_option})
-            check_cxx_compiler_flag(${_openmp_flag} _openmp_option)
-            set(CMAKE_REQUIRED_LIBRARIES ${_onedpl_saved_required_libs})
-            unset(_onedpl_saved_required_libs)
-
-            if (NOT _openmp_option AND ONEDPL_PAR_BACKEND STREQUAL "openmp")  # If OpenMP backend is requested explicitly, but not supported.
+            find_package(OpenMP)
+            if (NOT OpenMP_CXX_FOUND AND ONEDPL_PAR_BACKEND STREQUAL "openmp")  # If OpenMP backend is requested explicitly, but not supported.
                 message(STATUS "oneDPL: ONEDPL_PAR_BACKEND=${ONEDPL_PAR_BACKEND} requested, but not supported")
                 set(oneDPL_FOUND FALSE)
                 return()
-            elseif (_openmp_option)
+            elseif (OpenMP_CXX_FOUND)
                 set(ONEDPL_PAR_BACKEND openmp)
                 message(STATUS "oneDPL: ONEDPL_PAR_BACKEND=${ONEDPL_PAR_BACKEND}, disable oneTBB backend")
-                set_target_properties(oneDPL PROPERTIES INTERFACE_COMPILE_OPTIONS ${_openmp_flag})
-                set_target_properties(oneDPL PROPERTIES INTERFACE_LINK_LIBRARIES ${_openmp_flag})
+                set_target_properties(oneDPL PROPERTIES INTERFACE_LINK_LIBRARIES OpenMP::OpenMP_CXX)
                 set_property(TARGET oneDPL APPEND PROPERTY INTERFACE_COMPILE_DEFINITIONS ONEDPL_USE_TBB_BACKEND=0 ONEDPL_USE_OPENMP_BACKEND=1)
             endif()
         endif()


### PR DESCRIPTION
Modernize the inclusion of OpenMP in oneDPL's CMake with FindOpenMP, which has the functionality we need as of CMake 3.10 which is less than our required version.

https://cmake.org/cmake/help/latest/module/FindOpenMP.html

This makes #958 unnecessary, and replaces the need for any legacy workaround involving `CMAKE_REQUIRED_LIBRARIES`.

This would also address #960.