### PR TITLE
[KT] Memory allocation improvements

### DIFF
--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_cooperative.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_cooperative.h
@@ -365,16 +365,16 @@ void cooperative(sycl::queue __q, _Range&& __rng, ::std::size_t __n) {
     }
     assert(__groups <= MAX_GROUPS);
 
-    const size_t full_buffer_size_part1 = sizeof(::std::uint32_t) * (1024 + (__groups + 2) * BIN_COUNT);
-    const size_t full_buffer_size_part2 = sizeof(KeyT) * (__groups * __group_block_size);
-    const size_t full_buffer_size = full_buffer_size_part1 + full_buffer_size_part2;
+    const size_t full_buffer_size_sync = sizeof(::std::uint32_t) * (1024 + (__groups + 2) * BIN_COUNT);
+    const size_t full_buffer_size_tmp = sizeof(KeyT) * (__groups * __group_block_size);
+    const size_t full_buffer_size = full_buffer_size_sync + full_buffer_size_tmp;
 
     uint8_t* p_temp_memory = sycl::malloc_device<uint8_t>(full_buffer_size, __q);
 
     auto p_sync = reinterpret_cast<::std::uint32_t*>(p_temp_memory);
 
     // to correctly sort floating point values, a buffer to store data plus extra identity values is needed
-    KeyT* __tmpbuf = reinterpret_cast<KeyT*>(p_temp_memory + full_buffer_size_part1);
+    KeyT* __tmpbuf = reinterpret_cast<KeyT*>(p_temp_memory + full_buffer_size_sync);
 
     using _EsimRadixSort = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
             __esimd_radix_sort_cooperative<_KernelName>>;

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_cooperative.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_cooperative.h
@@ -369,12 +369,12 @@ void cooperative(sycl::queue __q, _Range&& __rng, ::std::size_t __n) {
     const size_t full_buffer_size_part2 = sizeof(KeyT) * (__groups * __group_block_size);
     const size_t full_buffer_size = full_buffer_size_part1 + full_buffer_size_part2;
 
-    uint8_t* p_full_buffer = sycl::malloc_device<uint8_t>(full_buffer_size, __q);
+    uint8_t* p_temp_memory = sycl::malloc_device<uint8_t>(full_buffer_size, __q);
 
-    auto p_sync = reinterpret_cast<::std::uint32_t*>(p_full_buffer);
+    auto p_sync = reinterpret_cast<::std::uint32_t*>(p_temp_memory);
 
     // to correctly sort floating point values, a buffer to store data plus extra identity values is needed
-    KeyT* __tmpbuf = reinterpret_cast<KeyT*>(p_full_buffer + full_buffer_size_part1);
+    KeyT* __tmpbuf = reinterpret_cast<KeyT*>(p_temp_memory + full_buffer_size_part1);
 
     using _EsimRadixSort = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
             __esimd_radix_sort_cooperative<_KernelName>>;
@@ -394,7 +394,7 @@ void cooperative(sycl::queue __q, _Range&& __rng, ::std::size_t __n) {
     }
     __e.wait();
 
-    sycl::free(p_full_buffer, __q);
+    sycl::free(p_temp_memory, __q);
 }
 
 } // oneapi::dpl::experimental::esimd::impl

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_cooperative.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_cooperative.h
@@ -365,9 +365,16 @@ void cooperative(sycl::queue __q, _Range&& __rng, ::std::size_t __n) {
     }
     assert(__groups <= MAX_GROUPS);
 
-    auto p_sync = sycl::malloc_device<::std::uint32_t>(1024 + (__groups+2) * BIN_COUNT, __q);
+    const size_t full_buffer_size_part1 = sizeof(::std::uint32_t) * (1024 + (__groups + 2) * BIN_COUNT);
+    const size_t full_buffer_size_part2 = sizeof(KeyT) * (__groups * __group_block_size);
+    const size_t full_buffer_size = full_buffer_size_part1 + full_buffer_size_part2;
+
+    uint8_t* p_full_buffer = sycl::malloc_device<uint8_t>(full_buffer_size, __q);
+
+    auto p_sync = reinterpret_cast<::std::uint32_t*>(p_full_buffer);
+
     // to correctly sort floating point values, a buffer to store data plus extra identity values is needed
-    KeyT* __tmpbuf = sycl::malloc_device<KeyT>(__groups * __group_block_size, __q);
+    KeyT* __tmpbuf = reinterpret_cast<KeyT*>(p_full_buffer + full_buffer_size_part1);
 
     using _EsimRadixSort = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
             __esimd_radix_sort_cooperative<_KernelName>>;
@@ -386,8 +393,8 @@ void cooperative(sycl::queue __q, _Range&& __rng, ::std::size_t __n) {
                 __q, ::std::forward<_Range>(__rng), __n, __groups, __tmpbuf, p_sync);
     }
     __e.wait();
-    sycl::free(__tmpbuf, __q);
-    sycl::free(p_sync, __q);
+
+    sycl::free(p_full_buffer, __q);
 }
 
 } // oneapi::dpl::experimental::esimd::impl

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
@@ -581,9 +581,9 @@ onesweep(sycl::queue __q, _Range&& __rng, ::std::size_t __n)
     constexpr uint32_t GLOBAL_OFFSET_SIZE = BINCOUNT * STAGES * sizeof(global_hist_t);
     size_t temp_buffer_size = GLOBAL_OFFSET_SIZE + SYNC_BUFFER_SIZE;
 
