### PR TITLE
[KT] Esimd radix sort code cleanup

### DIFF
--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
@@ -61,7 +61,7 @@ one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, const InputT& input)
     simd<bin_t, _DataPerWorkItem> bins;
     simd<device_addr_t, DATA_PER_STEP> lane_id(0, 1);
 
-    device_addr_t io_offset = _DataPerWorkItem * local_tid;
+    const device_addr_t io_offset = _DataPerWorkItem * local_tid;
 
 #pragma unroll
     for (uint32_t s = 0; s < _DataPerWorkItem; s += DATA_PER_STEP)

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
@@ -53,7 +53,7 @@ one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, const InputT& input)
     const uint32_t local_tid = idx.get_local_linear_id();
 
     const uint32_t slm_reorder_this_thread = local_tid * _DataPerWorkItem * sizeof(_KeyT);
-    uint32_t slm_bin_hist_this_thread = local_tid * HIST_STRIDE;
+    const uint32_t slm_bin_hist_this_thread = local_tid * HIST_STRIDE;
 
     simd<hist_t, BIN_COUNT> bin_offset;
     simd<device_addr_t, _DataPerWorkItem> write_addr;

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
@@ -51,11 +51,10 @@ one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, const InputT& input)
     slm_init(std::max(REORDER_SLM_SIZE, BIN_HIST_SLM_SIZE + INCOMING_OFFSET_SLM_SIZE));
 
     uint32_t local_tid = idx.get_local_linear_id();
-    uint32_t slm_reorder_start = 0;
     uint32_t slm_bin_hist_start = 0;
     uint32_t slm_incoming_offset = slm_bin_hist_start + BIN_HIST_SLM_SIZE;
 
-    uint32_t slm_reorder_this_thread = slm_reorder_start + local_tid * _DataPerWorkItem * sizeof(_KeyT);
+    uint32_t slm_reorder_this_thread = local_tid * _DataPerWorkItem * sizeof(_KeyT);
     uint32_t slm_bin_hist_this_thread = slm_bin_hist_start + local_tid * HIST_STRIDE;
 
     simd<hist_t, BIN_COUNT> bin_offset;
@@ -193,7 +192,7 @@ one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, const InputT& input)
             for (uint32_t s = 0; s < _DataPerWorkItem; s += DATA_PER_STEP)
             {
                 utils::VectorStore<_KeyT, 1, DATA_PER_STEP>(
-                    write_addr.template select<DATA_PER_STEP, 1>(s) * sizeof(_KeyT) + slm_reorder_start,
+                    write_addr.template select<DATA_PER_STEP, 1>(s) * sizeof(_KeyT),
                     keys.template select<DATA_PER_STEP, 1>(s));
             }
             barrier();

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
@@ -52,7 +52,7 @@ one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, const InputT& input)
 
     const uint32_t local_tid = idx.get_local_linear_id();
 
-    uint32_t slm_reorder_this_thread = local_tid * _DataPerWorkItem * sizeof(_KeyT);
+    const uint32_t slm_reorder_this_thread = local_tid * _DataPerWorkItem * sizeof(_KeyT);
     uint32_t slm_bin_hist_this_thread = local_tid * HIST_STRIDE;
 
     simd<hist_t, BIN_COUNT> bin_offset;

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
@@ -50,7 +50,7 @@ one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, const InputT& input)
     // to support 512 processing size, we can use all SLM as reorder buffer with cost of more barrier
     slm_init(std::max(REORDER_SLM_SIZE, BIN_HIST_SLM_SIZE + INCOMING_OFFSET_SLM_SIZE));
 
-    uint32_t local_tid = idx.get_local_linear_id();
+    const uint32_t local_tid = idx.get_local_linear_id();
 
     uint32_t slm_reorder_this_thread = local_tid * _DataPerWorkItem * sizeof(_KeyT);
     uint32_t slm_bin_hist_this_thread = local_tid * HIST_STRIDE;

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
@@ -324,9 +324,8 @@ struct radix_sort_onesweep_slm_reorder_kernel
                 utils::BlockStore(slm_bin_hist_group_incoming + local_tid * BIN_WIDTH * sizeof(hist_t),
                                   utils::scan<hist_t, hist_t>(thread_grf_hist_summary));
                 if (wg_id != 0)
-                    lsc_block_store<uint32_t, BIN_WIDTH, lsc_data_size::default_size, cache_hint::uncached,
-                                    cache_hint::write_back>(p_global_bin_this_group + local_tid * BIN_WIDTH,
-                                                            thread_grf_hist_summary | HIST_UPDATED);
+                    utils::BlockStore<uint32_t, BIN_WIDTH>(p_global_bin_this_group + local_tid * BIN_WIDTH,
+                                                           thread_grf_hist_summary | HIST_UPDATED);
             }
             barrier();
             if (local_tid == BIN_SUMMARY_GROUP_SIZE + 1)
@@ -367,9 +366,8 @@ struct radix_sort_onesweep_slm_reorder_kernel
                 } while (is_not_accumulated.any() && wg_id != 0);
                 prev_group_hist_sum &= GLOBAL_OFFSET_MASK;
                 simd<global_hist_t, BIN_WIDTH> after_group_hist_sum = prev_group_hist_sum + thread_grf_hist_summary;
-                lsc_block_store<uint32_t, BIN_WIDTH, lsc_data_size::default_size, cache_hint::uncached,
-                                cache_hint::write_back>(p_global_bin_this_group + local_tid * BIN_WIDTH,
-                                                        after_group_hist_sum | HIST_UPDATED | GLOBAL_ACCUMULATED);
+                utils::BlockStore<uint32_t, BIN_WIDTH>(p_global_bin_this_group + local_tid * BIN_WIDTH,
+                                                       after_group_hist_sum | HIST_UPDATED | GLOBAL_ACCUMULATED);
 
                 utils::BlockStore<uint32_t, BIN_WIDTH>(
                     slm_bin_hist_global_incoming + local_tid * BIN_WIDTH * sizeof(global_hist_t), prev_group_hist_sum);

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
@@ -206,7 +206,7 @@ struct radix_sort_onesweep_slm_reorder_kernel
     // then read reordered slm and look up global fix, need GLOBAL_LOOKUP_SIZE on top
 
     const uint32_t n;
-    uint32_t stage;
+    const uint32_t stage;
     InputT input;
     OutputT output;
     uint8_t* p_global_buffer;

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
@@ -205,7 +205,7 @@ struct radix_sort_onesweep_slm_reorder_kernel
     // then shuffle keys to workgroup order in SLM, need _DataPerWorkItem * sizeof(_KeyT) * _WorkGroupSize
     // then read reordered slm and look up global fix, need GLOBAL_LOOKUP_SIZE on top
 
-    uint32_t n;
+    const uint32_t n;
     uint32_t stage;
     InputT input;
     OutputT output;


### PR DESCRIPTION
In this PR we made next things:
- remove some unused local variables;
- remove some non modified zero-initialized local variables;
- declare not changed local variables and class members as ```const```;
- replaces ```lsc_gather``` calls to ```utils::gather```;
- replace ```lsc_block_store``` calls to ```utils::BlockStore```;