### PR TITLE
Adding guards for sycl vrs non sycl runs

### DIFF
--- a/include/oneapi/dpl/dynamic_selection
+++ b/include/oneapi/dpl/dynamic_selection
@@ -14,8 +14,14 @@
 #include "oneapi/dpl/pstl/onedpl_config.h"
 
 
-#define _DS_BACKEND_SYCL 1
+#if (ONEDPL_USE_DPCPP_BACKEND != 0)
+    #define _DS_BACKEND_SYCL 1
+#else
+    #define _DS_BACKEND_SYCL 0
+#endif
+
 #include "oneapi/dpl/internal/dynamic_selection.h"
+/*
 namespace oneapi {
 namespace dpl {
 namespace experimental {
@@ -30,5 +36,5 @@ namespace experimental {
 } //namespace experimental
 } //namespace dpl
 } //namespace oneapi
-
+*/
 #endif /* ONEDPL_DYNAMIC_SELECTION */

--- a/include/oneapi/dpl/dynamic_selection
+++ b/include/oneapi/dpl/dynamic_selection
@@ -14,7 +14,8 @@
 #include "oneapi/dpl/pstl/onedpl_config.h"
 
 
-#if (ONEDPL_USE_DPCPP_BACKEND != 0)
+//#if (ONEDPL_USE_DPCPP_BACKEND != 0)
+if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && (!defined(ONEDPL_USE_DPCPP_BACKEND) || ONEDPL_USE_DPCPP_BACKEND != 0)
     #define _DS_BACKEND_SYCL 1
 #else
     #define _DS_BACKEND_SYCL 0

--- a/include/oneapi/dpl/dynamic_selection
+++ b/include/oneapi/dpl/dynamic_selection
@@ -15,10 +15,12 @@
 
 
 //#if (ONEDPL_USE_DPCPP_BACKEND != 0)
-if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && (!defined(ONEDPL_USE_DPCPP_BACKEND) || ONEDPL_USE_DPCPP_BACKEND != 0)
+#if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && (!defined(ONEDPL_USE_DPCPP_BACKEND) || ONEDPL_USE_DPCPP_BACKEND != 0)
     #define _DS_BACKEND_SYCL 1
+    #pragma message("compiling with sycl compiler or backend")
 #else
     #define _DS_BACKEND_SYCL 0
+    #pragma message("non sycl compilation")
 #endif
 
 #include "oneapi/dpl/internal/dynamic_selection.h"

--- a/include/oneapi/dpl/dynamic_selection
+++ b/include/oneapi/dpl/dynamic_selection
@@ -13,31 +13,12 @@
 #include "oneapi/dpl/internal/common_config.h"
 #include "oneapi/dpl/pstl/onedpl_config.h"
 
-
-//#if (ONEDPL_USE_DPCPP_BACKEND != 0)
 #if (defined(CL_SYCL_LANGUAGE_VERSION) || defined(SYCL_LANGUAGE_VERSION)) && (!defined(ONEDPL_USE_DPCPP_BACKEND) || ONEDPL_USE_DPCPP_BACKEND != 0)
     #define _DS_BACKEND_SYCL 1
-    #pragma message("compiling with sycl compiler or backend")
 #else
     #define _DS_BACKEND_SYCL 0
-    #pragma message("non sycl compilation")
 #endif
 
 #include "oneapi/dpl/internal/dynamic_selection.h"
-/*
-namespace oneapi {
-namespace dpl {
-namespace experimental {
 
-#if _DS_BACKEND_SYCL != 0
-  using fixed_resource_policy = fixed_resource_policy_impl<sycl_backend>;
-  using round_robin_policy = round_robin_policy_impl<sycl_backend>;
-#endif
-  template<typename S> using fixed_resource_policy_t = fixed_resource_policy_impl<S>;
-  template<typename S> using round_robin_policy_t = round_robin_policy_impl<S>;
-
-} //namespace experimental
-} //namespace dpl
-} //namespace oneapi
-*/
 #endif /* ONEDPL_DYNAMIC_SELECTION */

--- a/include/oneapi/dpl/internal/dynamic_selection.h
+++ b/include/oneapi/dpl/internal/dynamic_selection.h
@@ -228,7 +228,9 @@ namespace experimental {
 } // namespace dpl
 } // namespace oneapi
 
-#include "oneapi/dpl/internal/dynamic_selection_impl/sycl_backend.h"
+#if _DS_BACKEND_SYCL != 0
+    #include "oneapi/dpl/internal/dynamic_selection_impl/sycl_backend.h"
+#endif
 #include "oneapi/dpl/internal/dynamic_selection_impl/static_policy_impl.h"
 #include "oneapi/dpl/internal/dynamic_selection_impl/round_robin_policy_impl.h"
 #include "oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h"

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h
@@ -17,8 +17,9 @@
 #include <mutex>
 #include <utility>
 #include <vector>
