### PR TITLE
[KT] Support work with accessors in scatter and gather functions for 8-byte data types

### DIFF
--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -66,13 +66,22 @@ gather(const T* input, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets
     return sycl::ext::intel::esimd::gather(input + base_offset, offsets * size32<T>, mask);
 }
 
-template <typename T, int N, sycl::access_mode Mode, sycl::access::placeholder P>
+template <typename T, int N, sycl::access_mode Mode, sycl::access::placeholder P, ::std::enable_if_t<sizeof(T) <= sizeof(::std::uint32_t), int> = 0>
 sycl::ext::intel::esimd::simd<T, N>
 gather(sycl::accessor<T, 1, Mode, sycl::target::device, P> input, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets,
        ::std::uint32_t base_offset, sycl::ext::intel::esimd::simd_mask<N> mask = 1)
 {
     return sycl::ext::intel::esimd::gather<T>(input, offsets * size32<T>, base_offset * size32<T>, mask);
 }
+
+//template <typename T, int N, sycl::access_mode Mode, sycl::access::placeholder P>
+//std::enable_if_t<(sizeof(T) == sizeof(::std::uint64_t) && (N == 1 || N == 8 || N == 16 || N == 32) && !std::is_pointer<AccessorTy>::value,
+//                 sycl::ext::intel::esimd::simd<T, N>>
+//gather(sycl::accessor<T, 1, Mode, sycl::target::device, P> input, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets,
+//       ::std::uint32_t base_offset, sycl::ext::intel::esimd::simd_mask<N> mask = 1)
+//{
+//    return sycl::ext::intel::esimd::gather<T>(input, offsets * size32<T>, base_offset * size32<T>, mask);
+//}
 
 template <typename T, int N>
 void
@@ -82,7 +91,7 @@ scatter(T* output, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets,
     sycl::ext::intel::esimd::scatter(output, offsets * size32<T>, values, mask);
 }
 
-template<typename T, int N, sycl::access_mode Mode, sycl::access::placeholder P>
+template<typename T, int N, sycl::access_mode Mode, sycl::access::placeholder P, ::std::enable_if_t<sizeof(T) <= sizeof(::std::uint32_t), int> = 0>
 void
 scatter(sycl::accessor<T, 1, Mode, sycl::target::device, P> output, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets,
         sycl::ext::intel::esimd::simd<T, N> values, sycl::ext::intel::esimd::simd_mask<N> mask = 1)

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -81,11 +81,7 @@ gather(sycl::accessor<T, 1, Mode, sycl::target::device, P> input,
        ::std::uint32_t base_offset,
        sycl::ext::intel::esimd::simd_mask<N> mask = 1)
 {
-    // https://intel.github.io/llvm-docs/doxygen/group__sycl__esimd__memory__lsc.html#gaca847de10e306818fca7bcec9b446bef
-    return __ESIMD_ENS::lsc_gather<T>(
-        input,                                                                      // acc	    is the SYCL accessor
-        offsets * size32<T> + base_offset * size32<T>,                              // offsets	is the zero-based offsets in bytes.
-        mask);                                                                      // pred	    is predicates.
+    return __ESIMD_ENS::lsc_gather<T>(input, offsets * size32<T> + base_offset * size32<T>, mask);
 }
 
 template <typename T, int N>
@@ -111,12 +107,7 @@ scatter(sycl::accessor<T, 1, Mode, sycl::target::device, P> output,
         sycl::ext::intel::esimd::simd<T, N> values,
         sycl::ext::intel::esimd::simd_mask<N> mask = 1)
 {
-    // https://intel.github.io/llvm-docs/doxygen/group__sycl__esimd__memory__lsc.html#gaf594e1ffb683161e3339e852874f9db3
-    __ESIMD_ENS::lsc_scatter<T>(
-        output,                                     // acc	    is the SYCL accessor.
-        offsets * size32<T>,                        // offsets	is the zero-based offsets in bytes.
-        values,                                     // vals	    is values to store.
-        mask);                                      // pred	    is predicates.
+    __ESIMD_ENS::lsc_scatter<T>(output, offsets * size32<T>, values, mask);
 }
 
 template <typename T, uint32_t R, uint32_t C>


### PR DESCRIPTION
In this PR we implement work with accessors in ```oneapi::dpl::experimental::esimd::impl::utils::scatter``` and ```oneapi::dpl::experimental::esimd::impl::utils::gather``` functions for 8-byte data types.