### PR TITLE
[KT] Improvement of BlockStore functions

### DIFF
--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
@@ -113,17 +113,17 @@ one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, const InputT& input)
                 simd<uint32_t, BIN_WIDTH_UD> tmp;
 
                 thread_grf_hist_summary.template bit_cast_view<uint32_t>() =
-                    utils::BlockLoad<uint32_t, BIN_WIDTH_UD>(slm_bin_hist_summary_offset);
+                    utils::BlockLoadSlm<uint32_t, BIN_WIDTH_UD>(slm_bin_hist_summary_offset);
                 slm_bin_hist_summary_offset += HIST_STRIDE;
                 for (uint32_t s = 1; s < _WorkGroupSize - 1; s++)
                 {
-                    tmp = utils::BlockLoad<uint32_t, BIN_WIDTH_UD>(slm_bin_hist_summary_offset);
+                    tmp = utils::BlockLoadSlm<uint32_t, BIN_WIDTH_UD>(slm_bin_hist_summary_offset);
                     thread_grf_hist_summary += tmp.template bit_cast_view<hist_t>();
                     utils::BlockStoreSlm<uint32_t, BIN_WIDTH_UD>(
                         slm_bin_hist_summary_offset, thread_grf_hist_summary.template bit_cast_view<uint32_t>());
                     slm_bin_hist_summary_offset += HIST_STRIDE;
                 }
-                tmp = utils::BlockLoad<uint32_t, BIN_WIDTH_UD>(slm_bin_hist_summary_offset);
+                tmp = utils::BlockLoadSlm<uint32_t, BIN_WIDTH_UD>(slm_bin_hist_summary_offset);
                 thread_grf_hist_summary += tmp.template bit_cast_view<hist_t>();
                 thread_grf_hist_summary = utils::scan<hist_t, hist_t>(thread_grf_hist_summary);
                 utils::BlockStoreSlm<uint32_t, BIN_WIDTH_UD>(
@@ -138,7 +138,7 @@ one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, const InputT& input)
                 for (uint32_t s = 0; s < BIN_COUNT; s += 128)
                 {
                     grf_hist_summary.template select<128, 1>(s).template bit_cast_view<uint32_t>() =
-                        utils::BlockLoad<uint32_t, 64>((_WorkGroupSize - 1) * HIST_STRIDE + s * sizeof(hist_t));
+                        utils::BlockLoadSlm<uint32_t, 64>((_WorkGroupSize - 1) * HIST_STRIDE + s * sizeof(hist_t));
                 }
                 grf_hist_summary_scan[0] = 0;
                 grf_hist_summary_scan.template select<32, 1>(1) = grf_hist_summary.template select<32, 1>(0);
@@ -162,7 +162,7 @@ one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, const InputT& input)
                 for (uint32_t s = 0; s < BIN_COUNT; s += 128)
                 {
                     bin_offset.template select<128, 1>(s).template bit_cast_view<uint32_t>() =
-                        utils::BlockLoad<uint32_t, 64>(BIN_HIST_SLM_SIZE + s * sizeof(hist_t));
+                        utils::BlockLoadSlm<uint32_t, 64>(BIN_HIST_SLM_SIZE + s * sizeof(hist_t));
                 }
                 if (local_tid > 0)
                 {
@@ -170,8 +170,8 @@ one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, const InputT& input)
                     for (uint32_t s = 0; s < BIN_COUNT; s += 128)
                     {
                         simd<hist_t, 128> group_local_sum;
-                        group_local_sum.template bit_cast_view<uint32_t>() = utils::BlockLoad<uint32_t, 64>(
-                            (local_tid - 1) * HIST_STRIDE + s * sizeof(hist_t));
+                        group_local_sum.template bit_cast_view<uint32_t>() =
+                            utils::BlockLoadSlm<uint32_t, 64>((local_tid - 1) * HIST_STRIDE + s * sizeof(hist_t));
                         bin_offset.template select<128, 1>(s) += group_local_sum;
                     }
                 }
@@ -196,7 +196,7 @@ one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, const InputT& input)
                     keys.template select<DATA_PER_STEP, 1>(s));
             }
             barrier();
