### PR TITLE
[KT] Async free memory

### DIFF
--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
@@ -610,7 +610,6 @@ struct __radix_sort_onesweep_mem_free_submitter
     }
 };
 
-
 template <typename _KeyT, typename _KernelName>
 struct __radix_sort_copyback_submitter;
 


### PR DESCRIPTION
In this PR we improve memory management in esimd radix sort (onesweep):
- we will call ```sycl::free``` function from separate Kernel in which we create special ```host_task``` and call ```sycl::free```.

**Pro**:
- we make really asynchronous esimd ```radix_sort``` implementation without ```wait()``` calls inside.

**Contra**:
- we will have memory leak in exceptional case.