### PR TITLE
Do not forward or move variables that are used later in the code

### DIFF
--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -66,7 +66,7 @@ pattern_exclusive_scan_by_segment(Policy&& policy, InputIterator1 first1, InputI
     auto flags = _flags.get();
     flags[0] = 1;
 
-    transform(::std::forward<Policy>(policy), first1, last1 - 1, first1 + 1, _flags.get() + 1,
+    transform(policy, first1, last1 - 1, first1 + 1, _flags.get() + 1,
               oneapi::dpl::__internal::__not_pred<BinaryPredicate>(binary_pred));
 
     // shift input one to the right and initialize segments with init
@@ -127,7 +127,7 @@ exclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIter
         flags[0] = 1;
     }
 
-    transform(::std::forward<Policy>(policy), first1, last1 - 1, first1 + 1, _flags.get() + 1,
+    transform(policy, first1, last1 - 1, first1 + 1, _flags.get() + 1,
               oneapi::dpl::__internal::__not_pred<BinaryPredicate>(binary_pred));
 
     // shift input one to the right and initialize segments with init

--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -151,7 +151,7 @@ exclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIter
                     ::std::negate<FlagType>(), init);
 #    endif
 
-    auto policy2 = oneapi::dpl::__par_backend_hetero::make_wrapped_policy<ExclusiveScan2>(policy);
+    auto policy2 = oneapi::dpl::__par_backend_hetero::make_wrapped_policy<ExclusiveScan2>(::std::forward<Policy>(policy));
 
     // scan key-flag tuples
     transform_inclusive_scan(::std::move(policy2), make_zip_iterator(_temp.get(), _flags.get()),

--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -151,7 +151,8 @@ exclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIter
                     ::std::negate<FlagType>(), init);
 #    endif
 
-    auto policy2 = oneapi::dpl::__par_backend_hetero::make_wrapped_policy<ExclusiveScan2>(::std::forward<Policy>(policy));
+    auto policy2 =
+        oneapi::dpl::__par_backend_hetero::make_wrapped_policy<ExclusiveScan2>(::std::forward<Policy>(policy));
 
     // scan key-flag tuples
     transform_inclusive_scan(::std::move(policy2), make_zip_iterator(_temp.get(), _flags.get()),

--- a/include/oneapi/dpl/internal/reduce_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/reduce_by_segment_impl.h
@@ -245,8 +245,7 @@ __sycl_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2&& 
     auto __seg_reduce_offset_kernel =
         __par_backend_hetero::__internal::__kernel_compiler<_SegReduceOffsetKernel>::__compile(__exec);
     auto __seg_reduce_wg_kernel =
-        __par_backend_hetero::__internal::__kernel_compiler<_SegReduceWgKernel>::__compile(
-        __exec);
+        __par_backend_hetero::__internal::__kernel_compiler<_SegReduceWgKernel>::__compile(__exec);
     auto __seg_reduce_prefix_kernel =
         __par_backend_hetero::__internal::__kernel_compiler<_SegReducePrefixKernel>::__compile(__exec);
     __wgroup_size =

--- a/include/oneapi/dpl/internal/reduce_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/reduce_by_segment_impl.h
@@ -122,7 +122,7 @@ reduce_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIterator1 la
     mask[n] = 1;
 
     // Identify where the first key in a sequence of equivalent keys is located
-    transform(::std::forward<Policy>(policy), first1, last1 - 1, first1 + 1, _mask.get() + 1,
+    transform(policy, first1, last1 - 1, first1 + 1, _mask.get() + 1,
               oneapi::dpl::__internal::__not_pred<BinaryPred>(binary_pred));
 
     // for example: _mask = { 1, 1, 1, 1, 1, 0, 1, 0, 1, 0, 1, 0, 1, 1}
@@ -233,35 +233,28 @@ __sycl_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2&& 
         16; // Each work item serially processes 16 items. Best observed performance on gpu
 
     ::std::size_t __wgroup_size =
-        oneapi::dpl::__internal::__max_work_group_size(::std::forward<_ExecutionPolicy>(__exec));
+        oneapi::dpl::__internal::__max_work_group_size(__exec);
 
     // adjust __wgroup_size according to local memory limit. Double the requirement on __val_type due to sycl group algorithm's use
     // of SLM.
     __wgroup_size = oneapi::dpl::__internal::__slm_adjusted_work_group_size(
-        ::std::forward<_ExecutionPolicy>(__exec), sizeof(__key_type) + 2 * sizeof(__val_type), __wgroup_size);
+        __exec, sizeof(__key_type) + 2 * sizeof(__val_type), __wgroup_size);
 
 #if _ONEDPL_COMPILE_KERNEL
     auto __seg_reduce_count_kernel =
-        __par_backend_hetero::__internal::__kernel_compiler<_SegReduceCountKernel>::__compile(
-            ::std::forward<_ExecutionPolicy>(__exec));
+        __par_backend_hetero::__internal::__kernel_compiler<_SegReduceCountKernel>::__compile(__exec);
     auto __seg_reduce_offset_kernel =
-        __par_backend_hetero::__internal::__kernel_compiler<_SegReduceOffsetKernel>::__compile(
-            ::std::forward<_ExecutionPolicy>(__exec));
+        __par_backend_hetero::__internal::__kernel_compiler<_SegReduceOffsetKernel>::__compile(__exec);
     auto __seg_reduce_wg_kernel = __par_backend_hetero::__internal::__kernel_compiler<_SegReduceWgKernel>::__compile(
-        ::std::forward<_ExecutionPolicy>(__exec));
+        __exec);
     auto __seg_reduce_prefix_kernel =
-        __par_backend_hetero::__internal::__kernel_compiler<_SegReducePrefixKernel>::__compile(
-            ::std::forward<_ExecutionPolicy>(__exec));
+        __par_backend_hetero::__internal::__kernel_compiler<_SegReducePrefixKernel>::__compile(__exec);
     __wgroup_size =
         ::std::min({__wgroup_size,
-                    oneapi::dpl::__internal::__kernel_work_group_size(::std::forward<_ExecutionPolicy>(__exec),
-                                                                      __seg_reduce_count_kernel),
-                    oneapi::dpl::__internal::__kernel_work_group_size(::std::forward<_ExecutionPolicy>(__exec),
-                                                                      __seg_reduce_offset_kernel),
-                    oneapi::dpl::__internal::__kernel_work_group_size(::std::forward<_ExecutionPolicy>(__exec),
-                                                                      __seg_reduce_wg_kernel),
-                    oneapi::dpl::__internal::__kernel_work_group_size(::std::forward<_ExecutionPolicy>(__exec),
-                                                                      __seg_reduce_prefix_kernel)});
+                    oneapi::dpl::__internal::__kernel_work_group_size(__exec, __seg_reduce_count_kernel),
+                    oneapi::dpl::__internal::__kernel_work_group_size(__exec, __seg_reduce_offset_kernel),
+                    oneapi::dpl::__internal::__kernel_work_group_size(__exec, __seg_reduce_wg_kernel),
+                    oneapi::dpl::__internal::__kernel_work_group_size(__exec, __seg_reduce_prefix_kernel)});
 #endif
 
     ::std::size_t __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __wgroup_size * __vals_per_item);

