### PR TITLE
Bugfix for set_intersection copying from second iterator range

### DIFF
--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -3551,6 +3551,7 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
                    _RandomAccessIterator2 __last2, _T* __result, _Compare __comp) {
                     return oneapi::dpl::__utils::__set_intersection_construct(__first1, __last1, __first2, __last2,
                                                                               __result, __comp,
+                                                                              oneapi::dpl::__internal::__op_uninitialized_copy<_ExecutionPolicy>{},
                                                                               /*CopyFromFirstSet = */ ::std::true_type());
                 }, __is_vector);
         });
@@ -3568,6 +3569,7 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
                    _RandomAccessIterator2 __last2, _T* __result, _Compare __comp) {
                     return oneapi::dpl::__utils::__set_intersection_construct(__first2, __last2, __first1, __last1,
                                                                               __result, __comp,
+                                                                              oneapi::dpl::__internal::__op_uninitialized_copy<_ExecutionPolicy>{},
                                                                               /*CopyFromFirstSet = */ ::std::false_type());
                 }, __is_vector);
             return __result;

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -3552,7 +3552,7 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
                     return oneapi::dpl::__utils::__set_intersection_construct(
                         __first1, __last1, __first2, __last2, __result, __comp,
                         oneapi::dpl::__internal::__op_uninitialized_copy<_ExecutionPolicy>{},
-                        /*CopyFromFirstSet = */ ::std::true_type());
+                        /*CopyFromFirstSet = */ std::true_type{});
                 });
         });
     }
@@ -3570,7 +3570,7 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
                     return oneapi::dpl::__utils::__set_intersection_construct(
                         __first2, __last2, __first1, __last1, __result, __comp,
                         oneapi::dpl::__internal::__op_uninitialized_copy<_ExecutionPolicy>{},
-                        /*CopyFromFirstSet = */ ::std::false_type());
+                        /*CopyFromFirstSet = */ std::false_type{});
                 });
             return __result;
         });

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -3550,7 +3550,7 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
                 [](_RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2,
                    _RandomAccessIterator2 __last2, _T* __result, _Compare __comp) {
                     return oneapi::dpl::__utils::__set_intersection_construct(__first1, __last1, __first2, __last2,
-                                                                              __result, __comp);
+                                                                              __result, __comp, [](auto&& a, auto&& b) { return std::forward<decltype(a)>(a); }); //copy first to output
                 });
         });
     }
@@ -3566,7 +3566,7 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
                 [](_RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2,
                    _RandomAccessIterator2 __last2, _T* __result, _Compare __comp) {
                     return oneapi::dpl::__utils::__set_intersection_construct(__first2, __last2, __first1, __last1,
-                                                                              __result, __comp);
+                                                                              __result, __comp, [](auto&& a, auto&& b) { return std::forward<decltype(b)>(b); }); //copy second to output                                                                              
                 });
             return __result;
         });

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -3553,7 +3553,7 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
                                                                               __result, __comp,
                                                                               oneapi::dpl::__internal::__op_uninitialized_copy<_ExecutionPolicy>{},
                                                                               /*CopyFromFirstSet = */ ::std::true_type());
-                }, __is_vector);
+                });
         });
     }
 
@@ -3571,7 +3571,7 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
                                                                               __result, __comp,
                                                                               oneapi::dpl::__internal::__op_uninitialized_copy<_ExecutionPolicy>{},
                                                                               /*CopyFromFirstSet = */ ::std::false_type());
-                }, __is_vector);
+                });
             return __result;
         });
     }

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -3550,8 +3550,9 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
                 [](_RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2,
                    _RandomAccessIterator2 __last2, _T* __result, _Compare __comp) {
                     return oneapi::dpl::__utils::__set_intersection_construct(__first1, __last1, __first2, __last2,
-                                                                              __result, __comp, [](auto&& a, auto&& b) { return std::forward<decltype(a)>(a); }); //copy first to output
-                });
+                                                                              __result, __comp,
+                                                                              /*CopyFromFirstSet = */ ::std::true_type());
+                }, __is_vector);
         });
     }
 