-            keys = utils::BlockLoad<_KeyT, _DataPerWorkItem>(slm_reorder_this_thread);
+            keys = utils::BlockLoadSlm<_KeyT, _DataPerWorkItem>(slm_reorder_this_thread);
         }
     }
 #pragma unroll

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_one_wg.h
@@ -98,7 +98,7 @@ one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, const InputT& input)
 #pragma unroll
             for (uint32_t s = 0; s < BIN_COUNT; s += 128)
             {
-                utils::BlockStore<uint32_t, 64>(
+                utils::BlockStoreSlm<uint32_t, 64>(
                     slm_bin_hist_this_thread + s * sizeof(hist_t),
                     bin_offset.template select<128, 1>(s).template bit_cast_view<uint32_t>());
             }
@@ -119,15 +119,15 @@ one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, const InputT& input)
                 {
                     tmp = utils::BlockLoad<uint32_t, BIN_WIDTH_UD>(slm_bin_hist_summary_offset);
                     thread_grf_hist_summary += tmp.template bit_cast_view<hist_t>();
-                    utils::BlockStore<uint32_t, BIN_WIDTH_UD>(
+                    utils::BlockStoreSlm<uint32_t, BIN_WIDTH_UD>(
                         slm_bin_hist_summary_offset, thread_grf_hist_summary.template bit_cast_view<uint32_t>());
                     slm_bin_hist_summary_offset += HIST_STRIDE;
                 }
                 tmp = utils::BlockLoad<uint32_t, BIN_WIDTH_UD>(slm_bin_hist_summary_offset);
                 thread_grf_hist_summary += tmp.template bit_cast_view<hist_t>();
                 thread_grf_hist_summary = utils::scan<hist_t, hist_t>(thread_grf_hist_summary);
-                utils::BlockStore<uint32_t, BIN_WIDTH_UD>(slm_bin_hist_summary_offset,
-                                                          thread_grf_hist_summary.template bit_cast_view<uint32_t>());
+                utils::BlockStoreSlm<uint32_t, BIN_WIDTH_UD>(
+                    slm_bin_hist_summary_offset, thread_grf_hist_summary.template bit_cast_view<uint32_t>());
             }
             barrier();
             if (local_tid == 0)
@@ -151,7 +151,7 @@ one_wg_kernel(sycl::nd_item<1> idx, uint32_t n, const InputT& input)
 #pragma unroll
                 for (uint32_t s = 0; s < BIN_COUNT; s += 128)
                 {
-                    utils::BlockStore<uint32_t, 64>(
+                    utils::BlockStoreSlm<uint32_t, 64>(
                         BIN_HIST_SLM_SIZE + s * sizeof(hist_t),
                         grf_hist_summary_scan.template select<128, 1>(s).template bit_cast_view<uint32_t>());
                 }

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
@@ -333,8 +333,8 @@ struct radix_sort_onesweep_slm_reorder_kernel
                 utils::BlockStoreSlm(slm_bin_hist_group_incoming + local_tid * BIN_WIDTH * sizeof(hist_t),
                                      utils::scan<hist_t, hist_t>(thread_grf_hist_summary));
                 if (wg_id != 0)
-                    utils::BlockStoreTo<uint32_t, BIN_WIDTH>(p_global_bin_this_group + local_tid * BIN_WIDTH,
-                                                             thread_grf_hist_summary | HIST_UPDATED);
+                    utils::BlockStore<uint32_t, BIN_WIDTH>(p_global_bin_this_group + local_tid * BIN_WIDTH,
+                                                           thread_grf_hist_summary | HIST_UPDATED);
             }
             barrier();
             if (local_tid == BIN_SUMMARY_GROUP_SIZE + 1)
@@ -375,8 +375,8 @@ struct radix_sort_onesweep_slm_reorder_kernel
                 } while (is_not_accumulated.any() && wg_id != 0);
                 prev_group_hist_sum &= GLOBAL_OFFSET_MASK;
                 simd<global_hist_t, BIN_WIDTH> after_group_hist_sum = prev_group_hist_sum + thread_grf_hist_summary;
-                utils::BlockStoreTo<uint32_t, BIN_WIDTH>(p_global_bin_this_group + local_tid * BIN_WIDTH,
-                                                         after_group_hist_sum | HIST_UPDATED | GLOBAL_ACCUMULATED);
+                utils::BlockStore<uint32_t, BIN_WIDTH>(p_global_bin_this_group + local_tid * BIN_WIDTH,
+                                                       after_group_hist_sum | HIST_UPDATED | GLOBAL_ACCUMULATED);
 
                 utils::BlockStoreSlm<uint32_t, BIN_WIDTH>(
                     slm_bin_hist_global_incoming + local_tid * BIN_WIDTH * sizeof(global_hist_t), prev_group_hist_sum);

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
@@ -62,7 +62,7 @@ global_histogram(sycl::nd_item<1> idx, size_t __n, const InputT& input, uint32_t
     }
 
     // 1. Initialize group-local histograms in SLM
