### PR TITLE
Use ND-range kernel in parallel_for kernel implementation to improve performance 

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -264,16 +264,16 @@ struct __parallel_for_submitter</*_IsGPU=*/::std::true_type, __internal::__optio
                 //get an access to data under SYCL buffer:
                 oneapi::dpl::__ranges::__require_access(__cgh, __rngs...);
 
-                __cgh.parallel_for<_Name...>(
-                    sycl::nd_range</*dim=*/1>(__n_groups * __wgroup_size, __wgroup_size),
-                    [=](sycl::nd_item</*dim=*/1> __item_id) {
-                        auto __local_id = __item_id.get_local_id(0);
-                        auto __grid_sz = __n_groups * __wgroup_size;
-                        for (::std::size_t __idx = __item_id.get_global_id(0); __idx < __count; __idx += __grid_sz)
-                        {
-                            __brick(__idx, __rngs...);
-                        }
-                    });
+                __cgh.parallel_for<_Name...>(sycl::nd_range</*dim=*/1>(__n_groups * __wgroup_size, __wgroup_size),
+                                             [=](sycl::nd_item</*dim=*/1> __item_id) {
+                                                 auto __local_id = __item_id.get_local_id(0);
+                                                 auto __grid_sz = __n_groups * __wgroup_size;
+                                                 for (::std::size_t __idx = __item_id.get_global_id(0); __idx < __count;
+                                                      __idx += __grid_sz)
+                                                 {
+                                                     __brick(__idx, __rngs...);
+                                                 }
+                                             });
             });
         return __future(__event);
     }
@@ -291,15 +291,17 @@ __parallel_for(_ExecutionPolicy&& __exec, _Fp __brick, _Index __count, _Ranges&&
 
     if (__exec.queue().get_device().is_gpu())
     {
-        using _ForKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<__parallel_for_kernel<::std::true_type, _CustomName>>;
-        return __parallel_for_submitter<::std::true_type, _ForKernel>()(::std::forward<_ExecutionPolicy>(__exec), __brick, __count,
-                                                                          ::std::forward<_Ranges>(__rngs)...);
+        using _ForKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
+            __parallel_for_kernel<::std::true_type, _CustomName>>;
+        return __parallel_for_submitter<::std::true_type, _ForKernel>()(
+            ::std::forward<_ExecutionPolicy>(__exec), __brick, __count, ::std::forward<_Ranges>(__rngs)...);
     }
     else
     {
-        using _ForKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<__parallel_for_kernel<::std::false_type, _CustomName>>;
-        return __parallel_for_submitter<::std::false_type, _ForKernel>()(::std::forward<_ExecutionPolicy>(__exec), __brick, __count,
-                                                                           ::std::forward<_Ranges>(__rngs)...);
+        using _ForKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
+            __parallel_for_kernel<::std::false_type, _CustomName>>;
+        return __parallel_for_submitter<::std::false_type, _ForKernel>()(
+            ::std::forward<_ExecutionPolicy>(__exec), __brick, __count, ::std::forward<_Ranges>(__rngs)...);
     }
 }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -230,8 +230,6 @@ struct __parallel_for_submitter</*_IsGPU=*/::std::false_type, __internal::__opti
     auto
     operator()(_ExecutionPolicy&& __exec, _Fp __brick, _Index __count, _Ranges&&... __rngs) const
     {
-        assert(oneapi::dpl::__ranges::__get_first_range_size(__rngs...) > 0);
-        _PRINT_INFO_IN_DEBUG_MODE(__exec);
         auto __event = __exec.queue().submit([&__rngs..., &__brick, __count](sycl::handler& __cgh) {
             //get an access to data under SYCL buffer:
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...);
@@ -253,8 +251,6 @@ struct __parallel_for_submitter</*_IsGPU=*/::std::true_type, __internal::__optio
     auto
     operator()(_ExecutionPolicy&& __exec, _Fp __brick, _Index __count, _Ranges&&... __rngs) const
     {
-        assert(oneapi::dpl::__ranges::__get_first_range_size(__rngs...) > 0);
-        _PRINT_INFO_IN_DEBUG_MODE(__exec);
         ::std::size_t __wgroup_size = oneapi::dpl::__internal::__max_work_group_size(__exec);
         ::std::size_t __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__count, __wgroup_size);
         ::std::size_t __max_cu = oneapi::dpl::__internal::__max_compute_units(__exec);
@@ -286,6 +282,8 @@ __parallel_for(_ExecutionPolicy&& __exec, _Fp __brick, _Index __count, _Ranges&&
 {
     using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
     using _CustomName = typename _Policy::kernel_name;
+    assert(oneapi::dpl::__ranges::__get_first_range_size(__rngs...) > 0);
+    _PRINT_INFO_IN_DEBUG_MODE(__exec);
 
     if (__exec.queue().get_device().is_gpu())
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -259,15 +259,13 @@ struct __parallel_for_submitter</*_IsGPU=*/::std::true_type, __internal::__optio
         ::std::size_t __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__count, __wgroup_size);
         ::std::size_t __max_cu = oneapi::dpl::__internal::__max_compute_units(__exec);
         __n_groups = ::std::min(__n_groups, __max_cu);
+        ::std::size_t __grid_sz = __n_groups * __wgroup_size;
         auto __event = __exec.queue().submit(
-            [&__rngs..., &__brick, __count, __wgroup_size, __n_groups, __max_cu](sycl::handler& __cgh) {
+            [&__rngs..., &__brick, __count, __wgroup_size, __n_groups, __grid_sz](sycl::handler& __cgh) {
                 //get an access to data under SYCL buffer:
                 oneapi::dpl::__ranges::__require_access(__cgh, __rngs...);
-
                 __cgh.parallel_for<_Name...>(sycl::nd_range</*dim=*/1>(__n_groups * __wgroup_size, __wgroup_size),
                                              [=](sycl::nd_item</*dim=*/1> __item_id) {
-                                                 auto __local_id = __item_id.get_local_id(0);
-                                                 auto __grid_sz = __n_groups * __wgroup_size;
                                                  for (::std::size_t __idx = __item_id.get_global_id(0); __idx < __count;
                                                       __idx += __grid_sz)
                                                  {


### PR DESCRIPTION
Performance issues have been identified within our `parallel_for` kernel on Intel® Data Center GPU Max for input sizes that are not powers of two. The root cause of this has been identified as the usage of a SYCL basic parallel kernel in our implementation.

This PR switches to using an explicit nd-range kernel for GPU devices only within the `parallel_for` pattern. A grid-strided memory access pattern is used which successfully resolves the identified performance issues. Additionally, performance improvements have been observed for powers of 2 as well.

Algorithms that internally rely on this kernel should see improvements on GPUs (ex: `for_each`, `copy`, etc.).