@@ -3566,8 +3567,9 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
                 [](_RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2,
                    _RandomAccessIterator2 __last2, _T* __result, _Compare __comp) {
                     return oneapi::dpl::__utils::__set_intersection_construct(__first2, __last2, __first1, __last1,
-                                                                              __result, __comp, [](auto&& a, auto&& b) { return std::forward<decltype(b)>(b); }); //copy second to output                                                                              
-                });
+                                                                              __result, __comp,
+                                                                              /*CopyFromFirstSet = */ ::std::false_type());
+                }, __is_vector);
             return __result;
         });
     }

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -3549,10 +3549,10 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
                 __result, __comp, [](_DifferenceType __n, _DifferenceType __m) { return ::std::min(__n, __m); },
                 [](_RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2,
                    _RandomAccessIterator2 __last2, _T* __result, _Compare __comp) {
-                    return oneapi::dpl::__utils::__set_intersection_construct(__first1, __last1, __first2, __last2,
-                                                                              __result, __comp,
-                                                                              oneapi::dpl::__internal::__op_uninitialized_copy<_ExecutionPolicy>{},
-                                                                              /*CopyFromFirstSet = */ ::std::true_type());
+                    return oneapi::dpl::__utils::__set_intersection_construct(
+                        __first1, __last1, __first2, __last2, __result, __comp,
+                        oneapi::dpl::__internal::__op_uninitialized_copy<_ExecutionPolicy>{},
+                        /*CopyFromFirstSet = */ ::std::true_type());
                 });
         });
     }
@@ -3567,10 +3567,10 @@ __pattern_set_intersection(__parallel_tag<_IsVector> __tag, _ExecutionPolicy&& _
                 __result, __comp, [](_DifferenceType __n, _DifferenceType __m) { return ::std::min(__n, __m); },
                 [](_RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2,
                    _RandomAccessIterator2 __last2, _T* __result, _Compare __comp) {
-                    return oneapi::dpl::__utils::__set_intersection_construct(__first2, __last2, __first1, __last1,
-                                                                              __result, __comp,
-                                                                              oneapi::dpl::__internal::__op_uninitialized_copy<_ExecutionPolicy>{},
-                                                                              /*CopyFromFirstSet = */ ::std::false_type());
+                    return oneapi::dpl::__utils::__set_intersection_construct(
+                        __first2, __last2, __first1, __last1, __result, __comp,
+                        oneapi::dpl::__internal::__op_uninitialized_copy<_ExecutionPolicy>{},
+                        /*CopyFromFirstSet = */ ::std::false_type());
                 });
             return __result;
         });

--- a/include/oneapi/dpl/pstl/memory_impl.h
+++ b/include/oneapi/dpl/pstl/memory_impl.h
@@ -119,8 +119,10 @@ struct __op_uninitialized_copy<_ExecutionPolicy>
     operator()(_SourceT&& __source, _TargetT& __target) const
     {
         using _TargetValueType = ::std::decay_t<_TargetT>;
-
-        ::new (::std::addressof(__target)) _TargetValueType(::std::forward<_SourceT>(__source));
+        if constexpr (::std::is_trivial_v<_TargetValueType>)
+            __target = ::std::forward<_SourceT>(__source);
+        else
+            ::new (::std::addressof(__target)) _TargetValueType(::std::forward<_SourceT>(__source));
     }
 };
 

