### PR TITLE
[oneDPL][async] fixed bug with reduce_async ignoring __binary_op parameter

### DIFF
--- a/include/oneapi/dpl/internal/async_impl/glue_async_impl.h
+++ b/include/oneapi/dpl/internal/async_impl/glue_async_impl.h
@@ -131,7 +131,6 @@ auto
 reduce_async(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Tp __init,
              _BinaryOperation __binary_op, _Events&&... __dependencies)
 {
-    using _ValueType = typename ::std::iterator_traits<_ForwardIterator>::value_type;
     wait_for_all(::std::forward<_Events>(__dependencies)...);
     auto ret_val = oneapi::dpl::__internal::__pattern_transform_reduce_async(::std::forward<_ExecutionPolicy>(__exec),
                                                                              __first, __last, __init, __binary_op,

--- a/include/oneapi/dpl/internal/async_impl/glue_async_impl.h
+++ b/include/oneapi/dpl/internal/async_impl/glue_async_impl.h
@@ -133,9 +133,9 @@ reduce_async(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterat
 {
     using _ValueType = typename ::std::iterator_traits<_ForwardIterator>::value_type;
     wait_for_all(::std::forward<_Events>(__dependencies)...);
-    auto ret_val = oneapi::dpl::__internal::__pattern_transform_reduce_async(
-        ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __init, __binary_op,
-        oneapi::dpl::__internal::__no_op());
+    auto ret_val = oneapi::dpl::__internal::__pattern_transform_reduce_async(::std::forward<_ExecutionPolicy>(__exec),
+                                                                             __first, __last, __init, __binary_op,
+                                                                             oneapi::dpl::__internal::__no_op());
     return ret_val;
 }
 

--- a/include/oneapi/dpl/internal/async_impl/glue_async_impl.h
+++ b/include/oneapi/dpl/internal/async_impl/glue_async_impl.h
@@ -134,7 +134,7 @@ reduce_async(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterat
     using _ValueType = typename ::std::iterator_traits<_ForwardIterator>::value_type;
     wait_for_all(::std::forward<_Events>(__dependencies)...);
     auto ret_val = oneapi::dpl::__internal::__pattern_transform_reduce_async(
-        ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __init, ::std::plus<_ValueType>(),
+        ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __init, __binary_op,
         oneapi::dpl::__internal::__no_op());
     return ret_val;
 }


### PR DESCRIPTION
`reduce_async` function with `binary_op` parameter was ignoring the parameter and always used `std::plus`.
I exposed the issue by a test and made a fix.

Please merge this bugfix and include in next RC, as the issue fails distributed-ranges project code (see `inclusive_scan` implemented in https://github.com/oneapi-src/distributed-ranges/pull/349)