### PR TITLE
Fix warning: 'get_pointer' is deprecated

### DIFF
--- a/include/oneapi/dpl/internal/reduce_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/reduce_by_segment_impl.h
@@ -326,8 +326,8 @@ __sycl_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2&& 
             __seg_reduce_offset_kernel,
 #endif
             sycl::nd_range<1>{__wgroup_size, __wgroup_size}, [=](sycl::nd_item<1> __item) {
-                auto __beg = __seg_ends_acc.get_pointer();
-                auto __out_beg = __seg_ends_scan_acc.get_pointer();
+                auto __beg = __dpl_sycl::__get_accessor_ptr(__seg_ends_acc);
+                auto __out_beg = __dpl_sycl::__get_accessor_ptr(__seg_ends_scan_acc);
                 __dpl_sycl::__joint_exclusive_scan(__item.get_group(), __beg, __beg + __n_groups, __out_beg,
                                                    __diff_type(0), sycl::plus<__diff_type>());
             });

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -610,7 +610,7 @@ struct __parallel_copy_if_static_single_group_submitter<_Size, _ElemsPerItem, _W
 #else
                     constexpr bool __can_use_subgroup_load_store = false;
 #endif
-                    auto __lacc_ptr = __get_accessor_ptr(__lacc);
+                    auto __lacc_ptr = __dpl_sycl::__get_accessor_ptr(__lacc);
                     if constexpr (__can_use_subgroup_load_store)
                     {
                         _ONEDPL_PRAGMA_UNROLL

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -444,8 +444,8 @@ struct __parallel_transform_scan_dynamic_single_group_submitter<_Inclusive,
                         __lacc[__idx] = __unary_op(__in_rng[__idx]);
                     }
 
-                    __scan_work_group<_ValueType, _Inclusive>(__group, __lacc.get_pointer(), __lacc.get_pointer() + __n,
-                                                              __lacc.get_pointer(), __bin_op, __init);
+                    auto __ptr = __dpl_sycl::__get_accessor_ptr(__lacc);
+                    __scan_work_group<_ValueType, _Inclusive>(__group, __ptr, __ptr + __n, __ptr, __bin_op, __init);
 
                     for (::std::uint16_t __idx = __item_id; __idx < __n; __idx += __wg_size)
                     {
@@ -505,6 +505,7 @@ struct __parallel_transform_scan_static_single_group_submitter<_Inclusive, _Elem
                     constexpr bool __can_use_subgroup_load_store = false;
 #endif
 
+                    auto __lacc_ptr = __dpl_sycl::__get_accessor_ptr(__lacc);
                     if constexpr (__can_use_subgroup_load_store)
                     {
                         _ONEDPL_PRAGMA_UNROLL
@@ -512,7 +513,7 @@ struct __parallel_transform_scan_static_single_group_submitter<_Inclusive, _Elem
                         {
                             auto __idx = __i * _WGSize + __subgroup_id * __subgroup_size;
                             auto __val = __unary_op(__subgroup.load(__in_rng.begin() + __idx));
-                            __subgroup.store(__lacc.get_pointer() + __idx, __val);
+                            __subgroup.store(__lacc_ptr + __idx, __val);
                         }
                     }
                     else
@@ -524,8 +525,8 @@ struct __parallel_transform_scan_static_single_group_submitter<_Inclusive, _Elem
                         }
                     }
 
-                    __scan_work_group<_ValueType, _Inclusive>(__group, __lacc.get_pointer(), __lacc.get_pointer() + __n,
-                                                              __lacc.get_pointer(), __bin_op, __init);
+                    __scan_work_group<_ValueType, _Inclusive>(__group, __lacc_ptr, __lacc_ptr + __n,
+                                                              __lacc_ptr, __bin_op, __init);
 
                     if constexpr (__can_use_subgroup_load_store)
                     {
@@ -533,7 +534,7 @@ struct __parallel_transform_scan_static_single_group_submitter<_Inclusive, _Elem
                         for (::std::uint16_t __i = 0; __i < _ElemsPerItem; ++__i)
                         {
                             auto __idx = __i * _WGSize + __subgroup_id * __subgroup_size;
-                            auto __val = __subgroup.load(__lacc.get_pointer() + __idx);
+                            auto __val = __subgroup.load(__lacc_ptr + __idx);
                             __subgroup.store(__out_rng.begin() + __idx, __val);
                         }
                     }