--- a/include/oneapi/dpl/pstl/memory_impl.h
+++ b/include/oneapi/dpl/pstl/memory_impl.h
@@ -118,11 +118,11 @@ struct __op_uninitialized_copy<_ExecutionPolicy>
     void
     operator()(_SourceT&& __source, _TargetT& __target) const
     {
-        using _TargetValueType = ::std::decay_t<_TargetT>;
-        if constexpr (::std::is_trivial_v<_TargetValueType>)
-            __target = ::std::forward<_SourceT>(__source);
+        using _TargetValueType = std::decay_t<_TargetT>;
+        if constexpr (std::is_trivial_v<_TargetValueType>)
+            __target = std::forward<_SourceT>(__source);
         else
-            ::new (::std::addressof(__target)) _TargetValueType(::std::forward<_SourceT>(__source));
+            ::new (std::addressof(__target)) _TargetValueType(std::forward<_SourceT>(__source));
     }
 };
 

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -20,6 +20,7 @@
 #include <utility>
 #include <cassert>
 #include "utils.h"
+#include "memory_fwd.h"
 
 namespace oneapi
 {
@@ -172,14 +173,13 @@ __set_union_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _Fo
 }
 
 template <typename _ForwardIterator1, typename _ForwardIterator2, typename _OutputIterator, typename _Compare,
-          typename _CopyFromFirstSet>
+          typename _CopyFunc, typename _CopyFromFirstSet>
 _OutputIterator
 __set_intersection_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
-                             _ForwardIterator2 __last2, _OutputIterator __result, _Compare __comp,
+                             _ForwardIterator2 __last2, _OutputIterator __result, _Compare __comp, _CopyFunc _copy,
                              _CopyFromFirstSet)
 {
     using _Tp = typename ::std::iterator_traits<_OutputIterator>::value_type;
-
     for (; __first1 != __last1 && __first2 != __last2;)
     {
         if (__comp(*__first1, *__first2))
@@ -195,10 +195,7 @@ __set_intersection_construct(_ForwardIterator1 __first1, _ForwardIterator1 __las
                     else
                         return ::std::forward<decltype(_f2)>(_f2);
                 };
-                if constexpr (::std::is_trivial_v<_Tp>)
-                    *__result = *(__select_element(__first1, __first2));
-                else
-                    ::new (::std::addressof(*__result)) _Tp(*(__select_element(__first1, __first2)));
+                _copy(*__select_element(__first1, __first2), *__result);
                 ++__result;
                 ++__first1;
             }

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -171,10 +171,12 @@ __set_union_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _Fo
     return __cc_range(__first2, __last2, __result);
 }
 
-template <typename _ForwardIterator1, typename _ForwardIterator2, typename _OutputIterator, typename _Compare>
+template <typename _ForwardIterator1, typename _ForwardIterator2, typename _OutputIterator, typename _Compare,
+          typename _SelectCopy>
 _OutputIterator
 __set_intersection_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
