### PR TITLE
[onedpl] Merge Path algorithm for oneDPL merge algorithm (SYCL backend)

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1466,6 +1466,134 @@ struct __partial_merge_kernel
     }
 };
 
+//Searching for an intersection of virtual matrix (n1, n2) diagonal with the Merge Path to define sub-ranges
+//to serial merge. For example, a merge matrix for [0,1,1,2,3] and [0,0,2,3] shown below:
+//     0   1  1  2   3
+//    ------------------
+//   |--->
+// 0 | 0 | 1  1  1   1
+//   |   |
+// 0 | 0 | 1  1  1   1
+//   |   ---------->
+// 2 | 0   0  0  0 | 1
+//   |             ---->
+// 3 | 0   0  0  0   0 |
+
+template<typename Rng1, typename Rng2>
+auto find_bounds(Rng1& __rng1, Rng2& __rng2, bool bUpper, int i_elem, int __n_1, int __n_2)
+{
+    int end1 = 0;
+    int end2 = 0;
+    if (bUpper)
+    {
+        auto q = i_elem - 1; //digonal index
+        auto n_diag = q < __n_2 ? q + 1 : __n_2; //digonal size
+
+        oneapi::dpl::counting_iterator<int> diag_it(0);
+        auto __res = std::lower_bound(diag_it, diag_it + n_diag, 1, [&__rng1, &__rng2, q](auto v1, auto v2)
+            {
+                auto val1 = __rng1[q - v1] < __rng2[v1];
+                return val1 < v2;
+            });
+        end1 = q + 1 - *__res;
+        end2 = *__res;
+    }
+    else
+    {
+        auto q = i_elem - __n_1; //diagonal index
+
+        auto n_diag = __n_2 - q;
+        n_diag = n_diag < __n_1 ? n_diag : __n_1; //digonal size
+
+        counting_iterator<int> diag_it(0);
+        auto __res = std::lower_bound(diag_it, diag_it + n_diag, 1, [&__rng1, &__rng2, __n_1, q](auto v1, auto v2)
+            {
+                auto val1 = __rng1[__n_1 - v1 - 1] < __rng2[q + v1];
+                return val1 < v2;
+            });
+
+        end1 = __n_1 - *__res;
+        end2 = q + *__res;
+    }
+    return std::make_pair(end1, end2);
+}
+
+template<typename _Rng1, typename _Rng2, typename _Rng3, typename Index1, typename Index2, typename Index3, typename _Compare>
+void
+__serial_merge(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, Index1 start1, Index1 end1, Index2 start2, Index2 end2,
+               Index3 start3, _Compare __comp)
+{
+    int sz1 = end1 - start1, sz2 = end2 - start2;
+    if(sz1 == 0) //rng1 is emppty
+    {
+        _ONEDPL_PRAGMA_UNROLL
+        for(int i = 0; i < sz2; ++i)
+            __rng3[start3 + i] = __rng2[start2 + i];
+    }
+    else if(sz2 == 0)  //rng2 is emppty
+    {
+        _ONEDPL_PRAGMA_UNROLL
+        for(int i = 0; i < sz1; ++i)
+            __rng3[start3 + i] = __rng1[start1 + i];
+    }
+    else if(!__comp(__rng2[start2], __rng1[end1 - 1])) // rng1 < rng2
+    {
+        _ONEDPL_PRAGMA_UNROLL
+        for(int i = 0; i < sz1; ++i)
+            __rng3[start3 + i] = __rng1[start1 + i];
+
+        start3 += sz1;
+        _ONEDPL_PRAGMA_UNROLL
+        for(int i = 0; i < sz2; ++i)
+            __rng3[start3 + i] = __rng2[start2 + i];
+    }
+    else if(!__comp(__rng1[start1], __rng2[end2 - 1])) // rng2 < rng1
+    {
+        _ONEDPL_PRAGMA_UNROLL
+        for(int i = 0; i < sz2; ++i)
+            __rng3[start3 + i] = __rng2[start2 + i];
+
+        start3 += sz2;
+        _ONEDPL_PRAGMA_UNROLL
+        for(int i = 0; i < sz1; ++i)
+            __rng3[start3 + i] = __rng1[start1 + i];
+    }
+    else
+    {
+        _ONEDPL_PRAGMA_UNROLL
+        while(start1 < end1 && start2 < end2)
+        {
+            const auto val1 = __rng1[start1];
+            const auto val2 = __rng2[start2];
+            if(__comp(val1, val2))
+            {
+                __rng3[start3] = val1;
+                ++start1;
+            }
+            else
+            {
+                __rng3[start3] = val2;
+                ++start2;
+            }
+            ++start3;
+        }
+        if(start1 >= end1)
+        {
+            sz2 = end2 - start2;
+            _ONEDPL_PRAGMA_UNROLL
+            for(int i = 0; i < sz2; ++i)
+                __rng3[start3 + i] = __rng2[start2 + i];
+        }
+        else
+        {
+            sz1 = end1 - start1;
+            _ONEDPL_PRAGMA_UNROLL
+            for(int i = 0; i < sz1; ++i)
+                __rng3[start3 + i] = __rng1[start1 + i];
+        }
+    }
+}
+
 // Please see the comment for __parallel_for_submitter for optional kernel name explanation
 template <typename _Name>
 struct __parallel_merge_submitter;
