### PR TITLE
[KT] Pass template parameters to the implementations

### DIFF
--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort.h
@@ -27,7 +27,7 @@ namespace oneapi::dpl::experimental::kt::esimd::impl
 {
 
 // TODO: allow calling it only for all_view (accessor) and guard_view (USM) ranges, views::subrange and sycl_iterator
-template <bool _IsAscending, std::uint16_t _RadixBits, typename _KernelParam, typename _Range>
+template <bool _IsAscending, std::uint8_t _RadixBits, typename _KernelParam, typename _Range>
 sycl::event
 radix_sort(sycl::queue __q, _Range&& __rng, _KernelParam __param)
 {
@@ -35,8 +35,8 @@ radix_sort(sycl::queue __q, _Range&& __rng, _KernelParam __param)
     assert(__n > 1);
 
     // _PRINT_INFO_IN_DEBUG_MODE(__exec); TODO: extend the utility to work with queues
-    constexpr ::std::uint16_t __data_per_workitem = _KernelParam::data_per_workitem;
-    constexpr ::std::uint16_t __workgroup_size = _KernelParam::workgroup_size;
+    constexpr auto __data_per_workitem = _KernelParam::data_per_workitem;
+    constexpr auto __workgroup_size = _KernelParam::workgroup_size;
     using _KernelName = typename _KernelParam::kernel_name;
 
     constexpr ::std::uint32_t __one_wg_cap = __data_per_workitem * __workgroup_size;
@@ -60,7 +60,7 @@ radix_sort(sycl::queue __q, _Range&& __rng, _KernelParam __param)
 namespace oneapi::dpl::experimental::kt::esimd
 {
 
-template <bool _IsAscending = true, std::uint16_t _RadixBits = 8, typename _KernelParam, typename _Range>
+template <bool _IsAscending = true, std::uint8_t _RadixBits = 8, typename _KernelParam, typename _Range>
 sycl::event
 radix_sort(sycl::queue __q, _Range&& __rng, _KernelParam __param = {})
 {
@@ -70,7 +70,7 @@ radix_sort(sycl::queue __q, _Range&& __rng, _KernelParam __param = {})
     return oneapi::dpl::experimental::kt::esimd::impl::radix_sort<_IsAscending, _RadixBits>(__q, ::std::forward<_Range>(__rng), __param);
 }
 
-template <bool _IsAscending = true, std::uint16_t _RadixBits = 8, typename _KernelParam, typename _Iterator>
+template <bool _IsAscending = true, std::uint8_t _RadixBits = 8, typename _KernelParam, typename _Iterator>
 sycl::event
 radix_sort(sycl::queue __q, _Iterator __first, _Iterator __last, _KernelParam __param = {})
 {

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort.h
@@ -25,44 +25,32 @@
 
 namespace oneapi::dpl::experimental::kt::esimd::impl
 {
-template <typename T, ::std::enable_if_t<sizeof(T) <= sizeof(::std::uint32_t), int> = 0>
-constexpr ::std::uint32_t
-__onesweep_process_size()
-{
-    return 384;
-}
-
-template <typename T, ::std::enable_if_t<sizeof(T) == sizeof(::std::uint64_t), int> = 0>
-constexpr ::std::uint32_t
-__onesweep_process_size()
-{
-    return 192;
-}
 
 // TODO: allow calling it only for all_view (accessor) and guard_view (USM) ranges, views::subrange and sycl_iterator
-template <bool _IsAscending, std::uint32_t _RadixBits, typename _KernelParam, typename _Range>
+template <bool _IsAscending, std::uint16_t _RadixBits, typename _KernelParam, typename _Range>
 sycl::event
 radix_sort(sycl::queue __q, _Range&& __rng, _KernelParam __param)
 {
-    using _KeyT = oneapi::dpl::__internal::__value_t<_Range>;
-
     const ::std::size_t __n = __rng.size();
     assert(__n > 1);
 
-//    _PRINT_INFO_IN_DEBUG_MODE(__exec); TODO: extend the utility to work with queues
+    // _PRINT_INFO_IN_DEBUG_MODE(__exec); TODO: extend the utility to work with queues
+    constexpr ::std::uint16_t __data_per_workitem = _KernelParam::data_per_workitem;
+    constexpr ::std::uint16_t __workgroup_size = _KernelParam::workgroup_size;
     using _KernelName = typename _KernelParam::kernel_name;
 
-    if (__n <= 16384)
+    constexpr ::std::uint32_t __one_wg_cap = __data_per_workitem * __workgroup_size;
+    if (__n <= __one_wg_cap)
     {
         // TODO: support different RadixBits values (only 7 or 8 are currently supported), WorkGroupSize and DataPerWorkItem
-        return oneapi::dpl::experimental::kt::esimd::impl::one_wg<_KernelName, _KeyT, _Range, _RadixBits, _IsAscending>(
+        return one_wg<_KernelName, _IsAscending, _RadixBits, __data_per_workitem, __workgroup_size>(
             __q, ::std::forward<_Range>(__rng), __n);
     }
     else
     {
         // TODO: avoid kernel duplication (generate the output storage with the same type as input storage and use swap)
         // TODO: support different RadixBits, WorkGroupSize and DataPerWorkItem
-        return oneapi::dpl::experimental::kt::esimd::impl::onesweep<_KernelName, _KeyT, _Range, _RadixBits, _IsAscending, __onesweep_process_size<_KeyT>()>(
+        return onesweep<_KernelName, _IsAscending, _RadixBits,  __data_per_workitem, __workgroup_size>(
             __q, ::std::forward<_Range>(__rng), __n);
     }
 }
@@ -72,7 +60,7 @@ radix_sort(sycl::queue __q, _Range&& __rng, _KernelParam __param)
 namespace oneapi::dpl::experimental::kt::esimd
 {
 
-template <bool _IsAscending = true, std::uint32_t _RadixBits = 8, typename _KernelParam, typename _Range>
+template <bool _IsAscending = true, std::uint16_t _RadixBits = 8, typename _KernelParam, typename _Range>
 sycl::event
 radix_sort(sycl::queue __q, _Range&& __rng, _KernelParam __param = {})
 {
@@ -82,7 +70,7 @@ radix_sort(sycl::queue __q, _Range&& __rng, _KernelParam __param = {})
     return oneapi::dpl::experimental::kt::esimd::impl::radix_sort<_IsAscending, _RadixBits>(__q, ::std::forward<_Range>(__rng), __param);
 }
 
-template <bool _IsAscending = true, std::uint32_t _RadixBits = 8, typename _KernelParam, typename _Iterator>
+template <bool _IsAscending = true, std::uint16_t _RadixBits = 8, typename _KernelParam, typename _Iterator>
 sycl::event
 radix_sort(sycl::queue __q, _Iterator __first, _Iterator __last, _KernelParam __param = {})
 {

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
@@ -25,7 +25,7 @@
 namespace oneapi::dpl::experimental::kt::esimd::impl
 {
 
-template <bool _IsAscending, ::std::uint16_t _RadixBits, ::std::uint16_t _DataPerWorkItem,
+template <bool _IsAscending, ::std::uint8_t _RadixBits, ::std::uint16_t _DataPerWorkItem,
           ::std::uint16_t _WorkGroupSize, typename _KeyT, typename InputT>
 void one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, const InputT& input) {
     using namespace sycl;
@@ -184,11 +184,11 @@ void one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, const InputT& input) {
 template <typename... _Name>
 class __esimd_radix_sort_one_wg;
 
-template <bool _IsAscending, ::std::uint16_t _RadixBits, ::std::uint16_t _DataPerWorkItem,
+template <bool _IsAscending, ::std::uint8_t _RadixBits, ::std::uint16_t _DataPerWorkItem,
           ::std::uint16_t _WorkGroupSize, typename _KeyT, typename _KernelName>
 struct __radix_sort_one_wg_submitter;
 
-template <bool _IsAscending, ::std::uint16_t _RadixBits, ::std::uint16_t _DataPerWorkItem,
+template <bool _IsAscending, ::std::uint8_t _RadixBits, ::std::uint16_t _DataPerWorkItem,
           ::std::uint16_t _WorkGroupSize, typename _KeyT, typename... _Name>
 struct __radix_sort_one_wg_submitter<_IsAscending, _RadixBits, _DataPerWorkItem, _WorkGroupSize, _KeyT,
                                      oneapi::dpl::__par_backend_hetero::__internal::__optional_kernel_name<_Name...>>
@@ -210,7 +210,7 @@ struct __radix_sort_one_wg_submitter<_IsAscending, _RadixBits, _DataPerWorkItem,
     }
 };
 
-template <typename _KernelName, bool _IsAscending, ::std::uint16_t _RadixBits, ::std::uint16_t _DataPerWorkItem,
+template <typename _KernelName, bool _IsAscending, ::std::uint8_t _RadixBits, ::std::uint16_t _DataPerWorkItem,
           ::std::uint16_t _WorkGroupSize, typename _Range>
 sycl::event
 one_wg(sycl::queue __q, _Range&& __rng, ::std::size_t __n)

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
@@ -20,12 +20,14 @@
 #include "../../pstl/utils.h"
 
 #include <cstdint>
+#include <cassert>
 
 namespace oneapi::dpl::experimental::kt::esimd::impl
 {
 
-template <typename KeyT, typename InputT, uint32_t RADIX_BITS, uint32_t PROCESS_SIZE, bool IsAscending>
-void one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, uint32_t THREAD_PER_TG, const InputT& input) {
+template <bool _IsAscending, ::std::uint16_t _RadixBits, ::std::uint16_t _DataPerWorkItem,
+          ::std::uint16_t _WorkGroupSize, typename _KeyT, typename InputT>
+void one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, const InputT& input) {
     using namespace sycl;
     using namespace __ESIMD_NS;
     using namespace __ESIMD_ENS;
@@ -35,49 +37,48 @@ void one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, uint32_t THREAD_PER_TG, con
     using device_addr_t = uint32_t;
 
     uint32_t local_tid = idx.get_local_linear_id();
-    constexpr uint32_t BIN_COUNT = 1 << RADIX_BITS;
-    constexpr uint32_t NBITS =  sizeof(KeyT) * 8;
-    constexpr uint32_t STAGES = oneapi::dpl::__internal::__dpl_ceiling_div(NBITS, RADIX_BITS);
+    constexpr uint32_t BIN_COUNT = 1 << _RadixBits;
+    constexpr uint32_t NBITS =  sizeof(_KeyT) * 8;
+    constexpr uint32_t STAGES = oneapi::dpl::__internal::__dpl_ceiling_div(NBITS, _RadixBits);
     constexpr uint32_t MAX_THREAD_PER_TG = 64;
     constexpr bin_t MASK = BIN_COUNT - 1;
     constexpr uint32_t HIST_STRIDE = sizeof(hist_t) * BIN_COUNT;
 
-    constexpr uint32_t REORDER_SLM_SIZE = PROCESS_SIZE * sizeof(KeyT) * MAX_THREAD_PER_TG; // reorder buffer
+    constexpr uint32_t REORDER_SLM_SIZE = _DataPerWorkItem * sizeof(_KeyT) * MAX_THREAD_PER_TG; // reorder buffer
     constexpr uint32_t BIN_HIST_SLM_SIZE = HIST_STRIDE * MAX_THREAD_PER_TG;             // bin hist working buffer
     constexpr uint32_t INCOMING_OFFSET_SLM_SIZE = (BIN_COUNT+1)*sizeof(hist_t);                // incoming offset buffer
 
-    // max SLM is 256 * 4 * 64 + 256 * 2 * 64 + 257*2, 97KB, when  PROCESS_SIZE = 256, BIN_COUNT = 256
+    // max SLM is 256 * 4 * 64 + 256 * 2 * 64 + 257*2, 97KB, when  _DataPerWorkItem = 256, BIN_COUNT = 256
     // to support 512 processing size, we can use all SLM as reorder buffer with cost of more barrier
     slm_init( std::max(REORDER_SLM_SIZE,  BIN_HIST_SLM_SIZE + INCOMING_OFFSET_SLM_SIZE));
     uint32_t slm_reorder_start = 0;
     uint32_t slm_bin_hist_start = 0;
     uint32_t slm_incoming_offset = slm_bin_hist_start + BIN_HIST_SLM_SIZE;
 
-    uint32_t slm_reorder_this_thread = slm_reorder_start + local_tid * PROCESS_SIZE * sizeof(KeyT);
+    uint32_t slm_reorder_this_thread = slm_reorder_start + local_tid * _DataPerWorkItem * sizeof(_KeyT);
     uint32_t slm_bin_hist_this_thread = slm_bin_hist_start + local_tid * HIST_STRIDE;
 
     simd<hist_t, BIN_COUNT> bin_offset;
-    simd<device_addr_t, PROCESS_SIZE> write_addr;
-    simd<KeyT, PROCESS_SIZE> keys;
-    simd<bin_t, PROCESS_SIZE> bins;
+    simd<device_addr_t, _DataPerWorkItem> write_addr;
+    simd<_KeyT, _DataPerWorkItem> keys;
+    simd<bin_t, _DataPerWorkItem> bins;
     simd<device_addr_t, 16> lane_id(0, 1);
 
-    device_addr_t io_offset = PROCESS_SIZE * local_tid;
+    device_addr_t io_offset = _DataPerWorkItem * local_tid;
 
     #pragma unroll
-    for (uint32_t s = 0; s<PROCESS_SIZE; s+=16) {
+    for (uint32_t s = 0; s<_DataPerWorkItem; s+=16) {
         simd_mask<16> m = (io_offset+lane_id+s)<n;
-        keys.template select<16, 1>(s) = merge(utils::gather<KeyT, 16>(input, lane_id, io_offset + s, m),
-                                               simd<KeyT, 16>(utils::__sort_identity<KeyT, IsAscending>()), m);
+        keys.template select<16, 1>(s) = merge(utils::gather<_KeyT, 16>(input, lane_id, io_offset + s, m),
+                                               simd<_KeyT, 16>(utils::__sort_identity<_KeyT, _IsAscending>()), m);
     }
 
     for (uint32_t stage=0; stage < STAGES; stage++) {
-        // bins = (keys >> (stage * RADIX_BITS)) & MASK;
-        bins = utils::__get_bucket<MASK>(utils::__order_preserving_cast<IsAscending>(keys), stage * RADIX_BITS);
+        bins = utils::__get_bucket<MASK>(utils::__order_preserving_cast<_IsAscending>(keys), stage * _RadixBits);
 
         bin_offset = 0;
         #pragma unroll
-        for (uint32_t s = 0; s<PROCESS_SIZE; s+=1) {
+        for (uint32_t s = 0; s<_DataPerWorkItem; s+=1) {
             write_addr[s] = bin_offset[bins[s]];
             bin_offset[bins[s]] += 1;
         }
@@ -105,7 +106,7 @@ void one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, uint32_t THREAD_PER_TG, con
 
                 thread_grf_hist_summary.template bit_cast_view<uint32_t>() = utils::BlockLoad<uint32_t, BIN_WIDTH_UD>(slm_bin_hist_summary_offset);
                 slm_bin_hist_summary_offset += HIST_STRIDE;
-                for (uint32_t s = 1; s<THREAD_PER_TG-1; s++) {
+                for (uint32_t s = 1; s<_WorkGroupSize-1; s++) {
                     tmp = utils::BlockLoad<uint32_t, BIN_WIDTH_UD>(slm_bin_hist_summary_offset);
                     thread_grf_hist_summary += tmp.template bit_cast_view<hist_t>();
                     utils::BlockStore<uint32_t, BIN_WIDTH_UD>(slm_bin_hist_summary_offset, thread_grf_hist_summary.template bit_cast_view<uint32_t>());
@@ -122,7 +123,7 @@ void one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, uint32_t THREAD_PER_TG, con
                 simd<hist_t, BIN_COUNT+1> grf_hist_summary_scan;
                 #pragma unroll
                 for (uint32_t s = 0; s<BIN_COUNT; s+=128) {
-                    grf_hist_summary.template select<128, 1>(s).template bit_cast_view<uint32_t>() = utils::BlockLoad<uint32_t, 64>(slm_bin_hist_start + (THREAD_PER_TG-1) * HIST_STRIDE + s*sizeof(hist_t));
+                    grf_hist_summary.template select<128, 1>(s).template bit_cast_view<uint32_t>() = utils::BlockLoad<uint32_t, 64>(slm_bin_hist_start + (_WorkGroupSize-1) * HIST_STRIDE + s*sizeof(hist_t));
                 }
                 grf_hist_summary_scan[0] = 0;
                 grf_hist_summary_scan.template select<32, 1>(1) = grf_hist_summary.template select<32, 1>(0);
@@ -154,25 +155,25 @@ void one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, uint32_t THREAD_PER_TG, con
         }
 
         #pragma unroll
-        for (uint32_t s = 0; s<PROCESS_SIZE; s+=16) {
+        for (uint32_t s = 0; s<_DataPerWorkItem; s+=16) {
             simd<uint16_t, 16> bins_uw = bins.template select<16, 1>(s);
             write_addr.template select<16, 1>(s) += bin_offset.template iselect(bins_uw);
         }
 
         if (stage != STAGES - 1) {
             #pragma unroll
-            for (uint32_t s = 0; s<PROCESS_SIZE; s+=16) {
-                utils::VectorStore<KeyT, 1, 16>(
-                    write_addr.template select<16, 1>(s)*sizeof(KeyT) + slm_reorder_start,
+            for (uint32_t s = 0; s<_DataPerWorkItem; s+=16) {
+                utils::VectorStore<_KeyT, 1, 16>(
+                    write_addr.template select<16, 1>(s)*sizeof(_KeyT) + slm_reorder_start,
                     keys.template select<16, 1>(s));
             }
             barrier();
-            keys = utils::BlockLoad<KeyT, PROCESS_SIZE>(slm_reorder_this_thread);
+            keys = utils::BlockLoad<_KeyT, _DataPerWorkItem>(slm_reorder_this_thread);
         }
     }
     #pragma unroll
-    for (uint32_t s = 0; s<PROCESS_SIZE; s+=16) {
-        utils::scatter<KeyT, 16>(input, write_addr.template select<16, 1>(s), keys.template select<16, 1>(s),
+    for (uint32_t s = 0; s<_DataPerWorkItem; s+=16) {
+        utils::scatter<_KeyT, 16>(input, write_addr.template select<16, 1>(s), keys.template select<16, 1>(s),
                                  write_addr.template select<16, 1>(s) < n);
     }
 }
@@ -183,79 +184,46 @@ void one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, uint32_t THREAD_PER_TG, con
 template <typename... _Name>
 class __esimd_radix_sort_one_wg;
 
-template <typename KeyT, ::std::uint32_t RADIX_BITS, ::std::uint32_t PROCESS_SIZE, bool IsAscending, typename _KernelName>
+template <bool _IsAscending, ::std::uint16_t _RadixBits, ::std::uint16_t _DataPerWorkItem,
+          ::std::uint16_t _WorkGroupSize, typename _KeyT, typename _KernelName>
 struct __radix_sort_one_wg_submitter;
 
-template <typename KeyT, ::std::uint32_t RADIX_BITS, ::std::uint32_t PROCESS_SIZE, bool IsAscending, typename... _Name>
-struct __radix_sort_one_wg_submitter<KeyT, RADIX_BITS, PROCESS_SIZE, IsAscending,
+template <bool _IsAscending, ::std::uint16_t _RadixBits, ::std::uint16_t _DataPerWorkItem,
+          ::std::uint16_t _WorkGroupSize, typename _KeyT, typename... _Name>
+struct __radix_sort_one_wg_submitter<_IsAscending, _RadixBits, _DataPerWorkItem, _WorkGroupSize, _KeyT,
                                      oneapi::dpl::__par_backend_hetero::__internal::__optional_kernel_name<_Name...>>
 {
     template <typename _Range>
     sycl::event
-    operator()(sycl::queue& __q, _Range&& __rng, ::std::size_t __n, ::std::uint32_t __tg_count) const
+    operator()(sycl::queue __q, _Range&& __rng, ::std::size_t __n) const
     {
-        sycl::nd_range<1> __nd_range{__tg_count, __tg_count};
-
+        sycl::nd_range<1> __nd_range{_WorkGroupSize, _WorkGroupSize};
         return __q.submit([&](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rng);
             auto __data = __rng.data();
             __cgh.parallel_for<_Name...>(
                     __nd_range, [=](sycl::nd_item<1> __nd_item) [[intel::sycl_explicit_simd]] {
-                        one_wg_kernel<KeyT,  decltype(__data), RADIX_BITS, PROCESS_SIZE, IsAscending> (
-                            __nd_item, __n, __tg_count, __data);
+                        one_wg_kernel<_IsAscending, _RadixBits, _DataPerWorkItem, _WorkGroupSize, _KeyT>(
+                            __nd_item, __n, __data);
                     });
         });
     }
 };
 
-template <typename _KernelName, typename KeyT, typename _Range, ::std::uint32_t RADIX_BITS, bool IsAscending>
+template <typename _KernelName, bool _IsAscending, ::std::uint16_t _RadixBits, ::std::uint16_t _DataPerWorkItem,
+          ::std::uint16_t _WorkGroupSize, typename _Range>
 sycl::event
 one_wg(sycl::queue __q, _Range&& __rng, ::std::size_t __n)
 {
-    using namespace sycl;
-    using namespace __ESIMD_NS;
-
-    constexpr uint32_t MAX_TG_COUNT = 64;
-    constexpr uint32_t MIN_TG_COUNT = 8;
-    uint32_t PROCESS_SIZE = 64;
-
-    if (__n < MIN_TG_COUNT*64)
-    {
-        PROCESS_SIZE = 64;
-    }
-    else if (__n < MIN_TG_COUNT*128)
-    {
-        PROCESS_SIZE = 128;
-    }
-    else
-    {
-        PROCESS_SIZE = 256;
-    }
-
-    uint32_t TG_COUNT = oneapi::dpl::__internal::__dpl_ceiling_div(__n, PROCESS_SIZE);
-    TG_COUNT = std::max(TG_COUNT, MIN_TG_COUNT);
-
+    using _KeyT = oneapi::dpl::__internal::__value_t<_Range>;
     using _EsimRadixSortKernel =
-    oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<__esimd_radix_sort_one_wg<_KernelName>>;
+        oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<__esimd_radix_sort_one_wg<_KernelName>>;
 
-    sycl::event __e;
-    if (PROCESS_SIZE == 64)
-    {
-        __e = __radix_sort_one_wg_submitter<KeyT, RADIX_BITS, 64, IsAscending, _EsimRadixSortKernel>()(__q,
-            ::std::forward<_Range>(__rng), __n, TG_COUNT);
-    }
-    else if (PROCESS_SIZE == 128)
-    {
-        __e = __radix_sort_one_wg_submitter<KeyT, RADIX_BITS, 128, IsAscending, _EsimRadixSortKernel>()(__q,
-            ::std::forward<_Range>(__rng), __n, TG_COUNT);
-    }
-    else
-    {
-        __e = __radix_sort_one_wg_submitter<KeyT, RADIX_BITS, 256, IsAscending, _EsimRadixSortKernel>()(__q,
-            ::std::forward<_Range>(__rng), __n, TG_COUNT);
-    }
+    // TODO: check if MAX_THREAD_PER_TG is necessary; remove the assert if it is not
+    assert((_WorkGroupSize <= 64) && "WorkGroupSize shall not exceed 64");
 
-    return __e;
+    return __radix_sort_one_wg_submitter<_IsAscending, _RadixBits, _DataPerWorkItem, _WorkGroupSize,
+        _KeyT, _EsimRadixSortKernel>()(__q, ::std::forward<_Range>(__rng), __n);
 }
 
 } // oneapi::dpl::experimental::kt::esimd::impl

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
@@ -167,7 +167,7 @@ struct slm_lookup_t {
     }
 };
 
-template <bool _IsAscending, ::std::uint16_t _RadixBits, ::std::uint16_t _DataPerWorkItem, ::std::uint16_t _WorkGroupSize,
+template <bool _IsAscending, ::std::uint8_t _RadixBits, ::std::uint16_t _DataPerWorkItem, ::std::uint16_t _WorkGroupSize,
           typename _KeyT, typename InputT, typename OutputT>
 struct radix_sort_onesweep_slm_reorder_kernel {
     using bin_t = uint16_t;
@@ -498,11 +498,11 @@ struct __radix_sort_onesweep_scan_submitter<STAGES, BINCOUNT,
     }
 };
 
-template <bool _IsAscending, ::std::uint16_t _RadixBits, ::std::uint16_t _DataPerWorkItem, ::std::uint16_t _WorkGroupSize,
+template <bool _IsAscending, ::std::uint8_t _RadixBits, ::std::uint16_t _DataPerWorkItem, ::std::uint16_t _WorkGroupSize,
           typename _KeyT, typename _KernelName>
 struct __radix_sort_onesweep_submitter;
 
-template <bool _IsAscending, ::std::uint16_t _RadixBits, ::std::uint16_t _DataPerWorkItem, ::std::uint16_t _WorkGroupSize,
+template <bool _IsAscending, ::std::uint8_t _RadixBits, ::std::uint16_t _DataPerWorkItem, ::std::uint16_t _WorkGroupSize,
           typename _KeyT, typename... _Name>
 struct __radix_sort_onesweep_submitter<_IsAscending, _RadixBits, _DataPerWorkItem, _WorkGroupSize, _KeyT,
                                        oneapi::dpl::__par_backend_hetero::__internal::__optional_kernel_name<_Name...>>
@@ -549,7 +549,7 @@ struct __radix_sort_copyback_submitter<_KeyT, oneapi::dpl::__par_backend_hetero:
     }
 };
 
-template <typename _KernelName, bool _IsAscending, ::std::uint16_t _RadixBits, ::std::uint16_t _DataPerWorkItem,
+template <typename _KernelName, bool _IsAscending, ::std::uint8_t _RadixBits, ::std::uint16_t _DataPerWorkItem,
           ::std::uint16_t _WorkGroupSize, typename _Range>
 sycl::event
 onesweep(sycl::queue __q, _Range&& __rng, ::std::size_t __n)

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
@@ -19,9 +19,8 @@
 
 namespace oneapi::dpl::experimental::kt::esimd::impl
 {
-
-template <typename KeyT, typename InputT, uint32_t RADIX_BITS, uint32_t STAGES, uint32_t WORK_GROUPS,
-          uint32_t WORK_GROUP_SIZE, bool IsAscending>
+template <typename _KeyT, typename InputT, uint32_t _RadixBits, uint32_t STAGES, uint32_t WORK_GROUPS,
+          uint32_t WORK_GROUP_SIZE, bool _IsAscending>
 void global_histogram(sycl::nd_item<1> idx, size_t __n, const InputT& input, uint32_t *p_global_offset) {
     using namespace sycl;
     using namespace __ESIMD_NS;
@@ -33,19 +32,19 @@ void global_histogram(sycl::nd_item<1> idx, size_t __n, const InputT& input, uin
 
     slm_init(16384);
 
-    constexpr uint32_t BIN_COUNT = 1 << RADIX_BITS;
+    constexpr uint32_t BIN_COUNT = 1 << _RadixBits;
     constexpr uint32_t DATA_PER_WORK_ITEM = 128;
     constexpr uint32_t DEVICE_WIDE_STEP = WORK_GROUPS * WORK_GROUP_SIZE * DATA_PER_WORK_ITEM;
 
     // Cap the number of histograms to reduce in SLM per input range read pass
     // due to excessive GRF usage for thread-local histograms
-    constexpr uint32_t STAGES_PER_BLOCK = sizeof(KeyT) < 4? sizeof(KeyT) : 4;
+    constexpr uint32_t STAGES_PER_BLOCK = sizeof(_KeyT) < 4? sizeof(_KeyT) : 4;
     constexpr uint32_t STAGE_BLOCKS = oneapi::dpl::__internal::__dpl_ceiling_div(STAGES, STAGES_PER_BLOCK);
 
     constexpr uint32_t HIST_BUFFER_SIZE = STAGES * BIN_COUNT;
     constexpr uint32_t HIST_DATA_PER_WORK_ITEM = HIST_BUFFER_SIZE / WORK_GROUP_SIZE;
 
-    simd<KeyT, DATA_PER_WORK_ITEM> keys;
+    simd<_KeyT, DATA_PER_WORK_ITEM> keys;
     simd<bin_t, DATA_PER_WORK_ITEM> bins;
 
     uint32_t local_id = idx.get_local_linear_id();
@@ -83,10 +82,10 @@ void global_histogram(sycl::nd_item<1> idx, size_t __n, const InputT& input, uin
                 #pragma unroll
                 for (uint32_t step_offset = 0; step_offset < DATA_PER_WORK_ITEM; step_offset += DATA_PER_STEP)
                 {
-                    simd<uint32_t, DATA_PER_STEP> byte_offsets = (lane_offsets + step_offset + wi_offset) * sizeof(KeyT);
-                    simd_mask<DATA_PER_STEP> is_in_range = byte_offsets < __n * sizeof(KeyT);
-                    simd<KeyT, DATA_PER_STEP> data = lsc_gather<KeyT>(input, byte_offsets, is_in_range);
-                    simd<KeyT, DATA_PER_STEP> sort_identities = utils::__sort_identity<KeyT, IsAscending>();
+                    simd<uint32_t, DATA_PER_STEP> byte_offsets = (lane_offsets + step_offset + wi_offset) * sizeof(_KeyT);
+                    simd_mask<DATA_PER_STEP> is_in_range = byte_offsets < __n * sizeof(_KeyT);
+                    simd<_KeyT, DATA_PER_STEP> data = lsc_gather<_KeyT>(input, byte_offsets, is_in_range);
+                    simd<_KeyT, DATA_PER_STEP> sort_identities = utils::__sort_identity<_KeyT, _IsAscending>();
                     keys.template select<DATA_PER_STEP, 1>(step_offset) = merge(data, sort_identities, is_in_range);
                 }
             }
@@ -96,7 +95,7 @@ void global_histogram(sycl::nd_item<1> idx, size_t __n, const InputT& input, uin
             {
                 constexpr bin_t MASK = BIN_COUNT - 1;
                 uint32_t stage_global = stage_block_start + stage_local;
-                bins = utils::__get_bucket<MASK>(utils::__order_preserving_cast<IsAscending>(keys), stage_global * RADIX_BITS);
+                bins = utils::__get_bucket<MASK>(utils::__order_preserving_cast<_IsAscending>(keys), stage_global * _RadixBits);
                 #pragma unroll
                 for (uint32_t i = 0; i < DATA_PER_WORK_ITEM; ++i)
                 {
@@ -168,28 +167,30 @@ struct slm_lookup_t {
     }
 };
 
-template <typename KeyT, typename InputT, typename OutputT, uint32_t RADIX_BITS, uint32_t SG_PER_WG, uint32_t PROCESS_SIZE, bool IsAscending>
+template <bool _IsAscending, ::std::uint16_t _RadixBits, ::std::uint16_t _DataPerWorkItem, ::std::uint16_t _WorkGroupSize,
+          typename _KeyT, typename InputT, typename OutputT>
 struct radix_sort_onesweep_slm_reorder_kernel {
     using bin_t = uint16_t;
     using hist_t = uint16_t;
     using global_hist_t = uint32_t;
     using device_addr_t = uint32_t;
 
-    static constexpr uint32_t BIN_COUNT = 1 << RADIX_BITS;
-    static constexpr uint32_t NBITS =  sizeof(KeyT) * 8;
-    static constexpr uint32_t STAGES = oneapi::dpl::__internal::__dpl_ceiling_div(NBITS, RADIX_BITS);
+    static constexpr uint32_t BIN_COUNT = 1 << _RadixBits;
+    static constexpr uint32_t NBITS =  sizeof(_KeyT) * 8;
+    static constexpr uint32_t STAGES = oneapi::dpl::__internal::__dpl_ceiling_div(NBITS, _RadixBits);
     static constexpr bin_t MASK = BIN_COUNT - 1;
-    static constexpr uint32_t REORDER_SLM_SIZE = PROCESS_SIZE * sizeof(KeyT) * SG_PER_WG; // reorder buffer
-    static constexpr uint32_t BIN_HIST_SLM_SIZE = BIN_COUNT * sizeof(hist_t) * SG_PER_WG;             // bin hist working buffer
-    static constexpr uint32_t SUBGROUP_LOOKUP_SIZE = BIN_COUNT * sizeof(hist_t) * SG_PER_WG;          // group offset lookup
-    static constexpr uint32_t GLOBAL_LOOKUP_SIZE = BIN_COUNT * sizeof(global_hist_t);                 // global fix look up
-    static constexpr uint32_t INCOMING_OFFSET_SLM_SIZE = (BIN_COUNT+1)*sizeof(hist_t);                // incoming offset buffer
+    static constexpr uint32_t REORDER_SLM_SIZE = _DataPerWorkItem * sizeof(_KeyT) * _WorkGroupSize; // reorder buffer
+    static constexpr uint32_t BIN_HIST_SLM_SIZE = BIN_COUNT * sizeof(hist_t) * _WorkGroupSize;      // bin hist working buffer
+    static constexpr uint32_t SUBGROUP_LOOKUP_SIZE = BIN_COUNT * sizeof(hist_t) * _WorkGroupSize;   // group offset lookup
+    static constexpr uint32_t GLOBAL_LOOKUP_SIZE = BIN_COUNT * sizeof(global_hist_t);               // global fix look up
+    static constexpr uint32_t INCOMING_OFFSET_SLM_SIZE = (BIN_COUNT+1)*sizeof(hist_t);              // incoming offset buffer
+    static constexpr uint32_t OFFSETS_SLM_SIZE = BIN_HIST_SLM_SIZE + GLOBAL_LOOKUP_SIZE + INCOMING_OFFSET_SLM_SIZE;
 
     //slm allocation:
-    // first stage, do subgroup ranks, need SG_PER_WG*BIN_COUNT*sizeof(hist_t)
-    // then do rank roll up in workgroup, need SG_PER_WG*BIN_COUNT*sizeof(hist_t) + BIN_COUNT*sizeof(hist_t) + BIN_COUNT*sizeof(global_hist_t)
+    // first stage, do subgroup ranks, need _WorkGroupSize*BIN_COUNT*sizeof(hist_t)
+    // then do rank roll up in workgroup, need _WorkGroupSize*BIN_COUNT*sizeof(hist_t) + BIN_COUNT*sizeof(hist_t) + BIN_COUNT*sizeof(global_hist_t)
     // after all these is done, update ranks to workgroup ranks, need SUBGROUP_LOOKUP_SIZE
-    // then shuffle keys to workgroup order in SLM, need PROCESS_SIZE * sizeof(KeyT) * SG_PER_WG
+    // then shuffle keys to workgroup order in SLM, need _DataPerWorkItem * sizeof(_KeyT) * _WorkGroupSize
     // then read reordered slm and look up global fix, need GLOBAL_LOOKUP_SIZE on top
 
     uint32_t n;
@@ -202,30 +203,30 @@ struct radix_sort_onesweep_slm_reorder_kernel {
         n(n), stage(stage), input(input), output(output), p_global_buffer(p_global_buffer) {}
 
     template <uint32_t CHUNK_SIZE>
-    inline void LoadKeys(uint32_t io_offset, __ESIMD_NS::simd<KeyT, PROCESS_SIZE> &keys, KeyT default_key) const {
+    inline void LoadKeys(uint32_t io_offset, __ESIMD_NS::simd<_KeyT, _DataPerWorkItem> &keys, _KeyT default_key) const {
         using namespace __ESIMD_NS;
         using namespace __ESIMD_ENS;
-        bool is_full_block = (io_offset+PROCESS_SIZE) < n;
+        bool is_full_block = (io_offset+_DataPerWorkItem) < n;
         if (is_full_block) {
             simd<uint32_t, CHUNK_SIZE> lane_id(0, 1);
             #pragma unroll
-            for (uint32_t s = 0; s<PROCESS_SIZE; s+=CHUNK_SIZE) {
-                sycl::ext::intel::esimd::simd offset((io_offset + s + lane_id) * sizeof(KeyT));
-                keys.template select<CHUNK_SIZE, 1>(s) = lsc_gather<KeyT, 1, lsc_data_size::default_size, cache_hint::cached, cache_hint::cached, 16>(input, offset);
+            for (uint32_t s = 0; s<_DataPerWorkItem; s+=CHUNK_SIZE) {
+                sycl::ext::intel::esimd::simd offset((io_offset + s + lane_id) * sizeof(_KeyT));
+                keys.template select<CHUNK_SIZE, 1>(s) = lsc_gather<_KeyT, 1, lsc_data_size::default_size, cache_hint::cached, cache_hint::cached, 16>(input, offset);
             }
         }
         else
         {
             simd<uint32_t, CHUNK_SIZE> lane_id(0, 1);
             #pragma unroll
-            for (uint32_t s = 0; s<PROCESS_SIZE; s+=CHUNK_SIZE) {
+            for (uint32_t s = 0; s<_DataPerWorkItem; s+=CHUNK_SIZE) {
                 simd_mask<CHUNK_SIZE> m = (io_offset+lane_id+s)<n;
 
-                sycl::ext::intel::esimd::simd offset((io_offset + s + lane_id) * sizeof(KeyT));
+                sycl::ext::intel::esimd::simd offset((io_offset + s + lane_id) * sizeof(_KeyT));
                 keys.template select<CHUNK_SIZE, 1>(s) =
                     merge(
-                        lsc_gather<KeyT, 1, lsc_data_size::default_size, cache_hint::cached, cache_hint::cached, 16>(input, offset, m),
-                        simd<KeyT, CHUNK_SIZE>(default_key),
+                        lsc_gather<_KeyT, 1, lsc_data_size::default_size, cache_hint::cached, cache_hint::cached, 16>(input, offset, m),
+                        simd<_KeyT, CHUNK_SIZE>(default_key),
                         m);
             }
         }
@@ -235,19 +236,19 @@ struct radix_sort_onesweep_slm_reorder_kernel {
         utils::BlockStore<hist_t, BIN_COUNT>(slm_bin_hist_this_thread, 0);
     }
 
-    inline auto RankSLM(__ESIMD_NS::simd<bin_t, PROCESS_SIZE> bins, uint32_t slm_counter_offset, uint32_t local_tid) const {
+    inline auto RankSLM(__ESIMD_NS::simd<bin_t, _DataPerWorkItem> bins, uint32_t slm_counter_offset, uint32_t local_tid) const {
         using namespace __ESIMD_NS;
         using namespace __ESIMD_ENS;
 
-        constexpr uint32_t BIN_COUNT = 1 << RADIX_BITS;
-        simd<uint32_t, PROCESS_SIZE> ranks;
+        constexpr uint32_t BIN_COUNT = 1 << _RadixBits;
+        simd<uint32_t, _DataPerWorkItem> ranks;
         utils::BlockStore<hist_t, BIN_COUNT>(slm_counter_offset, 0);
         simd<uint32_t, 32> remove_right_lanes, lane_id(0, 1);
         remove_right_lanes = 0x7fffffff >> (31-lane_id);
         #pragma unroll
-        for (uint32_t s = 0; s<PROCESS_SIZE; s+=32) {
+        for (uint32_t s = 0; s<_DataPerWorkItem; s+=32) {
             simd<uint32_t, 32> this_bins = bins.template select<32, 1>(s);
-            simd<uint32_t, 32> matched_bins = match_bins<RADIX_BITS>(this_bins, local_tid); // 40 insts
+            simd<uint32_t, 32> matched_bins = match_bins<_RadixBits>(this_bins, local_tid); // 40 insts
             simd<uint32_t, 32> pre_rank, this_round_rank;
             pre_rank = utils::VectorLoad<hist_t, 1, 32>(slm_counter_offset + this_bins*sizeof(hist_t)); // 2 mad+load.slm
             auto matched_left_lanes = matched_bins & remove_right_lanes;
@@ -278,7 +279,7 @@ struct radix_sort_onesweep_slm_reorder_kernel {
         */
         constexpr uint32_t HIST_STRIDE = sizeof(hist_t)*BIN_COUNT;
         const uint32_t slm_bin_hist_this_thread = local_tid*HIST_STRIDE;
-        const uint32_t slm_bin_hist_group_incoming = SG_PER_WG * HIST_STRIDE;
+        const uint32_t slm_bin_hist_group_incoming = _WorkGroupSize * HIST_STRIDE;
         const uint32_t slm_bin_hist_global_incoming = slm_bin_hist_group_incoming + HIST_STRIDE;
         constexpr uint32_t GLOBAL_ACCUMULATED = 0x40000000;
         constexpr uint32_t HIST_UPDATED = 0x80000000;
@@ -293,7 +294,7 @@ struct radix_sort_onesweep_slm_reorder_kernel {
                 uint32_t slm_bin_hist_summary_offset = local_tid * BIN_WIDTH * sizeof(hist_t);
                 thread_grf_hist_summary = utils::BlockLoad<hist_t, BIN_WIDTH>(slm_bin_hist_summary_offset);
                 slm_bin_hist_summary_offset += HIST_STRIDE;
-                for (uint32_t s = 1; s<SG_PER_WG; s++, slm_bin_hist_summary_offset += HIST_STRIDE) {
+                for (uint32_t s = 1; s<_WorkGroupSize; s++, slm_bin_hist_summary_offset += HIST_STRIDE) {
                     thread_grf_hist_summary += utils::BlockLoad<hist_t, BIN_WIDTH>(slm_bin_hist_summary_offset);
                     utils::BlockStore(slm_bin_hist_summary_offset, thread_grf_hist_summary);
                 }
@@ -356,7 +357,7 @@ struct radix_sort_onesweep_slm_reorder_kernel {
         uint32_t wg_size = idx.get_local_range(0);
         uint32_t wg_count = idx.get_group_range(0);
 
-        // max SLM is 256 * 4 * 64 + 256 * 2 * 64 + 257*2, 97KB, when  PROCESS_SIZE = 256, BIN_COUNT = 256
+        // max SLM is 256 * 4 * 64 + 256 * 2 * 64 + 257*2, 97KB, when  _DataPerWorkItem = 256, BIN_COUNT = 256
         // to support 512 processing size, we can use all SLM as reorder buffer with cost of more barrier
         // change slm to reuse
 
@@ -364,17 +365,17 @@ struct radix_sort_onesweep_slm_reorder_kernel {
         uint32_t slm_lookup_subgroup = local_tid*sizeof(hist_t)*BIN_COUNT;
 
         simd<hist_t, BIN_COUNT> bin_offset;
-        simd<hist_t, PROCESS_SIZE> ranks;
-        simd<KeyT, PROCESS_SIZE> keys;
-        simd<bin_t, PROCESS_SIZE> bins;
+        simd<hist_t, _DataPerWorkItem> ranks;
+        simd<_KeyT, _DataPerWorkItem> keys;
+        simd<bin_t, _DataPerWorkItem> bins;
         simd<device_addr_t, 16> lane_id(0, 1);
 
-        device_addr_t io_offset = PROCESS_SIZE * (wg_id*wg_size+local_tid);
-        constexpr KeyT default_key = utils::__sort_identity<KeyT, IsAscending>();
+        device_addr_t io_offset = _DataPerWorkItem * (wg_id*wg_size+local_tid);
+        constexpr _KeyT default_key = utils::__sort_identity<_KeyT, _IsAscending>();
 
         LoadKeys<16>(io_offset, keys, default_key);
 
-        bins = utils::__get_bucket<MASK>(utils::__order_preserving_cast<IsAscending>(keys), stage * RADIX_BITS);
+        bins = utils::__get_bucket<MASK>(utils::__order_preserving_cast<_IsAscending>(keys), stage * _RadixBits);
 
         ResetBinCounters(slm_bin_hist_this_thread);
 
@@ -397,13 +398,13 @@ struct radix_sort_onesweep_slm_reorder_kernel {
         UpdateGroupRank(local_tid, wg_id, subgroup_offset, global_fix, p_global_bin_prev_group, p_global_bin_this_group);
         barrier();
         {
-            bins = utils::__get_bucket<MASK>(utils::__order_preserving_cast<IsAscending>(keys), stage * RADIX_BITS);
+            bins = utils::__get_bucket<MASK>(utils::__order_preserving_cast<_IsAscending>(keys), stage * _RadixBits);
 
             slm_lookup_t<hist_t> subgroup_lookup(slm_lookup_subgroup);
-            simd<hist_t, PROCESS_SIZE> wg_offset = ranks + subgroup_lookup.template lookup<PROCESS_SIZE>(subgroup_offset, bins);
+            simd<hist_t, _DataPerWorkItem> wg_offset = ranks + subgroup_lookup.template lookup<_DataPerWorkItem>(subgroup_offset, bins);
             barrier();
 
-            utils::VectorStore<KeyT, 1, PROCESS_SIZE>(simd<uint32_t, PROCESS_SIZE>(wg_offset)*sizeof(KeyT), keys);
+            utils::VectorStore<_KeyT, 1, _DataPerWorkItem>(simd<uint32_t, _DataPerWorkItem>(wg_offset)*sizeof(_KeyT), keys);
         }
         barrier();
         slm_lookup_t<global_hist_t> l(REORDER_SLM_SIZE);
@@ -412,15 +413,15 @@ struct radix_sort_onesweep_slm_reorder_kernel {
         }
         barrier();
         {
-            keys = utils::BlockLoad<KeyT, PROCESS_SIZE>(local_tid * PROCESS_SIZE * sizeof(KeyT));
+            keys = utils::BlockLoad<_KeyT, _DataPerWorkItem>(local_tid * _DataPerWorkItem * sizeof(_KeyT));
 
-            bins = utils::__get_bucket<MASK>(utils::__order_preserving_cast<IsAscending>(keys), stage * RADIX_BITS);
+            bins = utils::__get_bucket<MASK>(utils::__order_preserving_cast<_IsAscending>(keys), stage * _RadixBits);
 
-            simd<hist_t, PROCESS_SIZE> group_offset = utils::create_simd<hist_t, PROCESS_SIZE>(local_tid*PROCESS_SIZE, 1);
+            simd<hist_t, _DataPerWorkItem> group_offset = utils::create_simd<hist_t, _DataPerWorkItem>(local_tid*_DataPerWorkItem, 1);
 
-            simd<device_addr_t, PROCESS_SIZE> global_offset = group_offset + l.template lookup<PROCESS_SIZE>(bins);
+            simd<device_addr_t, _DataPerWorkItem> global_offset = group_offset + l.template lookup<_DataPerWorkItem>(bins);
 
-            utils::VectorStore<KeyT, 1, PROCESS_SIZE>(output, global_offset * sizeof(KeyT), keys, global_offset<n);
+            utils::VectorStore<_KeyT, 1, _DataPerWorkItem>(output, global_offset * sizeof(_KeyT), keys, global_offset<n);
         }
     }
 };
@@ -443,13 +444,13 @@ class __esimd_radix_sort_onesweep_odd;
 template <typename... _Name>
 class __esimd_radix_sort_onesweep_copyback;
 
-template <typename KeyT, ::std::uint32_t RADIX_BITS, ::std::uint32_t STAGES, ::std::uint32_t HW_TG_COUNT,
-          ::std::uint32_t THREAD_PER_TG, bool IsAscending, typename _KernelName>
+template <typename _KeyT, ::std::uint32_t _RadixBits, ::std::uint32_t STAGES, ::std::uint32_t HW_TG_COUNT,
+          ::std::uint32_t _WorkGroupSize, bool _IsAscending, typename _KernelName>
 struct __radix_sort_onesweep_histogram_submitter;
 
-template <typename KeyT, ::std::uint32_t RADIX_BITS, ::std::uint32_t STAGES, ::std::uint32_t HW_TG_COUNT,
-          ::std::uint32_t THREAD_PER_TG, bool IsAscending, typename... _Name>
-struct __radix_sort_onesweep_histogram_submitter<KeyT, RADIX_BITS, STAGES, HW_TG_COUNT, THREAD_PER_TG, IsAscending,
+template <typename _KeyT, ::std::uint32_t _RadixBits, ::std::uint32_t STAGES, ::std::uint32_t HW_TG_COUNT,
+          ::std::uint32_t _WorkGroupSize, bool _IsAscending, typename... _Name>
+struct __radix_sort_onesweep_histogram_submitter<_KeyT, _RadixBits, STAGES, HW_TG_COUNT, _WorkGroupSize, _IsAscending,
                                                  oneapi::dpl::__par_backend_hetero::__internal::__optional_kernel_name<_Name...>>
 {
     template <typename _Range, typename _GlobalOffsetData>
@@ -457,14 +458,14 @@ struct __radix_sort_onesweep_histogram_submitter<KeyT, RADIX_BITS, STAGES, HW_TG
     operator()(sycl::queue& __q, _Range&& __rng, const _GlobalOffsetData& __global_offset_data, ::std::size_t __n,
                const sycl::event& __e) const
     {
-        sycl::nd_range<1> __nd_range(HW_TG_COUNT * THREAD_PER_TG, THREAD_PER_TG);
+        sycl::nd_range<1> __nd_range(HW_TG_COUNT * _WorkGroupSize, _WorkGroupSize);
         return __q.submit([&](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rng);
             __cgh.depends_on(__e);
             auto __data = __rng.data();
             __cgh.parallel_for<_Name...>(
                     __nd_range, [=](sycl::nd_item<1> __nd_item) [[intel::sycl_explicit_simd]] {
-                        global_histogram<KeyT, decltype(__data), RADIX_BITS, STAGES, HW_TG_COUNT, THREAD_PER_TG, IsAscending>(
+                        global_histogram<_KeyT, decltype(__data), _RadixBits, STAGES, HW_TG_COUNT, _WorkGroupSize, _IsAscending>(
                             __nd_item, __n, __data, __global_offset_data);
                     });
         });
@@ -497,13 +498,13 @@ struct __radix_sort_onesweep_scan_submitter<STAGES, BINCOUNT,
     }
 };
 
-template <typename KeyT, ::std::uint32_t RADIX_BITS, ::std::uint32_t THREAD_PER_TG, ::std::uint32_t PROCESS_SIZE,
-          bool IsAscending, typename _KernelName>
+template <bool _IsAscending, ::std::uint16_t _RadixBits, ::std::uint16_t _DataPerWorkItem, ::std::uint16_t _WorkGroupSize,
+          typename _KeyT, typename _KernelName>
 struct __radix_sort_onesweep_submitter;
 
-template <typename KeyT, ::std::uint32_t RADIX_BITS, ::std::uint32_t THREAD_PER_TG, ::std::uint32_t PROCESS_SIZE,
-          bool IsAscending, typename... _Name>
-struct __radix_sort_onesweep_submitter<KeyT, RADIX_BITS, THREAD_PER_TG, PROCESS_SIZE, IsAscending,
+template <bool _IsAscending, ::std::uint16_t _RadixBits, ::std::uint16_t _DataPerWorkItem, ::std::uint16_t _WorkGroupSize,
+          typename _KeyT, typename... _Name>
+struct __radix_sort_onesweep_submitter<_IsAscending, _RadixBits, _DataPerWorkItem, _WorkGroupSize, _KeyT,
                                        oneapi::dpl::__par_backend_hetero::__internal::__optional_kernel_name<_Name...>>
 {
     template <typename _InRange, typename _OutRange, typename _TmpData>
@@ -511,24 +512,24 @@ struct __radix_sort_onesweep_submitter<KeyT, RADIX_BITS, THREAD_PER_TG, PROCESS_
     operator()(sycl::queue& __q, _InRange& __rng, _OutRange& __out_rng, const _TmpData& __tmp_data,
                ::std::uint32_t __sweep_tg_count, ::std::size_t __n, ::std::uint32_t __stage, const sycl::event& __e) const
     {
-        sycl::nd_range<1> __nd_range(__sweep_tg_count * THREAD_PER_TG, THREAD_PER_TG);
+        sycl::nd_range<1> __nd_range(__sweep_tg_count * _WorkGroupSize, _WorkGroupSize);
         return __q.submit([&](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rng, __out_rng);
             auto __in_data = __rng.data();
             auto __out_data = __out_rng.data();
             __cgh.depends_on(__e);
-            radix_sort_onesweep_slm_reorder_kernel<KeyT, decltype(__in_data), decltype(__out_data), RADIX_BITS, THREAD_PER_TG, PROCESS_SIZE, IsAscending>
+            radix_sort_onesweep_slm_reorder_kernel<_IsAscending, _RadixBits, _DataPerWorkItem, _WorkGroupSize, _KeyT, decltype(__in_data), decltype(__out_data)>
                 K(__n, __stage, __in_data, __out_data, __tmp_data);
             __cgh.parallel_for<_Name...>(__nd_range, K);
         });
     }
 };
 
-template <typename KeyT, typename _KernelName>
+template <typename _KeyT, typename _KernelName>
 struct __radix_sort_copyback_submitter;
 
-template <typename KeyT, typename... _Name>
-struct __radix_sort_copyback_submitter<KeyT, oneapi::dpl::__par_backend_hetero::__internal::__optional_kernel_name<_Name...>>
+template <typename _KeyT, typename... _Name>
+struct __radix_sort_copyback_submitter<_KeyT, oneapi::dpl::__par_backend_hetero::__internal::__optional_kernel_name<_Name...>>
 {
     template <typename _TmpRange, typename _OutRange>
     sycl::event
@@ -548,13 +549,15 @@ struct __radix_sort_copyback_submitter<KeyT, oneapi::dpl::__par_backend_hetero::
     }
 };
 
-template <typename _KernelName, typename KeyT, typename _Range, ::std::uint32_t RADIX_BITS,
-          bool IsAscending, ::std::uint32_t PROCESS_SIZE>
+template <typename _KernelName, bool _IsAscending, ::std::uint16_t _RadixBits, ::std::uint16_t _DataPerWorkItem,
+          ::std::uint16_t _WorkGroupSize, typename _Range>
 sycl::event
 onesweep(sycl::queue __q, _Range&& __rng, ::std::size_t __n)
 {
     using namespace sycl;
     using namespace __ESIMD_NS;
+
+    using _KeyT = oneapi::dpl::__internal::__value_t<_Range>;
 
     using _EsimdRadixSortHistogram = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
             __esimd_radix_sort_onesweep_histogram<_KernelName>>;
@@ -568,13 +571,11 @@ onesweep(sycl::queue __q, _Range&& __rng, ::std::size_t __n)
             __esimd_radix_sort_onesweep_copyback<_KernelName>>;
 
     using global_hist_t = uint32_t;
-    constexpr uint32_t BINCOUNT = 1 << RADIX_BITS;
+    constexpr uint32_t BINCOUNT = 1 << _RadixBits;
     constexpr uint32_t HW_TG_COUNT = 64;
-    constexpr uint32_t THREAD_PER_TG = 64;
-    constexpr uint32_t SWEEP_PROCESSING_SIZE = PROCESS_SIZE;
-    const uint32_t sweep_tg_count = oneapi::dpl::__internal::__dpl_ceiling_div(__n, THREAD_PER_TG*SWEEP_PROCESSING_SIZE);
-    constexpr uint32_t NBITS =  sizeof(KeyT) * 8;
-    constexpr uint32_t STAGES = oneapi::dpl::__internal::__dpl_ceiling_div(NBITS, RADIX_BITS);
+    const uint32_t sweep_tg_count = oneapi::dpl::__internal::__dpl_ceiling_div(__n, _WorkGroupSize*_DataPerWorkItem);
+    constexpr uint32_t NBITS =  sizeof(_KeyT) * 8;
+    constexpr uint32_t STAGES = oneapi::dpl::__internal::__dpl_ceiling_div(NBITS, _RadixBits);
 
     // Memory for SYNC_BUFFER_SIZE is used by onesweep kernel implicitly
     // TODO: pass a pointer to the the memory allocated with SYNC_BUFFER_SIZE to onesweep kernel
@@ -583,7 +584,7 @@ onesweep(sycl::queue __q, _Range&& __rng, ::std::size_t __n)
     size_t temp_buffer_size = GLOBAL_OFFSET_SIZE + SYNC_BUFFER_SIZE;
 
     const size_t full_buffer_size_global_hist = temp_buffer_size * sizeof(uint8_t);
-    const size_t full_buffer_size_output = __n * sizeof(KeyT);
+    const size_t full_buffer_size_output = __n * sizeof(_KeyT);
     const size_t full_buffer_size = full_buffer_size_global_hist + full_buffer_size_output;
 
     uint8_t* p_temp_memory = sycl::malloc_device<uint8_t>(full_buffer_size, __q);
@@ -592,7 +593,7 @@ onesweep(sycl::queue __q, _Range&& __rng, ::std::size_t __n)
     auto p_global_offset = reinterpret_cast<uint32_t*>(p_globl_hist_buffer);
 
     // Memory for storing values sorted for an iteration
-    auto p_output = reinterpret_cast<KeyT*>(p_temp_memory + full_buffer_size_global_hist);
+    auto p_output = reinterpret_cast<_KeyT*>(p_temp_memory + full_buffer_size_global_hist);
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<oneapi::dpl::__par_backend_hetero::access_mode::read_write, decltype(p_output)>();
     auto __out_rng = __keep(p_output, p_output + __n).all_view();
 
@@ -600,7 +601,7 @@ onesweep(sycl::queue __q, _Range&& __rng, ::std::size_t __n)
     sycl::event event_chain = __q.memset(p_globl_hist_buffer, 0, temp_buffer_size);
 
     event_chain = __radix_sort_onesweep_histogram_submitter<
-        KeyT, RADIX_BITS, STAGES, HW_TG_COUNT, THREAD_PER_TG, IsAscending, _EsimdRadixSortHistogram>()(
+        _KeyT, _RadixBits, STAGES, HW_TG_COUNT, _WorkGroupSize, _IsAscending, _EsimdRadixSortHistogram>()(
             __q, __rng, p_global_offset, __n, event_chain);
 
     event_chain = __radix_sort_onesweep_scan_submitter<STAGES, BINCOUNT, _EsimdRadixSortScan>()(
@@ -610,20 +611,20 @@ onesweep(sycl::queue __q, _Range&& __rng, ::std::size_t __n)
         if((stage % 2) == 0)
         {
             event_chain = __radix_sort_onesweep_submitter<
-                    KeyT, RADIX_BITS, THREAD_PER_TG, SWEEP_PROCESSING_SIZE, IsAscending, _EsimdRadixSortSweepEven>()(
+                    _IsAscending, _RadixBits, _DataPerWorkItem, _WorkGroupSize, _KeyT, _EsimdRadixSortSweepEven>()(
                         __q, __rng, __out_rng, p_globl_hist_buffer, sweep_tg_count, __n, stage, event_chain);
         }
         else
         {
             event_chain = __radix_sort_onesweep_submitter<
-                    KeyT, RADIX_BITS, THREAD_PER_TG, SWEEP_PROCESSING_SIZE, IsAscending, _EsimdRadixSortSweepOdd>()(
+                    _IsAscending, _RadixBits, _DataPerWorkItem, _WorkGroupSize, _KeyT, _EsimdRadixSortSweepOdd>()(
                         __q, __out_rng, __rng, p_globl_hist_buffer, sweep_tg_count, __n, stage, event_chain);
         }
     }
 
     if constexpr (STAGES % 2 != 0)
     {
-        event_chain = __radix_sort_copyback_submitter<KeyT, _EsimdRadixSortCopyback>()(
+        event_chain = __radix_sort_copyback_submitter<_KeyT, _EsimdRadixSortCopyback>()(
             __q, __out_rng, __rng, __n, event_chain);
     }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -11,11 +11,13 @@
 # See https://llvm.org/LICENSE.txt for license information.
 #
 ##===----------------------------------------------------------------------===##
+add_subdirectory(kt)
+
 # rng_tests
 set (ranlux_24_48_test.pass_timeout_debug "900") # 15min
 set (ranlux_24_48_test.pass_timeout_release "720") # 12min
 
-# disable fast math for ALL TESTS 
+# disable fast math for ALL TESTS
 # icpx and dpcpp accept -fno-fast-math, but icx-cl and dpcpp-cl only accept /clang:-fno-fast-math
 foreach(_fno_fast_math_flag -fno-fast-math /clang:-fno-fast-math)
     string(MAKE_C_IDENTIFIER ${_fno_fast_math_flag} FLAG_DISPLAY_NAME)

--- a/test/kt/CMakeLists.txt
+++ b/test/kt/CMakeLists.txt
@@ -1,0 +1,51 @@
+
+function(generate_esimd_radix_sort_tests)
+    set(_test_base_name "esimd_radix_sort")
+    set(_test_source_file "esimd_radix_sort.cpp")
+
+    add_custom_target(build-esimd-tests COMMENT "Build all ESIMD tests")
+    add_custom_target(run-esimd-tests
+        COMMAND "${CMAKE_CTEST_COMMAND}" -R ${_test_base_name} --output-on-failure --no-label-summary
+        USES_TERMINAL
+        DEPENDS build-esimd-tests
+        COMMENT "Build and run all ESIMD tests")
+
+    # set(_key_type_all "char" "int8_t" "uint8_t" "int16_t" "uint16_t" "int" "uint32_t" "int64_t" "uint64_t" "float" "double")
+    # set(_work_group_size_all "16" "24" "32" "48" "56" "64")
+
+    set(_key_type_all "char" "uint16_t" "int" "uint64_t" "float" "double")
+    set(_data_per_work_item_all "32" "64" "96" "128" "160" "192" "224" "256" "288" "320" "352" "384" "416" "448" "480" "512")
+    set(_work_group_size_all "64")
+
+    foreach (_key_type ${_key_type_all})
+        foreach (_data_per_work_item ${_data_per_work_item_all})
+            foreach (_work_group_size ${_work_group_size_all})
+                string(REPLACE "_t" "" _key_type_short ${_key_type})
+                set(_test_name ${_test_base_name}_${_key_type_short}_dpwi${_data_per_work_item}_wgs${_work_group_size})
+                add_executable(${_test_name} EXCLUDE_FROM_ALL "${_test_source_file}")
+
+                target_link_libraries(${_test_name} PRIVATE oneDPL)
+                set_target_properties(${_test_name} PROPERTIES CXX_EXTENSIONS NO)
+
+                add_test(NAME ${_test_name} COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${_test_name})
+                if (DEFINED DEVICE_SELECTION_LINE)
+                    set_tests_properties(${_test_name} PROPERTIES ENVIRONMENT ${DEVICE_SELECTION_LINE})
+                endif()
+
+                target_compile_definitions(${_test_name} PRIVATE TEST_DATA_TYPE=${_key_type})
+                target_compile_definitions(${_test_name} PRIVATE TEST_DATA_PER_WORK_ITEM=${_data_per_work_item})
+                target_compile_definitions(${_test_name} PRIVATE TEST_WORK_GROUP_SIZE=${_work_group_size})
+
+                add_custom_target(run-${_test_name}
+                    COMMAND "${CMAKE_CTEST_COMMAND}" -R ^${_test_name}$$ --output-on-failure --no-label-summary
+                    USES_TERMINAL
+                    DEPENDS ${_test_name}
+                    COMMENT "Build and run test ${_test_name}")
+                add_dependencies(build-esimd-tests ${_test_name})
+                add_dependencies(run-esimd-tests ${_test_name})
+            endforeach()
+        endforeach()
+    endforeach()
+endfunction()
+
+generate_esimd_radix_sort_tests()

--- a/test/kt/esimd_radix_sort.cpp
+++ b/test/kt/esimd_radix_sort.cpp
@@ -249,7 +249,7 @@ void print_data(const Container1& expected, const Container2& actual, std::size_
 }
 
 #if _ENABLE_RANGES_TESTING
-template <typename T, bool IsAscending, std::uint16_t RadixBits, typename KernelParam>
+template <typename T, bool IsAscending, std::uint8_t RadixBits, typename KernelParam>
 void test_all_view(std::size_t size, KernelParam param)
 {
 #if LOG_TEST_INFO
@@ -273,7 +273,7 @@ void test_all_view(std::size_t size, KernelParam param)
     EXPECT_EQ_RANGES(ref, input, msg.c_str());
 }
 
-template <typename T, bool IsAscending, std::uint16_t RadixBits, typename KernelParam>
+template <typename T, bool IsAscending, std::uint8_t RadixBits, typename KernelParam>
 void test_subrange_view(std::size_t size, KernelParam param)
 {
 #if LOG_TEST_INFO
@@ -302,7 +302,7 @@ void test_subrange_view(std::size_t size, KernelParam param)
 
 #endif // _ENABLE_RANGES_TESTING
 
-template <typename T, bool IsAscending, std::uint16_t RadixBits, sycl::usm::alloc _alloc_type, typename KernelParam>
+template <typename T, bool IsAscending, std::uint8_t RadixBits, sycl::usm::alloc _alloc_type, typename KernelParam>
 void test_usm(std::size_t size, KernelParam param)
 {
 #if LOG_TEST_INFO
@@ -328,7 +328,7 @@ void test_usm(std::size_t size, KernelParam param)
     EXPECT_EQ_N(expected.begin(), actual.begin(), size, msg.c_str());
 }
 
-template <typename T, bool IsAscending, std::uint16_t RadixBits, typename KernelParam>
+template <typename T, bool IsAscending, std::uint8_t RadixBits, typename KernelParam>
 void test_sycl_iterators(std::size_t size, KernelParam param)
 {
 #if LOG_TEST_INFO
@@ -351,7 +351,7 @@ void test_sycl_iterators(std::size_t size, KernelParam param)
     EXPECT_EQ_RANGES(ref, input, msg.c_str());
 }
 
-template <typename T, bool IsAscending, std::uint16_t RadixBits, typename KernelParam>
+template <typename T, bool IsAscending, std::uint8_t RadixBits, typename KernelParam>
 void test_small_sizes(KernelParam param)
 {
 #if LOG_TEST_INFO
@@ -373,7 +373,7 @@ void test_small_sizes(KernelParam param)
     EXPECT_EQ_RANGES(ref, input, "sort modified input data when size == 1");
 }
 
-template <typename T, bool IsAscending, std::uint16_t RadixBits, typename KernelParam>
+template <typename T, bool IsAscending, std::uint8_t RadixBits, typename KernelParam>
 void test_general_cases(std::size_t size, KernelParam param)
 {
 #if _ENABLE_RANGES_TESTING

--- a/test/kt/esimd_radix_sort.cpp
+++ b/test/kt/esimd_radix_sort.cpp
@@ -1,5 +1,5 @@
 // -*- C++ -*-
-//===-- rasix_sort_esimd.pass.cpp -----------------------------------------===//
+//===-- esimd_radix_sort.cpp -----------------------------------------===//
 //
 // Copyright (C) 2023 Intel Corporation
 //
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "support/test_config.h"
+#include "../support/test_config.h"
 
 #if TEST_DPCPP_BACKEND_PRESENT
 
@@ -19,7 +19,7 @@
 #endif
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-#include "support/utils.h"
+#include "../support/utils.h"
 
 #if TEST_DPCPP_BACKEND_PRESENT
 #if __has_include(<sycl/sycl.hpp>)
@@ -28,7 +28,7 @@
 #include <CL/sycl.hpp>
 #endif
 
-#include "support/sycl_alloc_utils.h"
+#include "../support/sycl_alloc_utils.h"
 
 #include <vector>
 #include <algorithm>
@@ -51,8 +51,20 @@ struct Compare<T, false> : public std::greater<T> {};
 constexpr bool Ascending = true;
 constexpr bool Descending = false;
 
-using ParamType = oneapi::dpl::experimental::kt::kernel_param</*DataPerWorkItem*/16,/*WorkGroupSize*/256>;
-constexpr ParamType param;
+#ifndef TEST_DATA_TYPE
+#define TEST_DATA_TYPE int
+#endif
+
+#ifndef TEST_DATA_PER_WORK_ITEM
+#define TEST_DATA_PER_WORK_ITEM 256
+#endif
+
+#ifndef TEST_WORK_GROUP_SIZE
+#define TEST_WORK_GROUP_SIZE 64
+#endif
+
+using ParamType = oneapi::dpl::experimental::kt::kernel_param<TEST_DATA_PER_WORK_ITEM, TEST_WORK_GROUP_SIZE>;
+constexpr ParamType kernel_parameters;
 
 #if LOG_TEST_INFO
 struct TypeInfo
@@ -237,8 +249,8 @@ void print_data(const Container1& expected, const Container2& actual, std::size_
 }
 
 #if _ENABLE_RANGES_TESTING
-template<typename T, bool Order>
-void test_all_view(std::size_t size)
+template <typename T, bool IsAscending, std::uint16_t RadixBits, typename KernelParam>
+void test_all_view(std::size_t size, KernelParam param)
 {
 #if LOG_TEST_INFO
     std::cout << "\ttest_all_view(" << size << ") : " << TypeInfo().name<T>() << std::endl;
@@ -250,22 +262,22 @@ void test_all_view(std::size_t size)
     std::vector<T> input(size);
     generate_data(input.data(), size);
     std::vector<T> ref(input);
-    std::stable_sort(std::begin(ref), std::end(ref), Compare<T, Order>{});
+    std::stable_sort(std::begin(ref), std::end(ref), Compare<T, IsAscending>{});
     {
         sycl::buffer<T> buf(input.data(), input.size());
         oneapi::dpl::experimental::ranges::all_view<T, sycl::access::mode::read_write> view(buf);
-        oneapi::dpl::experimental::kt::esimd::radix_sort<Order>(policy, view, param).wait();
+        oneapi::dpl::experimental::kt::esimd::radix_sort<IsAscending>(policy, view, param).wait();
     }
 
     std::string msg = "wrong results with all_view, n: " + std::to_string(size);
     EXPECT_EQ_RANGES(ref, input, msg.c_str());
 }
 
-template<typename T, bool Order>
-void test_subrange_view(std::size_t size)
+template <typename T, bool IsAscending, std::uint16_t RadixBits, typename KernelParam>
+void test_subrange_view(std::size_t size, KernelParam param)
 {
 #if LOG_TEST_INFO
-    std::cout << "\ttest_subrange_view<T, " << Order << ">(" << size << ") : " << TypeInfo().name<T>() << std::endl;
+    std::cout << "\ttest_subrange_view<T, " << IsAscending << ">(" << size << ") : " << TypeInfo().name<T>() << std::endl;
 #endif
 
     sycl::queue q = TestUtils::get_test_queue();
@@ -276,10 +288,10 @@ void test_subrange_view(std::size_t size)
 
     TestUtils::usm_data_transfer<sycl::usm::alloc::device, T> dt_input(q, expected.begin(), expected.end());
 
-    std::stable_sort(expected.begin(), expected.end(), Compare<T, Order>{});
+    std::stable_sort(expected.begin(), expected.end(), Compare<T, IsAscending>{});
 
     oneapi::dpl::experimental::ranges::views::subrange view(dt_input.get_data(), dt_input.get_data() + size);
-    oneapi::dpl::experimental::kt::esimd::radix_sort<Order>(policy, view, param).wait();
+    oneapi::dpl::experimental::kt::esimd::radix_sort<IsAscending>(policy, view, param).wait();
 
     std::vector<T> actual(size);
     dt_input.retrieve_data(actual.begin());
@@ -290,11 +302,11 @@ void test_subrange_view(std::size_t size)
 
 #endif // _ENABLE_RANGES_TESTING
 
-template<typename T, sycl::usm::alloc _alloc_type, bool Order>
-void test_usm(std::size_t size)
+template <typename T, bool IsAscending, std::uint16_t RadixBits, sycl::usm::alloc _alloc_type, typename KernelParam>
+void test_usm(std::size_t size, KernelParam param)
 {
 #if LOG_TEST_INFO
-    std::cout << "\t\ttest_usm<" << TypeInfo().name<T>() << ", " << USMAllocPresentation().name<_alloc_type>() << ", " << Order << ">("<< size << ");" << std::endl;
+    std::cout << "\t\ttest_usm<" << TypeInfo().name<T>() << ", " << USMAllocPresentation().name<_alloc_type>() << ", " << IsAscending << ">("<< size << ");" << std::endl;
 #endif
 
     sycl::queue q = TestUtils::get_test_queue();
@@ -305,9 +317,9 @@ void test_usm(std::size_t size)
 
     TestUtils::usm_data_transfer<_alloc_type, T> dt_input(q, expected.begin(), expected.end());
 
-    std::stable_sort(expected.begin(), expected.end(), Compare<T, Order>{});
+    std::stable_sort(expected.begin(), expected.end(), Compare<T, IsAscending>{});
 
-    oneapi::dpl::experimental::kt::esimd::radix_sort<Order>(policy, dt_input.get_data(), dt_input.get_data() + size, param).wait();
+    oneapi::dpl::experimental::kt::esimd::radix_sort<IsAscending>(policy, dt_input.get_data(), dt_input.get_data() + size, param).wait();
 
     std::vector<T> actual(size);
     dt_input.retrieve_data(actual.begin());
@@ -316,20 +328,8 @@ void test_usm(std::size_t size)
     EXPECT_EQ_N(expected.begin(), actual.begin(), size, msg.c_str());
 }
 
-template <typename T, bool Order>
-void
-test_usm(std::size_t size)
-{
-#if LOG_TEST_INFO
-    std::cout << "\ttest_usm<T, " << Order << ">(" << size << ") : " << TypeInfo().name<T>() << std::endl;
-#endif
-
-    test_usm<T, sycl::usm::alloc::shared, Order>(size);
-    test_usm<T, sycl::usm::alloc::device, Order>(size);
-}
-
-template<typename T, bool Order>
-void test_sycl_iterators(std::size_t size)
+template <typename T, bool IsAscending, std::uint16_t RadixBits, typename KernelParam>
+void test_sycl_iterators(std::size_t size, KernelParam param)
 {
 #if LOG_TEST_INFO
     std::cout << "\t\ttest_sycl_iterators<" << TypeInfo().name<T>() << ">(" << size << ");" << std::endl;
@@ -341,17 +341,18 @@ void test_sycl_iterators(std::size_t size)
     std::vector<T> input(size);
     generate_data(input.data(), size);
     std::vector<T> ref(input);
-    std::stable_sort(std::begin(ref), std::end(ref), Compare<T, Order>{});
+    std::stable_sort(std::begin(ref), std::end(ref), Compare<T, IsAscending>{});
     {
         sycl::buffer<T> buf(input.data(), input.size());
-        oneapi::dpl::experimental::kt::esimd::radix_sort<Order>(policy, oneapi::dpl::begin(buf), oneapi::dpl::end(buf), param).wait();
+        oneapi::dpl::experimental::kt::esimd::radix_sort<IsAscending>(policy, oneapi::dpl::begin(buf), oneapi::dpl::end(buf), param).wait();
     }
 
     std::string msg = "wrong results with oneapi::dpl::begin/end, n: " + std::to_string(size);
     EXPECT_EQ_RANGES(ref, input, msg.c_str());
 }
 
-void test_small_sizes()
+template <typename T, bool IsAscending, std::uint16_t RadixBits, typename KernelParam>
+void test_small_sizes(KernelParam param)
 {
 #if LOG_TEST_INFO
     std::cout << "\t\ttest_small_sizes();" << std::endl;
@@ -363,28 +364,25 @@ void test_small_sizes()
     std::vector<uint32_t> input = {5, 11, 0, 17, 0};
     std::vector<uint32_t> ref(input);
 
-    oneapi::dpl::experimental::kt::esimd::radix_sort<Ascending,/*RadixBits=*/8,ParamType>(
-        policy, oneapi::dpl::begin(input), oneapi::dpl::begin(input)).wait();
+    oneapi::dpl::experimental::kt::esimd::radix_sort<Ascending, RadixBits>(
+        policy, oneapi::dpl::begin(input), oneapi::dpl::begin(input), param).wait();
     EXPECT_EQ_RANGES(ref, input, "sort modified input data when size == 0");
 
-    oneapi::dpl::experimental::kt::esimd::radix_sort<Ascending,/*RadixBits=*/8,ParamType>(
-        policy, oneapi::dpl::begin(input), oneapi::dpl::begin(input) + 1).wait();
+    oneapi::dpl::experimental::kt::esimd::radix_sort<Ascending, RadixBits>(
+        policy, oneapi::dpl::begin(input), oneapi::dpl::begin(input) + 1, param).wait();
     EXPECT_EQ_RANGES(ref, input, "sort modified input data when size == 1");
 }
 
-template <typename T>
-void test_general_cases(std::size_t size)
+template <typename T, bool IsAscending, std::uint16_t RadixBits, typename KernelParam>
+void test_general_cases(std::size_t size, KernelParam param)
 {
 #if _ENABLE_RANGES_TESTING
-    test_all_view<T, Ascending>(size);
-    test_all_view<T, Descending>(size);
-    test_subrange_view<T, Ascending>(size);
-    test_subrange_view<T, Descending>(size);
+    test_all_view<T, IsAscending, RadixBits>(size, param);
+    test_subrange_view<T, IsAscending, RadixBits>(size, param);
 #endif // _ENABLE_RANGES_TESTING
-    test_usm<T, Ascending>(size);
-    test_usm<T, Descending>(size);
-    test_sycl_iterators<T, Ascending>(size);
-    test_sycl_iterators<T, Descending>(size);
+    test_usm<T, IsAscending, RadixBits, sycl::usm::alloc::shared>(size, param);
+    test_usm<T, IsAscending, RadixBits, sycl::usm::alloc::device>(size, param);
+    test_sycl_iterators<T, IsAscending, RadixBits>(size, param);
 }
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
@@ -402,33 +400,15 @@ int main()
 #if TEST_LONG_RUN
         for(auto size: sizes)
         {
-            test_general_cases<char    >(size);
-            test_general_cases<int8_t  >(size);
-            test_general_cases<uint8_t >(size);
-            test_general_cases<int16_t >(size);
-            test_general_cases<uint16_t>(size);
-            test_general_cases<int     >(size);
-            test_general_cases<uint32_t>(size);
-            test_general_cases<float   >(size);
-            test_general_cases<int64_t >(size);
-            test_general_cases<uint64_t>(size);
-            test_general_cases<double  >(size);
+            test_general_cases<TEST_DATA_TYPE, Ascending, /*RadixBits*/8>(size, kernel_parameters);
+            test_general_cases<TEST_DATA_TYPE, Descending, /*RadixBits*/8>(size, kernel_parameters);
         }
-        test_small_sizes();
+        test_small_sizes<TEST_DATA_TYPE, Ascending, /*RadixBits*/8>(kernel_parameters);
 #else
         for(auto size: sizes)
         {
-            test_usm<char,     sycl::usm::alloc::shared, Ascending>(size);
-            test_usm<int,      sycl::usm::alloc::shared, Ascending>(size);
-            test_usm<uint32_t, sycl::usm::alloc::shared, Ascending>(size);
-            test_usm<float,    sycl::usm::alloc::shared, Ascending>(size);
-            test_usm<double,   sycl::usm::alloc::shared, Ascending>(size);
-
-            test_usm<int16_t,  sycl::usm::alloc::shared, Descending>(size);
-            test_usm<int,      sycl::usm::alloc::shared, Descending>(size);
-            test_usm<float,    sycl::usm::alloc::shared, Descending>(size);
-            test_usm<uint64_t, sycl::usm::alloc::shared, Descending>(size);
-            test_usm<double,   sycl::usm::alloc::shared, Descending>(size);
+            test_usm<TEST_DATA_TYPE, Ascending, /*RadixBits*/8, sycl::usm::alloc::shared>(size, kernel_parameters);
+            test_usm<TEST_DATA_TYPE, Descending, /*RadixBits*/8, sycl::usm::alloc::shared>(size, kernel_parameters);
         }
 #endif // TEST_LONG_RUN
     }


### PR DESCRIPTION
Improve the test system: test different DataPerWorkItem and WorkGroupSize

Additionally, names of some internal template parameters have been aligned with the public ones. 