### PR TITLE
[KT] Enable all types (excepting double) in esimd radix sort test

### DIFF
--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort.h
@@ -26,6 +26,19 @@
 
 namespace oneapi::dpl::experimental::esimd::impl
 {
+template <typename T, ::std::enable_if_t<sizeof(T) <= sizeof(::std::uint32_t), int> = 0>
+constexpr ::std::uint32_t
+__onesweep_process_size()
+{
+    return 384;
+}
+
+template <typename T, ::std::enable_if_t<sizeof(T) == sizeof(::std::uint64_t), int> = 0>
+constexpr ::std::uint32_t
+__onesweep_process_size()
+{
+    return 192;
+}
 
 /*
     Interface:
@@ -74,7 +87,7 @@ radix_sort(_ExecutionPolicy&& __exec, _Range&& __rng)
         // TODO: avoid kernel duplication (generate the output storage with the same type as input storage and use swap)
         // TODO: pass _ProcessSize according to DataPerWorkItem
         // TODO: support different WorkGroupSize, RadixBits
-        oneapi::dpl::experimental::esimd::impl::onesweep<_KernelName, _KeyT, _Range, RadixBits, IsAscending, /*_ProcessSize*/384>(
+        oneapi::dpl::experimental::esimd::impl::onesweep<_KernelName, _KeyT, _Range, RadixBits, IsAscending, __onesweep_process_size<_KeyT>()>(
             __exec.queue(), ::std::forward<_Range>(__rng), __n);
     }
 }

--- a/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
+++ b/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
@@ -421,11 +421,11 @@ int main()
             test_general_cases<int     >(size);
             test_general_cases<uint32_t>(size);
             test_general_cases<float   >(size);
+            test_general_cases<int64_t >(size);
+            test_general_cases<uint64_t>(size);
             // Not implemented for onesweep
             if (size <= 262144)
             {
-                test_general_cases<int64_t >(size);
-                test_general_cases<uint64_t>(size);
                 test_general_cases<double  >(size);
             }
         }
@@ -440,16 +440,16 @@ int main()
             // Not implemented for onesweep
             if (size <= 262144)
             {
-                test_usm<double, sycl::usm::alloc::shared, Ascending>(size);
+                test_usm<double,   sycl::usm::alloc::shared, Ascending>(size);
             }
-
-            test_usm<int16_t, sycl::usm::alloc::shared, Descending>(size);
-            test_usm<int,     sycl::usm::alloc::shared, Descending>(size);
-            test_usm<float,   sycl::usm::alloc::shared, Descending>(size);
+            
+            test_usm<int16_t,  sycl::usm::alloc::shared, Descending>(size);
+            test_usm<int,      sycl::usm::alloc::shared, Descending>(size);
+            test_usm<float,    sycl::usm::alloc::shared, Descending>(size);
+            test_usm<uint64_t, sycl::usm::alloc::shared, Descending>(size);
             // Not implemented for onesweep
             if (size <= 262144)
             {
-                test_usm<uint64_t, sycl::usm::alloc::shared, Descending>(size);
                 test_usm<double,   sycl::usm::alloc::shared, Descending>(size);
             }
         }

--- a/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
+++ b/test/parallel_api/experimental/radix_sort_esimd.pass.cpp
@@ -372,30 +372,16 @@ template <typename T>
 void test_general_cases(std::size_t size)
 {
 #if _ENABLE_RANGES_TESTING
-    if constexpr (sizeof(T) <= sizeof(::std::uint32_t))
-    {
-        test_all_view<T, Ascending>(size);
-        test_all_view<T, Descending>(size);
-        test_subrange_view<T, Ascending>(size);
-        test_subrange_view<T, Descending>(size);
-    }
-    else
-    {
-        // TODO required to implement
-    }
+    test_all_view<T, Ascending>(size);
+    test_all_view<T, Descending>(size);
+    test_subrange_view<T, Ascending>(size);
+    test_subrange_view<T, Descending>(size);
 #endif // _ENABLE_RANGES_TESTING
     test_usm<T, Ascending>(size);
     test_usm<T, Descending>(size);
 
-    if constexpr (sizeof(T) <= sizeof(::std::uint32_t))
-    {
-        test_sycl_iterators<T, Ascending>(size);
-        test_sycl_iterators<T, Descending>(size);
-    }
-    else
-    {
-        // TODO required to implement
-    }
+    test_sycl_iterators<T, Ascending>(size);
+    test_sycl_iterators<T, Descending>(size);
 }
 #endif // TEST_DPCPP_BACKEND_PRESENT
 


### PR DESCRIPTION
In this PR we define by default PROCESS_SIZE for ```onesweep``` impl in esimd radix sort as:

- ```384``` for all types with size <= 4 bytes;
- ```192``` for all types with size == 8 bytes;
- enable all types in esimd radix sort test: ```double``` will be included in separate PR.