### PR TITLE
[Dynamic Selection] Auto-tune ignores 1st timing

### DIFF
--- a/include/oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h
@@ -101,8 +101,9 @@ class auto_tune_policy;
 
       size_type get_resource_to_profile() {
         std::unique_lock<std::mutex> l(m_);
-        if (next_resource_to_profile_ < max_resource_to_profile_) {
-          return next_resource_to_profile_++;
+        if (next_resource_to_profile_ < 2*max_resource_to_profile_) {
+          // do everything twice
+          return next_resource_to_profile_++ % max_resource_to_profile_;
         } else if (resample_time_ == never_resample) {
           return use_best_resource;
         } else {
@@ -123,7 +124,8 @@ class auto_tune_policy;
         auto offset = r.offset_;
         timing_t new_value = t;
         if (time_by_offset_.count(offset) == 0) {
-          time_by_offset_[offset] = time_data_t{1, t};
+          // ignore the 1st timing to cover for JIT compilation
+          time_by_offset_[offset] = time_data_t{0, std::numeric_limits<timing_t>::max()};
         } else {
           auto &td = time_by_offset_[offset];
           auto n = td.num_timings_;

--- a/test/parallel_api/dynamic_selection/sycl/test_auto_tune_policy_sycl.pass.cpp
+++ b/test/parallel_api/dynamic_selection/sycl/test_auto_tune_policy_sycl.pass.cpp
@@ -59,7 +59,7 @@ int test_auto_submit_wait_on_event(UniverseContainer u, int best_resource) {
   bool pass = true;
 
   for (int i = 1; i <= N; ++i) {
-    if (i <= n_samples && i-1 != best_resource) {
+    if (i <= 2*n_samples && i-1 != best_resource) {
         *j = 10000;
     } else {
         *j = 1;
@@ -71,9 +71,9 @@ int test_auto_submit_wait_on_event(UniverseContainer u, int best_resource) {
     // The unwrapped wait type should be equal to the resource 
     if constexpr (call_select_before_submit) {
       auto f = [&](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type q) {
-                   if (i <= n_samples) {
+                   if (i <= 2*n_samples) {
                      // we should be round-robining through the resources
-                     if (q != u[i-1]) {
+                     if (q != u[(i-1)%n_samples]) {
                        std::cout << i << ": mismatch during rr phase\n" << std::flush;
                        pass = false;
                      }
@@ -99,9 +99,9 @@ int test_auto_submit_wait_on_event(UniverseContainer u, int best_resource) {
       // it's ok to capture by reference since we are waiting on each call
       auto s = oneapi::dpl::experimental::submit(p,
                  [&](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type q) {
-                   if (i <= n_samples) {
+                   if (i <= 2*n_samples) {
                      // we should be round-robining through the resources
-                     if (q != u[i-1]) {
+                     if (q != u[(i-1)%n_samples]) {
                        std::cout << i << ": mismatch during rr phase\n" << std::flush;
                        pass = false;
                      }
@@ -157,7 +157,7 @@ int test_auto_submit_wait_on_group(UniverseContainer u, int best_resource) {
   bool pass = true;
 
   for (int i = 1; i <= N; ++i) {
-    if (i <= n_samples && i-1 != best_resource) {
+    if (i <= 2*n_samples && i-1 != best_resource) {
         *j = 10000;
     } else {
         *j = 1;
@@ -169,9 +169,9 @@ int test_auto_submit_wait_on_group(UniverseContainer u, int best_resource) {
     // The unwrapped wait type should be equal to the resource 
     if constexpr (call_select_before_submit) {
       auto f = [&](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type q) {
-                   if (i <= n_samples) {
+                   if (i <= 2*n_samples) {
                      // we should be round-robining through the resources
-                     if (q != u[i-1]) {
+                     if (q != u[(i-1)%n_samples]) {
                        std::cout << i << ": mismatch during rr phase\n" << std::flush;
                        pass = false;
                      }
@@ -197,9 +197,9 @@ int test_auto_submit_wait_on_group(UniverseContainer u, int best_resource) {
       // it's ok to capture by reference since we are waiting on each call
       auto s = oneapi::dpl::experimental::submit(p,
                  [&](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type q) {
-                   if (i <= n_samples) {
+                   if (i <= 2*n_samples) {
                      // we should be round-robining through the resources
-                     if (q != u[i-1]) {
+                     if (q != u[(i-1)%n_samples]) {
                        std::cout << i << ": mismatch during rr phase\n" << std::flush;
                        pass = false;
                      }
@@ -255,7 +255,7 @@ int test_auto_submit_and_wait(UniverseContainer u, int best_resource) {
   bool pass = true;
 
   for (int i = 1; i <= N; ++i) {
-    if (i <= n_samples && i-1 != best_resource) {
+    if (i <= 2*n_samples && i-1 != best_resource) {
         *j = 10000;
     } else {
         *j = 1;
@@ -267,9 +267,9 @@ int test_auto_submit_and_wait(UniverseContainer u, int best_resource) {
     // The unwrapped wait type should be equal to the resource 
     if constexpr (call_select_before_submit) {
       auto f = [&](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type q) {
-                   if (i <= n_samples) {
+                   if (i <= 2*n_samples) {
                      // we should be round-robining through the resources
-                     if (q != u[i-1]) {
+                     if (q != u[(i-1)%n_samples]) {
                        std::cout << i << ": mismatch during rr phase\n" << std::flush;
                        pass = false;
                      }
@@ -294,9 +294,9 @@ int test_auto_submit_and_wait(UniverseContainer u, int best_resource) {
       // it's ok to capture by reference since we are waiting on each call
       oneapi::dpl::experimental::submit_and_wait(p,
                  [&](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type q) {
-                   if (i <= n_samples) {
+                   if (i <= 2*n_samples) {
                      // we should be round-robining through the resources
-                     if (q != u[i-1]) {
+                     if (q != u[(i-1)%n_samples]) {
                        std::cout << i << ": mismatch during rr phase\n" << std::flush;
                        pass = false;
                      }
@@ -345,8 +345,8 @@ int main() {
   std::vector<sycl::queue> u = {q1, q2, q3, q4};
 
   auto f = [u](int i) { 
-             if (i <= 4)
-               return u[i-1]; 
+             if (i <= 8)
+               return u[(i-1)%4]; 
              else
                return u[0]; 
            };

--- a/test/parallel_api/dynamic_selection/test_auto_tune_policy_inline.pass.cpp
+++ b/test/parallel_api/dynamic_selection/test_auto_tune_policy_inline.pass.cpp
@@ -31,9 +31,9 @@ int test_auto_submit(UniverseContainer u, int best_resource) {
     if constexpr (do_select) {
       auto f = [&](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type e) {
                    std::this_thread::sleep_for(std::chrono::milliseconds(e));
-                   if (i <= n_samples) {
+                   if (i <= 2*n_samples) {
                      // we should be round-robining through the resources
-                     if (e != u[i-1]) {
+                     if (e != u[(i-1)%n_samples]) {
                        pass = false;
                      }
                    } else {
@@ -50,9 +50,9 @@ int test_auto_submit(UniverseContainer u, int best_resource) {
       oneapi::dpl::experimental::submit(p,
                  [&](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type e) {
                    std::this_thread::sleep_for(std::chrono::milliseconds(e));
-                   if (i <= n_samples) {
+                   if (i <= 2*n_samples) {
                      // we should be round-robining through the resources
-                     if (e != u[i-1]) {
+                     if (e != u[(i-1)%n_samples]) {
                        pass = false;
                      }
                    } else {
@@ -99,9 +99,9 @@ int test_auto_submit_wait_on_event(UniverseContainer u, int best_resource) {
     if constexpr (do_select) {
       auto f =  [&](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type e) {
                    std::this_thread::sleep_for(std::chrono::milliseconds(e));
-                   if (i <= n_samples) {
+                   if (i <= 2*n_samples) {
                      // we should be round-robining through the resources
-                     if (e != u[i-1]) {
+                     if (e != u[(i-1)%n_samples]) {
                        pass = false;
                      }
                    } else {
@@ -120,9 +120,9 @@ int test_auto_submit_wait_on_event(UniverseContainer u, int best_resource) {
       auto e = oneapi::dpl::experimental::submit(p,
                  [&](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type e) {
                    std::this_thread::sleep_for(std::chrono::milliseconds(e));
-                   if (i <= n_samples) {
+                   if (i <= 2*n_samples) {
                      // we should be round-robining through the resources
-                     if (e != u[i-1]) {
+                     if (e != u[(i-1)%n_samples]) {
                        pass = false;
                      }
                    } else {
@@ -137,10 +137,10 @@ int test_auto_submit_wait_on_event(UniverseContainer u, int best_resource) {
       e_val = oneapi::dpl::experimental::unwrap(e);
     }
 
-    if (i <= n_samples && e_val != u[i-1]) {
+    if (i <= 2*n_samples && e_val != u[(i-1)%n_samples]) {
       std::cout << "ERROR: wrong value in unwrapped wait_type when sampling " << i << ": " << e_val << " != " << u[i-1] << "\n";
       return 1;
-    } else if (i > n_samples && e_val != best_resource) {
+    } else if (i > 2*n_samples && e_val != best_resource) {
       std::cout << "ERROR: wrong value in unwrapped wait_type " << i << ": " << e_val << " != " << best_resource << "\n";
       return 1;
     } 
@@ -175,9 +175,9 @@ int test_auto_submit_wait_on_group(UniverseContainer u, int best_resource) {
     if constexpr (do_select) {
       auto f = [&](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type e) {
                    std::this_thread::sleep_for(std::chrono::milliseconds(e));
-                   if (i <= n_samples) {
+                   if (i <= 2*n_samples) {
                      // we should be round-robining through the resources
-                     if (e != u[i-1]) {
+                     if (e != u[(i-1)%n_samples]) {
                        pass = false;
                      }
                    } else {
@@ -194,9 +194,9 @@ int test_auto_submit_wait_on_group(UniverseContainer u, int best_resource) {
       oneapi::dpl::experimental::submit(p,
                  [&](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type e) {
                    std::this_thread::sleep_for(std::chrono::milliseconds(e));
-                   if (i <= n_samples) {
+                   if (i <= 2*n_samples) {
                      // we should be round-robining through the resources
-                     if (e != u[i-1]) {
+                     if (e != u[(i-1)%n_samples]) {
                        pass = false;
                      }
                    } else {
@@ -242,9 +242,9 @@ int test_auto_submit_and_wait(UniverseContainer u, int best_resource) {
     if constexpr (do_select) {
       auto f =  [&](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type e) {
                    std::this_thread::sleep_for(std::chrono::milliseconds(e));
-                   if (i <= n_samples) {
+                   if (i <= 2*n_samples) {
                      // we should be round-robining through the resources
-                     if (e != u[i-1]) {
+                     if (e != u[(i-1)%n_samples]) {
                        pass = false;
                      }
                    } else {
@@ -261,9 +261,9 @@ int test_auto_submit_and_wait(UniverseContainer u, int best_resource) {
       oneapi::dpl::experimental::submit_and_wait(p,
                  [&](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type e) {
                    std::this_thread::sleep_for(std::chrono::milliseconds(e));
-                   if (i <= n_samples) {
+                   if (i <= 2*n_samples) {
                      // we should be round-robining through the resources
-                     if (e != u[i-1]) {
+                     if (e != u[(i-1)%n_samples]) {
                        pass = false;
                      }
                    } else {
@@ -299,8 +299,8 @@ int run_tests(std::vector<int> u, int best_resource) {
   // So the first 4 are round-robin and then afterwards, with no better
   // info, the first resource is used.
   auto f = [u](int i) { 
-             if (i <= 4)
-               return u[i-1]; 
+             if (i <= 8)
+               return u[(i-1)%4]; 
              else
                return u[0]; 
            };


### PR DESCRIPTION
Do not consider first timing in auto-tune so that any JIT compilation overhead is ignored in decisions.