@@ -609,7 +610,7 @@ struct __parallel_copy_if_static_single_group_submitter<_Size, _ElemsPerItem, _W
 #else
                     constexpr bool __can_use_subgroup_load_store = false;
 #endif
-
+                    auto __lacc_ptr = __get_accessor_ptr(__lacc);
                     if constexpr (__can_use_subgroup_load_store)
                     {
                         _ONEDPL_PRAGMA_UNROLL
@@ -617,7 +618,7 @@ struct __parallel_copy_if_static_single_group_submitter<_Size, _ElemsPerItem, _W
                         {
                             auto __idx = __i * _WGSize + __subgroup_id * __subgroup_size;
                             uint16_t __val = __unary_op(__subgroup.load(__in_rng.begin() + __idx));
-                            __subgroup.store(__lacc.get_pointer() + __idx, __val);
+                            __subgroup.store(__lacc_ptr + __idx, __val);
                         }
                     }
                     else
@@ -630,8 +631,8 @@ struct __parallel_copy_if_static_single_group_submitter<_Size, _ElemsPerItem, _W
                     }
 
                     __scan_work_group<_ValueType, /* _Inclusive */ false>(
-                        __group, __lacc.get_pointer(), __lacc.get_pointer() + __elems_per_wg,
-                        __lacc.get_pointer() + __elems_per_wg, __bin_op, __init);
+                        __group, __lacc_ptr, __lacc_ptr + __elems_per_wg, __lacc_ptr + __elems_per_wg, __bin_op,
+                         __init);
 
                     _ONEDPL_PRAGMA_UNROLL
                     for (::std::uint16_t __idx = __item_id; __idx < __n; __idx += _WGSize)
@@ -1140,9 +1141,9 @@ __parallel_find_or(_ExecutionPolicy&& __exec, _Brick __f, _BrickTag __brick_tag,
                     auto __local_idx = __item_id.get_local_id(0);
 
                     __dpl_sycl::__atomic_ref<_AtomicType, sycl::access::address_space::global_space> __found(
-                        *__temp_acc.get_pointer());
+                        *__dpl_sycl::__get_accessor_ptr(__temp_acc));
                     __dpl_sycl::__atomic_ref<_AtomicType, sycl::access::address_space::local_space> __found_local(
-                        *__temp_local.get_pointer());
+                        *__dpl_sycl::__get_accessor_ptr(__temp_local));
 
                     // 1. Set initial value to local atomic
                     if (__local_idx == 0)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -343,7 +343,7 @@ struct __peer_prefix_helper<_OffsetT, __peer_prefix_algo::atomic_fetch_or>
 
     __peer_prefix_helper(sycl::nd_item<1> __self_item, _TempStorageT __lacc)
         : __sgroup(__self_item.get_sub_group()), __self_lidx(__self_item.get_local_linear_id()),
-          __item_mask(~(~0u << (__self_lidx))), __atomic_peer_mask(*__lacc.get_pointer())
+          __item_mask(~(~0u << (__self_lidx))), __atomic_peer_mask(*__get_accessor_ptr(__lacc))
     {
     }
 
@@ -673,7 +673,7 @@ struct __parallel_radix_sort_iteration
 
         // work-group size must be a power of 2 and not less than the number of states.
         // TODO: Check how to get rid of that restriction.
-        __count_wg_size = 
+        __count_wg_size =
             sycl::max(oneapi::dpl::__internal::__dpl_bit_floor(__count_wg_size), ::std::size_t(__radix_states));
 
         // Compute the radix position for the given iteration

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -343,7 +343,7 @@ struct __peer_prefix_helper<_OffsetT, __peer_prefix_algo::atomic_fetch_or>
 
     __peer_prefix_helper(sycl::nd_item<1> __self_item, _TempStorageT __lacc)
         : __sgroup(__self_item.get_sub_group()), __self_lidx(__self_item.get_local_linear_id()),
-          __item_mask(~(~0u << (__self_lidx))), __atomic_peer_mask(*__get_accessor_ptr(__lacc))
+          __item_mask(~(~0u << (__self_lidx))), __atomic_peer_mask(*__dpl_sycl::__get_accessor_ptr(__lacc))
     {
     }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
