### PR TITLE
[Dynamic Selection] Introducing policy traits

### DIFF
--- a/include/oneapi/dpl/internal/dynamic_selection.h
+++ b/include/oneapi/dpl/internal/dynamic_selection.h
@@ -83,12 +83,12 @@ namespace experimental {
   }
 
   template<typename DSPolicy, typename... Args>
-  typename policy_traits<DSPolicy>::selection_t select(DSPolicy&& dp, Args&&... args) {
+  typename policy_traits<DSPolicy>::selection_type select(DSPolicy&& dp, Args&&... args) {
     return std::forward<DSPolicy>(dp).select(std::forward<Args>(args)...);
   }
 
   template<typename DSPolicy, typename Function, typename... Args>
-  typename policy_traits<DSPolicy>::submission_t invoke_async(DSPolicy&& dp, typename DSPolicy::selection_handle_t e, Function&&f, Args&&... args) {
+  auto invoke_async(DSPolicy&& dp, typename policy_traits<DSPolicy>::selection_type e, Function&&f, Args&&... args) {
     return std::forward<DSPolicy>(dp).invoke_async(e, std::forward<Function>(f), std::forward<Args>(args)...);
   }
 
@@ -102,7 +102,7 @@ namespace experimental {
   struct has_invoke_async : decltype(has_invoke_async_impl<DSPolicy, Function, Args...>(0)) {};
 
   template<typename DSPolicy, typename Function, typename... Args>
-  typename policy_traits<DSPolicy>::submission_t invoke_async(DSPolicy&& dp, Function&&f, Args&&... args) {
+  auto invoke_async(DSPolicy&& dp, Function&&f, Args&&... args) {
     if constexpr(has_invoke_async<DSPolicy, Function, Args...>::value == true) {
         return std::forward<DSPolicy>(dp).invoke_async(std::forward<Function>(f), std::forward<Args>(args)...);
     }
@@ -142,8 +142,8 @@ namespace experimental {
   struct has_invoke_handle : decltype(has_invoke_handle_impl<DSPolicy, SelectionHandle , Function, Args...>(0)) {};
 
   template<typename DSPolicy, typename Function, typename... Args>
-  auto invoke(DSPolicy&& dp, typename std::decay_t<DSPolicy>::selection_handle_t e, Function&&f, Args&&... args) {
-    if constexpr(has_invoke_handle<DSPolicy, typename std::decay_t<DSPolicy>::selection_handle_t, Function, Args...>::value == true) {
+  auto invoke(DSPolicy&& dp, typename policy_traits<DSPolicy>::selection_type e, Function&&f, Args&&... args) {
+    if constexpr(has_invoke_handle<DSPolicy, typename policy_traits<DSPolicy>::selection_type, Function, Args...>::value == true) {
         return std::forward<DSPolicy>(dp).invoke(e, std::forward<Function>(f), std::forward<Args>(args)...);
     }else{
         return wait(invoke_async(std::forward<DSPolicy>(dp), e, std::forward<Function>(f), std::forward<Args>(args)...));

--- a/include/oneapi/dpl/internal/dynamic_selection.h
+++ b/include/oneapi/dpl/internal/dynamic_selection.h
@@ -14,6 +14,7 @@
 #include <memory>
 #include <utility>
 #include <list>
+#include "oneapi/dpl/internal/dynamic_selection_impl/policy_traits.h"
 
 namespace oneapi {
 namespace dpl {
@@ -77,17 +78,17 @@ namespace experimental {
   }
 
   template<typename DSPolicy>
-  auto get_wait_list(DSPolicy&& dp){
+  auto  get_wait_list(DSPolicy&& dp){
     return std::forward<DSPolicy>(dp).get_wait_list();
   }
 
   template<typename DSPolicy, typename... Args>
-  auto select(DSPolicy&& dp, Args&&... args) {
+  typename policy_traits<DSPolicy>::selection_t select(DSPolicy&& dp, Args&&... args) {
     return std::forward<DSPolicy>(dp).select(std::forward<Args>(args)...);
   }
 
   template<typename DSPolicy, typename Function, typename... Args>
-  auto invoke_async(DSPolicy&& dp, typename DSPolicy::selection_handle_t e, Function&&f, Args&&... args) {
+  typename policy_traits<DSPolicy>::submission_t invoke_async(DSPolicy&& dp, typename DSPolicy::selection_handle_t e, Function&&f, Args&&... args) {
     return std::forward<DSPolicy>(dp).invoke_async(e, std::forward<Function>(f), std::forward<Args>(args)...);
   }
 
@@ -101,7 +102,7 @@ namespace experimental {
   struct has_invoke_async : decltype(has_invoke_async_impl<DSPolicy, Function, Args...>(0)) {};
 
   template<typename DSPolicy, typename Function, typename... Args>
-  auto invoke_async(DSPolicy&& dp, Function&&f, Args&&... args) {
+  typename policy_traits<DSPolicy>::submission_t invoke_async(DSPolicy&& dp, Function&&f, Args&&... args) {
     if constexpr(has_invoke_async<DSPolicy, Function, Args...>::value == true) {
         return std::forward<DSPolicy>(dp).invoke_async(std::forward<Function>(f), std::forward<Args>(args)...);
     }

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/policy_traits.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/policy_traits.h
@@ -20,7 +20,6 @@ namespace experimental{
         using resource_type = typename std::decay<Policy>::type::resource_type; //resource type
 
         using wait_type = typename std::decay<Policy>::type::wait_type; //wait_type
-        //using submission_group_t = typename std::decay<Policy>::type::submission_group_t; //submission group type
     };
 }
 }

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/policy_traits.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/policy_traits.h
@@ -16,13 +16,11 @@ namespace experimental{
 
     template<typename Policy>
     struct policy_traits{
-        //selection_type, resource_type, submission_type, wait_type, submission_group_type
-        using selection_t = typename std::decay<Policy>::type::selection_handle_t;  //selection type
-        using resource_t = typename std::decay<Policy>::type::execution_resource_t; //resource type
+        using selection_type = typename std::decay<Policy>::type::selection_type;  //selection type
+        using resource_type = typename std::decay<Policy>::type::resource_type; //resource type
 
-        using wait_t = typename std::decay<Policy>::type::native_sync_t; //wait_type
-        using submission_t = typename std::decay<Policy>::type::submission_t; //submission_type
-        using submission_group_t = typename std::decay<Policy>::type::submission_group_t; //submission group type
+        using wait_type = typename std::decay<Policy>::type::wait_type; //wait_type
+        //using submission_group_t = typename std::decay<Policy>::type::submission_group_t; //submission group type
     };
 }
 }

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/policy_traits.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/policy_traits.h
@@ -1,0 +1,31 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _ONEDPL_POLICY_TRAITS_H
+#define _ONEDPL_POLICY_TRAITS_H
+
+namespace oneapi {
+namespace dpl{
+namespace experimental{
+
+    template<typename Policy>
+    struct policy_traits{
+        //selection_type, resource_type, submission_type, wait_type, submission_group_type
+        using selection_t = typename std::decay<Policy>::type::selection_handle_t;  //selection type
+        using resource_t = typename std::decay<Policy>::type::execution_resource_t; //resource type
+
+        using wait_t = typename std::decay<Policy>::type::native_sync_t; //wait_type
+        using submission_t = typename std::decay<Policy>::type::submission_t; //submission_type
+        using submission_group_t = typename std::decay<Policy>::type::submission_group_t; //submission group type
+    };
+}
+}
+}
+#endif //_ONEDPL_POLICY_TRAITS_H
+

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/round_robin_policy_impl.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/round_robin_policy_impl.h
@@ -21,11 +21,16 @@ namespace experimental{
   struct round_robin_policy_impl {
     using scheduler_t = Scheduler;
     using native_resource_t = typename scheduler_t::native_resource_t;
+    using universe_container_t = typename scheduler_t::universe_container_t;
+    using universe_container_size_t = typename universe_container_t::size_type;
+    using waiter_container_t = typename scheduler_t::waiter_container_t;
+
+    //Policy Traits
     using execution_resource_t = typename scheduler_t::execution_resource_t;
     using native_sync_t = typename scheduler_t::native_sync_t;
-    using universe_container_t = typename scheduler_t::universe_container_t;
     using selection_handle_t = oneapi::dpl::experimental::basic_selection_handle_t<execution_resource_t>;
-    using universe_container_size_t = typename universe_container_t::size_type;
+    using submission_t = typename scheduler_t::template submission_t<typename selection_handle_t::property_handle_t>;
+    using submission_group_t = typename scheduler_t::template submission_group_t<typename selection_handle_t::property_handle_t>;
 
     std::shared_ptr<scheduler_t> sched_;
 

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/round_robin_policy_impl.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/round_robin_policy_impl.h
@@ -20,17 +20,17 @@ namespace experimental{
   template <typename Scheduler>
   struct round_robin_policy_impl {
     using scheduler_t = Scheduler;
-    using native_resource_t = typename scheduler_t::native_resource_t;
     using universe_container_t = typename scheduler_t::universe_container_t;
     using universe_container_size_t = typename universe_container_t::size_type;
     using waiter_container_t = typename scheduler_t::waiter_container_t;
 
-    //Policy Traits
     using execution_resource_t = typename scheduler_t::execution_resource_t;
-    using native_sync_t = typename scheduler_t::native_sync_t;
-    using selection_handle_t = oneapi::dpl::experimental::basic_selection_handle_t<execution_resource_t>;
-    using submission_t = typename scheduler_t::template submission_t<typename selection_handle_t::property_handle_t>;
-    using submission_group_t = typename scheduler_t::template submission_group_t<typename selection_handle_t::property_handle_t>;
+
+    //Policy Traits
+    using selection_type = oneapi::dpl::experimental::basic_selection_handle_t<execution_resource_t>;
+    using resource_type = typename scheduler_t::resource_type;
+    using wait_type = typename scheduler_t::wait_type;
+
 
     std::shared_ptr<scheduler_t> sched_;
 
@@ -81,7 +81,7 @@ namespace experimental{
     }
 
     template<typename ...Args>
-    selection_handle_t select(Args&&...) {
+    selection_type select(Args&&...) {
       size_t i=0;
       while(true){
           universe_container_size_t current_context_ = unit_->next_context_.load();
@@ -99,11 +99,11 @@ namespace experimental{
           }
       }
       auto &e = unit_->universe_[i];
-      return selection_handle_t{e};
+      return selection_type{e};
     }
 
     template<typename Function, typename ...Args>
-    auto invoke_async(selection_handle_t e, Function&& f, Args&&... args) {
+    auto invoke_async(selection_type e, Function&& f, Args&&... args) {
       return sched_->submit(e, std::forward<Function>(f), std::forward<Args>(args)...);
     }
 

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/static_policy_impl.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/static_policy_impl.h
@@ -19,16 +19,13 @@ namespace experimental {
   template <typename Scheduler>
   struct static_policy_impl {
     using scheduler_t = Scheduler;
-    using native_resource_t = typename scheduler_t::native_resource_t;
     using universe_container_t = typename scheduler_t::universe_container_t;
+    using execution_resource_t = typename scheduler_t::execution_resource_t;
 
     //policy traits
-    using native_sync_t = typename scheduler_t::native_sync_t;
-    using execution_resource_t = typename scheduler_t::execution_resource_t;
-    using selection_handle_t = oneapi::dpl::experimental::basic_selection_handle_t<execution_resource_t>;
-    using submission_t = typename scheduler_t::template submission_t<typename selection_handle_t::property_handle_t>;
-    using submission_group_t = typename scheduler_t::template submission_group_t<typename selection_handle_t::property_handle_t>;
-
+    using resource_type = typename scheduler_t::resource_type;
+    using selection_type = oneapi::dpl::experimental::basic_selection_handle_t<execution_resource_t>;
+    using wait_type = typename scheduler_t::wait_type;
     std::shared_ptr<scheduler_t> sched_;
 
 
@@ -70,15 +67,15 @@ namespace experimental {
     }
 
     template<typename ...Args>
-    selection_handle_t select(Args&&...) {
+    selection_type select(Args&&...) {
       if(!unit_->universe_.empty()) {
-          return selection_handle_t{unit_->universe_[0]};
+          return selection_type{unit_->universe_[0]};
       }
-      return selection_handle_t{};
+      return selection_type{};
     }
 
     template<typename Function, typename ...Args>
-    auto invoke_async(selection_handle_t e, Function&& f, Args&&... args) {
+    auto invoke_async(selection_type e, Function&& f, Args&&... args) {
       return sched_->submit(e, std::forward<Function>(f), std::forward<Args>(args)...);
     }
 

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/static_policy_impl.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/static_policy_impl.h
@@ -20,10 +20,14 @@ namespace experimental {
   struct static_policy_impl {
     using scheduler_t = Scheduler;
     using native_resource_t = typename scheduler_t::native_resource_t;
-    using execution_resource_t = typename scheduler_t::execution_resource_t;
-    using native_sync_t = typename scheduler_t::native_sync_t;
     using universe_container_t = typename scheduler_t::universe_container_t;
+
+    //policy traits
+    using native_sync_t = typename scheduler_t::native_sync_t;
+    using execution_resource_t = typename scheduler_t::execution_resource_t;
     using selection_handle_t = oneapi::dpl::experimental::basic_selection_handle_t<execution_resource_t>;
+    using submission_t = typename scheduler_t::template submission_t<typename selection_handle_t::property_handle_t>;
+    using submission_group_t = typename scheduler_t::template submission_group_t<typename selection_handle_t::property_handle_t>;
 
     std::shared_ptr<scheduler_t> sched_;
 

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/sycl_scheduler.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/sycl_scheduler.h
@@ -27,15 +27,16 @@ namespace experimental {
 
   struct sycl_scheduler {
 
-    using native_resource_t = sycl::queue;
-    using native_sync_t = sycl::event;
-    using execution_resource_t = oneapi::dpl::experimental::basic_execution_resource_t<native_resource_t>;
+    using resource_type = sycl::queue;
+    using wait_type = sycl::event;
+
+    using execution_resource_t = oneapi::dpl::experimental::basic_execution_resource_t<resource_type>;
     using universe_container_t = std::vector<execution_resource_t>;
 
     class async_wait_t {
     public:
       virtual void wait() = 0;
-      virtual native_sync_t get_native() const = 0;
+      virtual wait_type get_native() const = 0;
       virtual ~async_wait_t() {}
     };
     using waiter_container_t = util::concurrent_queue<async_wait_t *>;
@@ -43,14 +44,14 @@ namespace experimental {
     template<typename PropertyHandle>
     class async_wait_impl_t : public async_wait_t {
       PropertyHandle p_;
-      native_sync_t w_;
+      wait_type w_;
       std::shared_ptr<std::atomic<bool>> wait_reported_;
     public:
 
       async_wait_impl_t(PropertyHandle p, sycl::event e) : p_(p), w_(e),
                                                            wait_reported_{std::make_shared<std::atomic<bool>>(false)} { };
 
-      native_sync_t get_native() const override {
+      wait_type get_native() const override {
         return w_;
       }
 

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/sycl_scheduler.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/sycl_scheduler.h
@@ -66,12 +66,6 @@ namespace experimental {
       }
     };
 
-    template<typename PropertyHandle>
-    using submission_t = async_wait_impl_t<PropertyHandle>;
-
-    template<typename PropertyHandle>
-    using submission_group_t = std::list<submission_t<PropertyHandle>>;
-
     std::mutex global_rank_mutex_;
     universe_container_t global_rank_;
     waiter_container_t waiters_;

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/sycl_scheduler.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/sycl_scheduler.h
@@ -65,6 +65,12 @@ namespace experimental {
       }
     };
 
+    template<typename PropertyHandle>
+    using submission_t = async_wait_impl_t<PropertyHandle>;
+
+    template<typename PropertyHandle>
+    using submission_group_t = std::list<submission_t<PropertyHandle>>;
+
     std::mutex global_rank_mutex_;
     universe_container_t global_rank_;
     waiter_container_t waiters_;

--- a/test/support/inline_scheduler.h
+++ b/test/support/inline_scheduler.h
@@ -19,16 +19,16 @@
 
 namespace TestUtils {
 struct int_inline_scheduler_t {
-  using native_resource_t = int;
-  using native_sync_t = int;
-  using execution_resource_t = oneapi::dpl::experimental::basic_execution_resource_t<native_resource_t>;
-  using native_universe_container_t = std::vector<native_resource_t>;
+  using resource_type = int;
+  using wait_type = int;
+  using execution_resource_t = oneapi::dpl::experimental::basic_execution_resource_t<resource_type>;
+  using native_universe_container_t = std::vector<resource_type>;
   using universe_container_t = std::vector<execution_resource_t>;
 
   class async_wait_t {
   public:
     virtual void wait() = 0;
-    virtual native_sync_t get_native() const = 0;
+    virtual wait_type get_native() const = 0;
     virtual ~async_wait_t() {}
   };
   using waiter_container_t = concurrent_queue<async_wait_t *>;
@@ -36,14 +36,14 @@ struct int_inline_scheduler_t {
   template<typename PropertyHandle>
   class async_wait_impl_t : public async_wait_t {
     PropertyHandle p_;
-    native_sync_t w_;
+    wait_type w_;
     std::shared_ptr<std::atomic<bool>> wait_reported_;
   public:
 
-    async_wait_impl_t(PropertyHandle p, native_sync_t w) : p_(p), w_(w),
+    async_wait_impl_t(PropertyHandle p, wait_type w) : p_(p), w_(w),
                                                            wait_reported_{std::make_shared<std::atomic<bool>>(false)} { };
 
-    native_sync_t get_native() const override {
+    wait_type get_native() const override {
       return w_;
     }
     void wait() override {

--- a/test/support/test_ds_utils.h
+++ b/test/support/test_ds_utils.h
@@ -51,15 +51,15 @@ int test_invoke_async_and_wait_on_policy(UniverseContainer u, ResourceFunction&&
   for (int i = 1; i <= N; ++i) {
     auto test_resource = f(i);
     oneapi::dpl::experimental::invoke_async(p,
-                     [&pass,&ecount,test_resource, i](typename Policy::native_resource_t e) {
+                     [&pass,&ecount,test_resource, i](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type e) {
                        if (e != test_resource) {
                          pass = false;
                        }
                        ecount += i;
-                       if constexpr (std::is_same_v<typename Policy::native_resource_t, int>)
+                       if constexpr (std::is_same_v<typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type, int>)
                          return e;
                        else
-                         return typename Policy::native_sync_t{};
+                         return typename oneapi::dpl::experimental::policy_traits<Policy>::wait_type{};
                      });
   }
   oneapi::dpl::experimental::wait(p);
@@ -88,15 +88,15 @@ int test_invoke_async_and_get_wait_list(UniverseContainer u, ResourceFunction&& 
   for (int i = 1; i <= N; ++i) {
     auto test_resource = f(i);
     oneapi::dpl::experimental::invoke_async(p,
-                     [&pass,&ecount,test_resource, i](typename Policy::native_resource_t e) {
+                     [&pass,&ecount,test_resource, i](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type e) {
                        if (e != test_resource) {
                          pass = false;
                        }
                        ecount += i;
-                       if constexpr (std::is_same_v<typename Policy::native_resource_t, int>)
+                       if constexpr (std::is_same_v<typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type, int>)
                          return e;
                        else
-                         return typename Policy::native_sync_t{};
+                         return typename oneapi::dpl::experimental::policy_traits<Policy>::wait_type{};
                      });
   }
   auto wlist=oneapi::dpl::experimental::get_wait_list(p);
@@ -126,15 +126,15 @@ int test_invoke_async_and_get_wait_list_single_element(UniverseContainer u, Reso
   for (int i = 1; i <= N; ++i) {
     auto test_resource = f(i);
     oneapi::dpl::experimental::invoke_async(p,
-                     [&pass,&ecount,test_resource, i](typename Policy::native_resource_t e) {
+                     [&pass,&ecount,test_resource, i](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type e) {
                        if (e != test_resource) {
                          pass = false;
                        }
                        ecount += i;
-                       if constexpr (std::is_same_v<typename Policy::native_resource_t, int>)
+                       if constexpr (std::is_same_v<typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type, int>)
                          return e;
                        else
-                         return typename Policy::native_sync_t{};
+                         return typename oneapi::dpl::experimental::policy_traits<Policy>::wait_type{};
                      });
   }
   auto wlist=oneapi::dpl::experimental::get_wait_list(p);
@@ -164,15 +164,15 @@ int test_invoke_async_and_get_wait_list_empty(UniverseContainer u, ResourceFunct
   for (int i = 1; i <= N; ++i) {
     auto test_resource = f(i);
     oneapi::dpl::experimental::invoke_async(p,
-                     [&pass,&ecount,test_resource, i](typename Policy::native_resource_t e) {
+                     [&pass,&ecount,test_resource, i](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type e) {
                        if (e != test_resource) {
                          pass = false;
                        }
                        ecount += i;
-                       if constexpr (std::is_same_v<typename Policy::native_resource_t, int>)
+                       if constexpr (std::is_same_v<typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type, int>)
                          return e;
                        else
-                         return typename Policy::native_sync_t{};
+                         return typename oneapi::dpl::experimental::policy_traits<Policy>::wait_type{};
                      });
   }
   auto wlist=oneapi::dpl::experimental::get_wait_list(p);
@@ -202,15 +202,15 @@ int test_invoke_async_and_wait_on_sync(UniverseContainer u, ResourceFunction&& f
   for (int i = 1; i <= N; ++i) {
     auto test_resource = f(i);
     auto w = oneapi::dpl::experimental::invoke_async(p,
-                              [&pass,&ecount,test_resource, i](typename Policy::native_resource_t e) {
+                              [&pass,&ecount,test_resource, i](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type e) {
                                 if (e != test_resource) {
                                   pass = false;
                                 }
                                 ecount += i;
-                                if constexpr (std::is_same_v<typename Policy::native_resource_t, int>)
+                                if constexpr (std::is_same_v<typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type, int>)
                                   return e;
                                 else
-                                  return typename Policy::native_sync_t{};
+                                  return typename oneapi::dpl::experimental::policy_traits<Policy>::wait_type{};
                               });
     oneapi::dpl::experimental::wait(w);
     int count = ecount.load();
@@ -239,15 +239,15 @@ int test_invoke(UniverseContainer u, ResourceFunction&& f) {
   for (int i = 1; i <= N; ++i) {
     auto test_resource = f(i);
     oneapi::dpl::experimental::invoke(p,
-               [&pass,&ecount,test_resource, i](typename Policy::native_resource_t e) {
+               [&pass,&ecount,test_resource, i](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type e) {
                  if (e != test_resource) {
                    pass = false;
                  }
                  ecount += i;
-                 if constexpr (std::is_same_v<typename Policy::native_resource_t, int>)
+                 if constexpr (std::is_same_v<typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type, int>)
                    return e;
                  else
-                   return typename Policy::native_sync_t{};
+                   return typename oneapi::dpl::experimental::policy_traits<Policy>::wait_type{};
                });
     int count = ecount.load();
     if (count != i*(i+1)/2) {
@@ -276,15 +276,15 @@ int test_select_and_wait_on_policy(UniverseContainer u, ResourceFunction&& f) {
     auto test_resource = f(i);
     auto h = select(p);
     oneapi::dpl::experimental::invoke_async(p, h,
-                     [&pass,&ecount,test_resource,i](typename Policy::native_resource_t e) {
+                     [&pass,&ecount,test_resource,i](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type e) {
                        if (e != test_resource) {
                          pass = false;
                        }
                        ecount += i;
-                       if constexpr (std::is_same_v<typename Policy::native_resource_t, int>)
+                       if constexpr (std::is_same_v<typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type, int>)
                          return e;
                        else
-                         return typename Policy::native_sync_t{};
+                         return typename oneapi::dpl::experimental::policy_traits<Policy>::wait_type{};
                      });
   }
   oneapi::dpl::experimental::wait(p);
@@ -314,15 +314,15 @@ int test_select_and_wait_on_sync(UniverseContainer u, ResourceFunction&& f) {
     auto test_resource = f(i);
     auto h = select(p);
     auto w = oneapi::dpl::experimental::invoke_async(p, h,
-                     [&pass,&ecount,test_resource,i](typename Policy::native_resource_t e) {
+                     [&pass,&ecount,test_resource,i](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type e) {
                        if (e != test_resource) {
                          pass = false;
                        }
                        ecount += i;
-                       if constexpr (std::is_same_v<typename Policy::native_resource_t, int>)
+                       if constexpr (std::is_same_v<typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type, int>)
                          return e;
                        else
-                         return typename Policy::native_sync_t{};
+                         return typename oneapi::dpl::experimental::policy_traits<Policy>::wait_type{};
                      });
     oneapi::dpl::experimental::wait(w);
     int count = ecount.load();
@@ -352,15 +352,15 @@ int test_select_invoke(UniverseContainer u, ResourceFunction&& f) {
     auto test_resource = f(i);
     auto h = select(p);
     oneapi::dpl::experimental::invoke(p, h,
-               [&pass,&ecount,test_resource,i](typename Policy::native_resource_t e) {
+               [&pass,&ecount,test_resource,i](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type e) {
                  if (e != test_resource) {
                    pass = false;
                  }
                  ecount += i;
-                 if constexpr (std::is_same_v<typename Policy::native_resource_t, int>)
+                 if constexpr (std::is_same_v<typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type, int>)
                    return e;
                  else
-                   return typename Policy::native_sync_t{};
+                   return typename oneapi::dpl::experimental::policy_traits<Policy>::wait_type{};
                });
     int count = ecount.load();
     if (count != i*(i+1)/2) {


### PR DESCRIPTION
1.Type traits defined by policies 
2. Type traits defined by scheduler
3. Added a policy traits class
4. Made changes to use policy_traits<Policy>::trait_name where its needed
5. PR does not add the submission_group_type class, since it makes sense to add it after #1039 is merged.