-                             _ForwardIterator2 __last2, _OutputIterator __result, _Compare __comp)
+                             _ForwardIterator2 __last2, _OutputIterator __result, _Compare __comp,
+                             _SelectCopy __select_copy)
 {
     using _Tp = typename ::std::iterator_traits<_OutputIterator>::value_type;
 
@@ -186,7 +188,7 @@ __set_intersection_construct(_ForwardIterator1 __first1, _ForwardIterator1 __las
         {
             if (!__comp(*__first2, *__first1))
             {
-                ::new (::std::addressof(*__result)) _Tp(*__first1);
+                ::new (::std::addressof(*__result)) _Tp(*__select_copy(__first1, __first2));
                 ++__result;
                 ++__first1;
             }

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -189,13 +189,14 @@ __set_intersection_construct(_ForwardIterator1 __first1, _ForwardIterator1 __las
             if (!__comp(*__first2, *__first1))
             {
 
-                auto __select_element = [](auto&& _f1, auto&& _f2) {
-                    if constexpr (_CopyFromFirstSet::value)
-                        return ::std::forward<decltype(_f1)>(_f1);
-                    else
-                        return ::std::forward<decltype(_f2)>(_f2);
-                };
-                _copy(*__select_element(__first1, __first2), *__result);
+                if constexpr (_CopyFromFirstSet::value)
+                {
+                    _copy(*__first1, *__result);
+                }
+                else
+                {
+                    _copy(*__first2, *__result);
+                }
                 ++__result;
                 ++__first1;
             }

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -176,7 +176,7 @@ template <typename _ForwardIterator1, typename _ForwardIterator2, typename _Outp
 _OutputIterator
 __set_intersection_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
                              _ForwardIterator2 __last2, _OutputIterator __result, _Compare __comp,
-                             _CopyFromFirstSet __copy_from_first_set)
+                             _CopyFromFirstSet)
 {
     using _Tp = typename ::std::iterator_traits<_OutputIterator>::value_type;
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_common.h
+++ b/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_common.h
@@ -135,6 +135,37 @@ struct test_set_intersection
 
         EXPECT_TRUE(expect_res - expect.begin() == res - out.begin(), "wrong result for set_intersection");
         EXPECT_EQ_N(expect.begin(), out.begin(), ::std::distance(out.begin(), res), "wrong set_intersection effect");
+
+        if constexpr (TestUtils::is_base_of_iterator_category<::std::random_access_iterator_tag,
+                                                              InputIterator1>::value &&
+                      TestUtils::is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator2>::value)
+        {
+            // Check that set_intersection always copies from the first list to result.
+            // Will fail to compile if the second range is used to copy to the output.
+            // Comparator is designed to only compare the first element of a zip iterator.
+
+            auto zip_first1 = oneapi::dpl::make_zip_iterator(first1, oneapi::dpl::counting_iterator<int>(0));
+            auto zip_last1 = oneapi::dpl::make_zip_iterator(
+                last1, oneapi::dpl::counting_iterator<int>(std::distance(first1, last1)));
+
+            // Second value should be ignored and discarded in range 2 because the result should be copied from range 1
+            auto zip_first2 = oneapi::dpl::make_zip_iterator(first2, oneapi::dpl::discard_iterator());
+            auto zip_last2 = oneapi::dpl::make_zip_iterator(last2, oneapi::dpl::discard_iterator());
+
+            Sequence<int> expect_ints(std::distance(first1, last1) + std::distance(first2, last2));
+            Sequence<int> out_ints(std::distance(first1, last1) + std::distance(first2, last2));
+
+            auto zip_expect = oneapi::dpl::make_zip_iterator(sequences.first.begin(), expect_ints.begin());
+            auto zip_out = oneapi::dpl::make_zip_iterator(sequences.second.begin(), out_ints.begin());
+
+            auto zip_expect_res = ::std::set_intersection(zip_first1, zip_last1, zip_first2, zip_last2, zip_expect,
+                                                          comp_select_first(comp));
+            auto zip_res = ::std::set_intersection(exec, zip_first1, zip_last1, zip_first2, zip_last2, zip_out,
+                                                   comp_select_first(comp));
+            EXPECT_TRUE(zip_expect_res - zip_expect == zip_res - zip_out, "wrong result for zipped set_intersection");
+            EXPECT_EQ_N(zip_expect, zip_out, ::std::distance(zip_out, zip_res), "wrong zipped set_intersection effect");
+        }
+
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>

--- a/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_common.h
+++ b/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_common.h
@@ -129,7 +129,7 @@ struct comp_select_first
     bool
     operator()(_T1&& t1, _T2&& t2) const
     {
-        return comp(::std::get<0>(::std::forward<_T1>(t1)), ::std::get<0>(::std::forward<_T2>(t2)));
+        return comp(std::get<0>(std::forward<_T1>(t1)), std::get<0>(std::forward<_T2>(t2)));
     }
 };
 
@@ -150,9 +150,9 @@ struct test_set_intersection
         EXPECT_TRUE(expect_res - expect.begin() == res - out.begin(), "wrong result for set_intersection");
         EXPECT_EQ_N(expect.begin(), out.begin(), ::std::distance(out.begin(), res), "wrong set_intersection effect");
 
-        if constexpr (TestUtils::is_base_of_iterator_category<::std::random_access_iterator_tag,
+        if constexpr (TestUtils::is_base_of_iterator_category<std::random_access_iterator_tag,
                                                               InputIterator1>::value &&
-                      TestUtils::is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator2>::value)
+                      TestUtils::is_base_of_iterator_category<std::random_access_iterator_tag, InputIterator2>::value)
         {
             // Check that set_intersection always copies from the first list to result.
             // Will fail to compile if the second range is used to copy to the output.
@@ -172,12 +172,12 @@ struct test_set_intersection
             auto zip_expect = oneapi::dpl::make_zip_iterator(sequences.first.begin(), expect_ints.begin());
             auto zip_out = oneapi::dpl::make_zip_iterator(sequences.second.begin(), out_ints.begin());
 
-            auto zip_expect_res = ::std::set_intersection(zip_first1, zip_last1, zip_first2, zip_last2, zip_expect,
+            auto zip_expect_res = std::set_intersection(zip_first1, zip_last1, zip_first2, zip_last2, zip_expect,
                                                           comp_select_first(comp));
-            auto zip_res = ::std::set_intersection(exec, zip_first1, zip_last1, zip_first2, zip_last2, zip_out,
+            auto zip_res = std::set_intersection(exec, zip_first1, zip_last1, zip_first2, zip_last2, zip_out,
                                                    comp_select_first(comp));
             EXPECT_TRUE(zip_expect_res - zip_expect == zip_res - zip_out, "wrong result for zipped set_intersection");
-            EXPECT_EQ_N(zip_expect, zip_out, ::std::distance(zip_out, zip_res), "wrong zipped set_intersection effect");
+            EXPECT_EQ_N(zip_expect, zip_out, std::distance(zip_out, zip_res), "wrong zipped set_intersection effect");
         }
     }
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_common.h
+++ b/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_common.h
@@ -179,7 +179,6 @@ struct test_set_intersection
             EXPECT_TRUE(zip_expect_res - zip_expect == zip_res - zip_out, "wrong result for zipped set_intersection");
             EXPECT_EQ_N(zip_expect, zip_out, ::std::distance(zip_out, zip_res), "wrong zipped set_intersection effect");
         }
-
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>

--- a/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_common.h
+++ b/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_common.h
@@ -119,6 +119,20 @@ struct test_set_union
     }
 };
 
