### PR TITLE
Skip test configuration that causes optimizer crash in reduce_by_segment.pass

### DIFF
--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -327,10 +327,10 @@ main()
         test4buffers<sycl::usm::alloc::device, test_reduce_by_segment<ValueType, BinaryPredicate, BinaryOperation>>();
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-#if !_PSTL_ICC_TEST_SIMD_UDS_BROKEN
+#if !_PSTL_ICC_TEST_SIMD_UDS_BROKEN && !_PSTL_ICC_TEST_SIMD_UDS_BROKEN
 #    if TEST_DPCPP_BACKEND_PRESENT
         test_algo_four_sequences<test_reduce_by_segment<ValueType, BinaryPredicate, BinaryOperation>>();
-#else
+#    else
         test_algo_four_sequences<ValueType, test_reduce_by_segment<BinaryPredicate, BinaryOperation>>();
 #    endif // TEST_DPCPP_BACKEND_PRESENT
 #endif     // !_PSTL_ICC_TEST_SIMD_UDS_BROKEN
@@ -341,7 +341,7 @@ main()
         using BinaryPredicate = UserBinaryPredicate<ValueType>;
         using BinaryOperation = MaxAbsFunctor<ValueType>;
 
-#if TEST_DPCPP_BACKEND_PRESENT
+#if TEST_DPCPP_BACKEND_PRESENT && !_PSTL_ICPX_TEST_RED_BY_SEG_OPTIMIZER_CRASH
         // Run tests for USM shared memory
         test4buffers<sycl::usm::alloc::shared, test_reduce_by_segment<ValueType, BinaryPredicate, BinaryOperation>>();
         // Run tests for USM device memory
@@ -351,10 +351,10 @@ main()
         test_flag_pred<sycl::usm::alloc::device, class KernelName8, dpl::complex<float>>();
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-#if !_PSTL_ICC_TEST_SIMD_UDS_BROKEN
+#if !_PSTL_ICC_TEST_SIMD_UDS_BROKEN && !_PSTL_ICPX_TEST_RED_BY_SEG_OPTIMIZER_CRASH
 #    if TEST_DPCPP_BACKEND_PRESENT
         test_algo_four_sequences<test_reduce_by_segment<ValueType, BinaryPredicate, BinaryOperation>>();
-#else
+#    else
         test_algo_four_sequences<ValueType, test_reduce_by_segment<BinaryPredicate, BinaryOperation>>();
 #    endif // TEST_DPCPP_BACKEND_PRESENT
 #endif     // !_PSTL_ICC_TEST_SIMD_UDS_BROKEN

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -132,4 +132,12 @@
 #define _PSTL_CLANG_TEST_COMPLEX_ATAN_IS_CASE_BROKEN __clang__
 #define _PSTL_CLANG_TEST_COMPLEX_SIN_IS_CASE_BROKEN __clang__
 
+// oneAPI DPC++ compiler in 2023.2 release build crashes during optimization of reduce_by_segment.pass.cpp
+// with TBB backend.
+#if !PSTL_USE_DEBUG && TEST_TBB_BACKEND_PRESENT && defined(__INTEL_LLVM_COMPILER)
+#   define _PSTL_ICPX_TEST_RED_BY_SEG_OPTIMIZER_CRASH (__INTEL_LLVM_COMPILER == 20230200)
+#else
+#   define _PSTL_ICPX_TEST_RED_BY_SEG_OPTIMIZER_CRASH 0
+#endif
+
 #endif // _TEST_CONFIG_H


### PR DESCRIPTION
A compiler bug in the `2023.2` release of the oneAPI DPC++ Compiler causes a crash during optimization of `reduce_by_segment.pass.cpp` when compiling in release mode with the TBB backend. This PR adds the necessary preprocessor checks to exclude the code that causes the crash with this configuration.