### PR TITLE
Unify exit message in the tests

### DIFF
--- a/test/parallel_api/iterator/permutation_iterator.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator.pass.cpp
@@ -49,5 +49,5 @@ main()
 
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-    return 0;
+    return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT);
 }

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy.pass.cpp
@@ -101,5 +101,6 @@ main()
     test<const int*, bidirectional_iterator<int*>>(deviceQueue);
     test<const int*, random_access_iterator<int*>>(deviceQueue);
     test<const int*, int*>(deviceQueue);
-    return 0;
+
+    return TestUtils::done();
 }

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy_backward.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy_backward.pass.cpp
@@ -79,5 +79,6 @@ main()
     test<const int*, bidirectional_iterator<int*>>(deviceQueue);
     test<const int*, random_access_iterator<int*>>(deviceQueue);
     test<const int*, int*>(deviceQueue);
-    return 0;
+
+    return TestUtils::done();
 }

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy_if.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.copy/xpu_copy_if.pass.cpp
@@ -102,5 +102,6 @@ main()
     test<const int*, bidirectional_iterator<int*>>(deviceQueue);
     test<const int*, random_access_iterator<int*>>(deviceQueue);
     test<const int*, int*>(deviceQueue);
-    return 0;
+
+    return TestUtils::done();
 }

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.fill/xpu_fill_n.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.fill/xpu_fill_n.pass.cpp
@@ -49,5 +49,6 @@ main()
     test<bidirectional_iterator<int*>>(deviceQueue);
     test<random_access_iterator<int*>>(deviceQueue);
     test<int*>(deviceQueue);
-    return 0;
+
+    return TestUtils::done();
 }

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.generate/xpu_generate_n.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.generate/xpu_generate_n.pass.cpp
@@ -57,5 +57,5 @@ main()
     test<bidirectional_iterator<int*>>(deviceQueue);
     test<random_access_iterator<int*>>(deviceQueue);
     test<int*>(deviceQueue);
-    return 0;
+    return TestUtils::done();
 }

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.move/xpu_move_backward.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.move/xpu_move_backward.pass.cpp
@@ -77,5 +77,5 @@ main()
     test<const int*, bidirectional_iterator<int*>>(deviceQueue);
     test<const int*, random_access_iterator<int*>>(deviceQueue);
     test<const int*, int*>(deviceQueue);
-    return 0;
+    return TestUtils::done();
 }

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.transform/xpu_binary_transform.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.transform/xpu_binary_transform.pass.cpp
@@ -95,5 +95,5 @@ main()
     test<input_iterator<const int*>, const int*, random_access_iterator<int*>>(deviceQueue);
     test<input_iterator<const int*>, const int*, int*>(deviceQueue);
 
-    return 0;
+    return TestUtils::done();
 }

--- a/test/xpu_api/algorithms/alg.modifying.operations/alg.transform/xpu_unary_transform.pass.cpp
+++ b/test/xpu_api/algorithms/alg.modifying.operations/alg.transform/xpu_unary_transform.pass.cpp
@@ -104,5 +104,5 @@ main()
     test<const int*, random_access_iterator<int*>>(deviceQueue);
     test<const int*, int*>(deviceQueue);
 
-    return 0;
+    return TestUtils::done();
 }

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.all_of/xpu_all_of.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.all_of/xpu_all_of.pass.cpp
@@ -65,5 +65,5 @@ main()
 {
     sycl::queue deviceQueue = TestUtils::get_test_queue();
     kernel_test(deviceQueue);
-    return 0;
+    return TestUtils::done();
 }

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.any_of/xpu_any_of.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.any_of/xpu_any_of.pass.cpp
@@ -69,5 +69,5 @@ main()
 {
     sycl::queue deviceQueue = TestUtils::get_test_queue();
     kernel_test(deviceQueue);
-    return 0;
+    return TestUtils::done();
 }

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.count/xpu_count.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.count/xpu_count.pass.cpp
@@ -45,5 +45,5 @@ main()
 {
     sycl::queue deviceQueue = TestUtils::get_test_queue();
     kernel_test(deviceQueue);
-    return 0;
+    return TestUtils::done();
 }

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.find/xpu_find_if.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.find/xpu_find_if.pass.cpp
@@ -62,5 +62,5 @@ main()
     test<bidirectional_iterator<const int*>>(deviceQueue);
     test<random_access_iterator<const int*>>(deviceQueue);
     test<const int*>(deviceQueue);
-    return 0;
+    return TestUtils::done();
 }

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.foreach/xpu_for_each_n.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.foreach/xpu_for_each_n.pass.cpp
@@ -107,6 +107,5 @@ main(int, char**)
 {
     sycl::queue deviceQueue = TestUtils::get_test_queue();
     test(deviceQueue);
-
-    return 0;
+    return TestUtils::done();
 }

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.is_permutation/xpu_is_permutation_pred.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.is_permutation/xpu_is_permutation_pred.pass.cpp
@@ -91,5 +91,5 @@ main()
     kernel_test1<bidirectional_iterator<const int*>>(deviceQueue);
     kernel_test1<random_access_iterator<const int*>>(deviceQueue);
     kernel_test1<const int*>(deviceQueue);
-    return 0;
+    return TestUtils::done();
 }

