### PR TITLE
Adding note about required option for Windows compilation

### DIFF
--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -98,7 +98,8 @@ Known Limitations
   vector execution policies when building a program with GCC 10 and using ``-O0`` option.
 * Compiling ``reduce`` and ``transform_reduce`` algorithms with the Intel DPC++ Compiler, versions 2021 and older,
   may result in a runtime error. To fix this issue, use an Intel DPC++ Compiler version 2022 or newer.
-* When compiling on Windows, add the option ``/EHsc`` to the compilation command to avoid errors with oneDPL's experimental ranges API that uses exceptions.
+* When compiling on Windows, add the option ``/EHsc`` to the compilation command to avoid errors with oneDPL's experimental
+  ranges API that uses exceptions.
 * The use of |onedpl_short| together with the GNU C++ standard library (libstdc++) version 9 or 10 may lead to
   compilation errors (caused by oneTBB API changes).
   Using libstdc++ version 9 requires TBB version 2020 for the header file. This may result in compilation errors when

--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -98,6 +98,7 @@ Known Limitations
   vector execution policies when building a program with GCC 10 and using ``-O0`` option.
 * Compiling ``reduce`` and ``transform_reduce`` algorithms with the Intel DPC++ Compiler, versions 2021 and older,
   may result in a runtime error. To fix this issue, use an Intel DPC++ Compiler version 2022 or newer.
+* Compilation on Windows requires the addtion of the option ``/EHsc`` to the compile line in order to avoid errors about oneDPL's experimental ranges support throwing exceptions.
 * The use of |onedpl_short| together with the GNU C++ standard library (libstdc++) version 9 or 10 may lead to
   compilation errors (caused by oneTBB API changes).
   Using libstdc++ version 9 requires TBB version 2020 for the header file. This may result in compilation errors when

--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -98,7 +98,7 @@ Known Limitations
   vector execution policies when building a program with GCC 10 and using ``-O0`` option.
 * Compiling ``reduce`` and ``transform_reduce`` algorithms with the Intel DPC++ Compiler, versions 2021 and older,
   may result in a runtime error. To fix this issue, use an Intel DPC++ Compiler version 2022 or newer.
-* Compilation on Windows requires the addition of the option ``/EHsc`` to the compile line in order to avoid errors about oneDPL's experimental ranges support throwing exceptions.
+* When compiling on Windows, add the option ``/EHsc`` to the compilation command to avoid errors with oneDPL's experimental ranges API that uses exceptions.
 * The use of |onedpl_short| together with the GNU C++ standard library (libstdc++) version 9 or 10 may lead to
   compilation errors (caused by oneTBB API changes).
   Using libstdc++ version 9 requires TBB version 2020 for the header file. This may result in compilation errors when

--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -98,7 +98,7 @@ Known Limitations
   vector execution policies when building a program with GCC 10 and using ``-O0`` option.
 * Compiling ``reduce`` and ``transform_reduce`` algorithms with the Intel DPC++ Compiler, versions 2021 and older,
   may result in a runtime error. To fix this issue, use an Intel DPC++ Compiler version 2022 or newer.
-* Compilation on Windows requires the addtion of the option ``/EHsc`` to the compile line in order to avoid errors about oneDPL's experimental ranges support throwing exceptions.
+* Compilation on Windows requires the addition of the option ``/EHsc`` to the compile line in order to avoid errors about oneDPL's experimental ranges support throwing exceptions.
 * The use of |onedpl_short| together with the GNU C++ standard library (libstdc++) version 9 or 10 may lead to
   compilation errors (caused by oneTBB API changes).
   Using libstdc++ version 9 requires TBB version 2020 for the header file. This may result in compilation errors when


### PR DESCRIPTION
The experimental ranges support in oneDPL includes code that throws exceptions.  In order to avoid compilation errors on Windows users must add '/EHsc' to their compile line for each translation unit.