### PR TITLE
Fix UB when async algorithms called without save result

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -534,6 +534,11 @@ class __future : private std::tuple<_Args...>
   public:
     __future(_Event __e, _Args... __args) : std::tuple<_Args...>(__args...), __my_event(__e) {}
     __future(_Event __e, std::tuple<_Args...> __t) : std::tuple<_Args...>(__t), __my_event(__e) {}
+    ~__future()
+    {
+        // TODO: we able to have exceptions in this place -> in this case we will have chrash
+        wait();
+    }
 
     auto
     event() const

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -536,7 +536,7 @@ class __future : private std::tuple<_Args...>
     __future(_Event __e, std::tuple<_Args...> __t) : std::tuple<_Args...>(__t), __my_event(__e) {}
     ~__future()
     {
-        // TODO: we able to have exceptions in this place -> in this case we will have chrash
+        // TODO: we able to have exceptions in this place -> in this case we will have crash
         wait();
     }
 

--- a/test/parallel_api/experimental/future_impl.pass.cpp
+++ b/test/parallel_api/experimental/future_impl.pass.cpp
@@ -1,0 +1,73 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#include "support/test_config.h"
+
+#if TEST_DPCPP_BACKEND_PRESENT
+#    include "oneapi/dpl/async"
+#    include <oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h>
+#endif // TEST_DPCPP_BACKEND_PRESENT
+
+#include <memory>
+
+#include "support/utils.h"
+
+
+struct UserEvent
+{
+    void wait_and_throw()
+    {
+    }
+};
+
+auto
+create_future(UserEvent e, std::shared_ptr<int> ptr)
+{
+    return oneapi::dpl::__par_backend_hetero::__future(e, ptr);
+}
+
+int
+main()
+{
+#if TEST_DPCPP_BACKEND_PRESENT
+
+    long counter_state = 0;
+
+    // Case 1: we save future in result
+    {
+        auto ptr = std::make_shared<int>();
+        {
+            auto res = create_future(UserEvent{}, ptr);
+            counter_state = ptr.use_count();
+            EXPECT_TRUE(counter_state == 2, "wrong counter state #1");
+        }
+
+        EXPECT_TRUE(ptr.use_count() == 1, "wrong counter state #2");
+    }
+
+    // Case 2: we don't save the result
+    {
+        auto ptr = std::make_shared<int>();
+        {
+            /*auto res = */create_future(UserEvent{}, ptr);
+            EXPECT_TRUE(ptr.use_count() != counter_state, "wrong counter state #3");
+        }
+
+        EXPECT_TRUE(ptr.use_count() == 1, "wrong counter state #4");
+    }
+#endif
+
+    return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT);
+}

--- a/test/parallel_api/experimental/future_impl.pass.cpp
+++ b/test/parallel_api/experimental/future_impl.pass.cpp
@@ -63,6 +63,12 @@ main()
         {
             /*auto res = */create_future(UserEvent{}, ptr);
             EXPECT_TRUE(ptr.use_count() != counter_state, "wrong counter state #3");
+
+            // This means that managed resources already was destroyed because the instance of __future class wasn't saved.
+            // In the case of sycl__event this means that we haven't sycl::event::wait() call
+            // and destroyed some managed resources for example sycl::buffer,
+            // but our async algorithm can continue working after that.
+            EXPECT_TRUE(ptr.use_count() == 1, "wrong counter state #3");
         }
 
         EXPECT_TRUE(ptr.use_count() == 1, "wrong counter state #4");

--- a/test/parallel_api/experimental/future_impl.pass.cpp
+++ b/test/parallel_api/experimental/future_impl.pass.cpp
@@ -24,11 +24,23 @@
 
 #include "support/utils.h"
 
+// Required to comment next line for reproducing error case
+#define CALL_WAIT_AND_THROW_IN_DESTRUCTOR 1
 
 struct UserEvent
 {
+    inline static long wait_counter = 0;
+
+    ~UserEvent()
+    {
+#if CALL_WAIT_AND_THROW_IN_DESTRUCTOR
+        wait_and_throw();
+#endif // CALL_WAIT_AND_THROW_IN_DESTRUCTOR
+    }
+
     void wait_and_throw()
     {
+        ++wait_counter;
     }
 };
 
@@ -45,23 +57,36 @@ main()
 
     long counter_state = 0;
 
+    EXPECT_TRUE(UserEvent::wait_counter == 0, "wrong wait counter state #1");
+
     // Case 1: we save future in result
     {
         auto ptr = std::make_shared<int>();
+        long wait_counter_state = 0;
+
         {
-            auto res = create_future(UserEvent{}, ptr);
+            UserEvent ev;
+            auto res = create_future(ev, ptr);
+            wait_counter_state = UserEvent::wait_counter;
+
             counter_state = ptr.use_count();
             EXPECT_TRUE(counter_state == 2, "wrong counter state #1");
         }
 
-        EXPECT_TRUE(ptr.use_count() == 1, "wrong counter state #2");
+        EXPECT_TRUE(counter_state == 2, "wrong counter state #1");
+
+        EXPECT_TRUE(UserEvent::wait_counter != wait_counter_state, "wrong counter state #2");
     }
 
     // Case 2: we don't save the result
     {
         auto ptr = std::make_shared<int>();
+        long wait_counter_state = 0;
         {
+            UserEvent ev;
             /*auto res = */create_future(UserEvent{}, ptr);
+            wait_counter_state = UserEvent::wait_counter;
+
             EXPECT_TRUE(ptr.use_count() != counter_state, "wrong counter state #3");
 
             // This means that managed resources already was destroyed because the instance of __future class wasn't saved.
@@ -72,6 +97,8 @@ main()
         }
 
         EXPECT_TRUE(ptr.use_count() == 1, "wrong counter state #4");
+
+        EXPECT_TRUE(UserEvent::wait_counter != wait_counter_state, "wrong counter state #3");
     }
 #endif
 


### PR DESCRIPTION
In this PR we trying to fix the case with UB when we calls some async algorithm, receive result but doesn't save it on stack in some local variable:
 - in this case we can destroy some objects, which used in async algorithm implementation before async algorithm finished.

The example of problem code:
```
    const int n = 100;
    {
        sycl::buffer<int> x{n};

        auto my_policy = TestUtils::make_device_policy<class Copy1>(oneapi::dpl::execution::dpcpp_default);
        oneapi::dpl::experimental::copy_async(my_policy, oneapi::dpl::counting_iterator<int>(0),
                                                            oneapi::dpl::counting_iterator<int>(n),
                                                            oneapi::dpl::begin(x)); // x = [0..n]
        // UB is here (after exit from this scope) because we able to exit from scope
        // and destroy sycl::buffer x before copy_async finished
    }
```