### PR TITLE
[CI] Fix execution status of Windows CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,9 +248,9 @@ jobs:
           set CPATH=%CONDA_PREFIX%\include
           set TBB_DLL_PATH=%CONDA_PREFIX%\Library\bin
           reg add HKLM\SOFTWARE\khronos\OpenCL\Vendors /v intelocl64.dll /t REG_DWORD /d 00000000
-          cmake -G "Ninja" -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DONEDPL_BACKEND=${{ matrix.backend }} -DONEDPL_DEVICE_TYPE=${{ matrix.device_type }} .. || goto fail_fast
-          ninja -j 2 -v %ninja_targets% || goto fail_fast
-          ctest --timeout %TEST_TIMEOUT% -C ${{ matrix.build_type }} --output-on-failure %ctest_flags% || goto fail_fast
+          cmake -G "Ninja" -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DONEDPL_BACKEND=${{ matrix.backend }} -DONEDPL_DEVICE_TYPE=${{ matrix.device_type }} .. || goto :fail_fast
+          ninja -j 2 -v %ninja_targets% || goto :fail_fast
+          ctest --timeout %TEST_TIMEOUT% -C ${{ matrix.build_type }} --output-on-failure %ctest_flags% || goto :fail_fast
           exit /b 0
           :: modify the default behaviour of shell:cmd, which exits with the status of a last command, in order not to unintentially miss an error
           :fail_fast

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,9 +248,13 @@ jobs:
           set CPATH=%CONDA_PREFIX%\include
           set TBB_DLL_PATH=%CONDA_PREFIX%\Library\bin
           reg add HKLM\SOFTWARE\khronos\OpenCL\Vendors /v intelocl64.dll /t REG_DWORD /d 00000000
-          cmake -G "Ninja" -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DONEDPL_BACKEND=${{ matrix.backend }} -DONEDPL_DEVICE_TYPE=${{ matrix.device_type }} ..
-          ninja -j 2 -v %ninja_targets%
-          ctest --timeout %TEST_TIMEOUT% -C ${{ matrix.build_type }} --output-on-failure %ctest_flags%
+          cmake -G "Ninja" -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DONEDPL_BACKEND=${{ matrix.backend }} -DONEDPL_DEVICE_TYPE=${{ matrix.device_type }} .. || goto fail_fast
+          ninja -j 2 -v %ninja_targets% || goto fail_fast
+          ctest --timeout %TEST_TIMEOUT% -C ${{ matrix.build_type }} --output-on-failure %ctest_flags% || goto fail_fast
+          exit /b 0
+          :: modify the default behaviour of shell:cmd, which exits with the status of a last command, in order not to unintentially miss an error
+          :fail_fast
+          exit /b %errorlevel%
 
   macos-testing:
     name: HOST,bknd=${{ matrix.backend }},cmplr=${{ matrix.cxx_compiler }},${{ matrix.os }},std=c++${{ matrix.std }},cfg=${{ matrix.build_type }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,12 +248,12 @@ jobs:
           set CPATH=%CONDA_PREFIX%\include
           set TBB_DLL_PATH=%CONDA_PREFIX%\Library\bin
           reg add HKLM\SOFTWARE\khronos\OpenCL\Vendors /v intelocl64.dll /t REG_DWORD /d 00000000
-          cmake -G "Ninja" -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DONEDPL_BACKEND=${{ matrix.backend }} -DONEDPL_DEVICE_TYPE=${{ matrix.device_type }} .. || goto :fail_fast
-          ninja -j 2 -v %ninja_targets% || goto :fail_fast
-          ctest --timeout %TEST_TIMEOUT% -C ${{ matrix.build_type }} --output-on-failure %ctest_flags% || goto :fail_fast
+          cmake -G "Ninja" -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DONEDPL_BACKEND=${{ matrix.backend }} -DONEDPL_DEVICE_TYPE=${{ matrix.device_type }} .. || goto :short_circuit_fail
+          ninja -j 2 -v %ninja_targets% || goto :short_circuit_fail
+          ctest --timeout %TEST_TIMEOUT% -C ${{ matrix.build_type }} --output-on-failure %ctest_flags% || goto :short_circuit_fail
           exit /b 0
           :: modify the default behaviour of shell:cmd, which exits with the status of a last command, in order not to unintentially miss an error
-          :fail_fast
+          :short_circuit_fail
           exit /b %errorlevel%
 
   macos-testing:


### PR DESCRIPTION
This PR fixes most possible cases when CI provides "green" status despite of finishing with errors. This is a continuation of #886. 

Example:
![image](https://github.com/oneapi-src/oneDPL/assets/69916350/5141c350-3bb8-403f-8891-f8468a0e34a2)
This happens because of default behaviour of `shell: cmd`, which is described in https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference
