### PR TITLE
[KT] Remove extra namespace names

### DIFF
--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort.h
@@ -72,8 +72,7 @@ radix_sort(sycl::queue __q, _Range&& __rng, _KernelParam __param = {})
     if (__rng.size() < 2)
         return {};
 
-    return oneapi::dpl::experimental::kt::esimd::impl::radix_sort<_IsAscending, _RadixBits>(
-        __q, ::std::forward<_Range>(__rng), __param);
+    return impl::radix_sort<_IsAscending, _RadixBits>(__q, ::std::forward<_Range>(__rng), __param);
 }
 
 template <bool _IsAscending = true, std::uint8_t _RadixBits = 8, typename _KernelParam, typename _Iterator>
@@ -86,8 +85,7 @@ radix_sort(sycl::queue __q, _Iterator __first, _Iterator __last, _KernelParam __
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<oneapi::dpl::__par_backend_hetero::access_mode::read_write,
                                                           _Iterator>();
     auto __rng = __keep(__first, __last);
-    return oneapi::dpl::experimental::kt::esimd::impl::radix_sort<_IsAscending, _RadixBits>(__q, __rng.all_view(),
-                                                                                            __param);
+    return impl::radix_sort<_IsAscending, _RadixBits>(__q, __rng.all_view(), __param);
 }
 
 } // namespace oneapi::dpl::experimental::kt::esimd


### PR DESCRIPTION
In this PR we remove extra namespace names, because we are already inside required namespace:
- ```oneapi::dpl::experimental::kt::esimd::impl::``` -> ```impl::```