-    const size_t full_buffer_size_part1 = temp_buffer_size * sizeof(uint8_t);
-    const size_t full_buffer_size_part2 = __n * sizeof(KeyT);
-    const size_t full_buffer_size = full_buffer_size_part1 + full_buffer_size_part2;
+    const size_t full_buffer_size_global_hist = temp_buffer_size * sizeof(uint8_t);
+    const size_t full_buffer_size_output = __n * sizeof(KeyT);
+    const size_t full_buffer_size = full_buffer_size_global_hist + full_buffer_size_output;
 
     uint8_t* p_temp_memory = sycl::malloc_device<uint8_t>(full_buffer_size, __q);
 
@@ -591,7 +591,7 @@ onesweep(sycl::queue __q, _Range&& __rng, ::std::size_t __n)
     auto p_global_offset = reinterpret_cast<uint32_t*>(p_globl_hist_buffer);
 
     // Memory for storing values sorted for an iteration
-    auto p_output = reinterpret_cast<KeyT*>(p_temp_memory + full_buffer_size_part1);
+    auto p_output = reinterpret_cast<KeyT*>(p_temp_memory + full_buffer_size_global_hist);
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<oneapi::dpl::__par_backend_hetero::access_mode::read_write, decltype(p_output)>();
     auto __out_rng = __keep(p_output, p_output + __n).all_view();
 

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
@@ -581,11 +581,17 @@ onesweep(sycl::queue __q, _Range&& __rng, ::std::size_t __n)
     constexpr uint32_t GLOBAL_OFFSET_SIZE = BINCOUNT * STAGES * sizeof(global_hist_t);
     size_t temp_buffer_size = GLOBAL_OFFSET_SIZE + SYNC_BUFFER_SIZE;
 
-    uint8_t *tmp_buffer = sycl::malloc_device<uint8_t>(temp_buffer_size, __q);
+    const size_t full_buffer_size_part1 = temp_buffer_size * sizeof(uint8_t);
+    const size_t full_buffer_size_part2 = __n * sizeof(KeyT);
+    const size_t full_buffer_size = full_buffer_size_part1 + full_buffer_size_part2;
+
+    uint8_t* p_full_buffer = sycl::malloc_device<uint8_t>(full_buffer_size, __q);
+
+    uint8_t* tmp_buffer = p_full_buffer;
     auto p_global_offset = reinterpret_cast<uint32_t*>(tmp_buffer);
 
     // Memory for storing values sorted for an iteration
-    auto p_output = sycl::malloc_device<KeyT>(__n, __q);
+    auto p_output = reinterpret_cast<KeyT*>(p_full_buffer + full_buffer_size_part1);
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<oneapi::dpl::__par_backend_hetero::access_mode::read_write, decltype(p_output)>();
     auto __out_rng = __keep(p_output, p_output + __n).all_view();
 
@@ -621,8 +627,7 @@ onesweep(sycl::queue __q, _Range&& __rng, ::std::size_t __n)
     }
     event_chain.wait();
 
-    sycl::free(tmp_buffer, __q);
-    sycl::free(p_output, __q);
+    sycl::free(p_full_buffer, __q);
 }
 
 } // oneapi::dpl::experimental::esimd::impl

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
@@ -585,13 +585,13 @@ onesweep(sycl::queue __q, _Range&& __rng, ::std::size_t __n)
     const size_t full_buffer_size_part2 = __n * sizeof(KeyT);
     const size_t full_buffer_size = full_buffer_size_part1 + full_buffer_size_part2;
 
-    uint8_t* p_full_buffer = sycl::malloc_device<uint8_t>(full_buffer_size, __q);
+    uint8_t* p_temp_memory = sycl::malloc_device<uint8_t>(full_buffer_size, __q);
 
-    uint8_t* tmp_buffer = p_full_buffer;
+    uint8_t* tmp_buffer = p_temp_memory;
     auto p_global_offset = reinterpret_cast<uint32_t*>(tmp_buffer);
 
     // Memory for storing values sorted for an iteration
-    auto p_output = reinterpret_cast<KeyT*>(p_full_buffer + full_buffer_size_part1);
+    auto p_output = reinterpret_cast<KeyT*>(p_temp_memory + full_buffer_size_part1);
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<oneapi::dpl::__par_backend_hetero::access_mode::read_write, decltype(p_output)>();
     auto __out_rng = __keep(p_output, p_output + __n).all_view();
 
@@ -627,7 +627,7 @@ onesweep(sycl::queue __q, _Range&& __rng, ::std::size_t __n)
     }
     event_chain.wait();
 
-    sycl::free(p_full_buffer, __q);
+    sycl::free(p_temp_memory, __q);
 }
 
 } // oneapi::dpl::experimental::esimd::impl


### PR DESCRIPTION
In this PR we exclude twice memory allocations on device in onesweep and cooperatiove implementations of esimd radix sort.