@@ -168,7 +168,7 @@ struct __subgroup_radix_sort
 
                                 //1. "counting" phase
                                 //counter initialization
-                                auto __pcounter = __counter_lacc.get_pointer() + __wi;
+                                auto __pcounter = __dpl_sycl::__get_accessor_ptr(__counter_lacc) + __wi;
 
                                 _ONEDPL_PRAGMA_UNROLL
                                 for (uint16_t __i = 0; __i < __bin_count; ++__i)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -380,7 +380,8 @@ __get_host_access(_Buf&& __buf)
 }
 
 template <typename _Acc>
-auto __get_accessor_ptr(const _Acc& __acc)
+auto 
+__get_accessor_ptr(const _Acc& __acc)
 {
 #if _ONEDPL_LIBSYCL_VERSION >= 70000
     return __acc.template get_multi_ptr<sycl::access::decorated::no>().get();

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -380,7 +380,7 @@ __get_host_access(_Buf&& __buf)
 }
 
 template <typename _Acc>
-auto 
+auto
 __get_accessor_ptr(const _Acc& __acc)
 {
 #if _ONEDPL_LIBSYCL_VERSION >= 70000

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -360,12 +360,12 @@ struct __atomic_ref : sycl::atomic<_AtomicType, _Space>
 };
 #endif // _ONEDPL_SYCL2023_ATOMIC_REF_PRESENT
 
-template <typename DataT, int Dimensions = 1>
+template <typename _DataT, int _Dimensions = 1>
 using __local_accessor =
 #if _ONEDPL_LIBSYCL_VERSION >= 60000
-    sycl::local_accessor<DataT, Dimensions>;
+    sycl::local_accessor<_DataT, _Dimensions>;
 #else
-    sycl::accessor<DataT, Dimensions, sycl::access::mode::read_write, __dpl_sycl::__target::local>;
+    sycl::accessor<_DataT, _Dimensions, sycl::access::mode::read_write, __dpl_sycl::__target::local>;
 #endif
 
 template <typename _Buf>
@@ -376,6 +376,16 @@ __get_host_access(_Buf&& __buf)
     return ::std::forward<_Buf>(__buf).get_host_access(sycl::read_only);
 #else
     return ::std::forward<_Buf>(__buf).template get_access<sycl::access::mode::read>();
+#endif
+}
+
+template <typename _Acc>
+auto __get_accessor_ptr(const _Acc& __acc)
+{
+#if _ONEDPL_LIBSYCL_VERSION >= 70000
+    return __acc.template get_multi_ptr<sycl::access::decorated::no>().get();
+#else
+    return __acc.get_pointer();
 #endif
 }
 


### PR DESCRIPTION
`get_pointer` methods for buffer and local accessors recently became deprecated according to SYCL 2020 specification revision 8. 

You can find the information about the deprecation in [sycl-2020.pdf](https://github.com/oneapi-src/oneDPL/files/12422386/sycl-2020.pdf) (revision 8 is not published, this file has been generated from the latest sources on https://github.com/KhronosGroup/SYCL-Docs/tree/SYCL-2020/master). See Table 51 (Member functions of the accessor class) and Table 72 (Member functions of the local_accessor class). 

These APIs are already deprecated in the compiler in favor of `get_mult_ptr` (https://github.com/intel/llvm/pull/10174). This results in a warning, e.g:
> parallel_backend_sycl.h:634:32: warning: 'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr()

`get_pointer` returns a raw pointer, so it was replaced by `get_multi_ptr<sycl::access::decorated::no>().get()`, which also returns a raw, non-decorated, pointer. 

As a follow up task, we can investigate applicability of `sycl::access::decorated::yes`, but I am concerned about portability of it. Here are some notes from the specification: 
>Multi-pointer class
>If the value of access::decorated is access::decorated::yes, the interface exposes pointers and references type that are decorated by an address space. The decoration is implementation dependent and relies on device compiler extensions.
> ... 
> Member functions of multi_ptr class
> __unspecified__* get_decorated() const | Returns the underlying pointer decorated by the address space that it addresses. Note that the support involves implementation-defined device compiler extensions.
