### PR TITLE
[Integration] Update modulefile structure

### DIFF
--- a/integration/modulefiles/dpl
+++ b/integration/modulefiles/dpl
@@ -38,7 +38,7 @@ set componentroot "[file dirname [file dirname [file dirname [file dirname "${sc
 
 ##############################################################################
 
-module-whatis "Name: Intel® oneAPI DPC++ Library"
+module-whatis "Name: Intel® oneAPI DPC++ Library (oneDPL)"
 module-whatis "Version: $modulefilename/$modulefilever"
 module-whatis "Description: Intel® oneAPI DPC++ Library provides an alternative for C++ developers who create heterogeneous applications and solutions. Its APIs are based on familiar standards — C++ STL, Parallel STL (PSTL), Boost.Compute, and SYCL* — to maximize productivity and performance across CPUs, GPUs, and FPGAs."
 module-whatis "URL: https://www.intel.com/content/www/us/en/developer/tools/oneapi/dpc-library.html"

--- a/integration/modulefiles/dpl
+++ b/integration/modulefiles/dpl
@@ -14,17 +14,6 @@
 #
 ##===----------------------------------------------------------------------===##
 
-# Why all the directory and filename boilerplate code? It is needed in order
-# to properly remove symbolic links used in assembly of the modulefiles
-# folder as well as those found within the oneAPI installation folders.
-# Without it many modulefiles will fail to work as expected.
-
-# IMPORTANT: quotes around "$variables" and "[expressions]" are there
-# to insure that paths/filenames which include spaces are handled properly.
-
-# This modulefile requires Environment Modules 4.1 or later.
-# Type `module --version` to determine the current installed version.
-
 set min_tcl_ver 8.4
 if { $tcl_version < $min_tcl_ver } {
     puts stderr " "
@@ -33,68 +22,38 @@ if { $tcl_version < $min_tcl_ver } {
     exit 1
 }
 
-# get full pathname for this script file
+# if modulefile script name is a symlink, resolve it and then
+# get the fully qualified pathname to this modulefile script
 set scriptpath "${ModulesCurrentModulefile}"
-
-# if modulefile script name is a symlink, resolve it
 if { "[file type "$scriptpath"]" eq "link" } {
     set scriptpath "[file readlink "$scriptpath"]"
 }
-
-# if fullpath contains links, resolve them
 set scriptpath "[file normalize "$scriptpath"]"
 
-# get directory holding this modulefile script and others
-set modulefileroot "[file dirname "$scriptpath"]"
+# define componentroot, modulefileroot, modulefilename and modulefilever
+set modulefilename "[file tail [file dirname "${scriptpath}"]]"
+set modulefilever "[file tail "$scriptpath"]"
+set modulefilepath "${scriptpath}"
+set componentroot "[file dirname [file dirname [file dirname [file dirname "${scriptpath}"]]]]"
 
-# get name of modulefile script we are loading
-set modulefilename "[file tail "$scriptpath"]"
+##############################################################################
 
-# determine modulefile script version
-set modulefilever "[file dirname "$modulefileroot"]"
-set modulefilever "[file tail "$modulefilever"]"
+module-whatis "Name: Intel® oneAPI DPC++ Library"
+module-whatis "Version: $modulefilename/$modulefilever"
+module-whatis "Description: Intel® oneAPI DPC++ Library provides an alternative for C++ developers who create heterogeneous applications and solutions. Its APIs are based on familiar standards — C++ STL, Parallel STL (PSTL), Boost.Compute, and SYCL* — to maximize productivity and performance across CPUs, GPUs, and FPGAs."
+module-whatis "URL: https://www.intel.com/content/www/us/en/developer/tools/oneapi/dpc-library.html"
+module-whatis "Dependencies: none"
 
-# point to component top-level root folder
-set componentroot "[file dirname "$modulefileroot"]"
-set componentroot "[file dirname "$componentroot"]"
-
-# get component folder name
-set componentname "[file tail "$componentroot"]"
-
-# get oneAPI top-level root folder
-set oneapiroot "[file dirname "$componentroot"]"
-
-# disallow loading multiple versions of this modulefile
-# disallow loading multiple architectures of this modulefile
-# if only 64-bit architecture exists the test still works
-set mname32 $modulefilename
-set mname64 [string trimright $mname32 "32"]
-if { [string equal "$mname32" "$mname64"] } {
-    append mname32 "32"
-}
-conflict $mname32
-conflict $mname64
-
-
-# On load print component name and version being loaded
-if { [ module-info mode load ] } {
-    puts stderr "Loading $modulefilename version $modulefilever"
+proc ModulesHelp { } {
+    global modulefilename
+    global modulefilever
+    module whatis "${modulefilename}/${modulefilever}"
 }
 
-# On `module unload` print component module name and version being removed
-# Include `module list` message only if this modulefile loads dependent modules
-if { [ module-info mode ] == "unload" || [ module-info mode ] == "remove" } {
-    puts stderr "Removing $modulefilename version $modulefilever"
-    puts stderr "Use `module list` to view any remaining dependent modules."
-}
+##############################################################################
 
-
-# ###### Component Specific env vars setup ###################################
-
-module-whatis "Intel(R) DPC++ Library."
-
-set dpl_root "$componentroot/$modulefilever"
+set dpl_root "$componentroot"
 setenv DPL_ROOT "$dpl_root"
-
-# CPATH
-prepend-path CPATH "$dpl_root/linux/include"
+prepend-path CPATH "$dpl_root/include"
+prepend-path CMAKE_PREFIX_PATH "$dpl_root/lib/cmake/oneDPL"
+prepend-path PKG_CONFIG_PATH "$dpl_root/lib/pkgconfig"

--- a/integration/modulefiles/dpl
+++ b/integration/modulefiles/dpl
@@ -38,9 +38,9 @@ set componentroot "[file dirname [file dirname [file dirname [file dirname "${sc
 
 ##############################################################################
 
-module-whatis "Name: Intel® oneAPI DPC++ Library (oneDPL)"
+module-whatis "Name: Intel(R) oneAPI DPC++ Library (oneDPL)"
 module-whatis "Version: $modulefilename/$modulefilever"
-module-whatis "Description: Intel® oneAPI DPC++ Library provides an alternative for C++ developers who create heterogeneous applications and solutions. Its APIs are based on familiar standards — C++ STL, Parallel STL (PSTL), Boost.Compute, and SYCL* — to maximize productivity and performance across CPUs, GPUs, and FPGAs."
+module-whatis "Description: Intel(R) oneAPI DPC++ Library provides an alternative for C++ developers who create heterogeneous applications and solutions. Its APIs are based on familiar standards - C++ STL, Parallel STL (PSTL), Boost.Compute, and SYCL* - to maximize productivity and performance across CPUs, GPUs, and FPGAs."
 module-whatis "URL: https://www.intel.com/content/www/us/en/developer/tools/oneapi/dpc-library.html"
 module-whatis "Dependencies: none"
 


### PR DESCRIPTION
Such restructuring is expected in other oneAPI components; this change is done for alignment. 
There are improvements compared to the unchanged script: 

- simplified structure, 
- description of the library, 
- set `CMAKE_PREFIX_PATH` (for cmake) and `PKG_CONFIG_PATH` (for pkg-config).