--- a/include/oneapi/dpl/internal/reduce_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/reduce_by_segment_impl.h
@@ -232,8 +232,7 @@ __sycl_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2&& 
     constexpr ::std::uint16_t __vals_per_item =
         16; // Each work item serially processes 16 items. Best observed performance on gpu
 
-    ::std::size_t __wgroup_size =
-        oneapi::dpl::__internal::__max_work_group_size(__exec);
+    ::std::size_t __wgroup_size = oneapi::dpl::__internal::__max_work_group_size(__exec);
 
     // adjust __wgroup_size according to local memory limit. Double the requirement on __val_type due to sycl group algorithm's use
     // of SLM.
@@ -245,7 +244,8 @@ __sycl_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2&& 
         __par_backend_hetero::__internal::__kernel_compiler<_SegReduceCountKernel>::__compile(__exec);
     auto __seg_reduce_offset_kernel =
         __par_backend_hetero::__internal::__kernel_compiler<_SegReduceOffsetKernel>::__compile(__exec);
-    auto __seg_reduce_wg_kernel = __par_backend_hetero::__internal::__kernel_compiler<_SegReduceWgKernel>::__compile(
+    auto __seg_reduce_wg_kernel =
+        __par_backend_hetero::__internal::__kernel_compiler<_SegReduceWgKernel>::__compile(
         __exec);
     auto __seg_reduce_prefix_kernel =
         __par_backend_hetero::__internal::__kernel_compiler<_SegReducePrefixKernel>::__compile(__exec);

--- a/include/oneapi/dpl/internal/scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/scan_by_segment_impl.h
@@ -135,8 +135,7 @@ struct __sycl_scan_by_segment_impl
 
 #if _ONEDPL_COMPILE_KERNEL
         auto __seg_scan_wg_kernel =
-            __par_backend_hetero::__internal::__kernel_compiler<_SegScanWgKernel>::__compile(
-            __exec);
+            __par_backend_hetero::__internal::__kernel_compiler<_SegScanWgKernel>::__compile(__exec);
         auto __seg_scan_prefix_kernel =
             __par_backend_hetero::__internal::__kernel_compiler<_SegScanPrefixKernel>::__compile(__exec);
         __wgroup_size =

--- a/include/oneapi/dpl/internal/scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/scan_by_segment_impl.h
@@ -131,19 +131,18 @@ struct __sycl_scan_by_segment_impl
         // We require 2 * sizeof(__val_type) * __wgroup_size of SLM for the work group segmented scan. We add
         // an additional sizeof(__val_type) * __wgroup_size requirement to ensure sufficient SLM for the group algorithms.
         __wgroup_size = oneapi::dpl::__internal::__slm_adjusted_work_group_size(
-            ::std::forward<_ExecutionPolicy>(__exec), 3 * sizeof(__val_type), __wgroup_size);
+            __exec, 3 * sizeof(__val_type), __wgroup_size);
 
 #if _ONEDPL_COMPILE_KERNEL
         auto __seg_scan_wg_kernel = __par_backend_hetero::__internal::__kernel_compiler<_SegScanWgKernel>::__compile(
-            ::std::forward<_ExecutionPolicy>(__exec));
+            __exec);
         auto __seg_scan_prefix_kernel =
