### PR TITLE
[Documentation] Synchronizing both instances of onedpl_gsg.rst

### DIFF
--- a/documentation/library_guide/introduction/onedpl_gsg.rst
+++ b/documentation/library_guide/introduction/onedpl_gsg.rst
@@ -2,7 +2,7 @@ Get Started with the |onedpl_long|
 ##################################
 
 |onedpl_long| (|onedpl_short|) works with the
-`Intel® oneAPI DPC++/C++ Compiler <https://software.intel.com/content/www/us/en/develop/documentation/get-started-with-dpcpp-compiler/top.html>`_
+`Intel® oneAPI DPC++/C++ Compiler <https://www.intel.com/content/www/us/en/docs/dpcpp-cpp-compiler/get-started-guide/current/overview.html>`_
 to provide high-productivity APIs to developers, which can minimize SYCL*
 programming efforts across devices for high performance parallel applications.
 
@@ -14,14 +14,17 @@ programming efforts across devices for high performance parallel applications.
 
 
 For general information about |onedpl_short|, visit the `oneDPL GitHub* repository <https://github.com/oneapi-src/oneDPL>`_,
-or visit the `Intel® oneAPI DPC++ Library Guide <https://software.intel.com/content/www/us/en/develop/documentation/oneapi-dpcpp-library-guide/top.html>`_
-and the `Intel® oneAPI DPC++ Library main page <https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/dpc-library.html>`_.
+or visit the `Intel® oneAPI DPC++ Library Guide <https://www.intel.com/content/www/us/en/docs/onedpl/developer-guide/current/overview.html>`_
+and the `Intel® oneAPI DPC++ Library main page <https://www.intel.com/content/www/us/en/developer/tools/oneapi/dpc-library.html>`_.
 
-Before You Begin
-================
+Quick Start
+===========
+
+Installation
+------------
 
 Visit the |onedpl_short| `Release Notes
-<https://software.intel.com/content/www/us/en/develop/articles/intel-oneapi-dpcpp-library-release-notes.html>`_
+<https://www.intel.com/content/www/us/en/developer/articles/release-notes/intel-oneapi-dpcpp-library-release-notes.html>`_
 page for:
 
 * Where to Find the Release
@@ -30,7 +33,7 @@ page for:
 * Fixed Issues
 * Known Issues and Limitations
 
-Install the `Intel® oneAPI Base Toolkit (Base Kit) <https://software.intel.com/en-us/oneapi/base-kit>`_
+Install the `Intel® oneAPI Base Toolkit (Base Kit) <https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit.html>`_
 to use |onedpl_short|.
 
 To use Parallel API, include the corresponding header files in your source code.
@@ -43,13 +46,13 @@ and use the ``std`` namespace.
 
 
 pkg-config Support
-==================
+------------------
 
 The pkg-config program is used to retrieve information about your installed libraries, and
 to compile and link against one or more libraries.
 
 Use pkg-config with |onedpl_short|
-----------------------------------
+**********************************
 
 Use pkg-config with the ``--cflags`` flag to get the include path to the oneDPL directory:
 
@@ -69,14 +72,14 @@ This flag converts your compiling and linking flags to the appropriate form:
 
 
 Usage Examples
-==============
+--------------
 
 |onedpl_short| sample code is available from the
 `oneAPI GitHub samples repository <https://github.com/oneapi-src/oneAPI-samples/tree/master/Libraries/oneDPL>`_.
 Each sample includes a readme with build instructions.
 
 \<oneapi/dpl/random\> Header Usage Example
-------------------------------------------
+******************************************
 
 This example illustrates |onedpl_short| random number generator usage.
 The sample below shows you how to create an random number generator engine object (the source of pseudo-randomness),
@@ -107,7 +110,7 @@ This example performs its computations on your default SYCL device. You can set 
     }
 
 Pi Benchmark Usage Example
---------------------------
+**************************
 
 This example uses a Monte Carlo method to estimate the value of π.
 The basic idea is to generate random points within a square, and to check what
@@ -162,13 +165,13 @@ Find More
 
    * - Resource Link
      - Description
-   * - `Intel® oneAPI DPC++ Library Guide <https://software.intel.com/content/www/us/en/develop/documentation/oneapi-dpcpp-library-guide/top.html>`_
+   * - `Intel® oneAPI DPC++ Library Guide <https://www.intel.com/content/www/us/en/docs/onedpl/developer-guide/current/overview.html>`_
      - Refer to the |onedpl_short| guide for  more in depth information.
-   * - `System Requirements <https://software.intel.com/content/www/us/en/develop/articles/intel-oneapi-dpcpp-system-requirements.html>`_
+   * - `System Requirements <https://www.intel.com/content/www/us/en/developer/articles/system-requirements/intel-oneapi-dpcpp-system-requirements.html>`_
      - Check system requirements before you install |onedpl_short|.
-   * - `Intel® oneAPI DPC++ Library Release Notes <https://software.intel.com/content/www/us/en/develop/articles/intel-oneapi-dpcpp-library-release-notes.html>`_
+   * - `Intel® oneAPI DPC++ Library Release Notes <https://www.intel.com/content/www/us/en/developer/articles/release-notes/intel-oneapi-dpcpp-library-release-notes.html>`_
      - Check the release notes to learn about updates in the latest release.
    * - `oneDPL Samples <https://github.com/oneapi-src/oneAPI-samples/tree/master/Libraries/oneDPL>`_
      - Learn how to use |onedpl_short| with samples.
-   * - `Layers for Yocto* Project <https://www.intel.com/content/www/us/en/develop/documentation/get-started-with-intel-oneapi-iot-linux/top/adding-oneapi-components-to-yocto-project-builds.html>`_
+   * - `Layers for Yocto* Project <https://www.intel.com/content/www/us/en/docs/oneapi-iot-toolkit/get-started-guide-linux/current/adding-oneapi-components-to-yocto-project-builds.html>`_
      - Add oneAPI components to a Yocto project build using the meta-intel layers.


### PR DESCRIPTION
It seems that PR #692 and #932 did not update the copy of `documentation/library_guide/introduction/onedpl_gsg.rst`.  This adds the changes from those PRs to this file to synchronize the two instances of `onedpl_gsg.rst`.

The changes include updates to URLs and style guide updates.