### PR TITLE
[KT] Fix BlockLoad compile errors for different sizes N

### DIFF
--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -545,9 +545,8 @@ BlockLoad(uint32_t slm_offset)
     // char, 96 -> NElts = 24 -> ItemsCountsOfType_Uint32 = 16
     constexpr int ItemsCountsOfType_Uint32 = CalculateApropriateDataSize<NElts>();
 
-    constexpr int BLOCK_SIZE = EvalItemsCountIn<::std::uint32_t, ItemsCountsOfType_Uint32, T>();
-
     __ESIMD_NS::simd<T, N> result;
+    constexpr int BLOCK_SIZE = EvalItemsCountIn<::std::uint32_t, ItemsCountsOfType_Uint32, T>();
     result.template select<BLOCK_SIZE,     1>(0)          = BlockLoad<T,     BLOCK_SIZE>(slm_offset);
     result.template select<N - BLOCK_SIZE, 1>(BLOCK_SIZE) = BlockLoad<T, N - BLOCK_SIZE>(slm_offset + BLOCK_SIZE * sizeof(T));
     return result;

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -493,7 +493,7 @@ template <int NElts>
 constexpr int
 lsc_op_block_size_rounding()
 {
-    static_assert(NElts >= 1, "");
+    static_assert(NElts >= 1);
 
     if (NElts < 2)
         return 1;

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -544,10 +544,10 @@ template <typename T, int N, typename OpAlignedT = lsc_op_aligned_t<T>, int NElt
 inline __ESIMD_NS::simd<T, N>
 BlockLoad(uint32_t slm_offset)
 {
-    constexpr int ItemsCountsOfType_OpAlignedT = lsc_op_block_size_rounding<NElts>();
+    constexpr int BLOCK_SIZE_ROUNDED = lsc_op_block_size_rounding<NElts>();
 
     __ESIMD_NS::simd<T, N> result;
-    constexpr int BLOCK_SIZE = lsc_op_block_size<OpAlignedT, ItemsCountsOfType_OpAlignedT, T>();
+    constexpr int BLOCK_SIZE = lsc_op_block_size<OpAlignedT, BLOCK_SIZE_ROUNDED, T>();
     result.template select<BLOCK_SIZE, 1>(0) = BlockLoad<T, BLOCK_SIZE>(slm_offset);
     result.template select<N-BLOCK_SIZE, 1>(BLOCK_SIZE) = BlockLoad<T, N-BLOCK_SIZE>(slm_offset+BLOCK_SIZE*sizeof(T));
     return result;
@@ -566,9 +566,9 @@ template <typename T, int N, typename OpAlignedT = lsc_op_aligned_t<T>, int NElt
 void
 BlockStore(uint32_t slm_offset, __ESIMD_NS::simd<T, N> data)
 {
-    constexpr int ItemsCountsOfType_OpAlignedT = lsc_op_block_size_rounding<NElts>();
+    constexpr int BLOCK_SIZE_ROUNDED = lsc_op_block_size_rounding<NElts>();
 
-    constexpr int BLOCK_SIZE = lsc_op_block_size<OpAlignedT, ItemsCountsOfType_OpAlignedT, T>();
+    constexpr int BLOCK_SIZE = lsc_op_block_size<OpAlignedT, BLOCK_SIZE_ROUNDED, T>();
     BlockStore<T, BLOCK_SIZE>(slm_offset, data.template select<BLOCK_SIZE, 1>(0));
     BlockStore<T, N-BLOCK_SIZE>(slm_offset+BLOCK_SIZE*sizeof(T), data.template select<N-BLOCK_SIZE, 1>(BLOCK_SIZE));
 }

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -491,7 +491,7 @@ VectorStore(uint32_t offset,
 
 template <int NElts>
 constexpr int
-CalculateApropriateDataSize()
+lsc_op_block_size_rounding()
 {
     static_assert(NElts >= 1, "");
 
@@ -527,7 +527,7 @@ EvalItemsCountIn()
 }
 
 template <typename T, int N, int NElts = EvalItemsCountIn<T, N, ::std::uint32_t>(),
-          ::std::enable_if_t<NElts == CalculateApropriateDataSize<NElts>(), int> = 0>
+          ::std::enable_if_t<NElts == lsc_op_block_size_rounding<NElts>(), int> = 0>
 inline __ESIMD_NS::simd<T, N>
 BlockLoad(uint32_t slm_offset)
 {
@@ -537,11 +537,11 @@ BlockLoad(uint32_t slm_offset)
 }
 
 template <typename T, int N, int NElts = EvalItemsCountIn<T, N, ::std::uint32_t>(),
-          ::std::enable_if_t<NElts != CalculateApropriateDataSize<NElts>(), int> = 0>
+          ::std::enable_if_t<NElts != lsc_op_block_size_rounding<NElts>(), int> = 0>
 inline __ESIMD_NS::simd<T, N>
 BlockLoad(uint32_t slm_offset)
 {
-    constexpr int ItemsCountsOfType_Uint32 = CalculateApropriateDataSize<NElts>();
+    constexpr int ItemsCountsOfType_Uint32 = lsc_op_block_size_rounding<NElts>();
 
     __ESIMD_NS::simd<T, N> result;
     constexpr int BLOCK_SIZE = EvalItemsCountIn<::std::uint32_t, ItemsCountsOfType_Uint32, T>();
@@ -551,7 +551,7 @@ BlockLoad(uint32_t slm_offset)
 }
 
 template <typename T, int N, int NElts = EvalItemsCountIn<T, N, ::std::uint32_t>(),
-          ::std::enable_if_t<NElts == CalculateApropriateDataSize<NElts>(), int> = 0>
+          ::std::enable_if_t<NElts == lsc_op_block_size_rounding<NElts>(), int> = 0>
 void
 BlockStore(uint32_t slm_offset, __ESIMD_NS::simd<T, N> data)
 {
@@ -559,11 +559,11 @@ BlockStore(uint32_t slm_offset, __ESIMD_NS::simd<T, N> data)
 }
 
 template <typename T, int N, int NElts = EvalItemsCountIn<T, N, ::std::uint32_t>(),
-          ::std::enable_if_t<NElts != CalculateApropriateDataSize<NElts>(), int> = 0>
+          ::std::enable_if_t<NElts != lsc_op_block_size_rounding<NElts>(), int> = 0>
 void
 BlockStore(uint32_t slm_offset, __ESIMD_NS::simd<T, N> data)
 {
-    constexpr int ItemsCountsOfType_Uint32 = CalculateApropriateDataSize<NElts>();
+    constexpr int ItemsCountsOfType_Uint32 = lsc_op_block_size_rounding<NElts>();
 
     constexpr int BLOCK_SIZE = EvalItemsCountIn<::std::uint32_t, ItemsCountsOfType_Uint32, T>();
     BlockStore<T, BLOCK_SIZE>(slm_offset, data.template select<BLOCK_SIZE, 1>(0));

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -495,25 +495,25 @@ CalculateApropriateDataSize()
 {
     static_assert(NElts >= 1, "");
 
-    if constexpr (NElts < 2)
+    if (NElts < 2)
         return 1;
 
-    if constexpr (NElts < 3)
+    if (NElts < 3)
         return 2;
 
-    if constexpr (NElts < 4)
+    if (NElts < 4)
         return 3;
 
-    if constexpr (NElts < 8)
+    if (NElts < 8)
         return 4;
 
-    if constexpr (NElts < 16)
+    if (NElts < 16)
         return 8;
 
-    if constexpr (NElts < 32)
+    if (NElts < 32)
         return 16;
 
-    if constexpr (NElts < 64)
+    if (NElts < 64)
         return 32;
 
     return 64;

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -545,8 +545,8 @@ BlockLoad(uint32_t slm_offset)
 
     __ESIMD_NS::simd<T, N> result;
     constexpr int BLOCK_SIZE = EvalItemsCountIn<::std::uint32_t, ItemsCountsOfType_Uint32, T>();
-    result.template select<BLOCK_SIZE,     1>(0)          = BlockLoad<T,     BLOCK_SIZE>(slm_offset);
-    result.template select<N - BLOCK_SIZE, 1>(BLOCK_SIZE) = BlockLoad<T, N - BLOCK_SIZE>(slm_offset + BLOCK_SIZE * sizeof(T));
+    result.template select<BLOCK_SIZE, 1>(0) = BlockLoad<T, BLOCK_SIZE>(slm_offset);
+    result.template select<N-BLOCK_SIZE, 1>(BLOCK_SIZE) = BlockLoad<T, N-BLOCK_SIZE>(slm_offset+BLOCK_SIZE*sizeof(T));
     return result;
 }
 

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -536,13 +536,11 @@ BlockLoad(uint32_t slm_offset)
     return result;
 }
 
-// char, 96 -> NElts = 24
 template <typename T, int N, int NElts = EvalItemsCountIn<T, N, ::std::uint32_t>(),
           ::std::enable_if_t<NElts != CalculateApropriateDataSize<NElts>(), int> = 0>
 inline __ESIMD_NS::simd<T, N>
 BlockLoad(uint32_t slm_offset)
 {
-    // char, 96 -> NElts = 24 -> ItemsCountsOfType_Uint32 = 16
     constexpr int ItemsCountsOfType_Uint32 = CalculateApropriateDataSize<NElts>();
 
     __ESIMD_NS::simd<T, N> result;

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -489,32 +489,78 @@ VectorStore(uint32_t offset,
     return VectorStore<T, VSize, LANES>({offset, LaneStride*sizeof(T)}, data, mask);
 }
 
-template <typename T, int N>
-inline std::enable_if_t< (N*sizeof(T)/sizeof(uint32_t)<=64), __ESIMD_NS::simd<T, N> > BlockLoad(uint32_t slm_offset)
+template <int NElts>
+constexpr int
+CalculateApropriateDataSize()
+{
+    static_assert(NElts >= 1, "");
+
+    if constexpr (NElts < 2)
+        return 1;
+
+    if constexpr (NElts < 3)
+        return 2;
+
+    if constexpr (NElts < 4)
+        return 3;
+
+    if constexpr (NElts < 8)
+        return 4;
+
+    if constexpr (NElts < 16)
+        return 8;
+
+    if constexpr (NElts < 32)
+        return 16;
+
+    if constexpr (NElts < 64)
+        return 32;
+
+    return 64;
+}
+
+template <typename SrcType, int N, typename DestType>
+constexpr int
+EvalItemsCountIn()
+{
+    return N * sizeof(SrcType) / sizeof(DestType);
+}
+
+template <typename T, int N, int NElts = EvalItemsCountIn<T, N, ::std::uint32_t>(),
+          ::std::enable_if_t<NElts == CalculateApropriateDataSize<NElts>(), int> = 0>
+inline __ESIMD_NS::simd<T, N>
+BlockLoad(uint32_t slm_offset)
 {
     __ESIMD_NS::simd<T, N> result;
-    result.template bit_cast_view<uint32_t>() = __ESIMD_ENS::lsc_slm_block_load<uint32_t, N*sizeof(T)/sizeof(uint32_t)>(slm_offset);
+    result.template bit_cast_view<uint32_t>() = __ESIMD_ENS::lsc_slm_block_load<uint32_t, NElts>(slm_offset);
     return result;
 }
 
-template <typename T, int N>
-inline std::enable_if_t< (N*sizeof(T)/sizeof(uint32_t)>64), __ESIMD_NS::simd<T, N> > BlockLoad(uint32_t slm_offset)
+// char, 96 -> NElts = 24
+template <typename T, int N, int NElts = EvalItemsCountIn<T, N, ::std::uint32_t>(),
+          ::std::enable_if_t<NElts != CalculateApropriateDataSize<NElts>(), int> = 0>
+inline __ESIMD_NS::simd<T, N>
+BlockLoad(uint32_t slm_offset)
 {
+    // char, 96 -> NElts = 24 -> ItemsCountsOfType_Uint32 = 16
+    constexpr int ItemsCountsOfType_Uint32 = CalculateApropriateDataSize<NElts>();
+
+    constexpr int BLOCK_SIZE = EvalItemsCountIn<::std::uint32_t, ItemsCountsOfType_Uint32, T>();
+
     __ESIMD_NS::simd<T, N> result;
-    constexpr uint32_t BLOCK_SIZE = 64*sizeof(uint32_t)/sizeof(T);
-    result.template select<BLOCK_SIZE, 1>(0) = BlockLoad<T, BLOCK_SIZE>(slm_offset);
-    result.template select<N-BLOCK_SIZE, 1>(BLOCK_SIZE) = BlockLoad<T, N-BLOCK_SIZE>(slm_offset+BLOCK_SIZE*sizeof(T));
+    result.template select<BLOCK_SIZE,     1>(0)          = BlockLoad<T,     BLOCK_SIZE>(slm_offset);
+    result.template select<N - BLOCK_SIZE, 1>(BLOCK_SIZE) = BlockLoad<T, N - BLOCK_SIZE>(slm_offset + BLOCK_SIZE * sizeof(T));
     return result;
 }
 
-template <typename T, int N>
-inline std::enable_if_t< (N*sizeof(T)/sizeof(uint32_t)<=64), void> BlockStore(uint32_t slm_offset, __ESIMD_NS::simd<T, N> data)
+template <typename T, int N, int NElts = N * sizeof(T) / sizeof(uint32_t)>
+inline std::enable_if_t< (NElts<=64), void> BlockStore(uint32_t slm_offset, __ESIMD_NS::simd<T, N> data)
 {
-    __ESIMD_ENS::lsc_slm_block_store<uint32_t, N*sizeof(T)/sizeof(uint32_t)>(slm_offset, data.template bit_cast_view<uint32_t>());
+    __ESIMD_ENS::lsc_slm_block_store<uint32_t, NElts>(slm_offset, data.template bit_cast_view<uint32_t>());
 }
 
-template <typename T, int N>
-inline std::enable_if_t< (N*sizeof(T)/sizeof(uint32_t)>64), void> BlockStore(uint32_t slm_offset, __ESIMD_NS::simd<T, N> data)
+template <typename T, int N, int NElts = N * sizeof(T) / sizeof(uint32_t)>
+inline std::enable_if_t< (NElts>64), void> BlockStore(uint32_t slm_offset, __ESIMD_NS::simd<T, N> data)
 {
     constexpr uint32_t BLOCK_SIZE = 64*sizeof(uint32_t)/sizeof(T);
     BlockStore<T, BLOCK_SIZE>(slm_offset, data.template select<BLOCK_SIZE, 1>(0));

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -495,25 +495,25 @@ lsc_op_block_size_rounding()
 {
     static_assert(NElts >= 1);
 
-    if (NElts < 2)
+    if constexpr (NElts < 2)
         return 1;
 
-    if (NElts < 3)
+    if constexpr (NElts < 3)
         return 2;
 
-    if (NElts < 4)
+    if constexpr (NElts < 4)
         return 3;
 
-    if (NElts < 8)
+    if constexpr (NElts < 8)
         return 4;
 
-    if (NElts < 16)
+    if constexpr (NElts < 16)
         return 8;
 
-    if (NElts < 32)
+    if constexpr (NElts < 32)
         return 16;
 
-    if (NElts < 64)
+    if constexpr (NElts < 64)
         return 32;
 
     return 64;


### PR DESCRIPTION
In this PR we fix compile error in ```BlockLoad``` function for different sizes in ```N``` template param and ```sizeof<T>``` values.
The source compile error happens in this function for ```T``` as ```char``` type and ```int N``` as ```96``` value.

The source compile error was:
```
include/sycl/ext/intel/experimental/esimd/common.hpp:116:3: error: static assertion failed due to requirement '24 == 1 || 24 == 2 || 24 == 3 || 24 == 4 || 24 == 8 || 24 == 16 || 24 == 32 || 24 == 64': Unsupported vector size
  static_assert(VS == 1 || VS == 2 || VS == 3 || VS == 4 || VS == 8 ||
  ^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
include/sycl/ext/intel/experimental/esimd/memory.hpp:563:11: note: in instantiation of function template specialization 'sycl::_V1::ext::intel::experimental::esimd::detail::check_lsc_vector_size<24>' requested here
  detail::check_lsc_vector_size<NElts>();
          ^
include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h:496:62: note: in instantiation of function template specialization 'sycl::_V1::ext::intel::experimental::esimd::lsc_slm_block_load<unsigned int, 24, sycl::_V1::ext::intel::experimental::esimd::lsc_data_size::default_size>' requested here
    result.template bit_cast_view<uint32_t>() = __ESIMD_ENS::lsc_slm_block_load<uint32_t, N*sizeof(T)/sizeof(uint32_t)>(slm_offset);
                                                             ^
include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h:170:27: note: in instantiation of function template specialization 'oneapi::dpl::experimental::esimd::impl::utils::BlockLoad<char, 96>' requested here
            keys = utils::BlockLoad<KeyT, PROCESS_SIZE>(slm_reorder_this_thread);
                          ^
include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h:204:25: note: in instantiation of function template specialization 'oneapi::dpl::experimental::esimd::impl::one_wg_kernel<char, sycl::accessor<char, 1, sycl::access::mode::read_write, sycl::access::target::global_buffer, sycl::access::placeholder::true_t>, 8U, 96U, true>' requested here
                        one_wg_kernel<KeyT,  decltype(__data), RADIX_BITS, PROCESS_SIZE, IsAscending> (
```