@@ -1477,22 +1605,57 @@ struct __parallel_merge_submitter<__internal::__optional_kernel_name<_Name...>>
     auto
     operator()(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _Range3&& __rng3, _Compare __comp) const
     {
-        auto __n = __rng1.size();
+        using _Tp = oneapi::dpl::__internal::__value_t<_Range1>;
+
+        auto __n_1 = __rng1.size();
         auto __n_2 = __rng2.size();
 
-        assert(__n > 0 || __n_2 > 0);
+        assert(__n_1 > 0 || __n_2 > 0);
 
         _PRINT_INFO_IN_DEBUG_MODE(__exec);
 
-        const ::std::size_t __chunk = __exec.queue().get_device().is_cpu() ? 128 : 8;
-        const auto __max_n = ::std::max(__n, static_cast<decltype(__n)>(__n_2));
-        const ::std::size_t __steps = ((__max_n - 1) / __chunk) + 1;
+        const ::std::size_t __chunk = __exec.queue().get_device().is_cpu() ? 128 : 4;
+        const auto __n = __n_1 + __n_2;
+        const ::std::size_t __steps = ((__n - 1) / __chunk) + 1;
+
+        ::std::size_t wg_size = oneapi::dpl::__internal::__max_work_group_size(__exec);
+        const ::std::size_t wg_count = (__steps - 1 + 1) / (wg_size - 1) + 1; //(wg_size - 1) due to we skip zero item.
+        const ::std::size_t elems_per_wg = (wg_size - 1) * __chunk;
 
         auto __event = __exec.queue().submit([&](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rng1, __rng2, __rng3);
-            __cgh.parallel_for<_Name...>(sycl::range</*dim=*/1>(__steps), [=](sycl::item</*dim=*/1> __item_id) {
-                __full_merge_kernel()(__item_id.get_linear_id() * __chunk, __rng1, decltype(__n)(0), __n, __rng2,
-                                      decltype(__n_2)(0), __n_2, __rng3, decltype(__n)(0), __comp, __chunk);
+
+            auto __bounds = __dpl_sycl::__local_accessor<int, 2>(sycl::range<2>(wg_size, 2), __cgh);
+
+            __cgh.parallel_for<_Name...>(sycl::nd_range</*dim=*/1>(wg_count * wg_size, wg_size), [=](sycl::nd_item</*dim=*/1> __item_id){
+
+                    const auto idx = __item_id.get_global_linear_id();
+                    const auto local_id = __item_id.get_local_linear_id();
+                    const auto __group_id = __item_id.get_group(0);
+
+                    auto i_elem = local_id * __chunk + __group_id*elems_per_wg;
+
+                    if (i_elem > __n)
+                        i_elem = __n;
+
+                    //The cross-diagonal searching the bounds to define sub-ranges for the parallel serial merging
+                    if (i_elem <= __n)
+                    {
+                        const bool upper = i_elem < __n_1; //a flag to specify upper or down part of the merge matrix
+                        const auto bound = find_bounds(__rng1, __rng2, upper, i_elem, __n_1, __n_2);
+                        __bounds[local_id][0] = bound.first, __bounds[local_id][1] = bound.second;
+                    }
+                    __dpl_sycl::__group_barrier(__item_id);
+
+                    //The parallel serial merging
+                    if(local_id > 0 && i_elem <= __n)
+                    {
+                        const auto start1 = __bounds[local_id - 1][0], start2 = __bounds[local_id - 1][1];
+                        const auto end1 = __bounds[local_id][0], end2 = __bounds[local_id][1];
+                        const auto start3 = (local_id - 1) * __chunk + __group_id * elems_per_wg;
+
+                        __serial_merge(__rng1, __rng2, __rng3, start1, end1, start2, end2, start3, __comp);
+                    }
             });
         });
         return __future(__event);


### PR DESCRIPTION
[onedpl] Merge Path algorithm for oneDPL merge algorithm (SYCL backend).

This is a new implementation of the oneDPL merge algorithm  (merging two sorted ranges) based on new approach known as Merge Path parallel merging. It gives a significant speed up comparing to the current oneDPL implementation.
The main idea  - each work-item is searching for the start points in range 1 and range 2. After each work-item does M steps of sequential merging, where M = (N1+N2) / p, where  p -  number of threads. So, we have got well balanced parallel merging.