--- a/test/xpu_api/algorithms/alg.nonmodifying/alg.none_of/xpu_none_of.pass.cpp
+++ b/test/xpu_api/algorithms/alg.nonmodifying/alg.none_of/xpu_none_of.pass.cpp
@@ -71,5 +71,5 @@ main()
 {
     sycl::queue deviceQueue = TestUtils::get_test_queue();
     kernel_test(deviceQueue);
-    return 0;
+    return TestUtils::done();
 }

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap.pass.cpp
@@ -80,5 +80,5 @@ main()
         test<random_access_iterator<double*>>(deviceQueue);
         test<double*>(deviceQueue);
     }
-    return 0;
+    return TestUtils::done();
 }

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap_until_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/is.heap/xpu_is_heap_until_comp.pass.cpp
@@ -71,6 +71,5 @@ main()
         test<random_access_iterator<double*>>(deviceQueue);
         test<double*>(deviceQueue);
     }
-
-    return 0;
+    return TestUtils::done();
 }

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/make.heap/xpu_make_heap.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/make.heap/xpu_make_heap.pass.cpp
@@ -56,5 +56,5 @@ main()
         test<random_access_iterator<double*>>(deviceQueue);
         test<double*>(deviceQueue);
     }
-    return 0;
+    return TestUtils::done();
 }

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/pop.heap/xpu_pop_heap.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/pop.heap/xpu_pop_heap.pass.cpp
@@ -66,5 +66,5 @@ main()
     sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<random_access_iterator<int*>>(deviceQueue);
     test<int*>(deviceQueue);
-    return 0;
+    return TestUtils::done();
 }

--- a/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/push.heap/xpu_push_heap.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.heap.operations/push.heap/xpu_push_heap.pass.cpp
@@ -66,5 +66,5 @@ main()
     sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<random_access_iterator<int*>>(deviceQueue);
     test<int*>(deviceQueue);
-    return 0;
+    return TestUtils::done();
 }

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted.pass.cpp
@@ -81,5 +81,5 @@ main()
         test<random_access_iterator<const double*>>(deviceQueue);
         test<const float*>(deviceQueue);
     }
-    return 0;
+    return TestUtils::done();
 }

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted_until_comp.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/is.sorted/xpu_is_sorted_until_comp.pass.cpp
@@ -87,5 +87,5 @@ main()
         test<random_access_iterator<const double*>>(deviceQueue);
         test<const float*>(deviceQueue);
     }
-    return 0;
+    return TestUtils::done();
 }

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort.copy/xpu_partial_sort_copy.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort.copy/xpu_partial_sort_copy.pass.cpp
@@ -57,5 +57,5 @@ main()
     sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<random_access_iterator<int*>>(deviceQueue);
     test<int*>(deviceQueue);
-    return 0;
+    return TestUtils::done();
 }

--- a/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort/xpu_partial_sort.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.sort/partial.sort/xpu_partial_sort.pass.cpp
@@ -70,5 +70,5 @@ main()
     sycl::queue deviceQueue = TestUtils::get_test_queue();
     test<random_access_iterator<int*>>(deviceQueue);
     test<int*>(deviceQueue);
-    return 0;
+    return TestUtils::done();
 }

--- a/test/xpu_api/numerics/numeric.ops/accumulate/xpu_accumulate_op.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/accumulate/xpu_accumulate_op.pass.cpp
@@ -78,6 +78,5 @@ int main() {
   test<bidirectional_iterator<const int *>>();
   test<random_access_iterator<const int *>>();
   test<const int *>();
-  std::cout << "done" << std::endl;
-  return 0;
+  return TestUtils::done();
 }

--- a/test/xpu_api/numerics/numeric.ops/inner.product/xpu_inner_product_comp.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/inner.product/xpu_inner_product_comp.pass.cpp
@@ -118,7 +118,5 @@ main()
     test<const int*, random_access_iterator<const int*>>();
     test<const int*, const int*>();
 #endif
-
-    std::cout << "done" << std::endl;
-    return 0;
+    return TestUtils::done();
 }

--- a/test/xpu_api/numerics/numeric.ops/numeric.iota/xpu_iota.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/numeric.iota/xpu_iota.pass.cpp
@@ -54,6 +54,5 @@ int main() {
   test<bidirectional_iterator<int *>>();
   test<random_access_iterator<int *>>();
   test<int *>();
-  std::cout << "done" << std::endl;
-  return 0;
+  return TestUtils::done();
 }

--- a/test/xpu_api/numerics/numeric.ops/numeric.ops.lcm/xpu_lcm.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/numeric.ops.lcm/xpu_lcm.pass.cpp
@@ -113,7 +113,7 @@ main()
 
 // TODO: remove the macro guard once L0 backend fixes the issue
 #if defined(_WIN32)
-    std::cout << TestUtils::done(0) << ::std::endl;
+    return TestUtils::done(0);
 #else
     do_test<signed char>(deviceQueue);
     do_test<short>(deviceQueue);
@@ -132,9 +132,6 @@ main()
     do_test<long, int>(deviceQueue);
     do_test<int, long long>(deviceQueue);
     do_test<long long, int>(deviceQueue);
-
-    std::cout << "done" << std::endl;
 #endif
-
-    return 0;
+    return TestUtils::done();
 }

--- a/test/xpu_api/numerics/numeric.ops/partial.sum/xpu_partial_sum.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/partial.sum/xpu_partial_sum.pass.cpp
@@ -122,6 +122,6 @@ int main() {
   test<const int *, bidirectional_iterator<int *>, KernelTest23>();
   test<const int *, random_access_iterator<int *>, KernelTest24>();
   test<const int *, int *, KernelTest25>();
-  std::cout << "done" << std::endl;
-  return 0;
+
+  return TestUtils::done();
 }


### PR DESCRIPTION
Let's unify the output of the tests for easier handling with scripts.