-#include "oneapi/dpl/internal/dynamic_selection_impl/sycl_backend.h"
-
+#if _DS_BACKEND_SYCL != 0
+    #include "oneapi/dpl/internal/dynamic_selection_impl/sycl_backend.h"
+#endif
 namespace oneapi {
 namespace dpl {
 namespace experimental {

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h
@@ -23,9 +23,12 @@
 namespace oneapi {
 namespace dpl {
 namespace experimental {
-
+#if _DS_BACKEND_SYCL != 0
+  template <typename Backend=sycl_backend, typename... KeyArgs>
+#else 
   template <typename Backend, typename... KeyArgs>
-  class auto_tune_policy;
+#endif
+class auto_tune_policy;
 
   namespace internal { 
     template <typename Backend, typename Resource, typename Tuner, typename... KeyArgs>

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h
@@ -24,7 +24,7 @@ namespace oneapi {
 namespace dpl {
 namespace experimental {
 
-  template <typename Backend=sycl_backend, typename... KeyArgs>
+  template <typename Backend, typename... KeyArgs>
   class auto_tune_policy;
 
   namespace internal { 

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/dynamic_load_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/dynamic_load_policy.h
@@ -14,12 +14,15 @@
 #include <memory>
 #include <ostream>
 #include <vector>
+#if _DS_BACKEND_SYCL != 0
+    #include "oneapi/dpl/internal/dynamic_selection_impl/sycl_backend.h"
+#endif
 
 namespace oneapi {
 namespace dpl{
 namespace experimental{
 
-  template <typename Backend = sycl_backend>
+  template <typename Backend>
   struct dynamic_load_policy {
     private:
     using backend_t = Backend;

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/dynamic_load_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/dynamic_load_policy.h
@@ -22,7 +22,11 @@ namespace oneapi {
 namespace dpl{
 namespace experimental{
 
+#if _DS_BACKEND_SYCL != 0
+  template <typename Backend=sycl_backend>
+#else
   template <typename Backend>
+#endif
   struct dynamic_load_policy {
     private:
     using backend_t = Backend;

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/round_robin_policy_impl.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/round_robin_policy_impl.h
@@ -19,8 +19,11 @@
 namespace oneapi {
 namespace dpl{
 namespace experimental{
-
+#if _DS_BACKEND_SYCL != 0
+  template <typename Backend=sycl_backend>
+#else
   template <typename Backend>
+#endif
   struct round_robin_policy_impl {
     using backend_t = Backend;
     using resource_container_t = typename backend_t::resource_container_t;

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/round_robin_policy_impl.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/round_robin_policy_impl.h
@@ -12,6 +12,9 @@
 
 #include <atomic>
 #include "oneapi/dpl/internal/dynamic_selection_impl/scoring_policy_defs.h"
+#if _DS_BACKEND_SYCL != 0
+    #include "oneapi/dpl/internal/dynamic_selection_impl/sycl_backend.h"
+#endif
 
 namespace oneapi {
 namespace dpl{

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/round_robin_policy_impl.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/round_robin_policy_impl.h
@@ -20,7 +20,7 @@ namespace oneapi {
 namespace dpl{
 namespace experimental{
 
-  template <typename Backend = sycl_backend>
+  template <typename Backend>
   struct round_robin_policy_impl {
     using backend_t = Backend;
     using resource_container_t = typename backend_t::resource_container_t;

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/static_policy_impl.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/static_policy_impl.h
@@ -11,7 +11,9 @@
 #define _ONEDPL_STATIC_POLICY_IMPL_H
 
 #include "oneapi/dpl/internal/dynamic_selection_impl/scoring_policy_defs.h"
-
+#if _DS_BACKEND_SYCL != 0
+    #include "oneapi/dpl/internal/dynamic_selection_impl/sycl_backend.h"
+#endif
 namespace oneapi {
 namespace dpl {
 namespace experimental {

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/static_policy_impl.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/static_policy_impl.h
@@ -18,7 +18,11 @@ namespace oneapi {
 namespace dpl {
 namespace experimental {
 
+#if _DS_BACKEND_SYCL != 0
+  template <typename Backend=sycl_backend>
+#else
   template <typename Backend>
+#endif
   struct fixed_resource_policy_impl {
     using backend_t = Backend;
     using resource_container_t = typename backend_t::resource_container_t;


### PR DESCRIPTION
Added guards that ensure that non-sycl tests run when in non-sycl environments

(Culled into 1089, closing...)