-            __par_backend_hetero::__internal::__kernel_compiler<_SegScanPrefixKernel>::__compile(
-                ::std::forward<_ExecutionPolicy>(__exec));
+            __par_backend_hetero::__internal::__kernel_compiler<_SegScanPrefixKernel>::__compile(__exec);
         __wgroup_size = ::std::min({__wgroup_size,
                                     oneapi::dpl::__internal::__kernel_work_group_size(
-                                        ::std::forward<_ExecutionPolicy>(__exec), __seg_scan_wg_kernel),
+                                        __exec, __seg_scan_wg_kernel),
                                     oneapi::dpl::__internal::__kernel_work_group_size(
-                                        ::std::forward<_ExecutionPolicy>(__exec), __seg_scan_prefix_kernel)});
+                                        __exec, __seg_scan_prefix_kernel)});
 #endif
 
         ::std::size_t __n_groups = __internal::__dpl_ceiling_div(__n, __wgroup_size * __vals_per_item);

--- a/include/oneapi/dpl/internal/scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/scan_by_segment_impl.h
@@ -130,19 +130,18 @@ struct __sycl_scan_by_segment_impl
 
         // We require 2 * sizeof(__val_type) * __wgroup_size of SLM for the work group segmented scan. We add
         // an additional sizeof(__val_type) * __wgroup_size requirement to ensure sufficient SLM for the group algorithms.
-        __wgroup_size = oneapi::dpl::__internal::__slm_adjusted_work_group_size(
-            __exec, 3 * sizeof(__val_type), __wgroup_size);
+        __wgroup_size =
+            oneapi::dpl::__internal::__slm_adjusted_work_group_size(__exec, 3 * sizeof(__val_type), __wgroup_size);
 
 #if _ONEDPL_COMPILE_KERNEL
-        auto __seg_scan_wg_kernel = __par_backend_hetero::__internal::__kernel_compiler<_SegScanWgKernel>::__compile(
+        auto __seg_scan_wg_kernel =
+            __par_backend_hetero::__internal::__kernel_compiler<_SegScanWgKernel>::__compile(
             __exec);
         auto __seg_scan_prefix_kernel =
             __par_backend_hetero::__internal::__kernel_compiler<_SegScanPrefixKernel>::__compile(__exec);
-        __wgroup_size = ::std::min({__wgroup_size,
-                                    oneapi::dpl::__internal::__kernel_work_group_size(
-                                        __exec, __seg_scan_wg_kernel),
-                                    oneapi::dpl::__internal::__kernel_work_group_size(
-                                        __exec, __seg_scan_prefix_kernel)});
+        __wgroup_size =
+            ::std::min({__wgroup_size, oneapi::dpl::__internal::__kernel_work_group_size(__exec, __seg_scan_wg_kernel),
+                        oneapi::dpl::__internal::__kernel_work_group_size(__exec, __seg_scan_prefix_kernel)});
 #endif
 
         ::std::size_t __n_groups = __internal::__dpl_ceiling_div(__n, __wgroup_size * __vals_per_item);


### PR DESCRIPTION
Static analysis tools run since #862 and #608 were merged have identified more cases where variables were forwarded and then used later in the code. 