-    utils::BlockStore<global_hist_t, HIST_DATA_PER_WORK_ITEM>(
+    utils::BlockStoreSlm<global_hist_t, HIST_DATA_PER_WORK_ITEM>(
         local_id * HIST_DATA_PER_WORK_ITEM * sizeof(global_hist_t), 0);
     barrier();
 
@@ -162,7 +162,7 @@ struct slm_lookup_t
     inline void
     setup(__dpl_esimd_ns::simd<T, TABLE_SIZE> source) SYCL_ESIMD_FUNCTION
     {
-        utils::BlockStore<T, TABLE_SIZE>(slm, source);
+        utils::BlockStoreSlm<T, TABLE_SIZE>(slm, source);
     }
 
     template <int N, typename IDX>
@@ -256,7 +256,7 @@ struct radix_sort_onesweep_slm_reorder_kernel
     inline void
     ResetBinCounters(uint32_t slm_bin_hist_this_thread) const
     {
-        utils::BlockStore<hist_t, BIN_COUNT>(slm_bin_hist_this_thread, 0);
+        utils::BlockStoreSlm<hist_t, BIN_COUNT>(slm_bin_hist_this_thread, 0);
     }
 
     inline auto
@@ -270,7 +270,7 @@ struct radix_sort_onesweep_slm_reorder_kernel
 
         constexpr uint32_t BIN_COUNT = 1 << _RadixBits;
         simd<uint32_t, _DataPerWorkItem> ranks;
-        utils::BlockStore<hist_t, BIN_COUNT>(slm_counter_offset, 0);
+        utils::BlockStoreSlm<hist_t, BIN_COUNT>(slm_counter_offset, 0);
         simd<uint32_t, BinsPerStep> remove_right_lanes, lane_id(0, 1);
         remove_right_lanes = 0x7fffffff >> (BinsPerStep - 1 - lane_id);
 #pragma unroll
@@ -327,14 +327,14 @@ struct radix_sort_onesweep_slm_reorder_kernel
                 for (uint32_t s = 0; s < _WorkGroupSize; s++, slm_bin_hist_summary_offset += HIST_STRIDE)
                 {
                     thread_grf_hist_summary += utils::BlockLoad<hist_t, BIN_WIDTH>(slm_bin_hist_summary_offset);
-                    utils::BlockStore(slm_bin_hist_summary_offset, thread_grf_hist_summary);
+                    utils::BlockStoreSlm(slm_bin_hist_summary_offset, thread_grf_hist_summary);
                 }
 
-                utils::BlockStore(slm_bin_hist_group_incoming + local_tid * BIN_WIDTH * sizeof(hist_t),
-                                  utils::scan<hist_t, hist_t>(thread_grf_hist_summary));
+                utils::BlockStoreSlm(slm_bin_hist_group_incoming + local_tid * BIN_WIDTH * sizeof(hist_t),
+                                     utils::scan<hist_t, hist_t>(thread_grf_hist_summary));
                 if (wg_id != 0)
-                    utils::BlockStore<uint32_t, BIN_WIDTH>(p_global_bin_this_group + local_tid * BIN_WIDTH,
-                                                           thread_grf_hist_summary | HIST_UPDATED);
+                    utils::BlockStoreTo<uint32_t, BIN_WIDTH>(p_global_bin_this_group + local_tid * BIN_WIDTH,
+                                                             thread_grf_hist_summary | HIST_UPDATED);
             }
             barrier();
             if (local_tid == BIN_SUMMARY_GROUP_SIZE + 1)
@@ -352,8 +352,8 @@ struct radix_sort_onesweep_slm_reorder_kernel
                     grf_hist_summary_scan.template select<BIN_WIDTH, 1>(i + 1) =
                         grf_hist_summary.template select<BIN_WIDTH, 1>(i) + grf_hist_summary_scan[i];
                 }
-                utils::BlockStore<hist_t, BIN_COUNT>(slm_bin_hist_group_incoming,
-                                                     grf_hist_summary_scan.template select<BIN_COUNT, 1>());
+                utils::BlockStoreSlm<hist_t, BIN_COUNT>(slm_bin_hist_group_incoming,
+                                                        grf_hist_summary_scan.template select<BIN_COUNT, 1>());
             }
             else if (local_tid < BIN_SUMMARY_GROUP_SIZE)
             {
@@ -375,10 +375,10 @@ struct radix_sort_onesweep_slm_reorder_kernel
                 } while (is_not_accumulated.any() && wg_id != 0);
                 prev_group_hist_sum &= GLOBAL_OFFSET_MASK;
                 simd<global_hist_t, BIN_WIDTH> after_group_hist_sum = prev_group_hist_sum + thread_grf_hist_summary;
-                utils::BlockStore<uint32_t, BIN_WIDTH>(p_global_bin_this_group + local_tid * BIN_WIDTH,
-                                                       after_group_hist_sum | HIST_UPDATED | GLOBAL_ACCUMULATED);
+                utils::BlockStoreTo<uint32_t, BIN_WIDTH>(p_global_bin_this_group + local_tid * BIN_WIDTH,
+                                                         after_group_hist_sum | HIST_UPDATED | GLOBAL_ACCUMULATED);
 
