### PR TITLE
Add check for in-place scan before invoking __simd_scan

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -18,6 +18,7 @@
 
 #include <iterator>
 #include "../parallel_backend.h"
+#include "../utils.h"
 #if _ONEDPL_BACKEND_SYCL
 #    include "dpcpp/execution_sycl_defs.h"
 #    include "algorithm_impl_hetero.h" // to use __pattern_walk2_brick
@@ -98,61 +99,6 @@ __pattern_transform_reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, 
 //------------------------------------------------------------------------
 template <typename T>
 struct ExecutionPolicyWrapper;
-
-// TODO In C++20 we may try to use std::equality_comparable
-template <typename _Iterator1, typename _Iterator2, typename = void>
-struct __is_equality_comparable : std::false_type
-{
-};
-
-// All with implemented operator ==
-template <typename _Iterator1, typename _Iterator2>
-struct __is_equality_comparable<
-    _Iterator1, _Iterator2,
-    std::void_t<decltype(::std::declval<::std::decay_t<_Iterator1>>() == ::std::declval<::std::decay_t<_Iterator2>>())>>
-    : std::true_type
-{
-};
-
-#if _ONEDPL_BACKEND_SYCL
-template <sycl::access::mode _Mode1, sycl::access::mode _Mode2, typename _T, typename _Allocator>
-bool
-__iterators_possibly_equal(const sycl_iterator<_Mode1, _T, _Allocator>& __it1,
-                           const sycl_iterator<_Mode2, _T, _Allocator>& __it2)
-{
-    const auto buf1 = __it1.get_buffer();
-    const auto buf2 = __it2.get_buffer();
-
-    // If two different sycl iterators belongs to the different sycl buffers, they are different
-    if (buf1 != buf2)
-        return false;
-
-    // We are unable to compare two sycl_iterator's if one of them is sub_buffer and assume that
-    // two different sycl iterators are equal.
-    if (buf1.is_sub_buffer() || buf2.is_sub_buffer())
-        return true;
-
-    return __it1 == __it2;
-}
-#endif // _ONEDPL_BACKEND_SYCL
-
-template <typename _Iterator1, typename _Iterator2>
-constexpr bool
-__iterators_possibly_equal(_Iterator1 __it1, _Iterator2 __it2)
-{
-    if constexpr (__is_equality_comparable<_Iterator1, _Iterator2>::value)
-    {
-        return __it1 == __it2;
-    }
-    else if constexpr (__is_equality_comparable<_Iterator2, _Iterator1>::value)
-    {
-        return __it2 == __it1;
-    }
-    else
-    {
-        return false;
-    }
-}
 
 template <typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2, typename _UnaryOperation,
           typename _InitType, typename _BinaryOperation, typename _Inclusive>

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -207,7 +207,7 @@ __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __la
 {
 #if (_PSTL_UDS_PRESENT || _ONEDPL_UDS_PRESENT)
     // An in-place scan violates the intra-iteration dependency restriction of the omp scan directive. We must call our serial brick.
-    if (::std::addressof(*__first) != ::std::addressof(*__result))
+    if (reinterpret_cast<void*>(::std::addressof(*__first)) != reinterpret_cast<void*>(::std::addressof(*__result)))
     {
         return __unseq_backend::__simd_scan(__first, __last - __first, __result, __unary_op, __init, __binary_op,
                                             _Inclusive());

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -206,8 +206,10 @@ __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __la
                        /*is_vector=*/::std::true_type) noexcept
 {
 #if (_PSTL_UDS_PRESENT || _ONEDPL_UDS_PRESENT)
+    const auto& __first_tmp = *__first;
+    const auto& __result_tmp = *__result;
     // An in-place scan violates the intra-iteration dependency restriction of the omp scan directive. We must call our serial brick.
-    if (static_cast<const void*>(::std::addressof(*__first)) != static_cast<const void*>(::std::addressof(*__result)))
+    if (static_cast<const void*>(::std::addressof(__first_tmp)) != static_cast<const void*>(::std::addressof(__result_tmp)))
     {
         return __unseq_backend::__simd_scan(__first, __last - __first, __result, __unary_op, __init, __binary_op,
                                             _Inclusive());

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -207,7 +207,7 @@ __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __la
 {
 #if (_PSTL_UDS_PRESENT || _ONEDPL_UDS_PRESENT)
     // An in-place scan violates the intra-iteration dependency restriction of the omp scan directive. We must call our serial brick.
-    if (reinterpret_cast<void*>(::std::addressof(*__first)) != reinterpret_cast<void*>(::std::addressof(*__result)))
+    if (static_cast<const void*>(::std::addressof(*__first)) != static_cast<const void*>(::std::addressof(*__result)))
     {
         return __unseq_backend::__simd_scan(__first, __last - __first, __result, __unary_op, __init, __binary_op,
                                             _Inclusive());

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -209,7 +209,8 @@ __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __la
     const auto& __first_tmp = *__first;
     const auto& __result_tmp = *__result;
     // An in-place scan violates the intra-iteration dependency restriction of the omp scan directive. We must call our serial brick.
-    if (static_cast<const void*>(::std::addressof(__first_tmp)) != static_cast<const void*>(::std::addressof(__result_tmp)))
+    if (static_cast<const void*>(::std::addressof(__first_tmp)) !=
+        static_cast<const void*>(::std::addressof(__result_tmp)))
     {
         return __unseq_backend::__simd_scan(__first, __last - __first, __result, __unary_op, __init, __binary_op,
                                             _Inclusive());

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -206,13 +206,16 @@ __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __la
                        /*is_vector=*/::std::true_type) noexcept
 {
 #if (_PSTL_UDS_PRESENT || _ONEDPL_UDS_PRESENT)
-    return __unseq_backend::__simd_scan(__first, __last - __first, __result, __unary_op, __init, __binary_op,
-                                        _Inclusive());
-#else
+    if (::std::is_same_v<_Inclusive, ::std::true_type> ||
+        !oneapi::dpl::__internal::__iterators_possibly_equal(__first, __result))
+    {
+        return __unseq_backend::__simd_scan(__first, __last - __first, __result, __unary_op, __init, __binary_op,
+                                            _Inclusive());
+    }
+#endif
     // We need to call serial brick here to call function for inclusive and exclusive scan that depends on _Inclusive() value
     return __internal::__brick_transform_scan(__first, __last, __result, __unary_op, __init, __binary_op, _Inclusive(),
                                               /*is_vector=*/::std::false_type());
-#endif
 }
 
 template <class _RandomAccessIterator, class _OutputIterator, class _UnaryOperation, class _Tp, class _BinaryOperation,

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -202,11 +202,11 @@ template <class _RandomAccessIterator, class _OutputIterator, class _UnaryOperat
           class _Inclusive>
 ::std::enable_if_t<!is_arithmetic_udop<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>
 __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __last, _OutputIterator __result,
-                       _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op, _Inclusive,
+                       _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op, _Inclusive __is_inclusive,
                        /*is_vector=*/::std::true_type) noexcept
 {
 #if (_PSTL_UDS_PRESENT || _ONEDPL_UDS_PRESENT)
-    if (_Inclusive{} || !oneapi::dpl::__internal::__iterators_possibly_equal(__first, __result))
+    if (__is_inclusive || !oneapi::dpl::__internal::__iterators_possibly_equal(__first, __result))
     {
         return __unseq_backend::__simd_scan(__first, __last - __first, __result, __unary_op, __init, __binary_op,
                                             _Inclusive());

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -206,19 +206,13 @@ __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __la
                        /*is_vector=*/::std::true_type) noexcept
 {
 #if (_PSTL_UDS_PRESENT || _ONEDPL_UDS_PRESENT)
-    const auto& __first_tmp = *__first;
-    const auto& __result_tmp = *__result;
-    // An in-place scan violates the intra-iteration dependency restriction of the omp scan directive. We must call our serial brick.
-    if (static_cast<const void*>(::std::addressof(__first_tmp)) !=
-        static_cast<const void*>(::std::addressof(__result_tmp)))
-    {
-        return __unseq_backend::__simd_scan(__first, __last - __first, __result, __unary_op, __init, __binary_op,
-                                            _Inclusive());
-    }
-#endif
+    return __unseq_backend::__simd_scan(__first, __last - __first, __result, __unary_op, __init, __binary_op,
+                                        _Inclusive());
+#else
     // We need to call serial brick here to call function for inclusive and exclusive scan that depends on _Inclusive() value
     return __internal::__brick_transform_scan(__first, __last, __result, __unary_op, __init, __binary_op, _Inclusive(),
                                               /*is_vector=*/::std::false_type());
+#endif
 }
 
 template <class _RandomAccessIterator, class _OutputIterator, class _UnaryOperation, class _Tp, class _BinaryOperation,

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -202,11 +202,11 @@ template <class _RandomAccessIterator, class _OutputIterator, class _UnaryOperat
           class _Inclusive>
 ::std::enable_if_t<!is_arithmetic_udop<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>
 __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __last, _OutputIterator __result,
-                       _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op, _Inclusive __is_inclusive,
+                       _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op, _Inclusive,
                        /*is_vector=*/::std::true_type) noexcept
 {
 #if (_PSTL_UDS_PRESENT || _ONEDPL_UDS_PRESENT)
-    if (__is_inclusive || !oneapi::dpl::__internal::__iterators_possibly_equal(__first, __result))
+    if (_Inclusive() || !oneapi::dpl::__internal::__iterators_possibly_equal(__first, __result))
     {
         return __unseq_backend::__simd_scan(__first, __last - __first, __result, __unary_op, __init, __binary_op,
                                             _Inclusive());

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -206,8 +206,7 @@ __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __la
                        /*is_vector=*/::std::true_type) noexcept
 {
 #if (_PSTL_UDS_PRESENT || _ONEDPL_UDS_PRESENT)
-    if (::std::is_same_v<_Inclusive, ::std::true_type> ||
-        !oneapi::dpl::__internal::__iterators_possibly_equal(__first, __result))
+    if (_Inclusive{} || !oneapi::dpl::__internal::__iterators_possibly_equal(__first, __result))
     {
         return __unseq_backend::__simd_scan(__first, __last - __first, __result, __unary_op, __init, __binary_op,
                                             _Inclusive());

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -554,9 +554,12 @@ __simd_scan(_InputIterator __first, _Size __n, _OutputIterator __result, _UnaryO
     _ONEDPL_PRAGMA_SIMD_SCAN(+ : __init)
     for (_Size __i = 0; __i < __n; ++__i)
     {
-        __result[__i] = __init;
+        _Tp __tmp = __init;
         _ONEDPL_PRAGMA_SIMD_EXCLUSIVE_SCAN(__init)
-        __init += __unary_op(__first[__i]);
+        {
+            __init += __unary_op(__first[__i]);
+            __result[__i] = __tmp;
+        }
     }
     return ::std::make_pair(__result + __n, __init);
 }
@@ -597,10 +600,13 @@ __simd_scan(_InputIterator __first, _Size __n, _OutputIterator __result, _UnaryO
     _ONEDPL_PRAGMA_SIMD_SCAN(__bin_op : __init_)
     for (_Size __i = 0; __i < __n; ++__i)
     {
-        __result[__i] = __init_.__value;
+        _Tp __tmp = __init_.__value;
         _ONEDPL_PRAGMA_SIMD_EXCLUSIVE_SCAN(__init_)
-        _ONEDPL_PRAGMA_FORCEINLINE
-        __init_.__value = __binary_op(__init_.__value, __unary_op(__first[__i]));
+        {
+            _ONEDPL_PRAGMA_FORCEINLINE
+            __init_.__value = __binary_op(__init_.__value, __unary_op(__first[__i]));
+            __result[__i] = __tmp;
+        }
     }
     return ::std::make_pair(__result + __n, __init_.__value);
 }

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -551,16 +551,12 @@ template <class _InputIterator, class _Size, class _OutputIterator, class _Unary
 __simd_scan(_InputIterator __first, _Size __n, _OutputIterator __result, _UnaryOperation __unary_op, _Tp __init,
             _BinaryOperation, /*Inclusive*/ ::std::false_type)
 {
-    _Tp __cur_scan_value;
-    _ONEDPL_PRAGMA_SIMD_SCAN(+ : __cur_scan_value)
+    _ONEDPL_PRAGMA_SIMD_SCAN(+ : __init)
     for (_Size __i = 0; __i < __n; ++__i)
     {
-        __cur_scan_value = __init;
-        _ONEDPL_PRAGMA_SIMD_EXCLUSIVE_SCAN(__cur_scan_value)
-        {
-            __init += __unary_op(__first[__i]);
-            __result[__i] = __cur_scan_value;
-        }
+        __result[__i] = __init;
+        _ONEDPL_PRAGMA_SIMD_EXCLUSIVE_SCAN(__init)
+        __init += __unary_op(__first[__i]);
     }
     return ::std::make_pair(__result + __n, __init);
 }
@@ -595,20 +591,16 @@ __simd_scan(_InputIterator __first, _Size __n, _OutputIterator __result, _UnaryO
 {
     typedef _Combiner<_Tp, _BinaryOperation> _CombinerType;
     _CombinerType __init_{__init, &__binary_op};
-    _Tp __cur_scan_value;
 
     _ONEDPL_PRAGMA_DECLARE_REDUCTION(__bin_op, _CombinerType)
 
-    _ONEDPL_PRAGMA_SIMD_SCAN(__bin_op : __cur_scan_value)
+    _ONEDPL_PRAGMA_SIMD_SCAN(__bin_op : __init_)
     for (_Size __i = 0; __i < __n; ++__i)
     {
-        __cur_scan_value = __init_.__value;
-        _ONEDPL_PRAGMA_SIMD_EXCLUSIVE_SCAN(__cur_scan_value)
-        {
-            _ONEDPL_PRAGMA_FORCEINLINE
-            __init_.__value = __binary_op(__init_.__value, __unary_op(__first[__i]));
-            __result[__i] = __cur_scan_value;
-        }
+        __result[__i] = __init_.__value;
+        _ONEDPL_PRAGMA_SIMD_EXCLUSIVE_SCAN(__init_)
+        _ONEDPL_PRAGMA_FORCEINLINE
+        __init_.__value = __binary_op(__init_.__value, __unary_op(__first[__i]));
     }
     return ::std::make_pair(__result + __n, __init_.__value);
 }

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -551,14 +551,15 @@ template <class _InputIterator, class _Size, class _OutputIterator, class _Unary
 __simd_scan(_InputIterator __first, _Size __n, _OutputIterator __result, _UnaryOperation __unary_op, _Tp __init,
             _BinaryOperation, /*Inclusive*/ ::std::false_type)
 {
-    _ONEDPL_PRAGMA_SIMD_SCAN(+ : __init)
+    _Tp __cur_scan_value;
+    _ONEDPL_PRAGMA_SIMD_SCAN(+ : __cur_scan_value)
     for (_Size __i = 0; __i < __n; ++__i)
     {
-        _Tp __tmp = __init;
-        _ONEDPL_PRAGMA_SIMD_EXCLUSIVE_SCAN(__init)
+        __cur_scan_value = __init;
+        _ONEDPL_PRAGMA_SIMD_EXCLUSIVE_SCAN(__cur_scan_value)
         {
             __init += __unary_op(__first[__i]);
-            __result[__i] = __tmp;
+            __result[__i] = __cur_scan_value;
         }
     }
     return ::std::make_pair(__result + __n, __init);
@@ -594,18 +595,19 @@ __simd_scan(_InputIterator __first, _Size __n, _OutputIterator __result, _UnaryO
 {
     typedef _Combiner<_Tp, _BinaryOperation> _CombinerType;
     _CombinerType __init_{__init, &__binary_op};
+    _Tp __cur_scan_value;
 
     _ONEDPL_PRAGMA_DECLARE_REDUCTION(__bin_op, _CombinerType)
 
-    _ONEDPL_PRAGMA_SIMD_SCAN(__bin_op : __init_)
+    _ONEDPL_PRAGMA_SIMD_SCAN(__bin_op : __cur_scan_value)
     for (_Size __i = 0; __i < __n; ++__i)
     {
-        _Tp __tmp = __init_.__value;
-        _ONEDPL_PRAGMA_SIMD_EXCLUSIVE_SCAN(__init_)
+        __cur_scan_value = __init_.__value;
+        _ONEDPL_PRAGMA_SIMD_EXCLUSIVE_SCAN(__cur_scan_value)
         {
             _ONEDPL_PRAGMA_FORCEINLINE
             __init_.__value = __binary_op(__init_.__value, __unary_op(__first[__i]));
-            __result[__i] = __tmp;
+            __result[__i] = __cur_scan_value;
         }
     }
     return ::std::make_pair(__result + __n, __init_.__value);

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -646,6 +646,61 @@ __dpl_ceiling_div(_T1 __number, _T2 __divisor)
     return (__number - 1) / __divisor + 1;
 }
 
+// TODO In C++20 we may try to use std::equality_comparable
+template <typename _Iterator1, typename _Iterator2, typename = void>
+struct __is_equality_comparable : std::false_type
+{
+};
+
+// All with implemented operator ==
+template <typename _Iterator1, typename _Iterator2>
+struct __is_equality_comparable<
+    _Iterator1, _Iterator2,
+    std::void_t<decltype(::std::declval<::std::decay_t<_Iterator1>>() == ::std::declval<::std::decay_t<_Iterator2>>())>>
+    : std::true_type
+{
+};
+
+#if _ONEDPL_BACKEND_SYCL
+template <sycl::access::mode _Mode1, sycl::access::mode _Mode2, typename _T, typename _Allocator>
+bool
+__iterators_possibly_equal(const sycl_iterator<_Mode1, _T, _Allocator>& __it1,
+                           const sycl_iterator<_Mode2, _T, _Allocator>& __it2)
+{
+    const auto buf1 = __it1.get_buffer();
+    const auto buf2 = __it2.get_buffer();
+
+    // If two different sycl iterators belongs to the different sycl buffers, they are different
+    if (buf1 != buf2)
+        return false;
+
+    // We are unable to compare two sycl_iterator's if one of them is sub_buffer and assume that
+    // two different sycl iterators are equal.
+    if (buf1.is_sub_buffer() || buf2.is_sub_buffer())
+        return true;
+
+    return __it1 == __it2;
+}
+#endif // _ONEDPL_BACKEND_SYCL
+
+template <typename _Iterator1, typename _Iterator2>
+constexpr bool
+__iterators_possibly_equal(_Iterator1 __it1, _Iterator2 __it2)
+{
+    if constexpr (__is_equality_comparable<_Iterator1, _Iterator2>::value)
+    {
+        return __it1 == __it2;
+    }
+    else if constexpr (__is_equality_comparable<_Iterator2, _Iterator1>::value)
+    {
+        return __it2 == __it1;
+    }
+    else
+    {
+        return false;
+    }
+}
+
 } // namespace __internal
 } // namespace dpl
 } // namespace oneapi

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -661,28 +661,6 @@ struct __is_equality_comparable<
 {
 };
 
-#if _ONEDPL_BACKEND_SYCL
-template <sycl::access::mode _Mode1, sycl::access::mode _Mode2, typename _T, typename _Allocator>
-bool
-__iterators_possibly_equal(const sycl_iterator<_Mode1, _T, _Allocator>& __it1,
-                           const sycl_iterator<_Mode2, _T, _Allocator>& __it2)
-{
-    const auto buf1 = __it1.get_buffer();
-    const auto buf2 = __it2.get_buffer();
-
-    // If two different sycl iterators belongs to the different sycl buffers, they are different
-    if (buf1 != buf2)
-        return false;
-
-    // We are unable to compare two sycl_iterator's if one of them is sub_buffer and assume that
-    // two different sycl iterators are equal.
-    if (buf1.is_sub_buffer() || buf2.is_sub_buffer())
-        return true;
-
-    return __it1 == __it2;
-}
-#endif // _ONEDPL_BACKEND_SYCL
-
 template <typename _Iterator1, typename _Iterator2>
 constexpr bool
 __iterators_possibly_equal(_Iterator1 __it1, _Iterator2 __it2)


### PR DESCRIPTION
On compilers in which we enable the `__simd_scan` codepath (such as `icpc 2021.8`), our `scan.pass` test cases have been failing for `unseq` and `unseq_par` host policies. In particular, the specific cases that test in-place scans fail. This is due to the following restriction in the [OpenMP specification:](https://www.openmp.org/spec-html/5.0/openmpsu45.html)
```
"Intra-iteration dependences from a statement in the structured block preceding a scan directive to a statement in the 
structured block following a scan directive must not exist, except for dependences for the list items specified in an 
inclusive or exclusive clause."
```
When an in-place scan is performed, the `__first` and `__result` iterators in [__simd_scan](https://github.com/oneapi-src/oneDPL/blob/0b57a685568ea1ccfab50ad266da9c71fd8bf7d4/include/oneapi/dpl/pstl/unseq_backend_simd.h#L547) correspond to the same start address in memory. The scan update performed in the [scan phase](https://github.com/oneapi-src/oneDPL/blob/0b57a685568ea1ccfab50ad266da9c71fd8bf7d4/include/oneapi/dpl/pstl/unseq_backend_simd.h#L553) must be performed after the update to the sum variable in the [input phase](https://github.com/oneapi-src/oneDPL/blob/0b57a685568ea1ccfab50ad266da9c71fd8bf7d4/include/oneapi/dpl/pstl/unseq_backend_simd.h#L555) for the results to be correct. This represents a dependency outside of the list-item between the input and scan phase in the same loop iteration. This dependency exists for both inclusive and exclusive scans, and we should not use the scan directive in this case.

To fix this issue, we can check if the `__first` and `__last` iterators begin at the same start address and use the non-vectorized implementation. This resolves the encountered issues in the `scan.pass` test.