### PR TITLE
[KT] Create and use common defines in esimd radix sort

### DIFF
--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
@@ -22,9 +22,12 @@
 #include <cstdint>
 #include <cassert>
 
+#ifndef DATA_PER_STEP
+#define DATA_PER_STEP 16
+#endif
+
 namespace oneapi::dpl::experimental::kt::esimd::impl
 {
-
 template <bool _IsAscending, ::std::uint8_t _RadixBits, ::std::uint16_t _DataPerWorkItem,
           ::std::uint16_t _WorkGroupSize, typename _KeyT, typename InputT>
 void one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, const InputT& input) {
@@ -62,15 +65,17 @@ void one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, const InputT& input) {
     simd<device_addr_t, _DataPerWorkItem> write_addr;
     simd<_KeyT, _DataPerWorkItem> keys;
     simd<bin_t, _DataPerWorkItem> bins;
-    simd<device_addr_t, 16> lane_id(0, 1);
+    simd<device_addr_t, DATA_PER_STEP> lane_id(0, 1);
 
     device_addr_t io_offset = _DataPerWorkItem * local_tid;
 
     #pragma unroll
-    for (uint32_t s = 0; s<_DataPerWorkItem; s+=16) {
-        simd_mask<16> m = (io_offset+lane_id+s)<n;
-        keys.template select<16, 1>(s) = merge(utils::gather<_KeyT, 16>(input, lane_id, io_offset + s, m),
-                                               simd<_KeyT, 16>(utils::__sort_identity<_KeyT, _IsAscending>()), m);
+    for (uint32_t s = 0; s < _DataPerWorkItem; s += DATA_PER_STEP)
+    {
+        simd_mask<DATA_PER_STEP> m = (io_offset + lane_id + s) < n;
+        keys.template select<DATA_PER_STEP, 1>(s) =
+            merge(utils::gather<_KeyT, DATA_PER_STEP>(input, lane_id, io_offset + s, m),
+                  simd<_KeyT, DATA_PER_STEP>(utils::__sort_identity<_KeyT, _IsAscending>()), m);
     }
 
     for (uint32_t stage=0; stage < STAGES; stage++) {
@@ -155,26 +160,30 @@ void one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, const InputT& input) {
         }
 
         #pragma unroll
-        for (uint32_t s = 0; s<_DataPerWorkItem; s+=16) {
-            simd<uint16_t, 16> bins_uw = bins.template select<16, 1>(s);
-            write_addr.template select<16, 1>(s) += bin_offset.template iselect(bins_uw);
+        for (uint32_t s = 0; s < _DataPerWorkItem; s += DATA_PER_STEP)
+        {
+            simd<uint16_t, DATA_PER_STEP> bins_uw = bins.template select<DATA_PER_STEP, 1>(s);
+            write_addr.template select<DATA_PER_STEP, 1>(s) += bin_offset.template iselect(bins_uw);
         }
 
         if (stage != STAGES - 1) {
             #pragma unroll
-            for (uint32_t s = 0; s<_DataPerWorkItem; s+=16) {
-                utils::VectorStore<_KeyT, 1, 16>(
-                    write_addr.template select<16, 1>(s)*sizeof(_KeyT) + slm_reorder_start,
-                    keys.template select<16, 1>(s));
+            for (uint32_t s = 0; s < _DataPerWorkItem; s += DATA_PER_STEP)
+            {
+                utils::VectorStore<_KeyT, 1, DATA_PER_STEP>(
+                    write_addr.template select<DATA_PER_STEP, 1>(s) * sizeof(_KeyT) + slm_reorder_start,
+                    keys.template select<DATA_PER_STEP, 1>(s));
             }
             barrier();
             keys = utils::BlockLoad<_KeyT, _DataPerWorkItem>(slm_reorder_this_thread);
         }
     }
     #pragma unroll
-    for (uint32_t s = 0; s<_DataPerWorkItem; s+=16) {
-        utils::scatter<_KeyT, 16>(input, write_addr.template select<16, 1>(s), keys.template select<16, 1>(s),
-                                 write_addr.template select<16, 1>(s) < n);
+    for (uint32_t s = 0; s < _DataPerWorkItem; s += DATA_PER_STEP)
+    {
+        utils::scatter<_KeyT, DATA_PER_STEP>(
+            input, write_addr.template select<DATA_PER_STEP, 1>(s), keys.template select<DATA_PER_STEP, 1>(s),
+            write_addr.template select<DATA_PER_STEP, 1>(s) < n);
     }
 }
 

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
@@ -29,7 +29,7 @@ template <bool _IsAscending, ::std::uint8_t _RadixBits, ::std::uint16_t _DataPer
 void one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, const InputT& input) {
     using namespace sycl;
     using namespace __dpl_esimd_ns;
-    using namespace __ESIMD_ENS;
+    using namespace __dpl_esimd_ens;
 
     using bin_t = uint16_t;
     using hist_t = uint16_t;

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
@@ -22,10 +22,6 @@
 #include <cstdint>
 #include <cassert>
 
-#ifndef DATA_PER_STEP
-#define DATA_PER_STEP 16
-#endif
-
 namespace oneapi::dpl::experimental::kt::esimd::impl
 {
 template <bool _IsAscending, ::std::uint8_t _RadixBits, ::std::uint16_t _DataPerWorkItem,

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
@@ -28,7 +28,7 @@ template <bool _IsAscending, ::std::uint8_t _RadixBits, ::std::uint16_t _DataPer
           ::std::uint16_t _WorkGroupSize, typename _KeyT, typename InputT>
 void one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, const InputT& input) {
     using namespace sycl;
-    using namespace __ESIMD_NS;
+    using namespace __dpl_esimd_ns;
     using namespace __ESIMD_ENS;
 
     using bin_t = uint16_t;

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
@@ -24,7 +24,7 @@ template <typename _KeyT, typename InputT, uint32_t _RadixBits, uint32_t STAGES,
 void global_histogram(sycl::nd_item<1> idx, size_t __n, const InputT& input, uint32_t *p_global_offset) {
     using namespace sycl;
     using namespace __dpl_esimd_ns;
-    using namespace __ESIMD_ENS;
+    using namespace __dpl_esimd_ens;
 
     using bin_t = uint16_t;
     using hist_t = uint32_t;
@@ -210,7 +210,7 @@ struct radix_sort_onesweep_slm_reorder_kernel {
     LoadKeys(uint32_t io_offset, __dpl_esimd_ns::simd<_KeyT, _DataPerWorkItem>& keys, _KeyT default_key) const
     {
         using namespace __dpl_esimd_ns;
-        using namespace __ESIMD_ENS;
+        using namespace __dpl_esimd_ens;
         bool is_full_block = (io_offset+_DataPerWorkItem) < n;
         if (is_full_block) {
             simd<uint32_t, DATA_PER_STEP> lane_id(0, 1);
@@ -247,7 +247,7 @@ struct radix_sort_onesweep_slm_reorder_kernel {
     RankSLM(__dpl_esimd_ns::simd<bin_t, _DataPerWorkItem> bins, uint32_t slm_counter_offset, uint32_t local_tid) const
     {
         using namespace __dpl_esimd_ns;
-        using namespace __ESIMD_ENS;
+        using namespace __dpl_esimd_ens;
 
         constexpr int BinsPerStep = 32;
 
@@ -283,7 +283,7 @@ struct radix_sort_onesweep_slm_reorder_kernel {
         global_hist_t *p_global_bin_this_group
         ) const {
         using namespace __dpl_esimd_ns;
-        using namespace __ESIMD_ENS;
+        using namespace __dpl_esimd_ens;
         /*
         first do column scan by group, each thread do 32c,
         then last row do exclusive scan as group incoming offset
@@ -360,7 +360,7 @@ struct radix_sort_onesweep_slm_reorder_kernel {
 
     void operator() (sycl::nd_item<1> idx) const SYCL_ESIMD_KERNEL {
         using namespace __dpl_esimd_ns;
-        using namespace __ESIMD_ENS;
+        using namespace __dpl_esimd_ens;
 
         slm_init(128*1024);
 

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
@@ -17,10 +17,6 @@
 
 #include <cstdint>
 
-#ifndef DATA_PER_STEP
-#define DATA_PER_STEP 16
-#endif
-
 namespace oneapi::dpl::experimental::kt::esimd::impl
 {
 template <typename _KeyT, typename InputT, uint32_t _RadixBits, uint32_t STAGES, uint32_t WORK_GROUPS,

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -25,6 +25,8 @@ namespace oneapi::dpl::experimental::kt::esimd::impl
 {
 constexpr int DATA_PER_STEP = 16;
 
+namespace __dpl_esimd_ns = sycl::ext::intel::esimd;
+
 namespace utils
 {
 

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -21,7 +21,11 @@
 #include <type_traits>
 #include <limits>
 
-namespace oneapi::dpl::experimental::kt::esimd::impl::utils
+namespace oneapi::dpl::experimental::kt::esimd::impl
+{
+constexpr int DATA_PER_STEP = 16;
+
+namespace utils
 {
 
 // converts sizeof(T) to 32 bits, so that it could be used in operations with 32-bit SIMD without changing the type
@@ -606,5 +610,6 @@ inline std::enable_if_t< (N>16) && (N % 16 == 0), __ESIMD_NS::simd<T, N> > creat
 }
 
 } // oneapi::dpl::experimental::kt::esimd::impl::utils
+} // oneapi::dpl::experimental::kt::esimd::impl
 
 #endif // _ONEDPL_KT_ESIMD_RADIX_SORT_UTILS_H

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -26,6 +26,7 @@ namespace oneapi::dpl::experimental::kt::esimd::impl
 constexpr int DATA_PER_STEP = 16;
 
 namespace __dpl_esimd_ns = sycl::ext::intel::esimd;
+namespace __dpl_esimd_ens = sycl::ext::intel::experimental::esimd;
 
 namespace utils
 {
@@ -36,7 +37,7 @@ inline constexpr ::std::uint32_t size32 = sizeof(T);
 
 template <typename T, int N>
 void
-copy_from(const T* input, ::std::uint32_t base_offset, sycl::ext::intel::esimd::simd<T, N>& values)
+copy_from(const T* input, ::std::uint32_t base_offset, __dpl_esimd_ns::simd<T, N>& values)
 {
     values.copy_from(input + base_offset);
 }
@@ -44,14 +45,14 @@ copy_from(const T* input, ::std::uint32_t base_offset, sycl::ext::intel::esimd::
 template <typename T, int N, sycl::access_mode Mode, sycl::access::placeholder P>
 void
 copy_from(sycl::accessor<T, 1, Mode, sycl::target::device, P> input, ::std::uint32_t base_offset,
-          sycl::ext::intel::esimd::simd<T, N>& values)
+          __dpl_esimd_ns::simd<T, N>& values)
 {
     values.copy_from(input, base_offset * size32<T>);
 }
 
 template <typename T, int N>
 void
-copy_to(T* output, ::std::uint32_t base_offset, const sycl::ext::intel::esimd::simd<T, N>& values)
+copy_to(T* output, ::std::uint32_t base_offset, const __dpl_esimd_ns::simd<T, N>& values)
 {
     values.copy_to(output + base_offset);
 }
@@ -59,65 +60,66 @@ copy_to(T* output, ::std::uint32_t base_offset, const sycl::ext::intel::esimd::s
 template <typename T, int N, sycl::access_mode Mode, sycl::access::placeholder P>
 void
 copy_to(sycl::accessor<T, 1, Mode, sycl::target::device, P> output, ::std::uint32_t base_offset,
-        const sycl::ext::intel::esimd::simd<T, N>& values)
+        const __dpl_esimd_ns::simd<T, N>& values)
 {
     values.copy_to(output, base_offset * size32<T>);
 }
 
 template <typename T, int N>
-sycl::ext::intel::esimd::simd<T, N>
-gather(const T* input, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets, ::std::uint32_t base_offset,
-       sycl::ext::intel::esimd::simd_mask<N> mask = 1)
+__dpl_esimd_ns::simd<T, N>
+gather(const T* input, __dpl_esimd_ns::simd<::std::uint32_t, N> offsets, ::std::uint32_t base_offset,
+       __dpl_esimd_ns::simd_mask<N> mask = 1)
 {
-    return sycl::ext::intel::esimd::gather(input + base_offset, offsets * size32<T>, mask);
+    return __dpl_esimd_ns::gather(input + base_offset, offsets * size32<T>, mask);
 }
 
 template <typename T, int N, sycl::access_mode Mode, sycl::access::placeholder P, ::std::enable_if_t<sizeof(T) <= sizeof(::std::uint32_t), int> = 0>
-sycl::ext::intel::esimd::simd<T, N>
-gather(sycl::accessor<T, 1, Mode, sycl::target::device, P> input, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets,
-       ::std::uint32_t base_offset, sycl::ext::intel::esimd::simd_mask<N> mask = 1)
+__dpl_esimd_ns::simd<T, N>
+gather(sycl::accessor<T, 1, Mode, sycl::target::device, P> input, __dpl_esimd_ns::simd<::std::uint32_t, N> offsets,
+       ::std::uint32_t base_offset, __dpl_esimd_ns::simd_mask<N> mask = 1)
 {
-    return sycl::ext::intel::esimd::gather<T>(input, offsets * size32<T>, base_offset * size32<T>, mask);
+    return __dpl_esimd_ns::gather<T>(input, offsets * size32<T>, base_offset * size32<T>, mask);
 }
 
 template <typename T, int N, sycl::access_mode Mode, sycl::access::placeholder P, ::std::enable_if_t<sizeof(T) == sizeof(::std::uint64_t), int> = 0>
-sycl::ext::intel::esimd::simd<T, N>
+__dpl_esimd_ns::simd<T, N>
 gather(sycl::accessor<T, 1, Mode, sycl::target::device, P> input,
-       sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets,
+       __dpl_esimd_ns::simd<::std::uint32_t, N> offsets,
        ::std::uint32_t base_offset,
-       sycl::ext::intel::esimd::simd_mask<N> mask = 1)
+       __dpl_esimd_ns::simd_mask<N> mask = 1)
 {
-    return __ESIMD_ENS::lsc_gather<T>(input, offsets * size32<T> + base_offset * size32<T>, mask);
+    return __dpl_esimd_ens::lsc_gather<T>(input, offsets * size32<T> + base_offset * size32<T>, mask);
 }
 
 template <typename T, int N>
 void
-scatter(T* output, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets,
-        sycl::ext::intel::esimd::simd<T, N> values, sycl::ext::intel::esimd::simd_mask<N> mask = 1)
+scatter(T* output, __dpl_esimd_ns::simd<::std::uint32_t, N> offsets,
+        __dpl_esimd_ns::simd<T, N> values, __dpl_esimd_ns::simd_mask<N> mask = 1)
 {
-    sycl::ext::intel::esimd::scatter(output, offsets * size32<T>, values, mask);
+    __dpl_esimd_ns::scatter(output, offsets * size32<T>, values, mask);
 }
 
 template<typename T, int N, sycl::access_mode Mode, sycl::access::placeholder P, ::std::enable_if_t<sizeof(T) <= sizeof(::std::uint32_t), int> = 0>
 void
-scatter(sycl::accessor<T, 1, Mode, sycl::target::device, P> output, sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets,
-        sycl::ext::intel::esimd::simd<T, N> values, sycl::ext::intel::esimd::simd_mask<N> mask = 1)
+scatter(sycl::accessor<T, 1, Mode, sycl::target::device, P> output, __dpl_esimd_ns::simd<::std::uint32_t, N> offsets,
+        __dpl_esimd_ns::simd<T, N> values, __dpl_esimd_ns::simd_mask<N> mask = 1)
 {
-    sycl::ext::intel::esimd::scatter(output, offsets * size32<T>, values, /*global_offset*/ 0, mask);
+    __dpl_esimd_ns::scatter(output, offsets * size32<T>, values, /*global_offset*/ 0, mask);
 }
 
 template<typename T, int N, sycl::access_mode Mode, sycl::access::placeholder P, ::std::enable_if_t<sizeof(T) == sizeof(::std::uint64_t), int> = 0>
 void
 scatter(sycl::accessor<T, 1, Mode, sycl::target::device, P> output,
-        sycl::ext::intel::esimd::simd<::std::uint32_t, N> offsets,
-        sycl::ext::intel::esimd::simd<T, N> values,
-        sycl::ext::intel::esimd::simd_mask<N> mask = 1)
+        __dpl_esimd_ns::simd<::std::uint32_t, N> offsets,
+        __dpl_esimd_ns::simd<T, N> values,
+        __dpl_esimd_ns::simd_mask<N> mask = 1)
 {
-    __ESIMD_ENS::lsc_scatter<T>(output, offsets * size32<T>, values, mask);
+    __dpl_esimd_ens::lsc_scatter<T>(output, offsets * size32<T>, values, mask);
 }
 
 template <typename T, uint32_t R, uint32_t C>
-class simd2d : public sycl::ext::intel::esimd::simd<T, R*C> {
+class simd2d : public __dpl_esimd_ns::simd<T, R * C>
+{
     public:
         auto row(uint16_t r) {return this->template bit_cast_view<T, R, C>().row(r);}
         template <int SizeY, int StrideY, int SizeX, int StrideX>
@@ -127,8 +129,10 @@ class simd2d : public sycl::ext::intel::esimd::simd<T, R*C> {
 };
 
 template <typename RT, typename T>
-inline __ESIMD_NS::simd<RT, 32> scan(__ESIMD_NS::simd<T, 32> src, const T init=0) {
-    __ESIMD_NS::simd<RT, 32> result;
+inline __dpl_esimd_ns::simd<RT, 32>
+scan(__dpl_esimd_ns::simd<T, 32> src, const T init = 0)
+{
+    __dpl_esimd_ns::simd<RT, 32> result;
     result.template select<8, 4>(0) = src.template select<8, 4>(0);
     result[0] += init;
     result.template select<8, 4>(1) = src.template select<8, 4>(1) + result.template select<8, 4>(0);
@@ -145,8 +149,10 @@ inline __ESIMD_NS::simd<RT, 32> scan(__ESIMD_NS::simd<T, 32> src, const T init=0
 }
 
 template <typename RT, typename T>
-inline __ESIMD_NS::simd<RT, 16> scan(__ESIMD_NS::simd<T, 16> src, const T init=0) {
-    __ESIMD_NS::simd<RT, 16> result;
+inline __dpl_esimd_ns::simd<RT, 16>
+scan(__dpl_esimd_ns::simd<T, 16> src, const T init = 0)
+{
+    __dpl_esimd_ns::simd<RT, 16> result;
     result.template select<4, 4>(0) = src.template select<4, 4>(0);
     result[0] += init;
     result.template select<4, 4>(1) = src.template select<4, 4>(1) + result.template select<4, 4>(0);
@@ -159,8 +165,10 @@ inline __ESIMD_NS::simd<RT, 16> scan(__ESIMD_NS::simd<T, 16> src, const T init=0
 }
 
 template <typename RT, typename T>
-inline __ESIMD_NS::simd<RT, 64> scan(__ESIMD_NS::simd<T, 64> src, const T init=0) {
-    __ESIMD_NS::simd<RT, 64> result;
+inline __dpl_esimd_ns::simd<RT, 64>
+scan(__dpl_esimd_ns::simd<T, 64> src, const T init = 0)
+{
+    __dpl_esimd_ns::simd<RT, 64> result;
     result.template select<32, 1>(0) = scan<RT, T>(src.template select<32, 1>(0), init);
     result.template select<32, 1>(32) = scan<RT, T>(src.template select<32, 1>(32), result[31]);
     return result;
@@ -168,10 +176,10 @@ inline __ESIMD_NS::simd<RT, 64> scan(__ESIMD_NS::simd<T, 64> src, const T init=0
 
 // get bits value (bucket) in a certain radix position
 template <::std::uint16_t __radix_mask, typename _T, int _N, std::enable_if_t<::std::is_unsigned_v<_T>, int> = 0>
-sycl::ext::intel::esimd::simd<::std::uint16_t, _N>
-__get_bucket(sycl::ext::intel::esimd::simd<_T, _N> __value, ::std::uint32_t __radix_offset)
+__dpl_esimd_ns::simd<::std::uint16_t, _N>
+__get_bucket(__dpl_esimd_ns::simd<_T, _N> __value, ::std::uint32_t __radix_offset)
 {
-    return sycl::ext::intel::esimd::simd<::std::uint16_t, _N>(__value >> __radix_offset) & __radix_mask;
+    return __dpl_esimd_ns::simd<::std::uint16_t, _N>(__value >> __radix_offset) & __radix_mask;
 }
 
 template <typename T, bool __is_ascending, std::enable_if_t<::std::is_integral_v<T>, int> = 0>
@@ -212,8 +220,8 @@ __sort_identity()
 }
 
 template <bool __is_ascending, int _N>
-sycl::ext::intel::esimd::simd<bool, _N>
-__order_preserving_cast(sycl::ext::intel::esimd::simd<bool, _N> __src)
+__dpl_esimd_ns::simd<bool, _N>
+__order_preserving_cast(__dpl_esimd_ns::simd<bool, _N> __src)
 {
     if constexpr (__is_ascending)
         return __src;
@@ -222,8 +230,8 @@ __order_preserving_cast(sycl::ext::intel::esimd::simd<bool, _N> __src)
 }
 
 template <bool __is_ascending, typename _UInt, int _N, std::enable_if_t<::std::is_unsigned_v<_UInt>, int> = 0>
-sycl::ext::intel::esimd::simd<_UInt, _N>
-__order_preserving_cast(sycl::ext::intel::esimd::simd<_UInt, _N> __src)
+__dpl_esimd_ns::simd<_UInt, _N>
+__order_preserving_cast(__dpl_esimd_ns::simd<_UInt, _N> __src)
 {
     if constexpr (__is_ascending)
         return __src;
@@ -233,8 +241,8 @@ __order_preserving_cast(sycl::ext::intel::esimd::simd<_UInt, _N> __src)
 
 template <bool __is_ascending, typename _Int, int _N,
           std::enable_if_t<::std::is_integral_v<_Int> && ::std::is_signed_v<_Int>, int> = 0>
-sycl::ext::intel::esimd::simd<::std::make_unsigned_t<_Int>, _N>
-__order_preserving_cast(sycl::ext::intel::esimd::simd<_Int, _N> __src)
+__dpl_esimd_ns::simd<::std::make_unsigned_t<_Int>, _N>
+__order_preserving_cast(__dpl_esimd_ns::simd<_Int, _N> __src)
 {
     using _UInt = ::std::make_unsigned_t<_Int>;
     // mask: 100..0 for ascending, 011..1 for descending
@@ -245,62 +253,66 @@ __order_preserving_cast(sycl::ext::intel::esimd::simd<_Int, _N> __src)
 
 template <bool __is_ascending, typename _Float, int _N,
           std::enable_if_t<::std::is_floating_point_v<_Float> && sizeof(_Float) == sizeof(::std::uint32_t), int> = 0>
-sycl::ext::intel::esimd::simd<::std::uint32_t, _N>
-__order_preserving_cast(sycl::ext::intel::esimd::simd<_Float, _N> __src)
+__dpl_esimd_ns::simd<::std::uint32_t, _N>
+__order_preserving_cast(__dpl_esimd_ns::simd<_Float, _N> __src)
 {
-    sycl::ext::intel::esimd::simd<::std::uint32_t, _N> __uint32_src = __src.template bit_cast_view<::std::uint32_t>();
-    sycl::ext::intel::esimd::simd<::std::uint32_t, _N> __mask;
-    sycl::ext::intel::esimd::simd_mask<_N> __sign_bit_m = (__uint32_src >> 31 == 0);
+    __dpl_esimd_ns::simd<::std::uint32_t, _N> __uint32_src = __src.template bit_cast_view<::std::uint32_t>();
+    __dpl_esimd_ns::simd<::std::uint32_t, _N> __mask;
+    __dpl_esimd_ns::simd_mask<_N> __sign_bit_m = (__uint32_src >> 31 == 0);
     if constexpr (__is_ascending)
     {
-        __mask = sycl::ext::intel::esimd::merge(
-            sycl::ext::intel::esimd::simd<::std::uint32_t, _N>(0x80000000u),
-            sycl::ext::intel::esimd::simd<::std::uint32_t, _N>(0xFFFFFFFFu), __sign_bit_m);
+        __mask = __dpl_esimd_ns::merge(
+            __dpl_esimd_ns::simd<::std::uint32_t, _N>(0x80000000u),
+            __dpl_esimd_ns::simd<::std::uint32_t, _N>(0xFFFFFFFFu), __sign_bit_m);
     }
     else
     {
-        __mask = sycl::ext::intel::esimd::merge(
-            sycl::ext::intel::esimd::simd<::std::uint32_t, _N>(0x7FFFFFFFu),
-            sycl::ext::intel::esimd::simd<::std::uint32_t, _N>(::std::uint32_t(0)), __sign_bit_m);
+        __mask = __dpl_esimd_ns::merge(
+            __dpl_esimd_ns::simd<::std::uint32_t, _N>(0x7FFFFFFFu),
+            __dpl_esimd_ns::simd<::std::uint32_t, _N>(::std::uint32_t(0)), __sign_bit_m);
     }
     return __uint32_src ^ __mask;
 }
 
 template <bool __is_ascending, typename _Float, int _N,
           std::enable_if_t<::std::is_floating_point_v<_Float> && sizeof(_Float) == sizeof(::std::uint64_t), int> = 0>
-sycl::ext::intel::esimd::simd<::std::uint64_t, _N>
-__order_preserving_cast(sycl::ext::intel::esimd::simd<_Float, _N> __src)
+__dpl_esimd_ns::simd<::std::uint64_t, _N>
+__order_preserving_cast(__dpl_esimd_ns::simd<_Float, _N> __src)
 {
-    sycl::ext::intel::esimd::simd<::std::uint64_t, _N> __uint64_src = __src.template bit_cast_view<::std::uint64_t>();
-    sycl::ext::intel::esimd::simd<::std::uint64_t, _N> __mask;
-    sycl::ext::intel::esimd::simd_mask<_N> __sign_bit_m = (__uint64_src >> 63 == 0);
+    __dpl_esimd_ns::simd<::std::uint64_t, _N> __uint64_src = __src.template bit_cast_view<::std::uint64_t>();
+    __dpl_esimd_ns::simd<::std::uint64_t, _N> __mask;
+    __dpl_esimd_ns::simd_mask<_N> __sign_bit_m = (__uint64_src >> 63 == 0);
     if constexpr (__is_ascending)
     {
-        __mask = sycl::ext::intel::esimd::merge(
-            sycl::ext::intel::esimd::simd<::std::uint64_t, _N>(0x8000000000000000u),
-            sycl::ext::intel::esimd::simd<::std::uint64_t, _N>(0xFFFFFFFFFFFFFFFFu), __sign_bit_m);
+        __mask = __dpl_esimd_ns::merge(
+            __dpl_esimd_ns::simd<::std::uint64_t, _N>(0x8000000000000000u),
+            __dpl_esimd_ns::simd<::std::uint64_t, _N>(0xFFFFFFFFFFFFFFFFu), __sign_bit_m);
     }
     else
     {
-        __mask = sycl::ext::intel::esimd::merge(
-            sycl::ext::intel::esimd::simd<::std::uint64_t, _N>(0x7FFFFFFFFFFFFFFFu),
-            sycl::ext::intel::esimd::simd<::std::uint64_t, _N>(::std::uint64_t(0)), __sign_bit_m);
+        __mask = __dpl_esimd_ns::merge(
+            __dpl_esimd_ns::simd<::std::uint64_t, _N>(0x7FFFFFFFFFFFFFFFu),
+            __dpl_esimd_ns::simd<::std::uint64_t, _N>(::std::uint64_t(0)), __sign_bit_m);
     }
     return __uint64_src ^ __mask;
 }
 
 template <typename T, int VSize, int LANES,
-    __ESIMD_ENS::cache_hint H1=__ESIMD_ENS::cache_hint::none,
-    __ESIMD_ENS::cache_hint H3=__ESIMD_ENS::cache_hint::none>
-inline std::enable_if_t<(VSize<=4), __ESIMD_NS::simd<T, VSize*LANES> > VectorLoad(const T *src, const __ESIMD_NS::simd<uint32_t, LANES> offset, __ESIMD_NS::simd_mask<LANES> mask=1) {
-    return __ESIMD_ENS::lsc_gather<T, VSize, __ESIMD_ENS::lsc_data_size::default_size, H1, H3, LANES>(src, offset, mask);
+    __dpl_esimd_ens::cache_hint H1=__dpl_esimd_ens::cache_hint::none,
+    __dpl_esimd_ens::cache_hint H3=__dpl_esimd_ens::cache_hint::none>
+inline std::enable_if_t<(VSize <= 4), __dpl_esimd_ns::simd<T, VSize * LANES>>
+VectorLoad(const T* src, const __dpl_esimd_ns::simd<uint32_t, LANES> offset, __dpl_esimd_ns::simd_mask<LANES> mask = 1)
+{
+    return __dpl_esimd_ens::lsc_gather<T, VSize, __dpl_esimd_ens::lsc_data_size::default_size, H1, H3, LANES>(src, offset, mask);
 }
 
 template <typename T, int VSize, int LANES,
-    __ESIMD_ENS::cache_hint H1=__ESIMD_ENS::cache_hint::none,
-    __ESIMD_ENS::cache_hint H3=__ESIMD_ENS::cache_hint::none>
-inline std::enable_if_t<(VSize>4), __ESIMD_NS::simd<T, VSize*LANES> > VectorLoad(const T *src, const __ESIMD_NS::simd<uint32_t, LANES> offset, __ESIMD_NS::simd_mask<LANES> mask=1) {
-    __ESIMD_NS::simd<T, VSize*LANES> result;
+    __dpl_esimd_ens::cache_hint H1=__dpl_esimd_ens::cache_hint::none,
+    __dpl_esimd_ens::cache_hint H3=__dpl_esimd_ens::cache_hint::none>
+inline std::enable_if_t<(VSize > 4), __dpl_esimd_ns::simd<T, VSize * LANES>>
+VectorLoad(const T* src, const __dpl_esimd_ns::simd<uint32_t, LANES> offset, __dpl_esimd_ns::simd_mask<LANES> mask = 1)
+{
+    __dpl_esimd_ns::simd<T, VSize * LANES> result;
     result.template select<4*LANES, 1>(0) = VectorLoad<T, 4, LANES, H1, H3>(src, offset, mask);
     result.template select<(VSize-4)*LANES, 1>(4*LANES) = VectorLoad<T, VSize-4, LANES, H1, H3>(src, offset+4*sizeof(T), mask);
     return result;
@@ -308,27 +320,35 @@ inline std::enable_if_t<(VSize>4), __ESIMD_NS::simd<T, VSize*LANES> > VectorLoad
 
 template <typename T, int VSize, int LANES,
     int LaneStride=VSize,
-    __ESIMD_ENS::cache_hint H1=__ESIMD_ENS::cache_hint::none,
-    __ESIMD_ENS::cache_hint H3=__ESIMD_ENS::cache_hint::none>
-inline __ESIMD_NS::simd<T, VSize*LANES> VectorLoad(const T *src, uint32_t offset, __ESIMD_NS::simd_mask<LANES> mask=1) {
+    __dpl_esimd_ens::cache_hint H1=__dpl_esimd_ens::cache_hint::none,
+    __dpl_esimd_ens::cache_hint H3=__dpl_esimd_ens::cache_hint::none>
+inline __dpl_esimd_ns::simd<T, VSize * LANES>
+VectorLoad(const T* src, uint32_t offset, __dpl_esimd_ns::simd_mask<LANES> mask = 1)
+{
     return VectorLoad<T, VSize, LANES, H1, H3>(src, {offset, LaneStride*sizeof(T)}, mask);
 }
 
 template <typename T, int VSize, int LANES>
-inline std::enable_if_t<(VSize<=4), __ESIMD_NS::simd<T, VSize*LANES> > VectorLoad(const __ESIMD_NS::simd<uint32_t, LANES> offset, __ESIMD_NS::simd_mask<LANES> mask=1) {
-    return __ESIMD_ENS::lsc_slm_gather<T, VSize, __ESIMD_ENS::lsc_data_size::default_size, LANES>(offset, mask);
+inline std::enable_if_t<(VSize <= 4), __dpl_esimd_ns::simd<T, VSize * LANES>>
+VectorLoad(const __dpl_esimd_ns::simd<uint32_t, LANES> offset, __dpl_esimd_ns::simd_mask<LANES> mask = 1)
+{
+    return __dpl_esimd_ens::lsc_slm_gather<T, VSize, __dpl_esimd_ens::lsc_data_size::default_size, LANES>(offset, mask);
 }
 
 template <typename T, int VSize, int LANES>
-inline std::enable_if_t<(VSize>4), __ESIMD_NS::simd<T, VSize*LANES> > VectorLoad(const __ESIMD_NS::simd<uint32_t, LANES> offset, __ESIMD_NS::simd_mask<LANES> mask=1) {
-    __ESIMD_NS::simd<T, VSize*LANES> result;
+inline std::enable_if_t<(VSize > 4), __dpl_esimd_ns::simd<T, VSize * LANES>>
+VectorLoad(const __dpl_esimd_ns::simd<uint32_t, LANES> offset, __dpl_esimd_ns::simd_mask<LANES> mask = 1)
+{
+    __dpl_esimd_ns::simd<T, VSize * LANES> result;
     result.template select<4*LANES, 1>(0) = VectorLoad<T, 4, LANES>(offset, mask);
     result.template select<(VSize-4)*LANES, 1>(4*LANES) = VectorLoad<T, VSize-4, LANES>(offset+4*sizeof(T), mask);
     return result;
 }
 
 template <typename T, int VSize, int LANES, int LaneStride=VSize>
-inline __ESIMD_NS::simd<T, VSize*LANES> VectorLoad(uint32_t offset, __ESIMD_NS::simd_mask<LANES> mask=1) {
+inline __dpl_esimd_ns::simd<T, VSize * LANES>
+VectorLoad(uint32_t offset, __dpl_esimd_ns::simd_mask<LANES> mask = 1)
+{
     return VectorLoad<T, VSize, LANES>({offset, LaneStride*sizeof(T)}, mask);
 }
 
@@ -346,38 +366,38 @@ template <typename... _Tp>
 inline constexpr bool is_sycl_accessor_v = is_sycl_accessor<_Tp...>::value;
 
 template <typename T, int VSize, int LANES,
-    __ESIMD_ENS::cache_hint H1 = __ESIMD_ENS::cache_hint::none,
-    __ESIMD_ENS::cache_hint H3 = __ESIMD_ENS::cache_hint::none>
+    __dpl_esimd_ens::cache_hint H1 = __dpl_esimd_ens::cache_hint::none,
+    __dpl_esimd_ens::cache_hint H3 = __dpl_esimd_ens::cache_hint::none>
 inline std::enable_if_t<(VSize <= 4 && LANES <= 32), void>
 VectorStore(T* dest,
-            __ESIMD_NS::simd<uint32_t, LANES> offset,
-            __ESIMD_NS::simd<T, VSize * LANES> data,
-            __ESIMD_NS::simd_mask<LANES> mask = 1)
+            __dpl_esimd_ns::simd<uint32_t, LANES> offset,
+            __dpl_esimd_ns::simd<T, VSize * LANES> data,
+            __dpl_esimd_ns::simd_mask<LANES> mask = 1)
 {
-    __ESIMD_ENS::lsc_scatter<T, VSize, __ESIMD_ENS::lsc_data_size::default_size, H1, H3, LANES>(dest, offset, data, mask);
+    __dpl_esimd_ens::lsc_scatter<T, VSize, __dpl_esimd_ens::lsc_data_size::default_size, H1, H3, LANES>(dest, offset, data, mask);
 }
 
 template <typename T, int VSize, int LANES, typename AccessorTy,
-    __ESIMD_ENS::cache_hint H1 = __ESIMD_ENS::cache_hint::none,
-    __ESIMD_ENS::cache_hint H3 = __ESIMD_ENS::cache_hint::none>
+    __dpl_esimd_ens::cache_hint H1 = __dpl_esimd_ens::cache_hint::none,
+    __dpl_esimd_ens::cache_hint H3 = __dpl_esimd_ens::cache_hint::none>
 inline std::enable_if_t<(is_sycl_accessor_v<AccessorTy> && VSize <= 4 && LANES <= 32), void>
 VectorStore(AccessorTy acc,
-            __ESIMD_NS::simd<uint32_t, LANES> offset,
-            __ESIMD_NS::simd<T, VSize * LANES> data,
-            __ESIMD_NS::simd_mask<LANES> mask = 1)
+            __dpl_esimd_ns::simd<uint32_t, LANES> offset,
+            __dpl_esimd_ns::simd<T, VSize * LANES> data,
+            __dpl_esimd_ns::simd_mask<LANES> mask = 1)
 {
-    __ESIMD_ENS::lsc_scatter<T, VSize, __ESIMD_ENS::lsc_data_size::default_size, H1, H3, LANES>(acc, offset, data, mask);
+    __dpl_esimd_ens::lsc_scatter<T, VSize, __dpl_esimd_ens::lsc_data_size::default_size, H1, H3, LANES>(acc, offset, data, mask);
 }
 
 
 template <typename T, int VSize, int LANES,
-    __ESIMD_ENS::cache_hint H1 = __ESIMD_ENS::cache_hint::none,
-    __ESIMD_ENS::cache_hint H3 = __ESIMD_ENS::cache_hint::none>
+    __dpl_esimd_ens::cache_hint H1 = __dpl_esimd_ens::cache_hint::none,
+    __dpl_esimd_ens::cache_hint H3 = __dpl_esimd_ens::cache_hint::none>
 inline std::enable_if_t<(LANES > 32), void>
 VectorStore(T* dest,
-            __ESIMD_NS::simd<uint32_t, LANES> offset,
-            __ESIMD_NS::simd<T, VSize * LANES> data,
-            __ESIMD_NS::simd_mask<LANES> mask = 1)
+            __dpl_esimd_ns::simd<uint32_t, LANES> offset,
+            __dpl_esimd_ns::simd<T, VSize * LANES> data,
+            __dpl_esimd_ns::simd_mask<LANES> mask = 1)
 {
     VectorStore<T, VSize, 32>(dest, offset.template select<32, 1>(0), data.template select<VSize*32, 1>(0), mask.template select<32, 1>(0));
     VectorStore<T, VSize, LANES - 32>(dest, offset.template select<LANES - 32, 1>(32),
@@ -386,13 +406,13 @@ VectorStore(T* dest,
 }
 
 template <typename T, int VSize, int LANES, typename AccessorTy,
-    __ESIMD_ENS::cache_hint H1 = __ESIMD_ENS::cache_hint::none,
-    __ESIMD_ENS::cache_hint H3 = __ESIMD_ENS::cache_hint::none>
+    __dpl_esimd_ens::cache_hint H1 = __dpl_esimd_ens::cache_hint::none,
+    __dpl_esimd_ens::cache_hint H3 = __dpl_esimd_ens::cache_hint::none>
 inline std::enable_if_t<(is_sycl_accessor_v<AccessorTy> && LANES > 32), void>
 VectorStore(AccessorTy acc,
-            __ESIMD_NS::simd<uint32_t, LANES> offset,
-            __ESIMD_NS::simd<T, VSize * LANES> data,
-            __ESIMD_NS::simd_mask<LANES> mask = 1)
+            __dpl_esimd_ns::simd<uint32_t, LANES> offset,
+            __dpl_esimd_ns::simd<T, VSize * LANES> data,
+            __dpl_esimd_ns::simd_mask<LANES> mask = 1)
 {
     VectorStore<T, VSize, 32>(acc, offset.template select<32, 1>(0), data.template select<VSize*32, 1>(0), mask.template select<32, 1>(0));
     VectorStore<T, VSize, LANES - 32>(acc, offset.template select<LANES - 32, 1>(32),
@@ -402,26 +422,26 @@ VectorStore(AccessorTy acc,
 
 
 template <typename T, int VSize, int LANES,
-    __ESIMD_ENS::cache_hint H1 = __ESIMD_ENS::cache_hint::none,
-    __ESIMD_ENS::cache_hint H3 = __ESIMD_ENS::cache_hint::none>
+    __dpl_esimd_ens::cache_hint H1 = __dpl_esimd_ens::cache_hint::none,
+    __dpl_esimd_ens::cache_hint H3 = __dpl_esimd_ens::cache_hint::none>
 inline std::enable_if_t<(VSize > 4 && LANES <= 32), void>
 VectorStore(T* dest,
-            __ESIMD_NS::simd<uint32_t, LANES> offset,
-            __ESIMD_NS::simd<T, VSize * LANES> data,
-            __ESIMD_NS::simd_mask<LANES> mask = 1)
+            __dpl_esimd_ns::simd<uint32_t, LANES> offset,
+            __dpl_esimd_ns::simd<T, VSize * LANES> data,
+            __dpl_esimd_ns::simd_mask<LANES> mask = 1)
 {
     VectorStore<T, 4, LANES>(dest, offset, data.template select<4*LANES, 1>(0), mask);
     VectorStore<T, VSize-4, LANES>(dest, offset+4*sizeof(T), data.template select<(VSize-4)*LANES, 1>(4*LANES), mask);
 }
 
 template <typename T, int VSize, int LANES, typename AccessorTy,
-    __ESIMD_ENS::cache_hint H1 = __ESIMD_ENS::cache_hint::none,
-    __ESIMD_ENS::cache_hint H3 = __ESIMD_ENS::cache_hint::none>
+    __dpl_esimd_ens::cache_hint H1 = __dpl_esimd_ens::cache_hint::none,
+    __dpl_esimd_ens::cache_hint H3 = __dpl_esimd_ens::cache_hint::none>
 inline std::enable_if_t<(is_sycl_accessor_v<AccessorTy> && VSize > 4 && LANES <= 32), void>
 VectorStore(AccessorTy acc,
-            __ESIMD_NS::simd<uint32_t, LANES> offset,
-            __ESIMD_NS::simd<T, VSize * LANES> data,
-            __ESIMD_NS::simd_mask<LANES> mask = 1)
+            __dpl_esimd_ns::simd<uint32_t, LANES> offset,
+            __dpl_esimd_ns::simd<T, VSize * LANES> data,
+            __dpl_esimd_ns::simd_mask<LANES> mask = 1)
 {
     VectorStore<T, 4, LANES, AccessorTy>(acc, offset, data.template select<4 * LANES, 1>(0), mask);
     VectorStore<T, VSize - 4, LANES, AccessorTy>(acc, offset + 4 * sizeof(T),
@@ -431,13 +451,13 @@ VectorStore(AccessorTy acc,
 
 template <typename T, int VSize, int LANES,
     int LaneStride = VSize,
-    __ESIMD_ENS::cache_hint H1 = __ESIMD_ENS::cache_hint::none,
-    __ESIMD_ENS::cache_hint H3 = __ESIMD_ENS::cache_hint::none>
+    __dpl_esimd_ens::cache_hint H1 = __dpl_esimd_ens::cache_hint::none,
+    __dpl_esimd_ens::cache_hint H3 = __dpl_esimd_ens::cache_hint::none>
 inline void
 VectorStore(T* dest,
             uint32_t offset,
-            __ESIMD_NS::simd<T, VSize * LANES> data,
-            __ESIMD_NS::simd_mask<LANES> mask = 1)
+            __dpl_esimd_ns::simd<T, VSize * LANES> data,
+            __dpl_esimd_ns::simd_mask<LANES> mask = 1)
 {
     // optimization needed here, hard for compiler to optimize the offset vector calculation
     VectorStore<T, VSize, LANES, H1, H3>(dest, {offset, LaneStride*sizeof(T)}, data, mask);
@@ -445,13 +465,13 @@ VectorStore(T* dest,
 
 template <typename T, int VSize, int LANES, typename AccessorTy,
           int LaneStride = VSize,
-          __ESIMD_ENS::cache_hint H1 = __ESIMD_ENS::cache_hint::none,
-          __ESIMD_ENS::cache_hint H3 = __ESIMD_ENS::cache_hint::none>
+          __dpl_esimd_ens::cache_hint H1 = __dpl_esimd_ens::cache_hint::none,
+          __dpl_esimd_ens::cache_hint H3 = __dpl_esimd_ens::cache_hint::none>
 inline std::enable_if_t<(is_sycl_accessor_v<AccessorTy>), void>
 VectorStore(AccessorTy acc,
             uint32_t offset,
-            __ESIMD_NS::simd<T, VSize * LANES> data,
-            __ESIMD_NS::simd_mask<LANES> mask = 1)
+            __dpl_esimd_ns::simd<T, VSize * LANES> data,
+            __dpl_esimd_ns::simd_mask<LANES> mask = 1)
 {
     // optimization needed here, hard for compiler to optimize the offset vector calculation
     VectorStore<T, VSize, LANES, H1, H3>(acc, {offset, LaneStride*sizeof(T)}, data, mask);
@@ -459,18 +479,18 @@ VectorStore(AccessorTy acc,
 
 template <typename T, int VSize, int LANES>
 inline std::enable_if_t<(VSize <= 4 && LANES <= 32), void>
-VectorStore(__ESIMD_NS::simd<uint32_t, LANES> offset,
-            __ESIMD_NS::simd<T, VSize * LANES> data,
-            __ESIMD_NS::simd_mask<LANES> mask = 1)
+VectorStore(__dpl_esimd_ns::simd<uint32_t, LANES> offset,
+            __dpl_esimd_ns::simd<T, VSize * LANES> data,
+            __dpl_esimd_ns::simd_mask<LANES> mask = 1)
 {
-    __ESIMD_ENS::lsc_slm_scatter<T, VSize>(offset, data, mask);
+    __dpl_esimd_ens::lsc_slm_scatter<T, VSize>(offset, data, mask);
 }
 
 template <typename T, int VSize, int LANES>
 inline std::enable_if_t<(LANES > 32), void>
-VectorStore(__ESIMD_NS::simd<uint32_t, LANES> offset,
-            __ESIMD_NS::simd<T, VSize * LANES> data,
-            __ESIMD_NS::simd_mask<LANES> mask = 1)
+VectorStore(__dpl_esimd_ns::simd<uint32_t, LANES> offset,
+            __dpl_esimd_ns::simd<T, VSize * LANES> data,
+            __dpl_esimd_ns::simd_mask<LANES> mask = 1)
 {
     VectorStore<T, VSize, 32>(offset.template select<32, 1>(0), data.template select<VSize*32, 1>(0), mask.template select<32, 1>(0));
     VectorStore<T, VSize, LANES - 32>(offset.template select<LANES - 32, 1>(32), data.template select<VSize * (LANES - 32), 1>(32), mask.template select<LANES-32, 1>(32));
@@ -478,9 +498,9 @@ VectorStore(__ESIMD_NS::simd<uint32_t, LANES> offset,
 
 template <typename T, int VSize, int LANES>
 inline std::enable_if_t<(VSize > 4 && LANES <= 32), void>
-VectorStore(__ESIMD_NS::simd<uint32_t, LANES> offset,
-            __ESIMD_NS::simd<T, VSize * LANES> data,
-            __ESIMD_NS::simd_mask<LANES> mask = 1)
+VectorStore(__dpl_esimd_ns::simd<uint32_t, LANES> offset,
+            __dpl_esimd_ns::simd<T, VSize * LANES> data,
+            __dpl_esimd_ns::simd_mask<LANES> mask = 1)
 {
     VectorStore<T, 4, LANES>(offset, data.template select<4*LANES, 1>(0), mask);
     VectorStore<T, VSize-4, LANES>(offset+4*sizeof(T), data.template select<(VSize-4)*LANES, 1>(4*LANES), mask);
@@ -489,8 +509,8 @@ VectorStore(__ESIMD_NS::simd<uint32_t, LANES> offset,
 template <typename T, int VSize, int LANES, int LaneStride=VSize>
 inline void
 VectorStore(uint32_t offset,
-            __ESIMD_NS::simd<T, VSize * LANES> data,
-            __ESIMD_NS::simd_mask<LANES> mask = 1)
+            __dpl_esimd_ns::simd<T, VSize * LANES> data,
+            __dpl_esimd_ns::simd_mask<LANES> mask = 1)
 {
     return VectorStore<T, VSize, LANES>({offset, LaneStride*sizeof(T)}, data, mask);
 }
@@ -537,22 +557,22 @@ using lsc_op_aligned_t = ::std::conditional_t<sizeof(T) <= sizeof(::std::uint32_
 
 template <typename T, int N, typename OpAlignedT = lsc_op_aligned_t<T>, int NElts = lsc_op_block_size<T, N, OpAlignedT>(),
           ::std::enable_if_t<NElts == lsc_op_block_size_rounding<NElts>(), int> = 0>
-inline __ESIMD_NS::simd<T, N>
+inline __dpl_esimd_ns::simd<T, N>
 BlockLoad(uint32_t slm_offset)
 {
-    __ESIMD_NS::simd<T, N> result;
-    result.template bit_cast_view<OpAlignedT>() = __ESIMD_ENS::lsc_slm_block_load<OpAlignedT, NElts>(slm_offset);
+    __dpl_esimd_ns::simd<T, N> result;
+    result.template bit_cast_view<OpAlignedT>() = __dpl_esimd_ens::lsc_slm_block_load<OpAlignedT, NElts>(slm_offset);
     return result;
 }
 
 template <typename T, int N, typename OpAlignedT = lsc_op_aligned_t<T>, int NElts = lsc_op_block_size<T, N, OpAlignedT>(),
           ::std::enable_if_t<NElts != lsc_op_block_size_rounding<NElts>(), int> = 0>
-inline __ESIMD_NS::simd<T, N>
+inline __dpl_esimd_ns::simd<T, N>
 BlockLoad(uint32_t slm_offset)
 {
     constexpr int BLOCK_SIZE_ROUNDED = lsc_op_block_size_rounding<NElts>();
 
-    __ESIMD_NS::simd<T, N> result;
+    __dpl_esimd_ns::simd<T, N> result;
     constexpr int BLOCK_SIZE = lsc_op_block_size<OpAlignedT, BLOCK_SIZE_ROUNDED, T>();
     result.template select<BLOCK_SIZE, 1>(0) = BlockLoad<T, BLOCK_SIZE>(slm_offset);
     result.template select<N-BLOCK_SIZE, 1>(BLOCK_SIZE) = BlockLoad<T, N-BLOCK_SIZE>(slm_offset+BLOCK_SIZE*sizeof(T));
@@ -562,15 +582,15 @@ BlockLoad(uint32_t slm_offset)
 template <typename T, int N, typename OpAlignedT = lsc_op_aligned_t<T>, int NElts = lsc_op_block_size<T, N, OpAlignedT>(),
           ::std::enable_if_t<NElts == lsc_op_block_size_rounding<NElts>(), int> = 0>
 void
-BlockStore(uint32_t slm_offset, __ESIMD_NS::simd<T, N> data)
+BlockStore(uint32_t slm_offset, __dpl_esimd_ns::simd<T, N> data)
 {
-    __ESIMD_ENS::lsc_slm_block_store<OpAlignedT, NElts>(slm_offset, data.template bit_cast_view<uint32_t>());
+    __dpl_esimd_ens::lsc_slm_block_store<OpAlignedT, NElts>(slm_offset, data.template bit_cast_view<uint32_t>());
 }
 
 template <typename T, int N, typename OpAlignedT = lsc_op_aligned_t<T>, int NElts = lsc_op_block_size<T, N, OpAlignedT>(),
           ::std::enable_if_t<NElts != lsc_op_block_size_rounding<NElts>(), int> = 0>
 void
-BlockStore(uint32_t slm_offset, __ESIMD_NS::simd<T, N> data)
+BlockStore(uint32_t slm_offset, __dpl_esimd_ns::simd<T, N> data)
 {
     constexpr int BLOCK_SIZE_ROUNDED = lsc_op_block_size_rounding<NElts>();
 
@@ -580,17 +600,19 @@ BlockStore(uint32_t slm_offset, __ESIMD_NS::simd<T, N> data)
 }
 
 template <typename T, int N,
-    __ESIMD_ENS::cache_hint H1=__ESIMD_ENS::cache_hint::none,
-    __ESIMD_ENS::cache_hint H3=__ESIMD_ENS::cache_hint::none>
-inline std::enable_if_t< (N*sizeof(T)<=256), void> BlockStore(T* dst, __ESIMD_NS::simd<T, N> data)
+    __dpl_esimd_ens::cache_hint H1=__dpl_esimd_ens::cache_hint::none,
+    __dpl_esimd_ens::cache_hint H3=__dpl_esimd_ens::cache_hint::none>
+inline std::enable_if_t<(N * sizeof(T) <= 256), void>
+BlockStore(T* dst, __dpl_esimd_ns::simd<T, N> data)
 {
-    __ESIMD_ENS::lsc_block_store<uint32_t, N, __ESIMD_ENS::lsc_data_size::default_size, H1, H3>(dst, data.template bit_cast_view<uint32_t>(), 1);
+    __dpl_esimd_ens::lsc_block_store<uint32_t, N, __dpl_esimd_ens::lsc_data_size::default_size, H1, H3>(dst, data.template bit_cast_view<uint32_t>(), 1);
 }
 
 template <typename T, int N,
-    __ESIMD_ENS::cache_hint H1=__ESIMD_ENS::cache_hint::none,
-    __ESIMD_ENS::cache_hint H3=__ESIMD_ENS::cache_hint::none>
-inline std::enable_if_t< (N*sizeof(T)>256), void> BlockStore(T* dst, __ESIMD_NS::simd<T, N> data)
+    __dpl_esimd_ens::cache_hint H1=__dpl_esimd_ens::cache_hint::none,
+    __dpl_esimd_ens::cache_hint H3=__dpl_esimd_ens::cache_hint::none>
+inline std::enable_if_t<(N * sizeof(T) > 256), void>
+BlockStore(T* dst, __dpl_esimd_ns::simd<T, N> data)
 {
     constexpr uint32_t BLOCK_SIZE = 64*sizeof(uint32_t)/sizeof(T);
     BlockStore<T, BLOCK_SIZE>(dst, data.template select<BLOCK_SIZE, 1>(0));
@@ -598,9 +620,11 @@ inline std::enable_if_t< (N*sizeof(T)>256), void> BlockStore(T* dst, __ESIMD_NS:
 }
 
 template <typename T, int N>
-inline std::enable_if_t< (N>16) && (N % 16 == 0), __ESIMD_NS::simd<T, N> > create_simd(T initial, T step) {
-    using namespace __ESIMD_NS;
-    using namespace __ESIMD_ENS;
+inline std::enable_if_t<(N > 16) && (N % 16 == 0), __dpl_esimd_ns::simd<T, N>>
+create_simd(T initial, T step)
+{
+    using namespace __dpl_esimd_ns;
+    using namespace __dpl_esimd_ens;
     simd<T, N> ret;
     ret.template select<16, 1>(0) = simd<T, 16>(0, 1) * step + initial;
     fence<fence_mask::sw_barrier>();


### PR DESCRIPTION
In this PR we create and use common defines in esimd radix sort :
- ```constexpr int DATA_PER_STEP = 16;``` - use it instead of const ```16``` in code;
- ```namespace __dpl_esimd_ns = sycl::ext::intel::esimd;``` - use it instead of namespace names  ```__ESIMD_NS``` an ```sycl::ext::intel::esimd``` in code;
- ```namespace __dpl_esimd_ens = sycl::ext::intel::experimental::esimd;``` - use it instead of namespace names  ```__ESIMD_ENS``` an ```sycl::ext::intel::experimental::esimd``` in code;