-                utils::BlockStore<uint32_t, BIN_WIDTH>(
+                utils::BlockStoreSlm<uint32_t, BIN_WIDTH>(
                     slm_bin_hist_global_incoming + local_tid * BIN_WIDTH * sizeof(global_hist_t), prev_group_hist_sum);
             }
             barrier();

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -588,6 +588,42 @@ BlockStore(uint32_t slm_offset, __dpl_esimd_ns::simd<T, N> data)
                                   data.template select<N - BLOCK_SIZE, 1>(BLOCK_SIZE));
 }
 
+template <typename T, int NElts, ::std::enable_if_t<sizeof(T) == sizeof(::std::uint8_t), int> = 0>
+constexpr int
+lsc_block_store_size_rounding()
+{
+    // https://github.com/intel/llvm/blob/3dbc2c00c26e599e8a10d44e3168a45d3c496eeb/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp#L2067
+    // Allowed \c NElts values for  8 bit data are 4, 8, 12, 16, 32, 64, 128, 256, 512.
+
+    static_assert(NElts >= 1);
+
+    if constexpr (NElts < 8)
+        return 4;
+
+    if constexpr (NElts < 12)
+        return 8;
+
+    if constexpr (NElts < 16)
+        return 12;
+
+    if constexpr (NElts < 32)
+        return 16;
+
+    if constexpr (NElts < 64)
+        return 32;
+
+    if constexpr (NElts < 128)
+        return 64;
+
+    if constexpr (NElts < 256)
+        return 128;
+
+    if constexpr (NElts < 512)
+        return 256;
+
+    return 512;
+}
+
 template <typename T, int N, __dpl_esimd_ens::cache_hint H1 = __dpl_esimd_ens::cache_hint::none,
           __dpl_esimd_ens::cache_hint H3 = __dpl_esimd_ens::cache_hint::none>
 inline std::enable_if_t<(N * sizeof(T) <= 256), void>

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -593,6 +593,11 @@ template <typename T, int N, __dpl_esimd_ens::cache_hint H1 = __dpl_esimd_ens::c
 inline std::enable_if_t<(N * sizeof(T) <= 256), void>
 BlockStore(T* dst, __dpl_esimd_ns::simd<T, N> data)
 {
+    // https://github.com/intel/llvm/blob/3dbc2c00c26e599e8a10d44e3168a45d3c496eeb/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp#L2067
+    // Allowed \c NElts values for 64 bit data are 1, 2, 3, 4, 8, 16, 32, 64.
+    // Allowed \c NElts values for 32 bit data are 1, 2, 3, 4, 8, 16, 32, 64, 128.
+    // Allowed \c NElts values for 16 bit data are 2, 4, 8, 16, 32, 64, 128, 256.
+    // Allowed \c NElts values for  8 bit data are 4, 8, 12, 16, 32, 64, 128, 256, 512.
     __dpl_esimd_ens::lsc_block_store<uint32_t, N, __dpl_esimd_ens::lsc_data_size::default_size, H1, H3>(
         dst, data.template bit_cast_view<uint32_t>(), 1);
 }

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -594,10 +594,10 @@ inline std::enable_if_t<(N * sizeof(T) <= 256), void>
 BlockStore(T* dst, __dpl_esimd_ns::simd<T, N> data)
 {
     // https://github.com/intel/llvm/blob/3dbc2c00c26e599e8a10d44e3168a45d3c496eeb/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp#L2067
-    // Allowed \c NElts values for 64 bit data are 1, 2, 3, 4, 8, 16, 32, 64.
-    // Allowed \c NElts values for 32 bit data are 1, 2, 3, 4, 8, 16, 32, 64, 128.
-    // Allowed \c NElts values for 16 bit data are 2, 4, 8, 16, 32, 64, 128, 256.
-    // Allowed \c NElts values for  8 bit data are 4, 8, 12, 16, 32, 64, 128, 256, 512.
+    // Allowed \c NElts values for  8 bit data are          4, 8, 12, 16, 32, 64, 128, 256, 512.
+    // Allowed \c NElts values for 16 bit data are    2,    4, 8,     16, 32, 64, 128, 256.
+    // Allowed \c NElts values for 32 bit data are 1, 2, 3, 4, 8,     16, 32, 64, 128.
+    // Allowed \c NElts values for 64 bit data are 1, 2, 3, 4, 8,     16, 32, 64.
     __dpl_esimd_ens::lsc_block_store<uint32_t, N, __dpl_esimd_ens::lsc_data_size::default_size, H1, H3>(
         dst, data.template bit_cast_view<uint32_t>(), 1);
 }

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -732,7 +732,7 @@ lsc_block_store_size_rounding()
 template <typename T, int N, __dpl_esimd_ens::cache_hint H1 = __dpl_esimd_ens::cache_hint::none,
           __dpl_esimd_ens::cache_hint H3 = __dpl_esimd_ens::cache_hint::none,
           ::std::enable_if_t<N == lsc_block_store_size_rounding<T, N>(), int> = 0>
