### PR TITLE
[oneDPL] radix sort: workload optimization

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -746,8 +746,7 @@ __parallel_radix_sort(_ExecutionPolicy&& __exec, _Range&& __in_rng, _Proj __proj
         const ::std::uint32_t __radix_states = 1 << __radix_bits;
 
 #if _ONEDPL_RADIX_WORKLOAD_TUNING
-        const auto __wg_sz_k =
-            __n >= (1 << 15) /*32K*/ && __n < (1 << 19) /*512K*/ ? 8 : __n <= (1 << 21) /*2M*/ ? 4 : 1;
+        const auto __wg_sz_k = __n >= (1 << 15)/*32K*/ && __n < (1 << 19)/*512K*/ ? 8 : __n <= (1 << 21)/*2M*/ ? 4 : 1;
         const ::std::size_t __wg_size = __max_wg_size / __wg_sz_k;
 #else
         ::std::size_t __wg_size = __max_wg_size;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -592,7 +592,7 @@ struct __parallel_radix_sort_iteration
         ::std::size_t __reorder_sg_size = __max_sg_size;
         ::std::size_t __scan_wg_size = oneapi::dpl::__internal::__max_work_group_size(__exec);
 #if _ONEDPL_RADIX_WORKLOAD_TUNING
-        ::std::size_t __count_wg_size = (__n > (1<<21)/*2M*/ ? 128 : __max_sg_size);
+        ::std::size_t __count_wg_size = (__in_rng.size() > (1<<21)/*2M*/ ? 128 : __max_sg_size);
 #else
         ::std::size_t __count_wg_size = __max_sg_size;
 #endif

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -26,9 +26,9 @@
 #include "execution_sycl_defs.h"
 
 #define _ONEDPL_RADIX_WORKLOAD_TUNING 1
-//To achieve the better occupancy work group size and block size are variated depend on data size (32bits):
-//1. 32K...512K  - an estimated workgroup size is reduced down to 8 times
-//2. 512K...2M   - an estimated workgroup size is reduced down to 4 times
+//To achieve better performance number of segments and block size are variated depend on data size (32bits):
+//1. 32K...512K  - number of segments is increased up to 8 times
+//2. 512K...2M   - number of segments is increased up up 4 times
 //3. 2M...16M... - block size is increased up to 128
 
 namespace oneapi

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -746,7 +746,8 @@ __parallel_radix_sort(_ExecutionPolicy&& __exec, _Range&& __in_rng, _Proj __proj
         const ::std::uint32_t __radix_states = 1 << __radix_bits;
 
 #if _ONEDPL_RADIX_WORKLOAD_TUNING
-        const auto __wg_sz_k = __n >= (1<<15)/*32K*/ && __n <  (1<<19)/*512K*/ ? 8 : __n <= (1<<21)/*2M*/ ? 4 : 1;
+        const auto __wg_sz_k =
+            __n >= (1 << 15) /*32K*/ && __n < (1 << 19) /*512K*/ ? 8 : __n <= (1 << 21) /*2M*/ ? 4 : 1;
         const ::std::size_t __wg_size = __max_wg_size / __wg_sz_k;
 #else
         ::std::size_t __wg_size = __max_wg_size;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -595,7 +595,7 @@ struct __parallel_radix_sort_iteration
         ::std::size_t __count_wg_size = (__n > (1<<21)/*2M*/ ? 128 : __max_sg_size);
 #else
         ::std::size_t __count_wg_size = __max_sg_size;
-#ednif
+#endif
 
         // correct __count_wg_size, __scan_wg_size, __reorder_sg_size after introspection of the kernels
 #if _ONEDPL_COMPILE_KERNEL

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -26,10 +26,10 @@
 #include "execution_sycl_defs.h"
 
 #define _ONEDPL_RADIX_WORKLOAD_TUNING 1
-//To achieve better performance number of segments and work-group size  are variated depending on number of elements:
+//To achieve better performance, number of segments and work-group size are variated depending on a number of elements:
 //1. 32K...512K  - number of segments is increased up to 8 times
 //2. 512K...2M   - number of segments is increased up up 4 times
-//3. 2M...16M... - work-group size (count phase) is increased up to 128
+//3. 2M... - work-group size (count phase) is increased up to 128
 
 namespace oneapi
 {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -26,7 +26,7 @@
 #include "execution_sycl_defs.h"
 
 #define _ONEDPL_RADIX_WORKLOAD_TUNING 1
-//To achieve better performance number of segments and block size are variated depend on data size (32bits):
+//To achieve better performance number of segments and work-group size  are variated depending on number of elements:
 //1. 32K...512K  - number of segments is increased up to 8 times
 //2. 512K...2M   - number of segments is increased up up 4 times
 //3. 2M...16M... - work-group size (count phase) is increased up to 128


### PR DESCRIPTION
A macro _ONEDPL_RADIX_WORKLOAD_TUNING enables following workload tunning:

//To achieve better performance number of segments and block size are variated depend on data size (32bits):
//1. 32K...512K  - number of segments is increased up to 8 times
//2. 512K...2M   - number of segments is increased up up 4 times
//3. 2M...16M... - work-group size (count phase) is increased up to 128