+// Compare the first of a tuple using the supplied comparator
+template <typename _Comp>
+struct comp_select_first
+{
+    _Comp comp;
+    comp_select_first(_Comp __comp) : comp(__comp) {}
+    template <typename _T1, typename _T2>
+    bool
+    operator()(_T1&& t1, _T2&& t2) const
+    {
+        return comp(::std::get<0>(::std::forward<_T1>(t1)), ::std::get<0>(::std::forward<_T2>(t2)));
+    }
+};
+
 template <typename Type>
 struct test_set_intersection
 {


### PR DESCRIPTION
Bug Description
---
As implemented before this PR, `set_intersection` using `oneapi::dpl::execution::par` has a bug which results in incorrect semantics for some situations.  
For performance reasons, in some situations, we would prefer to reverse the order of arguments in the parallel loop for input iterators.  However, this results in copying from the second set of iterators which is against semantics found here:

https://en.cppreference.com/w/cpp/algorithm/set_intersection
..."elements will be copied from [first1, last1) to the output range, preserving order."  

In cases where the comparator does not compare ALL of the input type, this can be very important.  For instance, a comparator for a key value pair which only considers the key.  

Fix Summary
---
This PR fixes this bug by passing a functor to `__set_intersection_construct` which selects which element to copy to the output range.  This allows us to keep the structure of the reversed iterator arguments without the issue of copying from the wrong input set.

This PR also adds a test which fails to compile without this fix using a key value pair example which only compares the key.  It uses a `oneapi::dpl::counting_iterator<int>` as a "value" for the first set of iterators, a `oneapi::dpl::discard_iterator` as a "value" for the second set of iterators, and a sequence of integers for the output "values".  If the implementation were to attempt to copy from the second set of iterators, a compiler error will occur when attempting to assign the dereferenced `oneapi::dpl::discard_iterator` to an integer.
