### PR TITLE
[Dynamic Selection] Dynamic Load policy with host_task and tests

### DIFF
--- a/include/oneapi/dpl/internal/dynamic_selection.h
+++ b/include/oneapi/dpl/internal/dynamic_selection.h
@@ -123,8 +123,8 @@ namespace experimental {
   auto has_submit_and_wait_handle_impl(...) -> std::false_type;
 
   template<typename DSPolicy, typename SelectionHandle,  typename Function, typename... Args>
-  auto has_submit_and_wait_handle_impl(int) -> decltype(std::declval<DSPolicy>().submit_and_wait(std::declval<SelectionHandle>(), 
-                                                                                                 std::declval<Function>(), 
+  auto has_submit_and_wait_handle_impl(int) -> decltype(std::declval<DSPolicy>().submit_and_wait(std::declval<SelectionHandle>(),
+                                                                                                 std::declval<Function>(),
                                                                                                  std::declval<Args>()...), std::true_type{});
 
   template<typename DSPolicy, typename SelectionHandle, typename Function, typename... Args>
@@ -132,15 +132,15 @@ namespace experimental {
 
   template<typename T, typename Function, typename... Args>
   auto submit_and_wait(T&& t, Function&&f, Args&&... args) {
-    if constexpr (has_get_policy<T>::value == true) { 
+    if constexpr (has_get_policy<T>::value == true) {
       // t is a selection
       if constexpr (has_submit_and_wait_handle<decltype(std::declval<T>().get_policy()), T, Function, Args...>::value == true) {
         // policy has optional submit_and_wait(selection, f, args...)
         return t.get_policy().submit_and_wait(std::forward<T>(t), std::forward<Function>(f), std::forward<Args>(args)...);
-      } else {   
+      } else {
         // policy does not have optional submit_and_wait for a selection
         return wait(submit(std::forward<T>(t), std::forward<Function>(f), std::forward<Args>(args)...));
-      } 
+      }
     } else {
       // t is a policy
       if constexpr ( has_submit_and_wait<T, Function, Args...>::value == true) {
@@ -207,7 +207,7 @@ namespace experimental {
   void report(S&& s, const Info& i, const Value& v) {
     if constexpr(has_report_value<S,Info>::value == true) {
       std::forward<S>(s).report(i, v);
-    } 
+    }
   }
 
   template<typename S, typename Info>
@@ -232,6 +232,7 @@ namespace experimental {
 #include "oneapi/dpl/internal/dynamic_selection_impl/static_policy_impl.h"
 #include "oneapi/dpl/internal/dynamic_selection_impl/round_robin_policy_impl.h"
 #include "oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h"
+#include "oneapi/dpl/internal/dynamic_selection_impl/dynamic_load_policy.h"
 
 #endif /*_ONEDPL_INTERNAL_DYNAMIC_SELECTION_H*/
 

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/dynamic_load_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/dynamic_load_policy.h
@@ -114,7 +114,6 @@ namespace experimental{
     selection_type select(Args&&...) {
       std::shared_ptr<resource_t> least_loaded = nullptr;
       int least_load = std::numeric_limits<load_t>::max();
-      //for (auto& r : state_->resources_) {
       int least;
       for(int i = 0;i<state_->resources_.size();i++){
         auto r = state_->resources_[(i+state_->offset)%state_->resources_.size()];

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/dynamic_load_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/dynamic_load_policy.h
@@ -1,0 +1,148 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _ONEDPL_DYNAMIC_LOAD_POLICY_H
+#define _ONEDPL_DYNAMIC_LOAD_POLICY_H
+
+#include <atomic>
+#include <memory>
+#include <ostream>
+#include <vector>
+
+namespace oneapi {
+namespace dpl{
+namespace experimental{
+
+  template <typename Backend = sycl_backend>
+  struct dynamic_load_policy {
+    private:
+    using backend_t = Backend;
+    using load_t = int;
+    using execution_resource_t = typename backend_t::execution_resource_t;
+
+    public:
+    //Policy Traits
+    using resource_type = typename backend_t::resource_type;
+    using wait_type = typename backend_t::wait_type;
+
+    //private:
+    struct resource_t {
+      execution_resource_t e_;
+      std::atomic<load_t> load_;
+      resource_t(execution_resource_t e) : e_(e) {load_=0;}
+    };
+    using resource_container_t = std::vector<std::shared_ptr<resource_t>>;
+
+    template<typename Policy>
+    class dl_selection_handle_t {
+      Policy policy_;
+      std::shared_ptr<resource_t> resource_;
+
+    public:
+      dl_selection_handle_t(const Policy& p,std::shared_ptr<resource_t> r )
+        : policy_(p), resource_(r) {}
+
+      auto unwrap() { return ::oneapi::dpl::experimental::unwrap(resource_->e_); }
+
+      Policy get_policy() { return policy_; };
+
+      void report(const execution_info::task_submission_t&) {
+        resource_->load_.fetch_add(1);
+      }
+
+      void report(const execution_info::task_completion_t&) const  {
+        resource_->load_.fetch_sub(1);
+      }
+    };
+
+    std::shared_ptr<backend_t> backend_;
+
+    using selection_type = dl_selection_handle_t<dynamic_load_policy<Backend>>;
+
+    struct state_t{
+        resource_container_t resources_;
+        int offset;
+    };
+
+    std::shared_ptr<state_t> state_;
+
+    void initialize(int offset){
+        backend_ = std::make_shared<backend_t>();
+        state_= std::make_shared<state_t>();
+        state_->offset=offset;
+        auto u =  get_resources();
+        for(auto x : u){
+          state_->resources_.push_back(std::make_shared<resource_t>(x));
+        }
+
+    }
+    void initialize(const std::vector<resource_type> &u, int offset=0) {
+        backend_ = std::make_shared<backend_t>(u);
+        state_= std::make_shared<state_t>();
+        state_->offset=offset;
+        for(auto x : u){
+          state_->resources_.push_back(std::make_shared<resource_t>(x));
+        }
+    }
+
+    dynamic_load_policy(int offset=0) {
+        if(offset != deferred_initialization){
+            initialize(offset);
+        }
+    }
+
+    dynamic_load_policy(const std::vector<resource_type>& u,int offset=0) {
+        if(offset != deferred_initialization){
+            initialize(u, offset);
+        }
+    }
+
+    auto get_resources() {
+        if(backend_)
+            return backend_->get_resources();
+        else
+           throw std::runtime_error("Called get_resources before initialization\n");
+    }
+
+    template<typename ...Args>
+    selection_type select(Args&&...) {
+      std::shared_ptr<resource_t> least_loaded = nullptr;
+      int least_load = std::numeric_limits<load_t>::max();
+      //for (auto& r : state_->resources_) {
+      int least;
+      for(int i = 0;i<state_->resources_.size();i++){
+        auto r = state_->resources_[(i+state_->offset)%state_->resources_.size()];
+        load_t v = r->load_.load();
+          if (least_loaded == nullptr || v < least_load) {
+            least_load = v;
+            least_loaded = r;
+            least=(i+state_->offset)%state_->resources_.size();
+          }
+      }
+      return selection_type{dynamic_load_policy<Backend>(*this), least_loaded};
+    }
+
+    template<typename Function, typename ...Args>
+    auto submit(selection_type e, Function&& f, Args&&... args) {
+      return backend_->submit(e, std::forward<Function>(f), std::forward<Args>(args)...);
+    }
+
+    auto get_submission_group() {
+      return backend_->get_submission_group();
+    }
+
+  };
+} // namespace experimental
+
+} // namespace dpl
+
+} // namespace oneapi
+
+
+#endif //_ONEDPL_ROUND_ROBIN_POLICY_IMPL_H

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/sycl_backend.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/sycl_backend.h
@@ -82,9 +82,10 @@ namespace experimental {
         auto e2 = q.submit([=](sycl::handler& h){
             h.depends_on(e1);
             h.host_task([=](){
-              if constexpr(report_info_v<SelectionHandle, execution_info::task_completion_t>) 
-                report(s, execution_info::task_completion);
-              if constexpr(report_value_v<SelectionHandle, execution_info::task_time_t>) 
+              if constexpr(report_info_v<SelectionHandle, execution_info::task_completion_t>){
+                s.report(execution_info::task_completion);
+              }
+              if constexpr(report_value_v<SelectionHandle, execution_info::task_time_t>)
                 s.report(execution_info::task_time, (std::chrono::high_resolution_clock::now() - t0).count());
             });
         });

--- a/test/parallel_api/dynamic_selection/sycl/test_dynamic_load_policy_sycl.pass.cpp
+++ b/test/parallel_api/dynamic_selection/sycl/test_dynamic_load_policy_sycl.pass.cpp
@@ -49,7 +49,6 @@ int main() {
   };
 
   auto f2 = [test_resource, u, n](int i, int offset) {
-    std::cout<<"Ideal CPU : "<<offset<<"\n";
     return u[offset];
   };
   // should always pick first when waiting on sync in each iteration

--- a/test/parallel_api/dynamic_selection/sycl/test_dynamic_load_policy_sycl.pass.cpp
+++ b/test/parallel_api/dynamic_selection/sycl/test_dynamic_load_policy_sycl.pass.cpp
@@ -1,0 +1,81 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+
+#include <iostream>
+#include "oneapi/dpl/dynamic_selection"
+#include "support/test_dynamic_load_utils.h"
+#include "support/sycl_sanity.h"
+
+static inline void build_dl_universe(std::vector<sycl::queue> &u) {
+  try {
+    auto device_cpu1 = sycl::device(sycl::cpu_selector());
+    sycl::queue cpu1_queue(device_cpu1);
+    run_sycl_sanity_test(cpu1_queue);
+    u.push_back(cpu1_queue);
+  } catch (sycl::exception) {
+    std::cout << "SKIPPED: Unable to run with cpu_selector\n";
+  }
+  try {
+    auto device_cpu2 = sycl::device(sycl::cpu_selector());
+    sycl::queue cpu2_queue(device_cpu2);
+    run_sycl_sanity_test(cpu2_queue);
+    u.push_back(cpu2_queue);
+  } catch (sycl::exception) {
+    std::cout << "SKIPPED: Unable to run with cpu_selector\n";
+  }
+}
+
+int main() {
+  using policy_t = oneapi::dpl::experimental::dynamic_load_policy<oneapi::dpl::experimental::sycl_backend>;
+  std::vector<sycl::queue> u;
+  build_dl_universe(u);
+
+  sycl::queue test_resource = u[0];
+  auto n = u.size();
+
+  // should be similar to round_robin when waiting on policy
+  auto f = [test_resource, u, n](int i, int offset) {
+    if(i==offset) {
+        return u[offset];
+    }
+    return u[(i+offset)%u.size()];
+  };
+
+  auto f2 = [test_resource, u, n](int i, int offset) {
+    std::cout<<"Ideal CPU : "<<offset<<"\n";
+    return u[offset];
+  };
+  // should always pick first when waiting on sync in each iteration
+  //auto fs = [test_resource, u](int i) { return u[0]; };
+
+    constexpr bool just_call_submit = false;
+    constexpr bool call_select_before_submit = true;
+  if ( test_dl_initialization(u)
+       || test_submit_and_wait_on_event<just_call_submit, policy_t>(u, f2)
+       || test_submit_and_wait_on_event<just_call_submit, policy_t>(u, f2, 1)
+       || test_submit_and_wait_on_event<call_select_before_submit, policy_t>(u, f2)
+       || test_submit_and_wait_on_event<call_select_before_submit, policy_t>(u, f2, 1)
+       || test_submit_and_wait<just_call_submit, policy_t>(u, f2)
+       || test_submit_and_wait<just_call_submit, policy_t>(u, f2, 1)
+       || test_submit_and_wait<call_select_before_submit, policy_t>(u, f2)
+       || test_submit_and_wait<call_select_before_submit, policy_t>(u, f2, 1)
+       || test_submit_and_wait_on_group<just_call_submit, policy_t>(u, f)
+       || test_submit_and_wait_on_group<just_call_submit, policy_t>(u, f, 1)
+       || test_submit_and_wait_on_group<call_select_before_submit, policy_t>(u, f)
+       || test_submit_and_wait_on_group<call_select_before_submit, policy_t>(u, f, 1)
+
+     ) {
+    std::cout << "FAIL\n";
+    return 1;
+  } else {
+    std::cout << "PASS\n";
+    return 0;
+  }
+}

--- a/test/parallel_api/dynamic_selection/test_dynamic_load_policy_inline.pass.cpp
+++ b/test/parallel_api/dynamic_selection/test_dynamic_load_policy_inline.pass.cpp
@@ -1,0 +1,59 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <iostream>
+#include "oneapi/dpl/dynamic_selection"
+#include "support/test_dynamic_selection_utils.h"
+#include "support/inline_backend.h"
+
+int main() {
+  using policy_t = oneapi::dpl::experimental::dynamic_load_policy<TestUtils::int_inline_backend_t>;
+  std::vector<int> u{4, 5, 6, 7};
+
+  // should be similar to round_robin when waiting on policy
+  auto f = [u](int i, int offset) { return u[(i+offset-1)%4]; };
+
+  // should always pick first when waiting on sync in each iteration
+  auto f2 = [u](int i, int offset) { return u[offset]; };
+
+  constexpr bool just_call_submit = false;
+  constexpr bool call_select_before_submit = true;
+  if ( test_initialization<policy_t, int>(u)
+       || test_submit_and_wait_on_event<just_call_submit, policy_t>(u, f2)
+       || test_submit_and_wait_on_event<just_call_submit, policy_t>(u, f2, 1)
+       || test_submit_and_wait_on_event<just_call_submit, policy_t>(u, f2, 2)
+       || test_submit_and_wait_on_event<just_call_submit, policy_t>(u, f2, 3)
+       || test_submit_and_wait_on_event<call_select_before_submit, policy_t>(u, f2)
+       || test_submit_and_wait_on_event<call_select_before_submit, policy_t>(u, f2, 1)
+       || test_submit_and_wait_on_event<call_select_before_submit, policy_t>(u, f2, 2)
+       || test_submit_and_wait_on_event<call_select_before_submit, policy_t>(u, f2, 3)
+       || test_submit_and_wait<just_call_submit, policy_t>(u, f2)
+       || test_submit_and_wait<just_call_submit, policy_t>(u, f2, 1)
+       || test_submit_and_wait<just_call_submit, policy_t>(u, f2, 2)
+       || test_submit_and_wait<just_call_submit, policy_t>(u, f2, 3)
+       || test_submit_and_wait<call_select_before_submit, policy_t>(u, f2)
+       || test_submit_and_wait<call_select_before_submit, policy_t>(u, f2, 1)
+       || test_submit_and_wait<call_select_before_submit, policy_t>(u, f2, 2)
+       || test_submit_and_wait<call_select_before_submit, policy_t>(u, f2, 3)
+       || test_submit_and_wait_on_group<just_call_submit, policy_t>(u, f)
+       || test_submit_and_wait_on_group<just_call_submit, policy_t>(u, f, 1)
+       || test_submit_and_wait_on_group<just_call_submit, policy_t>(u, f, 2)
+       || test_submit_and_wait_on_group<just_call_submit, policy_t>(u, f, 3)
+       || test_submit_and_wait_on_group<call_select_before_submit, policy_t>(u, f)
+       || test_submit_and_wait_on_group<call_select_before_submit, policy_t>(u, f, 1)
+       || test_submit_and_wait_on_group<call_select_before_submit, policy_t>(u, f, 2)
+       || test_submit_and_wait_on_group<call_select_before_submit, policy_t>(u, f, 3)
+     ) {
+    std::cout << "FAIL\n";
+    return 1;
+  } else {
+    std::cout << "PASS\n";
+    return 0;
+  }
+}

--- a/test/support/inline_backend.h
+++ b/test/support/inline_backend.h
@@ -74,8 +74,11 @@ struct int_inline_backend_t {
     if constexpr (oneapi::dpl::experimental::report_value_v<SelectionHandle, oneapi::dpl::experimental::execution_info::task_time_t>) {
       t0 = std::chrono::high_resolution_clock::now();
     }
-    auto w = new async_wait_impl_t<SelectionHandle>(s, 
-                                                    std::forward<Function>(f)(oneapi::dpl::experimental::unwrap(s), 
+    if constexpr(oneapi::dpl::experimental::report_info_v<SelectionHandle, oneapi::dpl::experimental::execution_info::task_submission_t>){
+      s.report(oneapi::dpl::experimental::execution_info::task_submission);
+    }
+    auto w = new async_wait_impl_t<SelectionHandle>(s,
+                                                    std::forward<Function>(f)(oneapi::dpl::experimental::unwrap(s),
                                                     std::forward<Args>(args)...));
     if constexpr (oneapi::dpl::experimental::report_value_v<SelectionHandle, oneapi::dpl::experimental::execution_info::task_time_t>) {
       report(s, oneapi::dpl::experimental::execution_info::task_time, (std::chrono::high_resolution_clock::now()-t0).count());

--- a/test/support/test_ds_utils.h
+++ b/test/support/test_ds_utils.h
@@ -55,7 +55,7 @@ int test_initialization(UniverseContainer u) {
       return 1;
     }
   } catch (...)  { }
-  p2.initialize(u); 
+  p2.initialize(u);
   auto u3 = oneapi::dpl::experimental::get_resources(p);
   auto u3s = u3.size();
   if (!std::equal(std::begin(u3), std::end(u3), std::begin(u))) {
@@ -417,7 +417,7 @@ int test_select(UniverseContainer u, ResourceFunction&& f) {
 
   for (int i = 1; i <= N; ++i) {
     auto test_resource = f(i);
-    if constexpr (AutoTune) { 
+    if constexpr (AutoTune) {
       auto h = select(p, function_key);
       if (oneapi::dpl::experimental::unwrap(h) != test_resource) {
          pass = false;

--- a/test/support/test_dynamic_load_utils.h
+++ b/test/support/test_dynamic_load_utils.h
@@ -1,0 +1,279 @@
+// -*- C++ -*-
+//===---------------------------------------------------------------------===//
+//
+// Copyright (C) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+
+#ifndef _ONEDPL_TEST_DYNAMIC_LOAD_UTILS_H
+#define _ONEDPL_TEST_DYNAMIC_LOAD_UTILS_H
+
+#include<thread>
+#include<chrono>
+#include<random>
+#include<algorithm>
+
+int test_dl_initialization(const std::vector<sycl::queue>& u) {
+  // initialize
+  oneapi::dpl::experimental::dynamic_load_policy p{u};
+  auto u2 = oneapi::dpl::experimental::get_resources(p);
+  auto u2s = u2.size();
+  if (!std::equal(std::begin(u2), std::end(u2), std::begin(u))) {
+    std::cout << "ERROR: provided resources and queried resources are not equal\n";
+    return 1;
+  }
+
+  // deferred initialization
+ oneapi::dpl::experimental::dynamic_load_policy p2{oneapi::dpl::experimental::deferred_initialization};
+  try {
+    auto u3 = oneapi::dpl::experimental::get_resources(p2);
+    if (!u3.empty()) {
+      std::cout << "ERROR: deferred initialization not respected\n";
+      return 1;
+    }
+  } catch (...)  { }
+  p2.initialize(u);
+  auto u3 = oneapi::dpl::experimental::get_resources(p);
+  auto u3s = u3.size();
+  if (!std::equal(std::begin(u3), std::end(u3), std::begin(u))) {
+    std::cout << "ERROR: reported resources and queried resources are not equal after deferred initialization\n";
+    return 1;
+  }
+
+  std::cout << "initialization: OK\n" << std::flush;
+  return 0;
+}
+
+template<bool call_select_before_submit, typename Policy, typename UniverseContainer, typename ResourceFunction>
+int test_submit_and_wait_on_group(UniverseContainer u, ResourceFunction&& f, int offset=0) {
+    using my_policy_t = Policy;
+    my_policy_t p{u, offset};
+
+    constexpr size_t N = 1000; // Number of vectors
+    constexpr size_t D = 100;  // Dimension of each vector
+
+    std::array<std::array<int, D>, N> a;
+    std::array<std::array<int, D>, N> b;
+
+    std::default_random_engine generator;
+    std::uniform_int_distribution<int> distribution(1, 10);
+
+    for (size_t i = 0; i < N; ++i) {
+        for (size_t j = 0; j < D; ++j) {
+            a[i][j] = distribution(generator);
+            b[i][j] = distribution(generator);
+        }
+    }
+
+    std::array<std::array<int, N>, N> resultMatrix;
+    sycl::buffer<std::array<int, D>, 1> bufferA(a.data(), sycl::range<1>(N));
+    sycl::buffer<std::array<int, D>, 1> bufferB(b.data(), sycl::range<1>(N));
+    sycl::buffer<std::array<int, N>, 1> bufferResultMatrix(resultMatrix.data(), sycl::range<1>(N));
+
+    bool pass=true;
+    if constexpr(call_select_before_submit){
+        for(int i=0;i<6;i++){
+            int target=(i+offset)%u.size();
+            auto test_resource = f(i, offset);
+            auto func = [&](typename Policy::resource_type e){
+                   if (e != test_resource) {
+                         pass = false;
+                   }
+                   if(target==offset){
+                        auto e2 = e.submit([&](sycl::handler &cgh){
+                            auto accessorA = bufferA.get_access<sycl::access::mode::read>(cgh);
+                            auto accessorB = bufferB.get_access<sycl::access::mode::read>(cgh);
+                            auto accessorResultMatrix = bufferResultMatrix.get_access<sycl::access::mode::write>(cgh);
+                           cgh.parallel_for(
+                                sycl::range<1>(N),
+                                [=](sycl::item<1> item) {
+                                for (size_t j = 0; j < N; ++j) {
+                                    int dotProduct = 0;
+                                    for (size_t i = 0; i < D; ++i) {
+                                        dotProduct += accessorA[item][i] * accessorB[item][i];
+                                    }
+                                    accessorResultMatrix[item][j] = dotProduct;
+                               }
+                            });
+                        });
+                        return e2;
+                   }
+                   else{
+                       auto e2 = e.submit([&](sycl::handler &cgh){
+                           //for(int i=0;i<1;i++);
+                       });
+                       return e2;
+                   }
+
+            };
+            auto s = oneapi::dpl::experimental::select(p);
+            auto e = oneapi::dpl::experimental::submit(s, func);
+            if(i>0) std::this_thread::sleep_for (std::chrono::milliseconds(10));
+        }
+        oneapi::dpl::experimental::wait(p.get_submission_group());
+
+    }
+    else{
+        for (int i = 0; i < 6; ++i) {
+            int target=(i+offset)%u.size();
+            auto test_resource = f(i, offset);
+                oneapi::dpl::experimental::submit(p,[&](typename Policy::resource_type e){
+                   if (e != test_resource) {
+                         pass = false;
+                   }
+                   if(target==offset){
+                        auto e2 = e.submit([&](sycl::handler &cgh){
+                            auto accessorA = bufferA.get_access<sycl::access::mode::read>(cgh);
+                            auto accessorB = bufferB.get_access<sycl::access::mode::read>(cgh);
+                            auto accessorResultMatrix = bufferResultMatrix.get_access<sycl::access::mode::write>(cgh);
+                           cgh.parallel_for(
+                                sycl::range<1>(N),
+                                [=](sycl::item<1> item) {
+                                for (size_t j = 0; j < N; ++j) {
+                                    int dotProduct = 0;
+                                    for (size_t i = 0; i < D; ++i) {
+                                        dotProduct += accessorA[item][i] * accessorB[item][i];
+                                    }
+                                    accessorResultMatrix[item][j] = dotProduct;
+                               }
+                            });
+                        });
+                        return e2;
+                   }
+                   else{
+                       auto e2 = e.submit([&](sycl::handler &cgh){
+                          // for(int i=0;i<1;i++);
+                       });
+                       return e2;
+                   }
+                });
+                if(i>0) std::this_thread::sleep_for (std::chrono::milliseconds(10));
+            }
+            oneapi::dpl::experimental::wait(p.get_submission_group());
+    }
+    if (!pass) {
+        std::cout << "ERROR: did not select expected resources\n";
+        return 1;
+    }
+    std::cout << "async_invoke_wait_on_policy: OK\n";
+    return 0;
+
+}
+
+template<bool call_select_before_submit, typename Policy, typename UniverseContainer, typename ResourceFunction>
+int test_submit_and_wait_on_event(UniverseContainer u, ResourceFunction&& f, int offset=0) {
+  using my_policy_t = Policy;
+  my_policy_t p{u, offset};
+
+  const int N = 6;
+  bool pass = true;
+
+  std::atomic<int> ecount = 0;
+
+  if constexpr(call_select_before_submit){
+      for (int i = 1; i <= N; ++i) {
+        auto test_resource = f(i, offset);
+        auto func =   [&pass,test_resource, &ecount, i](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type e) {
+            if (e != test_resource) {
+              pass = false;
+            }
+            ecount += i;
+            return typename oneapi::dpl::experimental::policy_traits<Policy>::wait_type{};
+          };
+        auto s = oneapi::dpl::experimental::select(p,func);
+        auto w = oneapi::dpl::experimental::submit(s,func);
+        oneapi::dpl::experimental::wait(w);
+        int count = ecount.load();
+        if (count != i*(i+1)/2) {
+          std::cout << "ERROR: scheduler did not execute all tasks exactly once\n";
+          return 1;
+        }
+      }
+  }
+  else{
+      for (int i = 1; i <= N; ++i) {
+        auto test_resource = f(i, offset);
+        auto w = oneapi::dpl::experimental::submit(p,
+                                  [&pass,test_resource,&ecount,  i](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type e) {
+                                    if (e != test_resource) {
+                                      pass = false;
+                                    }
+                                    ecount += i;
+                                    return typename oneapi::dpl::experimental::policy_traits<Policy>::wait_type{};
+                                  });
+        oneapi::dpl::experimental::wait(w);
+        int count = ecount.load();
+        if (count != i*(i+1)/2) {
+          std::cout << "ERROR: scheduler did not execute all tasks exactly once\n";
+          return 1;
+        }
+      }
+  }
+  if (!pass) {
+    std::cout << "ERROR: did not select expected resources\n";
+    return 1;
+  }
+  std::cout << "submit_and_wait_on_sync: OK\n";
+  return 0;
+}
+
+template<bool call_select_before_submit, typename Policy, typename UniverseContainer, typename ResourceFunction>
+int test_submit_and_wait(UniverseContainer u, ResourceFunction&& f, int offset=0) {
+  using my_policy_t = Policy;
+  my_policy_t p{u, offset};
+
+  const int N = 6;
+  std::atomic<int> ecount = 0;
+  bool pass = true;
+
+  if constexpr(call_select_before_submit){
+      for (int i = 1; i <= N; ++i) {
+        auto test_resource = f(i, offset);
+        auto func =   [&pass,test_resource, &ecount, i](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type e) {
+            if (e != test_resource) {
+              pass = false;
+            }
+            ecount += i;
+            return typename oneapi::dpl::experimental::policy_traits<Policy>::wait_type{};
+          };
+        auto s = oneapi::dpl::experimental::select(p,func);
+        oneapi::dpl::experimental::submit_and_wait(s, func);
+        int count = ecount.load();
+        if (count != i*(i+1)/2) {
+          std::cout << "ERROR: scheduler did not execute all tasks exactly once\n";
+          return 1;
+        }
+      }
+  }else{
+      for (int i = 1; i <= N; ++i) {
+        auto test_resource = f(i, offset);
+        oneapi::dpl::experimental::submit_and_wait(p,
+                   [&pass,&ecount,test_resource, i](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type e) {
+                     if (e != test_resource) {
+                       pass = false;
+                     }
+                     ecount += i;
+                     if constexpr (std::is_same_v<typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type, int>)
+                       return e;
+                     else
+                       return typename oneapi::dpl::experimental::policy_traits<Policy>::wait_type{};
+                   });
+        int count = ecount.load();
+        if (count != i*(i+1)/2) {
+          std::cout << "ERROR: scheduler did not execute all tasks exactly once\n";
+          return 1;
+        }
+      }
+  }
+  if (!pass) {
+    std::cout << "ERROR: did not select expected resources\n";
+    return 1;
+  }
+  std::cout << "submit_and_wait: OK\n";
+  return 0;
+}
+
+#endif /* _ONEDPL_TEST_DYNAMIC_LOAD_UTILS_H */

--- a/test/support/test_dynamic_selection_utils.h
+++ b/test/support/test_dynamic_selection_utils.h
@@ -1,0 +1,225 @@
+// -*- C++ -*-
+//===---------------------------------------------------------------------===//
+//
+// Copyright (C) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+
+#ifndef _ONEDPL_TEST_DYNAMIC_LOAD_UTILS_H
+#define _ONEDPL_TEST_DYNAMIC_LOAD_UTILS_H
+
+#include<thread>
+#include<chrono>
+#include<random>
+#include<algorithm>
+
+template<typename Policy, typename T>
+int test_initialization(const std::vector<T>& u) {
+  // initialize
+  using my_policy_t = Policy;
+  my_policy_t p{u};
+  auto u2 = oneapi::dpl::experimental::get_resources(p);
+  auto u2s = u2.size();
+  if (!std::equal(std::begin(u2), std::end(u2), std::begin(u))) {
+    std::cout << "ERROR: provided resources and queried resources are not equal\n";
+    return 1;
+  }
+
+  // deferred initialization
+  my_policy_t p2{oneapi::dpl::experimental::deferred_initialization};
+  try {
+    auto u3 = oneapi::dpl::experimental::get_resources(p2);
+    if (!u3.empty()) {
+      std::cout << "ERROR: deferred initialization not respected\n";
+      return 1;
+    }
+  } catch (...)  { }
+  p2.initialize(u);
+  auto u3 = oneapi::dpl::experimental::get_resources(p);
+  auto u3s = u3.size();
+  if (!std::equal(std::begin(u3), std::end(u3), std::begin(u))) {
+    std::cout << "ERROR: reported resources and queried resources are not equal after deferred initialization\n";
+    return 1;
+  }
+
+  std::cout << "initialization: OK\n" << std::flush;
+  return 0;
+}
+
+template<bool call_select_before_submit, typename Policy, typename UniverseContainer, typename ResourceFunction>
+int test_submit_and_wait_on_group(UniverseContainer u, ResourceFunction&& f, int offset=0) {
+    using my_policy_t = Policy;
+    my_policy_t p{u, offset};
+
+    int N=100;
+  std::atomic<int> ecount = 0;
+    bool pass=true;
+    if constexpr(call_select_before_submit){
+        for(int i=1;i<=N;i++){
+            int target=(i+offset)%u.size();
+            auto test_resource = f(i, offset);
+            auto func = [&](typename Policy::resource_type e){
+                   if (e != test_resource) {
+                         pass = false;
+                   }
+                   ecount += i;
+                   if constexpr (std::is_same_v<typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type, int>)
+                     return e;
+                   else
+                     return typename oneapi::dpl::experimental::policy_traits<Policy>::wait_type{};
+            };
+            auto s = oneapi::dpl::experimental::select(p);
+            auto e = oneapi::dpl::experimental::submit(s, func);
+        }
+        oneapi::dpl::experimental::wait(p.get_submission_group());
+
+    }
+    else{
+            for (int i = 1; i <= N; ++i) {
+                auto test_resource = f(i, offset);
+                oneapi::dpl::experimental::submit(p,
+                     [&pass,&ecount,test_resource, i](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type e) {
+                       if (e != test_resource) {
+                         pass = false;
+                       }
+                       ecount += i;
+                       if constexpr (std::is_same_v<typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type, int>)
+                         return e;
+                       else
+                         return typename oneapi::dpl::experimental::policy_traits<Policy>::wait_type{};
+                     });
+            }
+            oneapi::dpl::experimental::wait(p.get_submission_group());
+    }
+    if (!pass) {
+        std::cout << "ERROR: did not select expected resources\n";
+        return 1;
+    }
+    std::cout << "async_invoke_wait_on_policy: OK\n";
+    return 0;
+
+}
+
+template<bool call_select_before_submit, typename Policy, typename UniverseContainer, typename ResourceFunction>
+int test_submit_and_wait_on_event(UniverseContainer u, ResourceFunction&& f, int offset=0) {
+  using my_policy_t = Policy;
+  my_policy_t p{u, offset};
+
+  const int N = 6;
+  bool pass = true;
+
+  std::atomic<int> ecount = 0;
+
+  if constexpr(call_select_before_submit){
+      for (int i = 1; i <= N; ++i) {
+        auto test_resource = f(i, offset);
+        auto func =   [&pass,test_resource, &ecount, i](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type e) {
+           if (e != test_resource) {
+             pass = false;
+           }
+           ecount += i;
+           if constexpr (std::is_same_v<typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type, int>)
+             return e;
+           else
+             return typename oneapi::dpl::experimental::policy_traits<Policy>::wait_type{};
+          };
+        auto s = oneapi::dpl::experimental::select(p,func);
+        auto w = oneapi::dpl::experimental::submit(s,func);
+        oneapi::dpl::experimental::wait(w);
+        int count = ecount.load();
+        if (count != i*(i+1)/2) {
+          std::cout << "ERROR: scheduler did not execute all tasks exactly once\n";
+          return 1;
+        }
+      }
+  }
+  else{
+      for (int i = 1; i <= N; ++i) {
+        auto test_resource = f(i, offset);
+        auto w = oneapi::dpl::experimental::submit(p,
+                                  [&pass,test_resource,&ecount,  i](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type e) {
+                                    if (e != test_resource) {
+                                      pass = false;
+                                    }
+                                    ecount += i;
+                                   if constexpr (std::is_same_v<typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type, int>)
+                                     return e;
+                                   else
+                                     return typename oneapi::dpl::experimental::policy_traits<Policy>::wait_type{};
+                                  });
+        oneapi::dpl::experimental::wait(w);
+        int count = ecount.load();
+        if (count != i*(i+1)/2) {
+          std::cout << "ERROR: scheduler did not execute all tasks exactly once\n";
+          return 1;
+        }
+      }
+  }
+  if (!pass) {
+    std::cout << "ERROR: did not select expected resources\n";
+    return 1;
+  }
+  std::cout << "submit_and_wait_on_sync: OK\n";
+  return 0;
+}
+
+template<bool call_select_before_submit, typename Policy, typename UniverseContainer, typename ResourceFunction>
+int test_submit_and_wait(UniverseContainer u, ResourceFunction&& f, int offset=0) {
+  using my_policy_t = Policy;
+  my_policy_t p{u, offset};
+
+  const int N = 6;
+  std::atomic<int> ecount = 0;
+  bool pass = true;
+
+  if constexpr(call_select_before_submit){
+      for (int i = 1; i <= N; ++i) {
+        auto test_resource = f(i, offset);
+        auto func =   [&pass,test_resource, &ecount, i](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type e) {
+            if (e != test_resource) {
+              pass = false;
+            }
+            ecount += i;
+            return typename oneapi::dpl::experimental::policy_traits<Policy>::wait_type{};
+          };
+        auto s = oneapi::dpl::experimental::select(p,func);
+        oneapi::dpl::experimental::submit_and_wait(s, func);
+        int count = ecount.load();
+        if (count != i*(i+1)/2) {
+          std::cout << "ERROR: scheduler did not execute all tasks exactly once\n";
+          return 1;
+        }
+      }
+  }else{
+      for (int i = 1; i <= N; ++i) {
+        auto test_resource = f(i, offset);
+        oneapi::dpl::experimental::submit_and_wait(p,
+                   [&pass,&ecount,test_resource, i](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type e) {
+                     if (e != test_resource) {
+                       pass = false;
+                     }
+                     ecount += i;
+                     if constexpr (std::is_same_v<typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type, int>)
+                       return e;
+                     else
+                       return typename oneapi::dpl::experimental::policy_traits<Policy>::wait_type{};
+                   });
+        int count = ecount.load();
+        if (count != i*(i+1)/2) {
+          std::cout << "ERROR: scheduler did not execute all tasks exactly once\n";
+          return 1;
+        }
+      }
+  }
+  if (!pass) {
+    std::cout << "ERROR: did not select expected resources\n";
+    return 1;
+  }
+  std::cout << "submit_and_wait: OK\n";
+  return 0;
+}
+
+#endif /* _ONEDPL_TEST_DYNAMIC_LOAD_UTILS_H */


### PR DESCRIPTION
1. Added a host task in the sycl_backend
2. Added the dynamic load policy
3. Added tests for dynamic_load_policy_sycl (Note : the test for group submission may fail just because of the nature of host task and dynamic_load_policy)
4. Added tests for dynamic_load_policy_inline
5. Added test/support/test_dynamic_load_utils.h for a comprehensive testing, the older files test/support/test_dl_utils.h exists to run round_robin and fixed_policy tests and should be removed 