### PR TITLE
Fix an error in __has_known_identity

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -48,7 +48,9 @@ using __has_known_identity =
     typename ::std::conjunction<
         ::std::is_arithmetic<_Tp>, __dpl_sycl::__has_known_identity<_BinaryOp, _Tp>,
         ::std::disjunction<::std::is_same<typename ::std::decay<_BinaryOp>::type, ::std::plus<_Tp>>,
+                           ::std::is_same<typename ::std::decay<_BinaryOp>::type, ::std::plus<void>>,
                            ::std::is_same<typename ::std::decay<_BinaryOp>::type, __dpl_sycl::__plus<_Tp>>,
+                           ::std::is_same<typename ::std::decay<_BinaryOp>::type, __dpl_sycl::__plus<void>>,
                            ::std::is_same<typename ::std::decay<_BinaryOp>::type, __dpl_sycl::__minimum<_Tp>>,
                            ::std::is_same<typename ::std::decay<_BinaryOp>::type, __dpl_sycl::__maximum<_Tp>>>>;
 #    else  //_ONEDPL_LIBSYCL_VERSION >= 50200


### PR DESCRIPTION
In this PR we add check of ```std::plus<void>``` and ```__dpl_sycl::__plus<void>``` functional objects into definition of ```__has_known_identity```