### PR TITLE
Removing free functions for set_universe and get_universe size

### DIFF
--- a/include/oneapi/dpl/internal/dynamic_selection.h
+++ b/include/oneapi/dpl/internal/dynamic_selection.h
@@ -55,16 +55,6 @@ namespace experimental {
     return std::forward<DSPolicy>(dp).get_universe();
   }
 
-  template<typename DSPolicy>
-  auto get_universe_size(DSPolicy&& dp) {
-    return std::forward<DSPolicy>(dp).get_universe_size();
-  }
-
-  template<typename DSPolicy, typename ...Args>
-  auto set_universe(DSPolicy&& dp, Args&&... args) {
-    return std::forward<DSPolicy>(dp).get_universe(std::forward<Args>(args)...);
-  }
-
   template<typename Handle>
   auto wait(Handle&& h) {
     return std::forward<Handle>(h).wait();

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/round_robin_policy_impl.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/round_robin_policy_impl.h
@@ -71,10 +71,6 @@ namespace experimental{
       return sched_->get_universe();
     }
 
-    auto get_universe_size() const noexcept {
-      return sched_->get_universe_size();
-    }
-
     template<typename ...Args>
     auto set_universe(Args&&... args) {
         return sched_->set_universe(std::forward<Args>(args)...);

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/static_policy_impl.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/static_policy_impl.h
@@ -57,10 +57,6 @@ namespace experimental {
       return sched_->get_universe();
     }
 
-    auto get_universe_size() const noexcept {
-      return sched_->get_universe_size();
-    }
-
     template<typename ...Args>
     auto set_universe(Args&&... args) {
         return sched_->set_universe(std::forward<Args>(args)...);

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/sycl_scheduler.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/sycl_scheduler.h
@@ -115,16 +115,6 @@ namespace experimental {
       return global_rank_;
     }
 
-    auto get_universe_size() noexcept {
-      if (global_rank_.empty()) {
-        global_rank_=get_universe();
-      }
-      {
-        std::unique_lock<std::mutex> l(global_rank_mutex_);
-        return global_rank_.size();
-      }
-    }
-
     auto set_universe(const universe_container_t &gr) noexcept {
       std::unique_lock<std::mutex> l(global_rank_mutex_);
       global_rank_ = gr;

--- a/test/support/test_ds_utils.h
+++ b/test/support/test_ds_utils.h
@@ -30,11 +30,6 @@ int test_properties(UniverseContainer u, typename UniverseContainer::value_type 
     std::cout << "ERROR: reported universe and queried universe are not equal\n";
     return 1;
   }
-  auto us = oneapi::dpl::experimental::get_universe_size(p);
-  if (u2s != us) {
-    std::cout << "ERROR: queried universe size inconsistent with queried universe\n";
-    return 1;
-  }
   std::cout << "properties: OK\n";
   return 0;
 }


### PR DESCRIPTION
Removing free functions for set_universe and get_universe size
The set_universe function in sycl_scheduler, round_robin_policy and static policy still exists and needs to be replaced in future PRs