### PR TITLE
[Docs] Adding req of const function objects for device policy algorithms 

### DIFF
--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -63,8 +63,6 @@ To use Parallel API with the device execution policies, you need to install the 
 Difference with Standard C++ Parallel Algorithms
 ************************************************
 
-* For algorithms executed with device policies, function object parameters which are passed must
-provide `const` function call operators.
 * oneDPL execution policies only result in parallel execution if random access iterators are provided,
   the execution will remain serial for other iterator types.
 * For the following algorithms, par_unseq and unseq policies do not result in vectorized execution:
@@ -93,6 +91,8 @@ When called with |dpcpp_short| execution policies, |onedpl_short| algorithms app
 Known Limitations
 *****************
 
+* Due to requirements of the SYCL specification, function object parameters passed in to algorithms executed with device
+  policies must provide `const` function call operators.
 * For ``transform_exclusive_scan``, ``transform_inclusive_scan`` algorithms the result of the unary operation should be
   convertible to the type of the initial value if one is provided, otherwise it is convertible to the type of values
   in the processed data sequence: ``std::iterator_traits<IteratorType>::value_type``.
@@ -126,7 +126,6 @@ Known Limitations
   the dereferenced value type of the provided iterators should satisfy the ``DefaultConstructible`` requirements.
 * For ``remove``, ``remove_if``, ``unique`` the dereferenced value type of the provided
   iterators should be ``MoveConstructible``.
-        
 
 Build Your Code with |onedpl_short|
 ===================================

--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -71,6 +71,8 @@ Difference with Standard C++ Parallel Algorithms
 * The following algorithms require additional O(n) memory space for parallel execution:
   ``copy_if``, ``inplace_merge``, ``partial_sort``, ``partial_sort_copy``, ``partition_copy``,
   ``remove``, ``remove_if``, ``rotate``, ``sort``, ``stable_sort``, ``unique``, ``unique_copy``.
+* For algorithms executed with device policies, callable function object parameters must provide `const`
+  function call operators.
 
 
 Restrictions

--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -63,6 +63,8 @@ To use Parallel API with the device execution policies, you need to install the 
 Difference with Standard C++ Parallel Algorithms
 ************************************************
 
+* Function object parameters passed in to algorithms executed with device policies must provide `const` function call
+  operators, due to requirements of the SYCL specification.
 * oneDPL execution policies only result in parallel execution if random access iterators are provided,
   the execution will remain serial for other iterator types.
 * For the following algorithms, par_unseq and unseq policies do not result in vectorized execution:
@@ -91,8 +93,6 @@ When called with |dpcpp_short| execution policies, |onedpl_short| algorithms app
 Known Limitations
 *****************
 
-* Due to requirements of the SYCL specification, function object parameters passed in to algorithms executed with device
-  policies must provide `const` function call operators.
 * For ``transform_exclusive_scan``, ``transform_inclusive_scan`` algorithms the result of the unary operation should be
   convertible to the type of the initial value if one is provided, otherwise it is convertible to the type of values
   in the processed data sequence: ``std::iterator_traits<IteratorType>::value_type``.

--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -63,6 +63,8 @@ To use Parallel API with the device execution policies, you need to install the 
 Difference with Standard C++ Parallel Algorithms
 ************************************************
 
+* For algorithms executed with device policies, function object parameters which are passed must
+provide `const` function call operators.
 * oneDPL execution policies only result in parallel execution if random access iterators are provided,
   the execution will remain serial for other iterator types.
 * For the following algorithms, par_unseq and unseq policies do not result in vectorized execution:
@@ -71,8 +73,6 @@ Difference with Standard C++ Parallel Algorithms
 * The following algorithms require additional O(n) memory space for parallel execution:
   ``copy_if``, ``inplace_merge``, ``partial_sort``, ``partial_sort_copy``, ``partition_copy``,
   ``remove``, ``remove_if``, ``rotate``, ``sort``, ``stable_sort``, ``unique``, ``unique_copy``.
-* For algorithms executed with device policies, callable function object parameters must provide `const`
-  function call operators.
 
 
 Restrictions


### PR DESCRIPTION
Adding a difference from the Standard C++ Parallel Algorithms.
Algorithms executed with a device policy must provide `const` function call operators for any provided functions objects.  

I'm not sure if it belongs here or as a "Known Limitations", as it is due to conflicting specifications between Standard Library and SYCL, but I prefer this placement.  There is no matching explicit requirement on function objects in the Standard C++ Parallel Algorithms.  

I don't expect SYCL to ever release this requirement, as using non-`const` functions of function objects in this context has some fundamental problems which run counter to performance and/or correctness.

---
Details of why this is required:
The SYCL spec requires kernels to use only `const` function call operators of function objects:

> 4.12.1 Defining kernels as named function objects
> “The operator() member function must be const-qualified” … “If the operator() function writes to any of the member variables, the behavior is undefined.”
> 4.12.2 Defining kernels as lambda functions
> “The kernel lambda must use copy for all of its captures (i.e. [=]), and the lambda must not use the mutable specifier.”

For a function object to be used in a SYCL kernel, it must either (1) be a member variable of named kernel function struct, or (2) it must be passed in to a lambda via a copy `=` capture.

1) If the kernel function struct will be using a `const` function call operator (4.12.1), which cannot modify any member functions of the kernel function struct. This means that it cannot call any non-`const` operators of member variables like the function object provided.
2) If a function object is passed by copy capture into the kernel lambda, it is marked `const` by default during the capture, and therefore non-`const` operators may not be called. If the lambda is marked as `mutable`, this removes the const qualification from the copy capture values, but this is explicitly disallowed for SYCL kernels (4.12.2).