-void    // inline std::enable_if_t<(N * sizeof(T) <= 256), void>
+void
 BlockStoreTo(T* dst, __dpl_esimd_ns::simd<T, N> data)
 {
     // https://github.com/intel/llvm/blob/3dbc2c00c26e599e8a10d44e3168a45d3c496eeb/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp#L2067
@@ -747,7 +747,7 @@ BlockStoreTo(T* dst, __dpl_esimd_ns::simd<T, N> data)
 template <typename T, int N, __dpl_esimd_ens::cache_hint H1 = __dpl_esimd_ens::cache_hint::none,
           __dpl_esimd_ens::cache_hint H3 = __dpl_esimd_ens::cache_hint::none,
           ::std::enable_if_t<N != lsc_block_store_size_rounding<T, N>(), int> = 0>
-void    // inline std::enable_if_t<(N * sizeof(T) > 256), void>
+void
 BlockStoreTo(T* dst, __dpl_esimd_ns::simd<T, N> data)
 {
     constexpr uint32_t BLOCK_SIZE = 64 * sizeof(uint32_t) / sizeof(T);

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -660,6 +660,42 @@ lsc_block_store_size_rounding()
     return 256;
 }
 
+template <typename T, int NElts, ::std::enable_if_t<sizeof(T) == sizeof(::std::uint32_t), int> = 0>
+constexpr int
+lsc_block_store_size_rounding()
+{
+    // https://github.com/intel/llvm/blob/3dbc2c00c26e599e8a10d44e3168a45d3c496eeb/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp#L2067
+    // Allowed \c NElts values for 32 bit data are 1, 2, 3, 4, 8, 16, 32, 64, 128.
+
+    static_assert(NElts >= 1);
+
+    if constexpr (NElts < 2)
+        return 1;
+
+    if constexpr (NElts < 3)
+        return 2;
+
+    if constexpr (NElts < 4)
+        return 3;
+
+    if constexpr (NElts < 8)
+        return 4;
+
+    if constexpr (NElts < 16)
+        return 8;
+
+    if constexpr (NElts < 32)
+        return 16;
+
+    if constexpr (NElts < 64)
+        return 32;
+
+    if constexpr (NElts < 128)
+        return 64;
+
+    return 128;
+}
+
 template <typename T, int N, __dpl_esimd_ens::cache_hint H1 = __dpl_esimd_ens::cache_hint::none,
           __dpl_esimd_ens::cache_hint H3 = __dpl_esimd_ens::cache_hint::none>
 inline std::enable_if_t<(N * sizeof(T) <= 256), void>

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -500,7 +500,7 @@ VectorStore(uint32_t offset, __dpl_esimd_ns::simd<T, VSize * LANES> data, __dpl_
 
 template <int NElts>
 constexpr int
-lsc_op_block_size_rounding()
+lsc_slm_block_size_rounding()
 {
     static_assert(NElts >= 1);
 
@@ -540,7 +540,7 @@ using lsc_op_aligned_t = ::std::conditional_t<sizeof(T) <= sizeof(::std::uint32_
 
 template <typename T, int N, typename OpAlignedT = lsc_op_aligned_t<T>,
           int NElts = lsc_op_block_size<T, N, OpAlignedT>(),
-          ::std::enable_if_t<NElts == lsc_op_block_size_rounding<NElts>(), int> = 0>
+          ::std::enable_if_t<NElts == lsc_slm_block_size_rounding<NElts>(), int> = 0>
 inline __dpl_esimd_ns::simd<T, N>
 BlockLoad(uint32_t slm_offset)
 {
@@ -551,11 +551,11 @@ BlockLoad(uint32_t slm_offset)
 
 template <typename T, int N, typename OpAlignedT = lsc_op_aligned_t<T>,
           int NElts = lsc_op_block_size<T, N, OpAlignedT>(),
-          ::std::enable_if_t<NElts != lsc_op_block_size_rounding<NElts>(), int> = 0>
+          ::std::enable_if_t<NElts != lsc_slm_block_size_rounding<NElts>(), int> = 0>
 inline __dpl_esimd_ns::simd<T, N>
 BlockLoad(uint32_t slm_offset)
 {
-    constexpr int BLOCK_SIZE_ROUNDED = lsc_op_block_size_rounding<NElts>();
+    constexpr int BLOCK_SIZE_ROUNDED = lsc_slm_block_size_rounding<NElts>();
 
     __dpl_esimd_ns::simd<T, N> result;
     constexpr int BLOCK_SIZE = lsc_op_block_size<OpAlignedT, BLOCK_SIZE_ROUNDED, T>();
@@ -567,7 +567,7 @@ BlockLoad(uint32_t slm_offset)
 
 template <typename T, int N, typename OpAlignedT = lsc_op_aligned_t<T>,
           int NElts = lsc_op_block_size<T, N, OpAlignedT>(),
-          ::std::enable_if_t<NElts == lsc_op_block_size_rounding<NElts>(), int> = 0>
+          ::std::enable_if_t<NElts == lsc_slm_block_size_rounding<NElts>(), int> = 0>
 void
 BlockStoreSlm(uint32_t slm_offset, __dpl_esimd_ns::simd<T, N> data)
 {
@@ -576,11 +576,11 @@ BlockStoreSlm(uint32_t slm_offset, __dpl_esimd_ns::simd<T, N> data)
 
 template <typename T, int N, typename OpAlignedT = lsc_op_aligned_t<T>,
           int NElts = lsc_op_block_size<T, N, OpAlignedT>(),
-          ::std::enable_if_t<NElts != lsc_op_block_size_rounding<NElts>(), int> = 0>
+          ::std::enable_if_t<NElts != lsc_slm_block_size_rounding<NElts>(), int> = 0>
 void
 BlockStoreSlm(uint32_t slm_offset, __dpl_esimd_ns::simd<T, N> data)
 {
-    constexpr int BLOCK_SIZE_ROUNDED = lsc_op_block_size_rounding<NElts>();
+    constexpr int BLOCK_SIZE_ROUNDED = lsc_slm_block_size_rounding<NElts>();
 
     constexpr int BLOCK_SIZE = lsc_op_block_size<OpAlignedT, BLOCK_SIZE_ROUNDED, T>();
     BlockStoreSlm<T, BLOCK_SIZE>(slm_offset, data.template select<BLOCK_SIZE, 1>(0));

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -733,7 +733,7 @@ template <typename T, int N, __dpl_esimd_ens::cache_hint H1 = __dpl_esimd_ens::c
           __dpl_esimd_ens::cache_hint H3 = __dpl_esimd_ens::cache_hint::none,
           ::std::enable_if_t<N == lsc_block_store_size_rounding<T, N>(), int> = 0>
 void
-BlockStoreTo(T* dst, __dpl_esimd_ns::simd<T, N> data)
+BlockStore(T* dst, __dpl_esimd_ns::simd<T, N> data)
 {
     // https://github.com/intel/llvm/blob/3dbc2c00c26e599e8a10d44e3168a45d3c496eeb/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp#L2067
     // Allowed \c NElts values for  8 bit data are          4, 8, 12, 16, 32, 64, 128, 256, 512.
@@ -748,15 +748,15 @@ template <typename T, int N, __dpl_esimd_ens::cache_hint H1 = __dpl_esimd_ens::c
           __dpl_esimd_ens::cache_hint H3 = __dpl_esimd_ens::cache_hint::none,
           ::std::enable_if_t<N != lsc_block_store_size_rounding<T, N>(), int> = 0>
 void
-BlockStoreTo(T* dst, __dpl_esimd_ns::simd<T, N> data)
+BlockStore(T* dst, __dpl_esimd_ns::simd<T, N> data)
 {
     constexpr uint32_t BLOCK_SIZE = 64 * sizeof(uint32_t) / sizeof(T);
 
     constexpr int BLOCK_SIZE_ROUNDED = lsc_block_store_size_rounding<T, N>();
     static_assert(BLOCK_SIZE == BLOCK_SIZE_ROUNDED);
 
-    BlockStoreTo<T, BLOCK_SIZE>(dst, data.template select<BLOCK_SIZE, 1>(0));
-    BlockStoreTo<T, N - BLOCK_SIZE>(dst + BLOCK_SIZE, data.template select<N - BLOCK_SIZE, 1>(BLOCK_SIZE));
+    BlockStore<T, BLOCK_SIZE>(dst, data.template select<BLOCK_SIZE, 1>(0));
+    BlockStore<T, N - BLOCK_SIZE>(dst + BLOCK_SIZE, data.template select<N - BLOCK_SIZE, 1>(BLOCK_SIZE));
 }
 
 template <typename T, int N>

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -751,6 +751,10 @@ void    // inline std::enable_if_t<(N * sizeof(T) > 256), void>
 BlockStore(T* dst, __dpl_esimd_ns::simd<T, N> data)
 {
     constexpr uint32_t BLOCK_SIZE = 64 * sizeof(uint32_t) / sizeof(T);
+
+    constexpr int BLOCK_SIZE_ROUNDED = lsc_block_store_size_rounding<T, N>();
+    static_assert(BLOCK_SIZE == BLOCK_SIZE_ROUNDED);
+
     BlockStore<T, BLOCK_SIZE>(dst, data.template select<BLOCK_SIZE, 1>(0));
     BlockStore<T, N - BLOCK_SIZE>(dst + BLOCK_SIZE, data.template select<N - BLOCK_SIZE, 1>(BLOCK_SIZE));
 }

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -696,6 +696,39 @@ lsc_block_store_size_rounding()
     return 128;
 }
 
+template <typename T, int NElts, ::std::enable_if_t<sizeof(T) == sizeof(::std::uint64_t), int> = 0>
+constexpr int
+lsc_block_store_size_rounding()
+{
+    // https://github.com/intel/llvm/blob/3dbc2c00c26e599e8a10d44e3168a45d3c496eeb/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp#L2067
+    // Allowed \c NElts values for 64 bit data are 1, 2, 3, 4, 8, 16, 32, 64.
+
+    static_assert(NElts >= 1);
+
+    if constexpr (NElts < 2)
+        return 1;
+
+    if constexpr (NElts < 3)
+        return 2;
+
+    if constexpr (NElts < 4)
+        return 3;
+
+    if constexpr (NElts < 8)
+        return 4;
+
+    if constexpr (NElts < 16)
+        return 8;
+
+    if constexpr (NElts < 32)
+        return 16;
+
+    if constexpr (NElts < 64)
+        return 32;
+
+    return 64;
+}
+
 template <typename T, int N, __dpl_esimd_ens::cache_hint H1 = __dpl_esimd_ens::cache_hint::none,
           __dpl_esimd_ens::cache_hint H3 = __dpl_esimd_ens::cache_hint::none>
 inline std::enable_if_t<(N * sizeof(T) <= 256), void>

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -542,7 +542,7 @@ template <typename T, int N, typename OpAlignedT = lsc_op_aligned_t<T>,
           int NElts = lsc_op_block_size<T, N, OpAlignedT>(),
           ::std::enable_if_t<NElts == lsc_slm_block_size_rounding<NElts>(), int> = 0>
 inline __dpl_esimd_ns::simd<T, N>
-BlockLoad(uint32_t slm_offset)
+BlockLoadSlm(uint32_t slm_offset)
 {
     __dpl_esimd_ns::simd<T, N> result;
     result.template bit_cast_view<OpAlignedT>() = __dpl_esimd_ens::lsc_slm_block_load<OpAlignedT, NElts>(slm_offset);
@@ -553,15 +553,15 @@ template <typename T, int N, typename OpAlignedT = lsc_op_aligned_t<T>,
           int NElts = lsc_op_block_size<T, N, OpAlignedT>(),
           ::std::enable_if_t<NElts != lsc_slm_block_size_rounding<NElts>(), int> = 0>
 inline __dpl_esimd_ns::simd<T, N>
-BlockLoad(uint32_t slm_offset)
+BlockLoadSlm(uint32_t slm_offset)
 {
     constexpr int BLOCK_SIZE_ROUNDED = lsc_slm_block_size_rounding<NElts>();
 
     __dpl_esimd_ns::simd<T, N> result;
     constexpr int BLOCK_SIZE = lsc_op_block_size<OpAlignedT, BLOCK_SIZE_ROUNDED, T>();
-    result.template select<BLOCK_SIZE, 1>(0) = BlockLoad<T, BLOCK_SIZE>(slm_offset);
+    result.template select<BLOCK_SIZE, 1>(0) = BlockLoadSlm<T, BLOCK_SIZE>(slm_offset);
     result.template select<N - BLOCK_SIZE, 1>(BLOCK_SIZE) =
-        BlockLoad<T, N - BLOCK_SIZE>(slm_offset + BLOCK_SIZE * sizeof(T));
+        BlockLoadSlm<T, N - BLOCK_SIZE>(slm_offset + BLOCK_SIZE * sizeof(T));
     return result;
 }
 

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -730,8 +730,9 @@ lsc_block_store_size_rounding()
 }
 
 template <typename T, int N, __dpl_esimd_ens::cache_hint H1 = __dpl_esimd_ens::cache_hint::none,
-          __dpl_esimd_ens::cache_hint H3 = __dpl_esimd_ens::cache_hint::none>
-inline std::enable_if_t<(N * sizeof(T) <= 256), void>
+          __dpl_esimd_ens::cache_hint H3 = __dpl_esimd_ens::cache_hint::none,
+          ::std::enable_if_t<N == lsc_block_store_size_rounding<T, N>(), int> = 0>
+void    // inline std::enable_if_t<(N * sizeof(T) <= 256), void>
 BlockStore(T* dst, __dpl_esimd_ns::simd<T, N> data)
 {
     // https://github.com/intel/llvm/blob/3dbc2c00c26e599e8a10d44e3168a45d3c496eeb/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp#L2067
@@ -744,8 +745,9 @@ BlockStore(T* dst, __dpl_esimd_ns::simd<T, N> data)
 }
 
 template <typename T, int N, __dpl_esimd_ens::cache_hint H1 = __dpl_esimd_ens::cache_hint::none,
-          __dpl_esimd_ens::cache_hint H3 = __dpl_esimd_ens::cache_hint::none>
-inline std::enable_if_t<(N * sizeof(T) > 256), void>
+          __dpl_esimd_ens::cache_hint H3 = __dpl_esimd_ens::cache_hint::none,
+          ::std::enable_if_t<N != lsc_block_store_size_rounding<T, N>(), int> = 0>
+void    // inline std::enable_if_t<(N * sizeof(T) > 256), void>
 BlockStore(T* dst, __dpl_esimd_ns::simd<T, N> data)
 {
     constexpr uint32_t BLOCK_SIZE = 64 * sizeof(uint32_t) / sizeof(T);

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -732,7 +732,7 @@ lsc_block_store_size_rounding()
 template <typename T, int N, __dpl_esimd_ens::cache_hint H1 = __dpl_esimd_ens::cache_hint::none,
           __dpl_esimd_ens::cache_hint H3 = __dpl_esimd_ens::cache_hint::none,
           ::std::enable_if_t<N == lsc_block_store_size_rounding<T, N>(), int> = 0>
-void
+inline void
 BlockStore(T* dst, __dpl_esimd_ns::simd<T, N> data)
 {
     // https://github.com/intel/llvm/blob/3dbc2c00c26e599e8a10d44e3168a45d3c496eeb/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp#L2067
@@ -747,7 +747,7 @@ BlockStore(T* dst, __dpl_esimd_ns::simd<T, N> data)
 template <typename T, int N, __dpl_esimd_ens::cache_hint H1 = __dpl_esimd_ens::cache_hint::none,
           __dpl_esimd_ens::cache_hint H3 = __dpl_esimd_ens::cache_hint::none,
           ::std::enable_if_t<N != lsc_block_store_size_rounding<T, N>(), int> = 0>
-void
+inline void
 BlockStore(T* dst, __dpl_esimd_ns::simd<T, N> data)
 {
     constexpr uint32_t BLOCK_SIZE = 64 * sizeof(uint32_t) / sizeof(T);

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -624,6 +624,42 @@ lsc_block_store_size_rounding()
     return 512;
 }
 
+template <typename T, int NElts, ::std::enable_if_t<sizeof(T) == sizeof(::std::uint16_t), int> = 0>
+constexpr int
+lsc_block_store_size_rounding()
+{
+    // https://github.com/intel/llvm/blob/3dbc2c00c26e599e8a10d44e3168a45d3c496eeb/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp#L2067
+    // Allowed \c NElts values for 16 bit data are 2, 4, 8, 16, 32, 64, 128, 256.
+
+    static_assert(NElts >= 1);
+
+    if constexpr (NElts < 2)
+        return 1;
+
+    if constexpr (NElts < 4)
+        return 2;
+
+    if constexpr (NElts < 8)
+        return 4;
+
+    if constexpr (NElts < 16)
+        return 8;
+
+    if constexpr (NElts < 32)
+        return 16;
+
+    if constexpr (NElts < 64)
+        return 32;
+
+    if constexpr (NElts < 128)
+        return 64;
+
+    if constexpr (NElts < 256)
+        return 128;
+
+    return 256;
+}
+
 template <typename T, int N, __dpl_esimd_ens::cache_hint H1 = __dpl_esimd_ens::cache_hint::none,
           __dpl_esimd_ens::cache_hint H3 = __dpl_esimd_ens::cache_hint::none>
 inline std::enable_if_t<(N * sizeof(T) <= 256), void>


### PR DESCRIPTION
In this PR we made next changes:
- rename: ```BlockLoad(uint32_t slm_offset)``` to ```BlockLoadSlm(uint32_t slm_offset)```;
- rename: ```BlockStore(uint32_t slm_offset, __dpl_esimd_ns::simd<T, N> data)``` to ```BlockStoreSlm(uint32_t slm_offset, __dpl_esimd_ns::simd<T, N> data)```
- in ```BlockStore``` insert additional static_assert to check dest size ```N```;
- change ```enable_if``` condition in ```BlockStore``` function;
- rename: ```lsc_op_block_size_rounding``` to ```lsc_slm_block_size_rounding```;
- 