### PR TITLE
[KT] Modify process size to fix onesweep with sycl::buffer

### DIFF
--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort.h
@@ -55,29 +55,27 @@ radix_sort(_ExecutionPolicy&& __exec, _Range&& __rng)
 
     _PRINT_INFO_IN_DEBUG_MODE(__exec);
     using _KernelName = typename ::std::decay_t<_ExecutionPolicy>::kernel_name;
-    
+
     if (__n <= 16384)
     {
-        // TODO: support double and small-size integers
-        // TODO: allow all RadixBits values (only 7 or 8 are currently supported)
+        // TODO: support different RadixBits values (only 7 or 8 are currently supported), WorkGroupSize and DataPerWorkItem
         oneapi::dpl::experimental::esimd::impl::one_wg<_KernelName, _KeyT, _Range, RadixBits, IsAscending>(
             __exec.queue(), ::std::forward<_Range>(__rng), __n);
     }
     else if (__n <= 262144)
     {
-        // TODO: support double and small-size integers
+        // TODO: support different RadixBits, WorkGroupSize and DataPerWorkItem
         oneapi::dpl::experimental::esimd::impl::cooperative<_KernelName, _KeyT, _Range, RadixBits, IsAscending>(
             __exec.queue(), ::std::forward<_Range>(__rng), __n);
     }
     else
     {
-        // TODO: support floating point types and small-size integers
+        // TODO: enable support of double, chart, uint8_t, int8_t types
         // TODO: avoid kernel duplication (generate the output storage with the same type as input storage and use swap)
-        // TODO: allow different RadixBits, make sure the data is in the input storage after the last stage
-        // TODO: pass _ProcessSize according to __n
-        // TODO: fix when compiled in -O0 mode: "esimd_radix_sort_one_wg.h : 54 : 5>: SLM init call is supported only in kernels"
-        // TODO: support inputs which are transferred to kernels as accessors (sycl_iterator, all_view)
-        oneapi::dpl::experimental::esimd::impl::onesweep<_KernelName, _KeyT, _Range, RadixBits, IsAscending, /*_ProcessSize*/416>(
+        // TODO: support different RadixBits, make sure the data is in the input storage after the last stage
+        // TODO: pass _ProcessSize according to DataPerWorkItem
+        // TODO: support different WorkGroupSize
+        oneapi::dpl::experimental::esimd::impl::onesweep<_KernelName, _KeyT, _Range, RadixBits, IsAscending, /*_ProcessSize*/384>(
             __exec.queue(), ::std::forward<_Range>(__rng), __n);
     }
 }

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort.h
@@ -58,19 +58,21 @@ radix_sort(_ExecutionPolicy&& __exec, _Range&& __rng)
 
     if (__n <= 16384)
     {
+        // TODO: enable support of char, uint8_t, int8_t types
         // TODO: support different RadixBits values (only 7 or 8 are currently supported), WorkGroupSize and DataPerWorkItem
         oneapi::dpl::experimental::esimd::impl::one_wg<_KernelName, _KeyT, _Range, RadixBits, IsAscending>(
             __exec.queue(), ::std::forward<_Range>(__rng), __n);
     }
     else if (__n <= 262144)
     {
+        // TODO: enable support of char, uint8_t, int8_t types
         // TODO: support different RadixBits, WorkGroupSize and DataPerWorkItem
         oneapi::dpl::experimental::esimd::impl::cooperative<_KernelName, _KeyT, _Range, RadixBits, IsAscending>(
             __exec.queue(), ::std::forward<_Range>(__rng), __n);
     }
     else
     {
-        // TODO: enable support of double, chart, uint8_t, int8_t types
+        // TODO: enable support of double, char, uint8_t, int8_t types
         // TODO: avoid kernel duplication (generate the output storage with the same type as input storage and use swap)
         // TODO: support different RadixBits, make sure the data is in the input storage after the last stage
         // TODO: pass _ProcessSize according to DataPerWorkItem

--- a/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
+++ b/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
@@ -389,51 +389,20 @@ int main()
     try
     {
 #if TEST_ALL_INPUTS
-        const std::vector<std::size_t> onewg_sizes   {std::begin(sizes),      std::begin(sizes) + 10};
-        const std::vector<std::size_t> coop_sizes    {std::begin(sizes) + 10, std::begin(sizes) + 18};
-        const std::vector<std::size_t> onesweep_sizes{std::begin(sizes) + 18, std::end(sizes)};
-
-        for(auto size: onewg_sizes)
+        for(auto size: sizes)
         {
             test_general_cases<int16_t >(size);
             test_general_cases<uint16_t>(size);
             test_general_cases<int     >(size);
             test_general_cases<uint32_t>(size);
-            test_general_cases<uint64_t>(size);
-            test_general_cases<int64_t >(size);
             test_general_cases<float   >(size);
-            //test_general_cases<double  >(size);
-        }
-        for(auto size: coop_sizes)
-        {
-            test_general_cases<int16_t >(size);
-            test_general_cases<uint16_t>(size);
-            test_general_cases<int     >(size);
-            test_general_cases<uint32_t>(size);
-            test_general_cases<uint64_t>(size);
-            test_general_cases<int64_t >(size);
-            test_general_cases<float   >(size);
-            //test_general_cases<double  >(size);
-        }
-        for(auto size: onesweep_sizes)
-        {
-            test_usm<int16_t,  kAscending>(size);
-            test_usm<uint16_t, kAscending>(size);
-            test_usm<int,      kAscending>(size);
-            test_usm<uint32_t, kAscending>(size);
             // Not implemented for onesweep
-            //test_usm<uint64_t, kAscending>(size);
-            //test_usm<int64_t,  kAscending>(size);
-            test_usm<float,    kAscending>(size);
-
-            test_usm<int16_t,  kDescending>(size);
-            test_usm<uint16_t, kDescending>(size);
-            test_usm<int,      kDescending>(size);
-            test_usm<uint32_t, kDescending>(size);
-            // Not implemented for onesweep
-            //test_usm<uint64_t, kDescending>(size);
-            //test_usm<int64_t,  kDescending>(size);
-            test_usm<float,    kDescending>(size);
+            if (size <= 262144)
+            {
+                test_general_cases<int64_t >(size);
+                test_general_cases<uint64_t>(size);
+                test_general_cases<double  >(size);
+            }
         }
         test_small_sizes();
 #else


### PR DESCRIPTION
Additionally, update TODO comments and enable more test cases with onesweep algorithm.