### PR TITLE
[KT] Extend supported WorkGroupSize

### DIFF
--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
@@ -36,21 +36,21 @@ void one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, const InputT& input) {
     using hist_t = uint16_t;
     using device_addr_t = uint32_t;
 
-    uint32_t local_tid = idx.get_local_linear_id();
     constexpr uint32_t BIN_COUNT = 1 << _RadixBits;
     constexpr uint32_t NBITS =  sizeof(_KeyT) * 8;
     constexpr uint32_t STAGES = oneapi::dpl::__internal::__dpl_ceiling_div(NBITS, _RadixBits);
-    constexpr uint32_t MAX_THREAD_PER_TG = 64;
     constexpr bin_t MASK = BIN_COUNT - 1;
     constexpr uint32_t HIST_STRIDE = sizeof(hist_t) * BIN_COUNT;
 
-    constexpr uint32_t REORDER_SLM_SIZE = _DataPerWorkItem * sizeof(_KeyT) * MAX_THREAD_PER_TG; // reorder buffer
-    constexpr uint32_t BIN_HIST_SLM_SIZE = HIST_STRIDE * MAX_THREAD_PER_TG;             // bin hist working buffer
-    constexpr uint32_t INCOMING_OFFSET_SLM_SIZE = (BIN_COUNT+1)*sizeof(hist_t);                // incoming offset buffer
+    constexpr uint32_t REORDER_SLM_SIZE = _DataPerWorkItem * sizeof(_KeyT) * _WorkGroupSize;
+    constexpr uint32_t BIN_HIST_SLM_SIZE = HIST_STRIDE * _WorkGroupSize;
+    constexpr uint32_t INCOMING_OFFSET_SLM_SIZE = (BIN_COUNT+1)*sizeof(hist_t);
 
     // max SLM is 256 * 4 * 64 + 256 * 2 * 64 + 257*2, 97KB, when  _DataPerWorkItem = 256, BIN_COUNT = 256
     // to support 512 processing size, we can use all SLM as reorder buffer with cost of more barrier
-    slm_init( std::max(REORDER_SLM_SIZE,  BIN_HIST_SLM_SIZE + INCOMING_OFFSET_SLM_SIZE));
+    slm_init(std::max(REORDER_SLM_SIZE,  BIN_HIST_SLM_SIZE + INCOMING_OFFSET_SLM_SIZE));
+
+    uint32_t local_tid = idx.get_local_linear_id();
     uint32_t slm_reorder_start = 0;
     uint32_t slm_bin_hist_start = 0;
     uint32_t slm_incoming_offset = slm_bin_hist_start + BIN_HIST_SLM_SIZE;
@@ -218,9 +218,6 @@ one_wg(sycl::queue __q, _Range&& __rng, ::std::size_t __n)
     using _KeyT = oneapi::dpl::__internal::__value_t<_Range>;
     using _EsimRadixSortKernel =
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<__esimd_radix_sort_one_wg<_KernelName>>;
-
-    // TODO: check if MAX_THREAD_PER_TG is necessary; remove the assert if it is not
-    assert((_WorkGroupSize <= 64) && "WorkGroupSize shall not exceed 64");
 
     return __radix_sort_one_wg_submitter<_IsAscending, _RadixBits, _DataPerWorkItem, _WorkGroupSize,
         _KeyT, _EsimRadixSortKernel>()(__q, ::std::forward<_Range>(__rng), __n);

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
@@ -572,7 +572,11 @@ onesweep(sycl::queue __q, _Range&& __rng, ::std::size_t __n)
 
     using global_hist_t = uint32_t;
     constexpr uint32_t BINCOUNT = 1 << _RadixBits;
-    constexpr uint32_t HW_TG_COUNT = 64;
+
+    // TODO: consider adding a more versatile API, e.g. passing special kernel_config parameters for histogram computation
+    constexpr uint32_t _HistWorkGroupCount = 64;
+    constexpr uint32_t _HistWorkGroupSize = 64;
+
     const uint32_t sweep_tg_count = oneapi::dpl::__internal::__dpl_ceiling_div(__n, _WorkGroupSize*_DataPerWorkItem);
     constexpr uint32_t NBITS =  sizeof(_KeyT) * 8;
     constexpr uint32_t STAGES = oneapi::dpl::__internal::__dpl_ceiling_div(NBITS, _RadixBits);
@@ -601,7 +605,7 @@ onesweep(sycl::queue __q, _Range&& __rng, ::std::size_t __n)
     sycl::event event_chain = __q.memset(p_globl_hist_buffer, 0, temp_buffer_size);
 
     event_chain = __radix_sort_onesweep_histogram_submitter<
-        _KeyT, _RadixBits, STAGES, HW_TG_COUNT, _WorkGroupSize, _IsAscending, _EsimdRadixSortHistogram>()(
+        _KeyT, _RadixBits, STAGES, _HistWorkGroupCount, _HistWorkGroupSize, _IsAscending, _EsimdRadixSortHistogram>()(
             __q, __rng, p_global_offset, __n, event_chain);
 
     event_chain = __radix_sort_onesweep_scan_submitter<STAGES, BINCOUNT, _EsimdRadixSortScan>()(

--- a/test/kt/CMakeLists.txt
+++ b/test/kt/CMakeLists.txt
@@ -15,7 +15,7 @@ function(generate_esimd_radix_sort_tests)
 
     set(_key_type_all "char" "uint16_t" "int" "uint64_t" "float" "double")
     set(_data_per_work_item_all "32" "64" "96" "128" "160" "192" "224" "256" "288" "320" "352" "384" "416" "448" "480" "512")
-    set(_work_group_size_all "64")
+    set(_work_group_size_all "32" "64")
 
     foreach (_key_type ${_key_type_all})
         foreach (_data_per_work_item ${_data_per_work_item_all})

--- a/test/kt/esimd_radix_sort.cpp
+++ b/test/kt/esimd_radix_sort.cpp
@@ -371,8 +371,6 @@ can_run_test(sycl::queue q, KernelParam param)
 {
     const auto max_slm_size = q.get_device().template get_info<sycl::info::device::local_mem_size>();
     // skip tests with error: LLVM ERROR: SLM size exceeds target limits
-    // due to speculative kernel compilation and runtime nature of this functin,
-    // one might need to specify an option for split kernel compilation
     return sizeof(T) * param.data_per_workitem * param.workgroup_size < max_slm_size;
 }
 

--- a/test/kt/esimd_radix_sort.cpp
+++ b/test/kt/esimd_radix_sort.cpp
@@ -371,6 +371,8 @@ can_run_test(sycl::queue q, KernelParam param)
 {
     const auto max_slm_size = q.get_device().template get_info<sycl::info::device::local_mem_size>();
     // skip tests with error: LLVM ERROR: SLM size exceeds target limits
+    // due to speculative kernel compilation and runtime nature of this functin,
+    // one might need to specify an option for split kernel compilation
     return sizeof(T) * param.data_per_workitem * param.workgroup_size < max_slm_size;
 }
 
@@ -409,8 +411,8 @@ int main()
             std::cerr << "Exception: " << exc.what() << std::endl;
             return EXIT_FAILURE;
         }
-#endif // TEST_DPCPP_BACKEND_PRESENT
     }
+#endif // TEST_DPCPP_BACKEND_PRESENT
 
     return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT && run_test);
 }


### PR DESCRIPTION
Pin histogram kernel configuration, because it is not as versatile as onesweep kernel.  This is needed to support more WorkGroupSize options.