### PR TITLE
Remove typename .... ::type deom oneDPL code

### DIFF
--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -70,7 +70,7 @@ struct custom_brick
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename StrictWeakOrdering>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<typename ::std::decay<Policy>::type, OutputIterator>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<::std::decay_t<Policy>, OutputIterator>
 lower_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, InputIterator2 value_start,
                  InputIterator2 value_end, OutputIterator result, StrictWeakOrdering comp)
 {
@@ -82,7 +82,7 @@ lower_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, Inpu
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename StrictWeakOrdering>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<typename ::std::decay<Policy>::type, OutputIterator>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<::std::decay_t<Policy>, OutputIterator>
 upper_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, InputIterator2 value_start,
                  InputIterator2 value_end, OutputIterator result, StrictWeakOrdering comp)
 {
@@ -94,7 +94,7 @@ upper_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, Inpu
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename StrictWeakOrdering>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<typename ::std::decay<Policy>::type, OutputIterator>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<::std::decay_t<Policy>, OutputIterator>
 binary_search_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, InputIterator2 value_start,
                    InputIterator2 value_end, OutputIterator result, StrictWeakOrdering comp)
 {
@@ -107,7 +107,7 @@ binary_search_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, In
 #if _ONEDPL_BACKEND_SYCL
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename StrictWeakOrdering>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<typename ::std::decay<Policy>::type, OutputIterator>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<::std::decay_t<Policy>, OutputIterator>
 lower_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, InputIterator2 value_start,
                  InputIterator2 value_end, OutputIterator result, StrictWeakOrdering comp)
 {
@@ -137,7 +137,7 @@ lower_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, Inpu
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename StrictWeakOrdering>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<typename ::std::decay<Policy>::type, OutputIterator>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<::std::decay_t<Policy>, OutputIterator>
 upper_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, InputIterator2 value_start,
                  InputIterator2 value_end, OutputIterator result, StrictWeakOrdering comp)
 {
@@ -167,7 +167,7 @@ upper_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, Inpu
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename StrictWeakOrdering>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<typename ::std::decay<Policy>::type, OutputIterator>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<::std::decay_t<Policy>, OutputIterator>
 binary_search_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, InputIterator2 value_start,
                    InputIterator2 value_end, OutputIterator result, StrictWeakOrdering comp)
 {

--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -39,7 +39,7 @@ class ExclusiveScan2;
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator, typename T,
           typename BinaryPredicate, typename Operator>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<typename ::std::decay<Policy>::type, OutputIterator>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<::std::decay_t<Policy>, OutputIterator>
 pattern_exclusive_scan_by_segment(Policy&& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                                   OutputIterator result, T init, BinaryPredicate binary_pred, Operator binary_op)
 {
@@ -57,7 +57,7 @@ pattern_exclusive_scan_by_segment(Policy&& policy, InputIterator1 first1, InputI
     typedef typename ::std::iterator_traits<OutputIterator>::value_type OutputType;
     typedef typename ::std::iterator_traits<InputIterator2>::value_type ValueType;
     typedef unsigned int FlagType;
-    typedef typename ::std::decay<Policy>::type policy_type;
+    typedef ::std::decay_t<Policy> policy_type;
 
     InputIterator2 last2 = first2 + n;
 
@@ -94,7 +94,7 @@ pattern_exclusive_scan_by_segment(Policy&& policy, InputIterator1 first1, InputI
 #if _ONEDPL_BACKEND_SYCL
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator, typename T,
           typename BinaryPredicate, typename Operator>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<typename ::std::decay<Policy>::type, OutputIterator>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<::std::decay_t<Policy>, OutputIterator>
 exclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                                OutputIterator result, T init, BinaryPredicate binary_pred, Operator binary_op,
                                ::std::true_type /* has_known_identity*/)
@@ -105,7 +105,7 @@ exclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIter
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator, typename T,
           typename BinaryPredicate, typename Operator>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<typename ::std::decay<Policy>::type, OutputIterator>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<::std::decay_t<Policy>, OutputIterator>
 exclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                                OutputIterator result, T init, BinaryPredicate binary_pred, Operator binary_op,
                                ::std::false_type /* has_known_identity*/)
@@ -115,7 +115,7 @@ exclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIter
     typedef typename ::std::iterator_traits<OutputIterator>::value_type OutputType;
     typedef typename ::std::iterator_traits<InputIterator2>::value_type ValueType;
     typedef unsigned int FlagType;
-    typedef typename ::std::decay<Policy>::type policy_type;
+    typedef ::std::decay_t<Policy> policy_type;
 
     InputIterator2 last2 = first2 + n;
 

--- a/include/oneapi/dpl/internal/function.h
+++ b/include/oneapi/dpl/internal/function.h
@@ -41,7 +41,7 @@ using oneapi::dpl::__par_backend_hetero::__internal::__buffer;
 // algorithm from either a SYCL iterator or a USM pointer.
 template <sycl::access::mode Mode, typename Policy, typename Iterator>
 auto
-get_access(Policy, Iterator i, typename ::std::enable_if<is_hetero_iterator<Iterator>::value, void>::type* = nullptr)
+get_access(Policy, Iterator i, ::std::enable_if_t<is_hetero_iterator<Iterator>::value, void>* = nullptr)
     -> decltype(i.get_buffer().template get_access<Mode>())
 {
     return i.get_buffer().template get_access<Mode>();
@@ -49,7 +49,7 @@ get_access(Policy, Iterator i, typename ::std::enable_if<is_hetero_iterator<Iter
 
 template <sycl::access::mode Mode, typename Policy, typename Iterator>
 Iterator
-get_access(Policy, Iterator i, typename ::std::enable_if<!is_hetero_iterator<Iterator>::value, void>::type* = nullptr)
+get_access(Policy, Iterator i, ::std::enable_if_t<!is_hetero_iterator<Iterator>::value, void>* = nullptr)
 {
     return i;
 }
@@ -77,7 +77,7 @@ struct is_discard_iterator : ::std::false_type
 };
 
 template <typename Iter> // for discard iterators
-struct is_discard_iterator<Iter, typename ::std::enable_if<Iter::is_discard::value, void>::type> : ::std::true_type
+struct is_discard_iterator<Iter, ::std::enable_if_t<Iter::is_discard::value, void>> : ::std::true_type
 {
 };
 

--- a/include/oneapi/dpl/internal/gcd_impl.h
+++ b/include/oneapi/dpl/internal/gcd_impl.h
@@ -65,8 +65,8 @@ gcd(_Mn __m, _Nn __n)
 {
     static_assert((::std::is_integral<_Mn>::value && ::std::is_integral<_Nn>::value),
                   "Arguments to gcd must be integer types");
-    static_assert((!::std::is_same<::std::remove_cv_t<_Mn>, bool>::value), "First argument to gcd cannot be bool");
-    static_assert((!::std::is_same<::std::remove_cv_t<_Nn>, bool>::value), "Second argument to gcd cannot be bool");
+    static_assert((!::std::is_same_v<::std::remove_cv_t<_Mn>, bool>), "First argument to gcd cannot be bool");
+    static_assert((!::std::is_same_v<::std::remove_cv_t<_Nn>, bool>), "Second argument to gcd cannot be bool");
     using _Rp = ::std::common_type_t<_Mn, _Nn>;
     using _Wp = ::std::make_unsigned_t<_Rp>;
     _Wp __m1 = static_cast<_Wp>(oneapi::dpl::internal::__get_abs<_Rp>(__m));
@@ -88,8 +88,8 @@ lcm(_Mn __m, _Nn __n)
 {
     static_assert((::std::is_integral<_Mn>::value && ::std::is_integral<_Nn>::value),
                   "Arguments to lcm must be integer types");
-    static_assert((!::std::is_same<::std::remove_cv_t<_Mn>, bool>::value), "First argument to lcm cannot be bool");
-    static_assert((!::std::is_same<::std::remove_cv_t<_Nn>, bool>::value), "Second argument to lcm cannot be bool");
+    static_assert((!::std::is_same_v<::std::remove_cv_t<_Mn>, bool>), "First argument to lcm cannot be bool");
+    static_assert((!::std::is_same_v<::std::remove_cv_t<_Nn>, bool>), "Second argument to lcm cannot be bool");
     if (__m == 0 || __n == 0)
         return 0;
     using _Rp = ::std::common_type_t<_Mn, _Nn>;

--- a/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
@@ -38,7 +38,7 @@ class InclusiveScan1;
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename BinaryPredicate, typename BinaryOperator>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<typename ::std::decay<Policy>::type, OutputIterator>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<::std::decay_t<Policy>, OutputIterator>
 pattern_inclusive_scan_by_segment(Policy&& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                                   OutputIterator result, BinaryPredicate binary_pred, BinaryOperator binary_op)
 {
@@ -55,7 +55,7 @@ pattern_inclusive_scan_by_segment(Policy&& policy, InputIterator1 first1, InputI
 
     typedef unsigned int FlagType;
     typedef typename ::std::iterator_traits<InputIterator2>::value_type ValueType;
-    typedef typename ::std::decay<Policy>::type policy_type;
+    typedef ::std::decay_t<Policy> policy_type;
 
     oneapi::dpl::__par_backend::__buffer<policy_type, FlagType> _mask(n);
     auto mask = _mask.get();
@@ -75,7 +75,7 @@ pattern_inclusive_scan_by_segment(Policy&& policy, InputIterator1 first1, InputI
 #if _ONEDPL_BACKEND_SYCL
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename BinaryPredicate, typename BinaryOperator>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<typename ::std::decay<Policy>::type, OutputIterator>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<::std::decay_t<Policy>, OutputIterator>
 inclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                                OutputIterator result, BinaryPredicate binary_pred, BinaryOperator binary_op,
                                ::std::true_type /* has_known_identity */)
@@ -88,7 +88,7 @@ inclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIter
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename BinaryPredicate, typename BinaryOperator>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<typename ::std::decay<Policy>::type, OutputIterator>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<::std::decay_t<Policy>, OutputIterator>
 inclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                                OutputIterator result, BinaryPredicate binary_pred, BinaryOperator binary_op,
                                ::std::false_type /* has_known_identity */)
@@ -96,7 +96,7 @@ inclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIter
 
     typedef unsigned int FlagType;
     typedef typename ::std::iterator_traits<InputIterator2>::value_type ValueType;
-    typedef typename ::std::decay<Policy>::type policy_type;
+    typedef ::std::decay_t<Policy> policy_type;
 
     const auto n = ::std::distance(first1, last1);
 
@@ -127,7 +127,7 @@ inclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIter
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename BinaryPredicate, typename BinaryOperator>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<typename ::std::decay<Policy>::type, OutputIterator>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<::std::decay_t<Policy>, OutputIterator>
 pattern_inclusive_scan_by_segment(Policy&& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                                   OutputIterator result, BinaryPredicate binary_pred, BinaryOperator binary_op)
 {

--- a/include/oneapi/dpl/internal/random_impl/bernoulli_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/bernoulli_distribution.h
@@ -141,7 +141,7 @@ class bernoulli_distribution
 
     // Implementation for generate function
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         return generate_vec<_Ndistr, _Engine>(__engine, __params);
@@ -149,7 +149,7 @@ class bernoulli_distribution
 
     // Specialization of the scalar generation
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr == 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr == 0), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         oneapi::dpl::uniform_real_distribution<double> __distr;
@@ -158,7 +158,7 @@ class bernoulli_distribution
 
     // Specialization of the vector generation with size = [1; 2; 3]
     template <int __N, class _Engine>
-    typename ::std::enable_if<(__N <= 3), result_type>::type
+    ::std::enable_if_t<(__N <= 3), result_type>
     generate_vec(_Engine& __engine, const param_type& __params)
     {
         return generate_n_elems<_Engine>(__engine, __params, __N);
@@ -166,7 +166,7 @@ class bernoulli_distribution
 
     // Specialization of the vector generation with size = [4; 8; 16]
     template <int __N, class _Engine>
-    typename ::std::enable_if<(__N > 3), result_type>::type
+    ::std::enable_if_t<(__N > 3), result_type>
     generate_vec(_Engine& __engine, const param_type& __params)
     {
         oneapi::dpl::uniform_real_distribution<sycl::vec<double, __N>> __distr;
@@ -192,7 +192,7 @@ class bernoulli_distribution
 
     // Implementation for result_portion function
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     result_portion_internal(_Engine& __engine, const param_type& __params, unsigned int __N)
     {
         result_type __part_vec;

--- a/include/oneapi/dpl/internal/random_impl/bernoulli_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/bernoulli_distribution.h
@@ -133,7 +133,7 @@ class bernoulli_distribution
     static constexpr int size_of_type_ = internal::type_traits_t<result_type>::num_elems;
 
     // Static asserts
-    static_assert(::std::is_same<scalar_type, bool>::value,
+    static_assert(::std::is_same_v<scalar_type, bool>,
                   "oneapi::dpl::bernoulli_distribution. Error: unsupported data type");
 
     // Distribution parameters

--- a/include/oneapi/dpl/internal/random_impl/cauchy_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/cauchy_distribution.h
@@ -155,7 +155,7 @@ class cauchy_distribution
 
     // Implementation for generate function
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         return generate_vec<_Ndistr, _Engine>(__engine, __params);
@@ -163,7 +163,7 @@ class cauchy_distribution
 
     // Specialization of the scalar generation
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr == 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr == 0), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         oneapi::dpl::uniform_real_distribution<scalar_type> __u;
@@ -172,7 +172,7 @@ class cauchy_distribution
 
     // Specialization of the vector generation with size = [1; 2; 3]
     template <int __N, class _Engine>
-    typename ::std::enable_if<(__N <= 3), result_type>::type
+    ::std::enable_if_t<(__N <= 3), result_type>
     generate_vec(_Engine& __engine, const param_type& __params)
     {
         return generate_n_elems<_Engine>(__engine, __params, __N);
@@ -180,7 +180,7 @@ class cauchy_distribution
 
     // Specialization of the vector generation with size = [4; 8; 16]
     template <int __N, class _Engine>
-    typename ::std::enable_if<(__N > 3), result_type>::type
+    ::std::enable_if_t<(__N > 3), result_type>
     generate_vec(_Engine& __engine, const param_type& __params)
     {
         oneapi::dpl::uniform_real_distribution<sycl::vec<scalar_type, __N>> __distr;
@@ -202,7 +202,7 @@ class cauchy_distribution
 
     // Implementation for result_portion function
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     result_portion_internal(_Engine& __engine, const param_type& __params, unsigned int __N)
     {
         result_type __part_vec;

--- a/include/oneapi/dpl/internal/random_impl/discard_block_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/discard_block_engine.h
@@ -139,7 +139,7 @@ class discard_block_engine
 
     // Function for state adjustment
     template <int _N>
-    typename ::std::enable_if<(_N == 0), scalar_type>::type
+    ::std::enable_if_t<(_N == 0), scalar_type>
     generate_internal_scalar()
     {
         if (n_ >= used_block)
@@ -152,7 +152,7 @@ class discard_block_engine
     };
 
     template <int N>
-    typename ::std::enable_if<(N > 0), scalar_type>::type
+    ::std::enable_if_t<(N > 0), scalar_type>
     generate_internal_scalar()
     {
         if (n_ >= used_block)
@@ -166,14 +166,14 @@ class discard_block_engine
 
     // Generate implementation
     template <int _N>
-    typename ::std::enable_if<(_N == 0), result_type>::type
+    ::std::enable_if_t<(_N == 0), result_type>
     generate_internal()
     {
         return generate_internal_scalar<internal::type_traits_t<result_type>::num_elems>();
     }
 
     template <int _N>
-    typename ::std::enable_if<(_N > 0), result_type>::type
+    ::std::enable_if_t<(_N > 0), result_type>
     generate_internal()
     {
         result_type __res;
@@ -193,7 +193,7 @@ class discard_block_engine
     }
 
     template <int _N>
-    typename ::std::enable_if<(_N > 0), result_type>::type
+    ::std::enable_if_t<(_N > 0), result_type>
     generate_internal(unsigned int __random_nums)
     {
         if (__random_nums >= _N)

--- a/include/oneapi/dpl/internal/random_impl/exponential_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/exponential_distribution.h
@@ -141,7 +141,7 @@ class exponential_distribution
 
     // Implementation for generate function
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         return generate_vec<_Ndistr, _Engine>(__engine, __params);
@@ -149,7 +149,7 @@ class exponential_distribution
 
     // Specialization of the scalar generation
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr == 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr == 0), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         result_type __res;
@@ -160,7 +160,7 @@ class exponential_distribution
 
     // Specialization of the vector generation  with size = [1; 2; 3]
     template <int __N, class _Engine>
-    typename ::std::enable_if<(__N <= 3), result_type>::type
+    ::std::enable_if_t<(__N <= 3), result_type>
     generate_vec(_Engine& __engine, const param_type& __params)
     {
         return generate_n_elems<_Engine>(__engine, __params, __N);
@@ -168,7 +168,7 @@ class exponential_distribution
 
     // Specialization of the vector generation with size = [4; 8; 16]
     template <int __N, class _Engine>
-    typename ::std::enable_if<(__N > 3), result_type>::type
+    ::std::enable_if_t<(__N > 3), result_type>
     generate_vec(_Engine& __engine, const param_type& __params)
     {
         oneapi::dpl::uniform_real_distribution<result_type> __u;
@@ -194,7 +194,7 @@ class exponential_distribution
 
     // Implementation for result_portion function
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     result_portion_internal(_Engine& __engine, const param_type& __params, unsigned int __N)
     {
         result_type __part_vec;

--- a/include/oneapi/dpl/internal/random_impl/extreme_value_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/extreme_value_distribution.h
@@ -170,7 +170,7 @@ class extreme_value_distribution
 
     // Implementation for generate function
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         return generate_vec<_Ndistr, _Engine>(__engine, __params);
@@ -178,7 +178,7 @@ class extreme_value_distribution
 
     // Specialization of the scalar generation
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr == 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr == 0), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         oneapi::dpl::exponential_distribution<scalar_type> __distr;
@@ -189,7 +189,7 @@ class extreme_value_distribution
 
     // Specialization of the vector generation with size = [1; 2; 3]
     template <int __N, class _Engine>
-    typename ::std::enable_if<(__N <= 3), result_type>::type
+    ::std::enable_if_t<(__N <= 3), result_type>
     generate_vec(_Engine& __engine, const param_type& __params)
     {
         return generate_n_elems<_Engine>(__engine, __params, __N);
@@ -197,7 +197,7 @@ class extreme_value_distribution
 
     // Specialization of the vector generation with size = [4; 8; 16]
     template <int __N, class _Engine>
-    typename ::std::enable_if<(__N > 3), result_type>::type
+    ::std::enable_if_t<(__N > 3), result_type>
     generate_vec(_Engine& __engine, const param_type& __params)
     {
         oneapi::dpl::exponential_distribution<result_type> __distr;
@@ -226,7 +226,7 @@ class extreme_value_distribution
 
     // Implementation for result_portion function
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     result_portion_internal(_Engine& __engine, const param_type& __params, unsigned int __N)
     {
         result_type __part_vec;

--- a/include/oneapi/dpl/internal/random_impl/geometric_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/geometric_distribution.h
@@ -141,7 +141,7 @@ class geometric_distribution
 
     // Implementation for generate function
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         return generate_vec<_Ndistr, _Engine>(__engine, __params);
@@ -149,7 +149,7 @@ class geometric_distribution
 
     // Specialization of the scalar generation
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr == 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr == 0), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         oneapi::dpl::uniform_real_distribution<double> __u;
@@ -158,7 +158,7 @@ class geometric_distribution
 
     // Specialization of the vector generation with size = [1; 2; 3]
     template <int __N, class _Engine>
-    typename ::std::enable_if<(__N <= 3), result_type>::type
+    ::std::enable_if_t<(__N <= 3), result_type>
     generate_vec(_Engine& __engine, const param_type& __params)
     {
         return generate_n_elems<_Engine>(__engine, __params, __N);
@@ -166,7 +166,7 @@ class geometric_distribution
 
     // Specialization of the vector generation with size = [4; 8; 16]
     template <int __N, class _Engine>
-    typename ::std::enable_if<(__N > 3), result_type>::type
+    ::std::enable_if_t<(__N > 3), result_type>
     generate_vec(_Engine& __engine, const param_type& __params)
     {
         oneapi::dpl::uniform_real_distribution<sycl::vec<double, __N>> __distr;
@@ -191,7 +191,7 @@ class geometric_distribution
 
     // Implementation for result_portion function
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     result_portion_internal(_Engine& __engine, const param_type& __params, unsigned int __N)
     {
         result_type __part_vec;

--- a/include/oneapi/dpl/internal/random_impl/linear_congruential_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/linear_congruential_engine.h
@@ -114,7 +114,7 @@ class linear_congruential_engine
 
     // Initialization function
     template <int _N = 0>
-    typename ::std::enable_if<(_N == 0)>::type
+    ::std::enable_if_t<(_N == 0)>
     init(scalar_type __seed)
     {
         if ((increment % modulus == 0) && (__seed % modulus == 0))
@@ -129,7 +129,7 @@ class linear_congruential_engine
     }
 
     template <int _N = 0>
-    typename ::std::enable_if<(_N > 0)>::type
+    ::std::enable_if_t<(_N > 0)>
     init(scalar_type __seed)
     {
         if ((increment % modulus == 0) && (__seed % modulus == 0))
@@ -177,7 +177,7 @@ class linear_congruential_engine
     // _FLAG - is flag that used for optimizations
     // if _FLAG == true in this case we can used optimized versions of skip_seq
     template <int _N = 0, bool _FLAG = false>
-    typename ::std::enable_if<(_N == 0) && (_FLAG == false)>::type
+    ::std::enable_if_t<(_N == 0) && (_FLAG == false)>
     skip_seq(unsigned long long __num_to_skip)
     {
         for (; __num_to_skip > 0; --__num_to_skip)
@@ -185,7 +185,7 @@ class linear_congruential_engine
     }
 
     template <int _N = 0, bool _FLAG = false>
-    typename ::std::enable_if<(_N == 1) && (_FLAG == false)>::type
+    ::std::enable_if_t<(_N == 1) && (_FLAG == false)>
     skip_seq(unsigned long long __num_to_skip)
     {
         for (; __num_to_skip > 0; --__num_to_skip)
@@ -193,7 +193,7 @@ class linear_congruential_engine
     }
 
     template <int _N = 0, bool _FLAG = false>
-    typename ::std::enable_if<(_N > 1) && (_FLAG == false)>::type
+    ::std::enable_if_t<(_N > 1) && (_FLAG == false)>
     skip_seq(unsigned long long __num_to_skip)
     {
         for (; __num_to_skip > 0; --__num_to_skip)
@@ -207,7 +207,7 @@ class linear_congruential_engine
     }
 
     template <int _N = 0, bool _FLAG = false>
-    typename ::std::enable_if<(_N == 0) && (_FLAG == true)>::type
+    ::std::enable_if_t<(_N == 0) && (_FLAG == true)>
     skip_seq(unsigned long long __num_to_skip)
     {
         ::std::uint64_t __mod = modulus;
@@ -216,7 +216,7 @@ class linear_congruential_engine
     }
 
     template <int _N = 0, bool _FLAG = false>
-    typename ::std::enable_if<(_N == 1) && (_FLAG == true)>::type
+    ::std::enable_if_t<(_N == 1) && (_FLAG == true)>
     skip_seq(unsigned long long __num_to_skip)
     {
         ::std::uint64_t __mod = modulus;
@@ -225,7 +225,7 @@ class linear_congruential_engine
     }
 
     template <int _N = 0, bool _FLAG = false>
-    typename ::std::enable_if<(_N > 1) && (_FLAG == true)>::type
+    ::std::enable_if_t<(_N > 1) && (_FLAG == true)>
     skip_seq(unsigned long long __num_to_skip)
     {
         ::std::uint64_t __mod = modulus;
@@ -235,7 +235,7 @@ class linear_congruential_engine
 
     // result_portion implementation
     template <int _N>
-    typename ::std::enable_if<(_N > 0), result_type>::type
+    ::std::enable_if_t<(_N > 0), result_type>
     result_portion_internal(unsigned int __random_nums)
     {
         result_type __part_vec;

--- a/include/oneapi/dpl/internal/random_impl/lognormal_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/lognormal_distribution.h
@@ -147,8 +147,8 @@ class lognormal_distribution
     // Size of type
     static constexpr int size_of_type_ = internal::type_traits_t<result_type>::num_elems;
 
-    using normal_distr = oneapi::dpl::normal_distribution<
-        typename ::std::conditional<(size_of_type_ <= 3), scalar_type, result_type>::type>;
+    using normal_distr =
+        oneapi::dpl::normal_distribution<::std::conditional_t<(size_of_type_ <= 3), scalar_type, result_type>>;
     using normal_distr_param_type = typename normal_distr::param_type;
 
     // Static asserts

--- a/include/oneapi/dpl/internal/random_impl/lognormal_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/lognormal_distribution.h
@@ -160,7 +160,7 @@ class lognormal_distribution
 
     // Implementation for generate function
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         return generate_vec<_Ndistr, _Engine>(__engine, __params);
@@ -168,7 +168,7 @@ class lognormal_distribution
 
     // Specialization of the scalar generation
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr == 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr == 0), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         return sycl::exp(nd_(__engine, normal_distr_param_type(__params.m(), __params.s())));
@@ -176,7 +176,7 @@ class lognormal_distribution
 
     // Specialization of the vector generation with size = [1; 2; 3]
     template <int __N, class _Engine>
-    typename ::std::enable_if<(__N <= 3), result_type>::type
+    ::std::enable_if_t<(__N <= 3), result_type>
     generate_vec(_Engine& __engine, const param_type& __params)
     {
         result_type __res;
@@ -187,7 +187,7 @@ class lognormal_distribution
 
     // Specialization of the vector generation with size = [4; 8; 16]
     template <int __N, class _Engine>
-    typename ::std::enable_if<(__N > 3), result_type>::type
+    ::std::enable_if_t<(__N > 3), result_type>
     generate_vec(_Engine& __engine, const param_type& __params)
     {
         return sycl::exp(nd_(__engine, normal_distr_param_type(__params.m(), __params.s())));
@@ -195,7 +195,7 @@ class lognormal_distribution
 
     // Implementation for the N vector's elements generation with size = [4; 8; 16]
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr > 3), result_type>::type
+    ::std::enable_if_t<(_Ndistr > 3), result_type>
     generate_n_elems(_Engine& __engine, const param_type& __params, unsigned int __N)
     {
         result_type __res = nd_(__engine, normal_distr_param_type(__params.m(), __params.s()), __N);
@@ -206,7 +206,7 @@ class lognormal_distribution
 
     // Implementation for the N vector's elements generation with size = [1; 2; 3]
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr <= 3), result_type>::type
+    ::std::enable_if_t<(_Ndistr <= 3), result_type>
     generate_n_elems(_Engine& __engine, const param_type& __params, unsigned int __N)
     {
         result_type __res;
@@ -217,7 +217,7 @@ class lognormal_distribution
 
     // Implementation for result_portion function
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     result_portion_internal(_Engine& __engine, const param_type& __params, unsigned int __N)
     {
         result_type __part_vec;

--- a/include/oneapi/dpl/internal/random_impl/normal_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/normal_distribution.h
@@ -166,7 +166,7 @@ class normal_distribution
 
     // Type of real distribution
     using uniform_result_type =
-        typename ::std::conditional<size_of_type_ % 2, sycl::vec<scalar_type, size_of_type_ + 1>, result_type>::type;
+        ::std::conditional_t<size_of_type_ % 2, sycl::vec<scalar_type, size_of_type_ + 1>, result_type>;
 
     // Distribution parameters
     scalar_type mean_;

--- a/include/oneapi/dpl/internal/random_impl/normal_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/normal_distribution.h
@@ -215,7 +215,7 @@ class normal_distribution
 
     // Implementation for generate function
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     generate(_Engine& __engine, const param_type __params)
     {
         return generate_vec<_Ndistr, _Engine>(__engine, __params);
@@ -223,7 +223,7 @@ class normal_distribution
 
     // Specialization of the scalar generation
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr == 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr == 0), result_type>
     generate(_Engine& __engine, const param_type __params)
     {
         result_type __res;
@@ -257,7 +257,7 @@ class normal_distribution
 
     // Specialization of the vector generation with size = [1; 2; 3]
     template <int __N, class _Engine>
-    typename ::std::enable_if<(__N <= 3), result_type>::type
+    ::std::enable_if_t<(__N <= 3), result_type>
     generate_vec(_Engine& __engine, const param_type __params)
     {
         return generate_n_elems<_Engine>(__engine, __params, __N);
@@ -265,7 +265,7 @@ class normal_distribution
 
     // Specialization of the vector generation with size = [4; 8; 16]
     template <int __N, class _Engine>
-    typename ::std::enable_if<(__N > 3), result_type>::type
+    ::std::enable_if_t<(__N > 3), result_type>
     generate_vec(_Engine& __engine, const param_type __params)
     {
         uniform_result_type __u;
@@ -404,7 +404,7 @@ class normal_distribution
 
     // Implementation for result_portion function
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     result_portion_internal(_Engine& __engine, const param_type __params, unsigned int __N)
     {
         result_type __part_vec;

--- a/include/oneapi/dpl/internal/random_impl/subtract_with_carry_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/subtract_with_carry_engine.h
@@ -136,14 +136,14 @@ class subtract_with_carry_engine
 
     // Generate implementation
     template <int _N>
-    typename ::std::enable_if<(_N == 0), result_type>::type
+    ::std::enable_if_t<(_N == 0), result_type>
     generate_internal()
     {
         return generate_internal_scalar();
     }
 
     template <int _N>
-    typename ::std::enable_if<(_N > 0), result_type>::type
+    ::std::enable_if_t<(_N > 0), result_type>
     generate_internal()
     {
         result_type __res;
@@ -156,7 +156,7 @@ class subtract_with_carry_engine
 
     // result_portion implementation
     template <int _N>
-    typename ::std::enable_if<(_N > 0), result_type>::type
+    ::std::enable_if_t<(_N > 0), result_type>
     result_portion_internal(unsigned int __random_nums)
     {
         result_type __part_vec;

--- a/include/oneapi/dpl/internal/random_impl/uniform_int_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/uniform_int_distribution.h
@@ -151,7 +151,7 @@ class uniform_int_distribution
     static constexpr int size_of_type_ = internal::type_traits_t<result_type>::num_elems;
 
     // Type of real distribution
-    using RealType = typename ::std::conditional<size_of_type_ == 0, double, sycl::vec<double, size_of_type_>>::type;
+    using RealType = ::std::conditional_t<size_of_type_ == 0, double, sycl::vec<double, size_of_type_>>;
 
     // Static asserts
     static_assert(::std::is_integral<scalar_type>::value,

--- a/include/oneapi/dpl/internal/random_impl/uniform_int_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/uniform_int_distribution.h
@@ -166,7 +166,7 @@ class uniform_int_distribution
 
     // Implementation for generate function
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         RealType __res = uniform_real_distribution_(
@@ -181,7 +181,7 @@ class uniform_int_distribution
     }
 
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr == 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr == 0), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         RealType __res = uniform_real_distribution_(
@@ -193,7 +193,7 @@ class uniform_int_distribution
 
     // Implementation for result_portion function
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     result_portion_internal(_Engine& __engine, const param_type& __params, unsigned int __N)
     {
         result_type __part_vec;

--- a/include/oneapi/dpl/internal/random_impl/uniform_real_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/uniform_real_distribution.h
@@ -158,7 +158,7 @@ class uniform_real_distribution
 
     // Implementation for generate function
     template <int _Ndistr, int _Nengine, class _Engine>
-    typename ::std::enable_if<((_Ndistr == _Nengine) & (_Ndistr != 0)), result_type>::type
+    ::std::enable_if_t<((_Ndistr == _Nengine) & (_Ndistr != 0)), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         auto __engine_output = __engine();
@@ -174,7 +174,7 @@ class uniform_real_distribution
     }
 
     template <int _Ndistr, int _Nengine, class _Engine>
-    typename ::std::enable_if<((_Ndistr == _Nengine) & (_Ndistr == 0)), result_type>::type
+    ::std::enable_if_t<((_Ndistr == _Nengine) & (_Ndistr == 0)), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         auto __engine_output = __engine();
@@ -187,7 +187,7 @@ class uniform_real_distribution
     }
 
     template <int _Ndistr, int _Nengine, class _Engine>
-    typename ::std::enable_if<((_Ndistr < _Nengine) & (_Ndistr != 0)), result_type>::type
+    ::std::enable_if_t<((_Ndistr < _Nengine) & (_Ndistr != 0)), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         auto __engine_output = __engine(_Ndistr);
@@ -204,7 +204,7 @@ class uniform_real_distribution
     }
 
     template <int _Ndistr, int _Nengine, class _Engine>
-    typename ::std::enable_if<((_Ndistr < _Nengine) & (_Ndistr == 0)), result_type>::type
+    ::std::enable_if_t<((_Ndistr < _Nengine) & (_Ndistr == 0)), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         scalar_type __res = static_cast<scalar_type>(__engine(1)[0]);
@@ -215,7 +215,7 @@ class uniform_real_distribution
     }
 
     template <int _Ndistr, int _Nengine, class _Engine>
-    typename ::std::enable_if<((_Ndistr > _Nengine) & (_Nengine != 0)), result_type>::type
+    ::std::enable_if_t<((_Ndistr > _Nengine) & (_Nengine != 0)), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         sycl::vec<scalar_type, _Ndistr> __res;
@@ -250,7 +250,7 @@ class uniform_real_distribution
     }
 
     template <int _Ndistr, int _Nengine, class _Engine>
-    typename ::std::enable_if<((_Ndistr > _Nengine) & (_Nengine == 0)), result_type>::type
+    ::std::enable_if_t<((_Ndistr > _Nengine) & (_Nengine == 0)), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         sycl::vec<scalar_type, _Ndistr> __res;
@@ -267,7 +267,7 @@ class uniform_real_distribution
 
     // Implementation for result_portion function
     template <int _Ndistr, int _Nengine, class _Engine>
-    typename ::std::enable_if<((_Ndistr <= _Nengine) & (_Ndistr != 0)), result_type>::type
+    ::std::enable_if_t<((_Ndistr <= _Nengine) & (_Ndistr != 0)), result_type>
     generate_n_elems(_Engine& __engine, const param_type& __params, unsigned int __N)
     {
         auto __engine_output = __engine(__N);
@@ -284,7 +284,7 @@ class uniform_real_distribution
     }
 
     template <int _Ndistr, int _Nengine, class _Engine>
-    typename ::std::enable_if<((_Ndistr > _Nengine) & (_Nengine != 0)), result_type>::type
+    ::std::enable_if_t<((_Ndistr > _Nengine) & (_Nengine != 0)), result_type>
     generate_n_elems(_Engine& __engine, const param_type& __params, unsigned int __N)
     {
         result_type __res;
@@ -338,7 +338,7 @@ class uniform_real_distribution
     }
 
     template <int _Ndistr, int _Nengine, class _Engine>
-    typename ::std::enable_if<((_Ndistr > _Nengine) & (_Nengine == 0)), result_type>::type
+    ::std::enable_if_t<((_Ndistr > _Nengine) & (_Nengine == 0)), result_type>
     generate_n_elems(_Engine& __engine, const param_type& __params, unsigned int __N)
     {
         result_type __res;
@@ -355,7 +355,7 @@ class uniform_real_distribution
 
     // Implementation for result_portion function
     template <int _Ndistr, int _Nengine, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     result_portion_internal(_Engine& __engine, const param_type __params, unsigned int __N)
     {
         result_type __part_vec;

--- a/include/oneapi/dpl/internal/random_impl/weibull_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/weibull_distribution.h
@@ -155,7 +155,7 @@ class weibull_distribution
 
     // Implementation for generate function
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         return generate_vec<_Ndistr, _Engine>(__engine, __params);
@@ -163,7 +163,7 @@ class weibull_distribution
 
     // Specialization of the scalar generation
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr == 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr == 0), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         oneapi::dpl::uniform_real_distribution<scalar_type> __u;
@@ -172,7 +172,7 @@ class weibull_distribution
 
     // Specialization of the vector generation with size = [1; 2; 3]
     template <int __N, class _Engine>
-    typename ::std::enable_if<(__N <= 3), result_type>::type
+    ::std::enable_if_t<(__N <= 3), result_type>
     generate_vec(_Engine& __engine, const param_type& __params)
     {
         return generate_n_elems<_Engine>(__engine, __params, __N);
@@ -180,7 +180,7 @@ class weibull_distribution
 
     // Specialization of the vector generation with size = [4; 8; 16]
     template <int __N, class _Engine>
-    typename ::std::enable_if<(__N > 3), result_type>::type
+    ::std::enable_if_t<(__N > 3), result_type>
     generate_vec(_Engine& __engine, const param_type& __params)
     {
         oneapi::dpl::uniform_real_distribution<sycl::vec<scalar_type, __N>> __distr;
@@ -203,7 +203,7 @@ class weibull_distribution
 
     // Implementation for result_portion function
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     result_portion_internal(_Engine& __engine, const param_type& __params, unsigned int __N)
     {
         result_type __part_vec;

--- a/include/oneapi/dpl/internal/reduce_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/reduce_by_segment_impl.h
@@ -80,7 +80,7 @@ class Reduce4;
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator1,
           typename OutputIterator2, typename BinaryPred, typename BinaryOperator>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<typename ::std::decay<Policy>::type,
+oneapi::dpl::__internal::__enable_if_host_execution_policy<::std::decay_t<Policy>,
                                                            ::std::pair<OutputIterator1, OutputIterator2>>
 reduce_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                        OutputIterator1 result1, OutputIterator2 result2, BinaryPred binary_pred,
@@ -110,7 +110,7 @@ reduce_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIterator1 la
     typedef uint64_t FlagType;
     typedef typename ::std::iterator_traits<InputIterator2>::value_type ValueType;
     typedef uint64_t CountType;
-    typedef typename ::std::decay<Policy>::type policy_type;
+    typedef ::std::decay_t<Policy> policy_type;
 
     // buffer that is used to store a flag indicating if the associated key is not equal to
     // the next key, and thus its associated sum should be part of the final result
@@ -578,7 +578,7 @@ __sycl_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2&& 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator1,
           typename OutputIterator2, typename BinaryPred, typename BinaryOperator>
 typename ::std::enable_if<
-    oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<Policy>::type>::value,
+    oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value,
     ::std::pair<OutputIterator1, OutputIterator2>>::type
 reduce_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                        OutputIterator1 result1, OutputIterator2 result2, BinaryPred binary_pred,

--- a/include/oneapi/dpl/internal/reduce_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/reduce_by_segment_impl.h
@@ -577,9 +577,9 @@ __sycl_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2&& 
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator1,
           typename OutputIterator2, typename BinaryPred, typename BinaryOperator>
-typename ::std::enable_if<
+::std::enable_if_t<
     oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value,
-    ::std::pair<OutputIterator1, OutputIterator2>>::type
+    ::std::pair<OutputIterator1, OutputIterator2>>
 reduce_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                        OutputIterator1 result1, OutputIterator2 result2, BinaryPred binary_pred,
                        BinaryOperator binary_op)

--- a/include/oneapi/dpl/internal/scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/scan_by_segment_impl.h
@@ -367,7 +367,7 @@ struct __sycl_scan_by_segment_impl
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator, typename T,
           typename BinaryPredicate, typename Operator, typename Inclusive>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<typename ::std::decay<Policy>::type, OutputIterator>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<::std::decay_t<Policy>, OutputIterator>
 __scan_by_segment_impl_common(Policy&& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                               OutputIterator result, T init, BinaryPredicate binary_pred, Operator binary_op, Inclusive)
 {

--- a/include/oneapi/dpl/pstl/execution_defs.h
+++ b/include/oneapi/dpl/pstl/execution_defs.h
@@ -177,17 +177,17 @@ struct __is_host_execution_policy<oneapi::dpl::execution::unsequenced_policy> : 
 };
 
 template <class _ExecPolicy, class _T>
-using __enable_if_execution_policy = typename ::std::enable_if<
-    oneapi::dpl::execution::is_execution_policy<::std::decay_t<_ExecPolicy>>::value, _T>::type;
+using __enable_if_execution_policy = ::std::enable_if_t<
+    oneapi::dpl::execution::is_execution_policy<::std::decay_t<_ExecPolicy>>::value, _T>;
 
 template <class _ExecPolicy, class _T>
-using __enable_if_host_execution_policy = typename ::std::enable_if<
-    oneapi::dpl::__internal::__is_host_execution_policy<::std::decay_t<_ExecPolicy>>::value, _T>::type;
+using __enable_if_host_execution_policy = ::std::enable_if_t<
+    oneapi::dpl::__internal::__is_host_execution_policy<::std::decay_t<_ExecPolicy>>::value, _T>;
 
 template <class _ExecPolicy, const bool __condition, class _T>
-using __enable_if_host_execution_policy_conditional = typename ::std::enable_if<
+using __enable_if_host_execution_policy_conditional = ::std::enable_if_t<
     oneapi::dpl::__internal::__is_host_execution_policy<::std::decay_t<_ExecPolicy>>::value && __condition,
-    _T>::type;
+    _T>;
 
 template <typename _ExecPolicy, typename _T>
 struct __ref_or_copy_impl

--- a/include/oneapi/dpl/pstl/execution_defs.h
+++ b/include/oneapi/dpl/pstl/execution_defs.h
@@ -209,7 +209,7 @@ auto
 __check_size(...) -> decltype(::std::declval<_R&>().get_count());
 
 template <typename _R>
-using __difference_t = typename ::std::make_signed<decltype(__check_size<_R>(0))>::type;
+using __difference_t = ::std::make_signed_t<decltype(__check_size<_R>(0))>;
 
 } // namespace __internal
 

--- a/include/oneapi/dpl/pstl/execution_defs.h
+++ b/include/oneapi/dpl/pstl/execution_defs.h
@@ -178,15 +178,15 @@ struct __is_host_execution_policy<oneapi::dpl::execution::unsequenced_policy> : 
 
 template <class _ExecPolicy, class _T>
 using __enable_if_execution_policy = typename ::std::enable_if<
-    oneapi::dpl::execution::is_execution_policy<typename ::std::decay<_ExecPolicy>::type>::value, _T>::type;
+    oneapi::dpl::execution::is_execution_policy<::std::decay_t<_ExecPolicy>>::value, _T>::type;
 
 template <class _ExecPolicy, class _T>
 using __enable_if_host_execution_policy = typename ::std::enable_if<
-    oneapi::dpl::__internal::__is_host_execution_policy<typename ::std::decay<_ExecPolicy>::type>::value, _T>::type;
+    oneapi::dpl::__internal::__is_host_execution_policy<::std::decay_t<_ExecPolicy>>::value, _T>::type;
 
 template <class _ExecPolicy, const bool __condition, class _T>
 using __enable_if_host_execution_policy_conditional = typename ::std::enable_if<
-    oneapi::dpl::__internal::__is_host_execution_policy<typename ::std::decay<_ExecPolicy>::type>::value && __condition,
+    oneapi::dpl::__internal::__is_host_execution_policy<::std::decay_t<_ExecPolicy>>::value && __condition,
     _T>::type;
 
 template <typename _ExecPolicy, typename _T>
@@ -197,7 +197,7 @@ struct __ref_or_copy_impl
 
 template <typename _ExecPolicy, typename _T>
 using __ref_or_copy =
-    typename oneapi::dpl::__internal::__ref_or_copy_impl<typename ::std::decay<_ExecPolicy>::type, _T>::type;
+    typename oneapi::dpl::__internal::__ref_or_copy_impl<::std::decay_t<_ExecPolicy>, _T>::type;
 
 // utilities for Range API
 template <typename _R>

--- a/include/oneapi/dpl/pstl/execution_impl.h
+++ b/include/oneapi/dpl/pstl/execution_impl.h
@@ -97,19 +97,19 @@ struct __policy_traits<oneapi::dpl::execution::parallel_unsequenced_policy>
 
 template <typename _ExecutionPolicy>
 using __collector_t =
-    typename __internal::__policy_traits<typename ::std::decay<_ExecutionPolicy>::type>::__collector_type;
+    typename __internal::__policy_traits<::std::decay_t<_ExecutionPolicy>>::__collector_type;
 
 template <typename _ExecutionPolicy>
 using __allow_vector =
-    typename __internal::__policy_traits<typename ::std::decay<_ExecutionPolicy>::type>::__allow_vector;
+    typename __internal::__policy_traits<::std::decay_t<_ExecutionPolicy>>::__allow_vector;
 
 template <typename _ExecutionPolicy>
 using __allow_unsequenced =
-    typename __internal::__policy_traits<typename ::std::decay<_ExecutionPolicy>::type>::__allow_unsequenced;
+    typename __internal::__policy_traits<::std::decay_t<_ExecutionPolicy>>::__allow_unsequenced;
 
 template <typename _ExecutionPolicy>
 using __allow_parallel =
-    typename __internal::__policy_traits<typename ::std::decay<_ExecutionPolicy>::type>::__allow_parallel;
+    typename __internal::__policy_traits<::std::decay_t<_ExecutionPolicy>>::__allow_parallel;
 
 template <typename _ExecutionPolicy, typename... _IteratorTypes>
 auto

--- a/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
@@ -230,9 +230,9 @@ __pattern_for_loop(_ExecutionPolicy&& __exec, _Ip __first, _Ip __last, _Function
 }
 
 template <typename _Ip, typename _Function, typename _Sp, typename _Pack, typename _IndexType>
-typename ::std::enable_if<::std::is_same<typename oneapi::dpl::__internal::__iterator_traits<_Ip>::iterator_category,
-                                         ::std::bidirectional_iterator_tag>::value,
-                          _IndexType>::type
+::std::enable_if_t<::std::is_same<typename oneapi::dpl::__internal::__iterator_traits<_Ip>::iterator_category,
+                                  ::std::bidirectional_iterator_tag>::value,
+                   _IndexType>
 __execute_loop_strided(_Ip __first, _Ip __last, _Function __f, _Sp __stride, _Pack& __pack, _IndexType) noexcept
 {
     _IndexType __ordinal_position = 0;
@@ -267,12 +267,12 @@ __execute_loop_strided(_Ip __first, _Ip __last, _Function __f, _Sp __stride, _Pa
 }
 
 template <typename _Ip, typename _Function, typename _Sp, typename _Pack, typename _IndexType>
-typename ::std::enable_if<
+::std::enable_if_t<
     ::std::is_same<typename oneapi::dpl::__internal::__iterator_traits<_Ip>::iterator_category,
                    ::std::forward_iterator_tag>::value ||
         ::std::is_same<typename oneapi::dpl::__internal::__iterator_traits<_Ip>::iterator_category,
                        ::std::input_iterator_tag>::value,
-    _IndexType>::type
+    _IndexType>
 __execute_loop_strided(_Ip __first, _Ip __last, _Function __f, _Sp __stride, _Pack& __pack, _IndexType) noexcept
 {
     _IndexType __ordinal_position = 0;

--- a/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
@@ -102,7 +102,7 @@ class __reduction_pack
 {
     // No matter how the Ts objects are provided(lvalue or rvalue) we need to store copies of them,
     // to avoid modification of the original ones.
-    ::std::tuple<typename ::std::remove_cv<::std::remove_reference_t<_Ts>>::type...> __objects_;
+    ::std::tuple<::std::remove_cv_t<::std::remove_reference_t<_Ts>>...> __objects_;
 
     template <typename _Fp, typename _Ip, typename _Position, ::std::size_t... _Is>
     void

--- a/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
@@ -102,7 +102,7 @@ class __reduction_pack
 {
     // No matter how the Ts objects are provided(lvalue or rvalue) we need to store copies of them,
     // to avoid modification of the original ones.
-    ::std::tuple<typename ::std::remove_cv<typename ::std::remove_reference<_Ts>::type>::type...> __objects_;
+    ::std::tuple<typename ::std::remove_cv<::std::remove_reference_t<_Ts>>::type...> __objects_;
 
     template <typename _Fp, typename _Ip, typename _Position, ::std::size_t... _Is>
     void

--- a/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
@@ -38,14 +38,14 @@ namespace __internal
 
 // Generalization of ::std::advance to work with an argitraty integral type
 template <typename _Ip, typename _Diff>
-typename ::std::enable_if<::std::is_integral<_Ip>::value>::type
+::std::enable_if_t<::std::is_integral<_Ip>::value>
 __advance(_Ip& __val, _Diff __diff)
 {
     __val += __diff;
 }
 
 template <typename _Ip, typename _Diff>
-typename ::std::enable_if<!::std::is_integral<_Ip>::value>::type
+::std::enable_if_t<!::std::is_integral<_Ip>::value>
 __advance(_Ip& __val, _Diff __diff)
 {
     ::std::advance(__val, __diff);
@@ -56,14 +56,14 @@ template <typename _Ip, typename = void>
 struct __difference;
 
 template <typename _Ip>
-struct __difference<_Ip, typename ::std::enable_if<::std::is_integral<_Ip>::value>::type>
+struct __difference<_Ip, ::std::enable_if_t<::std::is_integral<_Ip>::value>>
 {
     // Define the type similar to C++20's incrementable_traits
     using __type = typename ::std::make_signed<decltype(::std::declval<_Ip>() - ::std::declval<_Ip>())>::type;
 };
 
 template <typename _Ip>
-struct __difference<_Ip, typename ::std::enable_if<!::std::is_integral<_Ip>::value>::type>
+struct __difference<_Ip, ::std::enable_if_t<!::std::is_integral<_Ip>::value>>
 {
     using __type = typename oneapi::dpl::__internal::__iterator_traits<_Ip>::difference_type;
 };
@@ -205,21 +205,21 @@ struct __is_random_access_or_integral : ::std::false_type
 };
 
 template <typename _Ip>
-struct __is_random_access_or_integral<_Ip, typename ::std::enable_if<::std::is_integral<_Ip>::value>::type>
+struct __is_random_access_or_integral<_Ip, ::std::enable_if_t<::std::is_integral<_Ip>::value>>
     : ::std::true_type
 {
 };
 
 template <typename _Ip>
 struct __is_random_access_or_integral<
-    _Ip, typename ::std::enable_if<oneapi::dpl::__internal::__is_random_access_iterator<_Ip>::value>::type>
+    _Ip, ::std::enable_if_t<oneapi::dpl::__internal::__is_random_access_iterator<_Ip>::value>>
     : ::std::true_type
 {
 };
 
 // Sequenced version of for_loop for RAI and integral types
 template <typename _ExecutionPolicy, typename _Ip, typename _Function, typename _Sp, typename... _Rest>
-typename ::std::enable_if<__is_random_access_or_integral<_Ip>::value>::type
+::std::enable_if_t<__is_random_access_or_integral<_Ip>::value>
 __pattern_for_loop(_ExecutionPolicy&& __exec, _Ip __first, _Ip __last, _Function __f, _Sp __stride,
                    /*vector=*/::std::false_type, /*parallel=*/::std::false_type, _Rest&&... __rest) noexcept
 {
@@ -293,7 +293,7 @@ __execute_loop_strided(_Ip __first, _Ip __last, _Function __f, _Sp __stride, _Pa
 
 // Sequenced version of for_loop for non-RAI and non-integral types
 template <typename _ExecutionPolicy, typename _Ip, typename _Function, typename... _Rest>
-typename ::std::enable_if<!__is_random_access_or_integral<_Ip>::value>::type
+::std::enable_if_t<!__is_random_access_or_integral<_Ip>::value>
 __pattern_for_loop(_ExecutionPolicy&&, _Ip __first, _Ip __last, _Function __f, __single_stride_type,
                    /*vector=*/::std::false_type, /*parallel=*/::std::false_type, _Rest&&... __rest) noexcept
 {
@@ -311,7 +311,7 @@ __pattern_for_loop(_ExecutionPolicy&&, _Ip __first, _Ip __last, _Function __f, _
 }
 
 template <typename _ExecutionPolicy, typename _Ip, typename _Function, typename _Sp, typename... _Rest>
-typename ::std::enable_if<!__is_random_access_or_integral<_Ip>::value>::type
+::std::enable_if_t<!__is_random_access_or_integral<_Ip>::value>
 __pattern_for_loop(_ExecutionPolicy&&, _Ip __first, _Ip __last, _Function __f, _Sp __stride,
                    /*vector=*/::std::false_type, /*parallel=*/::std::false_type, _Rest&&... __rest) noexcept
 {
@@ -475,7 +475,7 @@ template <typename _Ip, typename = void>
 struct __use_par_vec_helper;
 
 template <typename _Ip>
-struct __use_par_vec_helper<_Ip, typename ::std::enable_if<::std::is_integral<_Ip>::value>::type>
+struct __use_par_vec_helper<_Ip, ::std::enable_if_t<::std::is_integral<_Ip>::value>>
 {
     template <typename _ExecutionPolicy>
     static constexpr auto
@@ -493,7 +493,7 @@ struct __use_par_vec_helper<_Ip, typename ::std::enable_if<::std::is_integral<_I
 };
 
 template <typename _Ip>
-struct __use_par_vec_helper<_Ip, typename ::std::enable_if<!::std::is_integral<_Ip>::value>::type>
+struct __use_par_vec_helper<_Ip, ::std::enable_if_t<!::std::is_integral<_Ip>::value>>
 {
     template <typename _ExecutionPolicy>
     static constexpr auto

--- a/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
@@ -59,7 +59,7 @@ template <typename _Ip>
 struct __difference<_Ip, ::std::enable_if_t<::std::is_integral<_Ip>::value>>
 {
     // Define the type similar to C++20's incrementable_traits
-    using __type = typename ::std::make_signed<decltype(::std::declval<_Ip>() - ::std::declval<_Ip>())>::type;
+    using __type = ::std::make_signed_t<decltype(::std::declval<_Ip>() - ::std::declval<_Ip>())>;
 };
 
 template <typename _Ip>

--- a/include/oneapi/dpl/pstl/experimental/internal/induction_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/induction_impl.h
@@ -33,8 +33,8 @@ namespace __internal
 // construction the induction object
 template <typename _Tp>
 using __induction_value_type = typename ::std::conditional<
-    ::std::is_lvalue_reference<_Tp>::value && !::std::is_const<typename ::std::remove_reference<_Tp>::type>::value, _Tp,
-    typename ::std::remove_cv<typename ::std::remove_reference<_Tp>::type>::type>::type;
+    ::std::is_lvalue_reference<_Tp>::value && !::std::is_const<::std::remove_reference_t<_Tp>>::value, _Tp,
+    typename ::std::remove_cv<::std::remove_reference_t<_Tp>>::type>::type;
 
 // Definition of induction_object structure to represent "induction" object.
 
@@ -58,7 +58,7 @@ class __induction_object
     }
 
     template <typename _Index>
-    typename ::std::remove_reference<__value_type>::type
+    ::std::remove_reference_t<__value_type>
     __get_induction_or_reduction_value(_Index __p)
     {
         return __var_ + __p * __stride_;
@@ -96,7 +96,7 @@ class __induction_object<_Tp, void>
     }
 
     template <typename _Index>
-    typename ::std::remove_reference<__value_type>::type
+    ::std::remove_reference_t<__value_type>
     __get_induction_or_reduction_value(_Index __p)
     {
         return __var_ + __p;

--- a/include/oneapi/dpl/pstl/experimental/internal/induction_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/induction_impl.h
@@ -32,9 +32,9 @@ namespace __internal
 // We're not interested in T&& here as the rvalue-ness is stripped from T before
 // construction the induction object
 template <typename _Tp>
-using __induction_value_type = typename ::std::conditional<
+using __induction_value_type = ::std::conditional_t<
     ::std::is_lvalue_reference<_Tp>::value && !::std::is_const<::std::remove_reference_t<_Tp>>::value, _Tp,
-    ::std::remove_cv_t<::std::remove_reference_t<_Tp>>>::type;
+    ::std::remove_cv_t<::std::remove_reference_t<_Tp>>>;
 
 // Definition of induction_object structure to represent "induction" object.
 

--- a/include/oneapi/dpl/pstl/experimental/internal/induction_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/induction_impl.h
@@ -34,7 +34,7 @@ namespace __internal
 template <typename _Tp>
 using __induction_value_type = typename ::std::conditional<
     ::std::is_lvalue_reference<_Tp>::value && !::std::is_const<::std::remove_reference_t<_Tp>>::value, _Tp,
-    ::std::remove_cv_t<typename ::std::remove_reference<_Tp>::type>>::type;
+    ::std::remove_cv_t<::std::remove_reference_t<_Tp>>>::type;
 
 // Definition of induction_object structure to represent "induction" object.
 

--- a/include/oneapi/dpl/pstl/experimental/internal/induction_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/induction_impl.h
@@ -34,7 +34,7 @@ namespace __internal
 template <typename _Tp>
 using __induction_value_type = typename ::std::conditional<
     ::std::is_lvalue_reference<_Tp>::value && !::std::is_const<::std::remove_reference_t<_Tp>>::value, _Tp,
-    typename ::std::remove_cv<::std::remove_reference_t<_Tp>>::type>::type;
+    ::std::remove_cv_t<typename ::std::remove_reference<_Tp>::type>>::type;
 
 // Definition of induction_object structure to represent "induction" object.
 

--- a/include/oneapi/dpl/pstl/glue_algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_impl.h
@@ -393,9 +393,9 @@ replace_copy_if(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIt
         ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
         oneapi::dpl::__internal::__replace_copy_functor<
             oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _Tp>,
-            typename ::std::conditional<
+            ::std::conditional_t<
                 oneapi::dpl::__internal::__is_const_callable_object<_UnaryPredicate>::value, _UnaryPredicate,
-                oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, _UnaryPredicate>>::type>(__new_value, __pred),
+                oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, _UnaryPredicate>>>(__new_value, __pred),
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(
             __exec),
         oneapi::dpl::__internal::__is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(

--- a/include/oneapi/dpl/pstl/glue_algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_impl.h
@@ -283,7 +283,7 @@ template <class _ExecutionPolicy, class _ForwardIterator1, class _Size, class _F
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
 copy_n(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _Size __n, _ForwardIterator2 __result)
 {
-    using _DecayedExecutionPolicy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _DecayedExecutionPolicy = ::std::decay_t<_ExecutionPolicy>;
 
     return oneapi::dpl::__internal::__pattern_walk2_brick_n(
         ::std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
@@ -806,7 +806,7 @@ template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterato
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
 move(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __d_first)
 {
-    using _DecayedExecutionPolicy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _DecayedExecutionPolicy = ::std::decay_t<_ExecutionPolicy>;
 
     return oneapi::dpl::__internal::__pattern_walk2_brick(
         ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __d_first,

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -436,9 +436,9 @@ replace_copy_if(_ExecutionPolicy&& __exec, _Range1&& __rng, _Range2&& __result, 
         ::std::forward<_ExecutionPolicy>(__exec),
         oneapi::dpl::__internal::__replace_copy_functor<
             oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _Tp>,
-            typename ::std::conditional<
+            ::std::conditional_t<
                 oneapi::dpl::__internal::__is_const_callable_object<_UnaryPredicate>::value, _UnaryPredicate,
-                oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, _UnaryPredicate>>::type>(__new_value, __pred),
+                oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, _UnaryPredicate>>>(__new_value, __pred),
         __src, views::all_write(::std::forward<_Range2>(__result)));
     return __src.size();
 }

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -557,7 +557,7 @@ template <typename _ExecutionPolicy, typename _Range1, typename _Range2>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
 move(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2)
 {
-    using _DecayedExecutionPolicy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _DecayedExecutionPolicy = ::std::decay_t<_ExecutionPolicy>;
 
     oneapi::dpl::__internal::__ranges::__pattern_walk_n(
         ::std::forward<_ExecutionPolicy>(__exec), oneapi::dpl::__internal::__brick_move<_DecayedExecutionPolicy>{},

--- a/include/oneapi/dpl/pstl/glue_memory_impl.h
+++ b/include/oneapi/dpl/pstl/glue_memory_impl.h
@@ -41,7 +41,7 @@ uninitialized_copy(_ExecutionPolicy&& __exec, _InputIterator __first, _InputIter
 {
     typedef typename ::std::iterator_traits<_InputIterator>::value_type _ValueType1;
     typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType2;
-    typedef typename ::std::decay<_ExecutionPolicy>::type _DecayedExecutionPolicy;
+    typedef ::std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     const auto __is_parallel =
         oneapi::dpl::__internal::__is_parallelization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(
@@ -71,7 +71,7 @@ uninitialized_copy_n(_ExecutionPolicy&& __exec, _InputIterator __first, _Size __
 {
     typedef typename ::std::iterator_traits<_InputIterator>::value_type _ValueType1;
     typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType2;
-    typedef typename ::std::decay<_ExecutionPolicy>::type _DecayedExecutionPolicy;
+    typedef ::std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     const auto __is_parallel =
         oneapi::dpl::__internal::__is_parallelization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(
@@ -103,7 +103,7 @@ uninitialized_move(_ExecutionPolicy&& __exec, _InputIterator __first, _InputIter
 {
     typedef typename ::std::iterator_traits<_InputIterator>::value_type _ValueType1;
     typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType2;
-    typedef typename ::std::decay<_ExecutionPolicy>::type _DecayedExecutionPolicy;
+    typedef ::std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     const auto __is_parallel =
         oneapi::dpl::__internal::__is_parallelization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(
@@ -133,7 +133,7 @@ uninitialized_move_n(_ExecutionPolicy&& __exec, _InputIterator __first, _Size __
 {
     typedef typename ::std::iterator_traits<_InputIterator>::value_type _ValueType1;
     typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType2;
-    typedef typename ::std::decay<_ExecutionPolicy>::type _DecayedExecutionPolicy;
+    typedef ::std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     const auto __is_parallel =
         oneapi::dpl::__internal::__is_parallelization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(
@@ -164,7 +164,7 @@ oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
 uninitialized_fill(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value)
 {
     typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType;
-    typedef typename ::std::decay<_ExecutionPolicy>::type _DecayedExecutionPolicy;
+    typedef ::std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     const auto __is_parallel =
         oneapi::dpl::__internal::__is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
@@ -192,7 +192,7 @@ oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _Forward
 uninitialized_fill_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n, const _Tp& __value)
 {
     typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType;
-    typedef typename ::std::decay<_ExecutionPolicy>::type _DecayedExecutionPolicy;
+    typedef ::std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     const auto __is_parallel =
         oneapi::dpl::__internal::__is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
@@ -268,7 +268,7 @@ oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
 uninitialized_default_construct(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last)
 {
     typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType;
-    typedef typename ::std::decay<_ExecutionPolicy>::type _DecayedExecutionPolicy;
+    typedef ::std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     const auto __is_parallel =
         oneapi::dpl::__internal::__is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
@@ -289,7 +289,7 @@ oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _Forward
 uninitialized_default_construct_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n)
 {
     typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType;
-    typedef typename ::std::decay<_ExecutionPolicy>::type _DecayedExecutionPolicy;
+    typedef ::std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     const auto __is_parallel =
         oneapi::dpl::__internal::__is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
@@ -316,7 +316,7 @@ oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
 uninitialized_value_construct(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last)
 {
     typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType;
-    typedef typename ::std::decay<_ExecutionPolicy>::type _DecayedExecutionPolicy;
+    typedef ::std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     const auto __is_parallel =
         oneapi::dpl::__internal::__is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
@@ -344,7 +344,7 @@ oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _Forward
 uninitialized_value_construct_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n)
 {
     typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType;
-    typedef typename ::std::decay<_ExecutionPolicy>::type _DecayedExecutionPolicy;
+    typedef ::std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     const auto __is_parallel =
         oneapi::dpl::__internal::__is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -380,8 +380,7 @@ __pattern_min_element(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __
         return __last;
 
     using _IteratorValueType = typename ::std::iterator_traits<_Iterator>::value_type;
-    using _IndexValueType =
-        typename ::std::make_unsigned<typename ::std::iterator_traits<_Iterator>::difference_type>::type;
+    using _IndexValueType = ::std::make_unsigned_t<typename ::std::iterator_traits<_Iterator>::difference_type>;
     using _ReduceValueType = tuple<_IndexValueType, _IteratorValueType>;
 
     // This operator doesn't track the lowest found index in case of equal min. or max. values. Thus, this operator is
@@ -433,8 +432,7 @@ __pattern_minmax_element(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator
         return ::std::make_pair(__first, __first);
 
     using _IteratorValueType = typename ::std::iterator_traits<_Iterator>::value_type;
-    using _IndexValueType =
-        typename ::std::make_unsigned<typename ::std::iterator_traits<_Iterator>::difference_type>::type;
+    using _IndexValueType = ::std::make_unsigned_t<typename ::std::iterator_traits<_Iterator>::difference_type>;
     using _ReduceValueType = ::std::tuple<_IndexValueType, _IndexValueType, _IteratorValueType, _IteratorValueType>;
 
     // This operator doesn't track the lowest found index in case of equal min. values and the highest found index in

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1042,7 +1042,7 @@ struct __is_heap_check
     operator()(const _Idx __idx, const _Accessor& __acc) const
     {
         // Make sure that we have a signed integer here to avoid getting negative value when __idx == 0
-        using _SignedIdx = typename ::std::make_signed<_Idx>::type;
+        using _SignedIdx = ::std::make_signed_t<_Idx>;
         return __comp_(__acc[(static_cast<_SignedIdx>(__idx) - 1) / 2], __acc[__idx]);
     }
 };

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -285,8 +285,8 @@ __pattern_adjacent_find(_ExecutionPolicy&& __exec, _Range&& __rng, _BinaryPredic
     using _Predicate =
         oneapi::dpl::unseq_backend::single_match_pred<_ExecutionPolicy, adjacent_find_fn<_BinaryPredicate>>;
     using _TagType =
-        typename ::std::conditional<__is__or_semantic(), oneapi::dpl::__par_backend_hetero::__parallel_or_tag,
-                                    oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_Range>>::type;
+        ::std::conditional_t<__is__or_semantic(), oneapi::dpl::__par_backend_hetero::__parallel_or_tag,
+                             oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_Range>>;
 
     auto __rng1 = __rng | oneapi::dpl::experimental::ranges::views::take(__rng.size() - 1);
     auto __rng2 = __rng | oneapi::dpl::experimental::ranges::views::drop(1);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -249,7 +249,7 @@ template <typename _ExecutionPolicy, typename _Fp, typename _Index,
 auto
 __parallel_for(_ExecutionPolicy&& __exec, _Fp __brick, _Index __count, _Ranges&&... __rngs)
 {
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using _CustomName = typename _Policy::kernel_name;
     using _ForKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<_CustomName>;
 
@@ -378,9 +378,9 @@ struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name
             auto __wg_sums_acc = __wg_sums.template get_access<access_mode::read>(__cgh);
             __cgh.parallel_for<_PropagateScanName...>(
                 sycl::range<1>(__n_groups * __size_per_wg),
-                __global_scan_caller<_GlobalScan, typename ::std::decay<_Range2>::type,
-                                     typename ::std::decay<_Range1>::type, decltype(__wg_sums_acc), decltype(__n)>(
-                    __global_scan, __rng2, __rng1, __wg_sums_acc, __n, __size_per_wg));
+                    __global_scan_caller<_GlobalScan, ::std::decay_t<_Range2>, ::std::decay_t<_Range1>,
+                                         decltype(__wg_sums_acc), decltype(__n)>(__global_scan, __rng2, __rng1,
+                                                                                 __wg_sums_acc, __n, __size_per_wg));
         });
 
         return __future(__final_event, sycl::buffer(__wg_sums, sycl::id<1>(__n_groups - 1), sycl::range<1>(1)));
@@ -747,7 +747,7 @@ __parallel_transform_scan_base(_ExecutionPolicy&& __exec, _Range1&& __in_rng, _R
                                _BinaryOperation __binary_op, _InitType __init, _LocalScan __local_scan,
                                _GroupScan __group_scan, _GlobalScan __global_scan)
 {
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using _CustomName = typename _Policy::kernel_name;
 
     using _PropagateKernel =
@@ -1085,7 +1085,7 @@ oneapi::dpl::__internal::__enable_if_device_execution_policy<
                                     typename oneapi::dpl::__ranges::__get_first_range_type<_Ranges...>::type>>::type>
 __parallel_find_or(_ExecutionPolicy&& __exec, _Brick __f, _BrickTag __brick_tag, _Ranges&&... __rngs)
 {
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using _CustomName = typename _Policy::kernel_name;
     using _AtomicType = typename _BrickTag::_AtomicType;
     using _FindOrKernel =
@@ -1630,7 +1630,7 @@ template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typenam
 auto
 __parallel_merge(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _Range3&& __rng3, _Compare __comp)
 {
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using _CustomName = typename _Policy::kernel_name;
     using _MergeKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<_CustomName>;
 
@@ -1678,7 +1678,7 @@ struct __parallel_sort_submitter<__internal::__optional_kernel_name<_LeafSortNam
     auto
     operator()(_ExecutionPolicy&& __exec, _Range&& __rng, _Merge __merge, _Compare __comp) const
     {
-        using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+        using _Policy = ::std::decay_t<_ExecutionPolicy>;
         using _Tp = oneapi::dpl::__internal::__value_t<_Range>;
         using _Size = oneapi::dpl::__internal::__difference_t<_Range>;
 
@@ -1810,7 +1810,7 @@ template <typename _ExecutionPolicy, typename _Range, typename _Merge, typename 
 auto
 __parallel_sort_impl(_ExecutionPolicy&& __exec, _Range&& __rng, _Merge __merge, _Compare __comp)
 {
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using _CustomName = typename _Policy::kernel_name;
     using _LeafSortKernel =
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<__sort_leaf_kernel<_CustomName>>;
@@ -1835,7 +1835,7 @@ struct __parallel_partial_sort_submitter<__internal::__optional_kernel_name<_Glo
     auto
     operator()(_ExecutionPolicy&& __exec, _Range&& __rng, _Merge __merge, _Compare __comp) const
     {
-        using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+        using _Policy = ::std::decay_t<_ExecutionPolicy>;
         using _Tp = oneapi::dpl::__internal::__value_t<_Range>;
         using _Size = oneapi::dpl::__internal::__difference_t<_Range>;
 
@@ -1902,7 +1902,7 @@ template <typename _ExecutionPolicy, typename _Range, typename _Merge, typename 
 auto
 __parallel_partial_sort_impl(_ExecutionPolicy&& __exec, _Range&& __rng, _Merge __merge, _Compare __comp)
 {
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using _CustomName = typename _Policy::kernel_name;
     using _GlobalSortKernel =
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<__sort_global_kernel<_CustomName>>;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1079,7 +1079,7 @@ struct __early_exit_find_or
 template <typename _ExecutionPolicy, typename _Brick, typename _BrickTag, typename... _Ranges>
 oneapi::dpl::__internal::__enable_if_device_execution_policy<
     _ExecutionPolicy,
-    ::std::conditional_t<::std::is_same<_BrickTag, __parallel_or_tag>::value, bool,
+    ::std::conditional_t<::std::is_same_v<_BrickTag, __parallel_or_tag>, bool,
                          oneapi::dpl::__internal::__difference_t<
                              typename oneapi::dpl::__ranges::__get_first_range_type<_Ranges...>::type>>>
 __parallel_find_or(_ExecutionPolicy&& __exec, _Brick __f, _BrickTag __brick_tag, _Ranges&&... __rngs)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1045,9 +1045,8 @@ struct __early_exit_find_or
         for (_IterSize __i = 0; __i < __n_iter; ++__i)
         {
             //in case of find-semantic __shifted_idx must be the same type as the atomic for a correct comparison
-            using _ShiftedIdxType =
-                typename ::std::conditional<_OrTagType::value, decltype(__init_index + __i * __shift),
-                                            decltype(__found_local.load())>::type;
+            using _ShiftedIdxType = ::std::conditional_t<_OrTagType::value, decltype(__init_index + __i * __shift),
+                                                         decltype(__found_local.load())>;
 
             _IterSize __current_iter = __i;
             if constexpr (_BackwardTagType::value)
@@ -1080,9 +1079,9 @@ struct __early_exit_find_or
 template <typename _ExecutionPolicy, typename _Brick, typename _BrickTag, typename... _Ranges>
 oneapi::dpl::__internal::__enable_if_device_execution_policy<
     _ExecutionPolicy,
-    typename ::std::conditional<::std::is_same<_BrickTag, __parallel_or_tag>::value, bool,
-                                oneapi::dpl::__internal::__difference_t<
-                                    typename oneapi::dpl::__ranges::__get_first_range_type<_Ranges...>::type>>::type>
+    ::std::conditional_t<::std::is_same<_BrickTag, __parallel_or_tag>::value, bool,
+                         oneapi::dpl::__internal::__difference_t<
+                             typename oneapi::dpl::__ranges::__get_first_range_type<_Ranges...>::type>>>
 __parallel_find_or(_ExecutionPolicy&& __exec, _Brick __f, _BrickTag __brick_tag, _Ranges&&... __rngs)
 {
     using _Policy = ::std::decay_t<_ExecutionPolicy>;
@@ -1238,9 +1237,8 @@ __parallel_find(_ExecutionPolicy&& __exec, _Iterator1 __first, _Iterator1 __last
     auto __s_keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator2>();
     auto __s_buf = __s_keep(__s_first, __s_last);
 
-    using _TagType =
-        typename ::std::conditional<_IsFirst::value, __parallel_find_forward_tag<decltype(__buf.all_view())>,
-                                    __parallel_find_backward_tag<decltype(__buf.all_view())>>::type;
+    using _TagType = ::std::conditional_t<_IsFirst::value, __parallel_find_forward_tag<decltype(__buf.all_view())>,
+                                          __parallel_find_backward_tag<decltype(__buf.all_view())>>;
     return __first + oneapi::dpl::__par_backend_hetero::__parallel_find_or(
                          __par_backend_hetero::make_wrapped_policy<__find_policy_wrapper>(
                              ::std::forward<_ExecutionPolicy>(__exec)),
@@ -1257,9 +1255,8 @@ __parallel_find(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, 
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
     auto __buf = __keep(__first, __last);
 
-    using _TagType =
-        typename ::std::conditional<_IsFirst::value, __parallel_find_forward_tag<decltype(__buf.all_view())>,
-                                    __parallel_find_backward_tag<decltype(__buf.all_view())>>::type;
+    using _TagType = ::std::conditional_t<_IsFirst::value, __parallel_find_forward_tag<decltype(__buf.all_view())>,
+                                          __parallel_find_backward_tag<decltype(__buf.all_view())>>;
     return __first + oneapi::dpl::__par_backend_hetero::__parallel_find_or(
                          __par_backend_hetero::make_wrapped_policy<__find_policy_wrapper>(
                              ::std::forward<_ExecutionPolicy>(__exec)),

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
@@ -181,9 +181,9 @@ __parallel_scan_copy(_ExecutionPolicy&& __exec, _InRng&& __in_rng, _OutRng&& __o
 template <typename _ExecutionPolicy, typename _Brick, typename _BrickTag, typename... _Ranges>
 oneapi::dpl::__internal::__enable_if_fpga_execution_policy<
     _ExecutionPolicy,
-    typename ::std::conditional<::std::is_same<_BrickTag, __parallel_or_tag>::value, bool,
-                                oneapi::dpl::__internal::__difference_t<
-                                    typename oneapi::dpl::__ranges::__get_first_range_type<_Ranges...>::type>>::type>
+    ::std::conditional_t<::std::is_same<_BrickTag, __parallel_or_tag>::value, bool,
+                         oneapi::dpl::__internal::__difference_t<
+                             typename oneapi::dpl::__ranges::__get_first_range_type<_Ranges...>::type>>>
 __parallel_find_or(_ExecutionPolicy&& __exec, _Brick __f, _BrickTag __brick_tag, _Ranges&&... __rngs)
 {
     using _Policy = ::std::decay_t<_ExecutionPolicy>;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
@@ -81,7 +81,7 @@ template <typename _ExecutionPolicy, typename _Fp, typename _Index, typename... 
 auto
 __parallel_for(_ExecutionPolicy&& __exec, _Fp __brick, _Index __count, _Ranges&&... __rngs)
 {
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using __parallel_for_name = __internal::__kernel_name_provider<typename _Policy::kernel_name>;
 
     return __parallel_for_fpga_submitter<__parallel_for_name>()(std::forward<_ExecutionPolicy>(__exec), __brick,
@@ -100,7 +100,7 @@ __parallel_transform_reduce(_ExecutionPolicy&& __exec, _ReduceOp __reduce_op, _T
                             _InitType __init, _Ranges&&... __rngs)
 {
     // workaround until we implement more performant version for patterns
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using __kernel_name = typename _Policy::kernel_name;
     auto __device_policy = oneapi::dpl::execution::make_device_policy<__kernel_name>(__exec.queue());
     return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_Tp, _Commutative>(
@@ -119,7 +119,7 @@ __parallel_transform_scan(_ExecutionPolicy&& __exec, _Range1&& __in_rng, _Range2
                           _UnaryOperation __unary_op, _InitType __init, _BinaryOperation __binary_op, _Inclusive)
 {
     // workaround until we implement more performant version for patterns
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using __kernel_name = typename _Policy::kernel_name;
     auto __device_policy = oneapi::dpl::execution::make_device_policy<__kernel_name>(__exec.queue());
     return oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(
@@ -136,7 +136,7 @@ __parallel_transform_scan_base(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Ran
                                _GroupScan __group_scan, _GlobalScan __global_scan)
 {
     // workaround until we implement more performant version for patterns
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using __kernel_name = typename _Policy::kernel_name;
     auto __device_policy = oneapi::dpl::execution::make_device_policy<__kernel_name>(__exec.queue());
     return oneapi::dpl::__par_backend_hetero::__parallel_transform_scan_base(
@@ -150,7 +150,7 @@ auto
 __parallel_copy_if(_ExecutionPolicy&& __exec, _InRng&& __in_rng, _OutRng&& __out_rng, _Size __n, _Pred __pred)
 {
     // workaround until we implement more performant version for patterns
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using __kernel_name = typename _Policy::kernel_name;
     auto __device_policy = oneapi::dpl::execution::make_device_policy<__kernel_name>(__exec.queue());
     return oneapi::dpl::__par_backend_hetero::__parallel_copy_if(
@@ -167,7 +167,7 @@ __parallel_scan_copy(_ExecutionPolicy&& __exec, _InRng&& __in_rng, _OutRng&& __o
                      _CreateMaskOp __create_mask_op, _CopyByMaskOp __copy_by_mask_op)
 {
     // workaround until we implement more performant version for patterns
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using __kernel_name = typename _Policy::kernel_name;
     auto __device_policy = oneapi::dpl::execution::make_device_policy<__kernel_name>(__exec.queue());
     return oneapi::dpl::__par_backend_hetero::__parallel_scan_copy(
@@ -186,7 +186,7 @@ oneapi::dpl::__internal::__enable_if_fpga_execution_policy<
                                     typename oneapi::dpl::__ranges::__get_first_range_type<_Ranges...>::type>>::type>
 __parallel_find_or(_ExecutionPolicy&& __exec, _Brick __f, _BrickTag __brick_tag, _Ranges&&... __rngs)
 {
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using __kernel_name = typename _Policy::kernel_name;
     auto __device_policy = oneapi::dpl::execution::make_device_policy<__kernel_name>(__exec.queue());
     return oneapi::dpl::__par_backend_hetero::__parallel_find_or(__device_policy, __f, __brick_tag,
@@ -202,7 +202,7 @@ __parallel_or(_ExecutionPolicy&& __exec, _Iterator1 __first, _Iterator1 __last, 
               _Iterator2 __s_last, _Brick __f)
 {
     // workaround until we implement more performant version for patterns
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using __kernel_name = typename _Policy::kernel_name;
     auto __device_policy = oneapi::dpl::execution::make_device_policy<__kernel_name>(__exec.queue());
     return oneapi::dpl::__par_backend_hetero::__parallel_or(__device_policy, __first, __last, __s_first, __s_last, __f);
@@ -213,7 +213,7 @@ oneapi::dpl::__internal::__enable_if_fpga_execution_policy<_ExecutionPolicy, boo
 __parallel_or(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, _Brick __f)
 {
     // workaround until we implement more performant version for patterns
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using __kernel_name = typename _Policy::kernel_name;
     auto __device_policy = oneapi::dpl::execution::make_device_policy<__kernel_name>(__exec.queue());
     return oneapi::dpl::__par_backend_hetero::__parallel_or(__device_policy, __first, __last, __f);
@@ -229,7 +229,7 @@ __parallel_find(_ExecutionPolicy&& __exec, _Iterator1 __first, _Iterator1 __last
                 _Iterator2 __s_last, _Brick __f, _IsFirst __is_first)
 {
     // workaround until we implement more performant version for patterns
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using __kernel_name = typename _Policy::kernel_name;
     auto __device_policy = oneapi::dpl::execution::make_device_policy<__kernel_name>(__exec.queue());
     return oneapi::dpl::__par_backend_hetero::__parallel_find(__device_policy, __first, __last, __s_first, __s_last,
@@ -241,7 +241,7 @@ oneapi::dpl::__internal::__enable_if_fpga_execution_policy<_ExecutionPolicy, _It
 __parallel_find(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, _Brick __f, _IsFirst __is_first)
 {
     // workaround until we implement more performant version for patterns
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using __kernel_name = typename _Policy::kernel_name;
     auto __device_policy = oneapi::dpl::execution::make_device_policy<__kernel_name>(__exec.queue());
     return oneapi::dpl::__par_backend_hetero::__parallel_find(__device_policy, __first, __last, __f, __is_first);
@@ -250,10 +250,10 @@ __parallel_find(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, 
 template <typename _ExecutionPolicy>
 auto
 __device_policy(_ExecutionPolicy&& __exec)
-    -> decltype(oneapi::dpl::execution::make_device_policy<typename ::std::decay<_ExecutionPolicy>::type::kernel_name>(
+    -> decltype(oneapi::dpl::execution::make_device_policy<::std::decay_t<_ExecutionPolicy>::kernel_name>(
         __exec.queue()))
 {
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using __kernel_name = typename _Policy::kernel_name;
     return oneapi::dpl::execution::make_device_policy<__kernel_name>(__exec.queue());
 }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
@@ -181,7 +181,7 @@ __parallel_scan_copy(_ExecutionPolicy&& __exec, _InRng&& __in_rng, _OutRng&& __o
 template <typename _ExecutionPolicy, typename _Brick, typename _BrickTag, typename... _Ranges>
 oneapi::dpl::__internal::__enable_if_fpga_execution_policy<
     _ExecutionPolicy,
-    ::std::conditional_t<::std::is_same<_BrickTag, __parallel_or_tag>::value, bool,
+    ::std::conditional_t<::std::is_same_v<_BrickTag, __parallel_or_tag>, bool,
                          oneapi::dpl::__internal::__difference_t<
                              typename oneapi::dpl::__ranges::__get_first_range_type<_Ranges...>::type>>>
 __parallel_find_or(_ExecutionPolicy&& __exec, _Brick __f, _BrickTag __brick_tag, _Ranges&&... __rngs)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -138,7 +138,7 @@ auto
 __parallel_transform_reduce_small_impl(_ExecutionPolicy&& __exec, const _Size __n, _ReduceOp __reduce_op,
                                        _TransformOp __transform_op, _InitType __init, _Ranges&&... __rngs)
 {
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using _CustomName = typename _Policy::kernel_name;
     using _ReduceKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
         __reduce_small_kernel<::std::integral_constant<::std::uint8_t, __iters_per_work_item>, _CustomName>>;
@@ -255,7 +255,7 @@ auto
 __parallel_transform_reduce_mid_impl(_ExecutionPolicy&& __exec, _Size __n, _ReduceOp __reduce_op,
                                      _TransformOp __transform_op, _InitType __init, _Ranges&&... __rngs)
 {
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using _CustomName = typename _Policy::kernel_name;
 
     // The same value for __iters_per_work_item_device_kernel is currently used. Include
@@ -293,7 +293,7 @@ struct __parallel_transform_reduce_impl
     submit(_ExecutionPolicy&& __exec, _Size __n, ::std::uint16_t __work_group_size, _ReduceOp __reduce_op,
            _TransformOp __transform_op, _InitType __init, _Ranges&&... __rngs)
     {
-        using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+        using _Policy = ::std::decay_t<_ExecutionPolicy>;
         using _CustomName = typename _Policy::kernel_name;
         using _NoOpFunctor = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;
         using _ReduceKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -218,8 +218,8 @@ struct __optional_kernel_name;
 template <typename _CustomName>
 using __kernel_name_provider =
 #if __SYCL_UNNAMED_LAMBDA__
-    typename ::std::conditional<_HasDefaultName<_CustomName>::value, __optional_kernel_name<>,
-                                __optional_kernel_name<_CustomName>>::type;
+    ::std::conditional_t<_HasDefaultName<_CustomName>::value, __optional_kernel_name<>,
+                         __optional_kernel_name<_CustomName>>;
 #else
     __optional_kernel_name<_CustomName>;
 #endif

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -199,9 +199,9 @@ namespace __internal
 template <typename _CustomName>
 struct _HasDefaultName
 {
-    static constexpr bool value = ::std::is_same<_CustomName, oneapi::dpl::execution::DefaultKernelName>::value
+    static constexpr bool value = ::std::is_same_v<_CustomName, oneapi::dpl::execution::DefaultKernelName>
 #if _ONEDPL_FPGA_DEVICE
-                                  || ::std::is_same<_CustomName, oneapi::dpl::execution::DefaultKernelNameFPGA>::value
+                                  || ::std::is_same_v<_CustomName, oneapi::dpl::execution::DefaultKernelNameFPGA>
 #endif
         ;
 };

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -149,7 +149,7 @@ using access_mode = sycl::access_mode;
 
 // substitution for C++17 convenience types
 template <typename _T>
-using __decay_t = typename ::std::decay<_T>::type;
+using __decay_t = ::std::decay_t<_T>;
 template <bool __flag, typename _T = void>
 using __enable_if_t = typename ::std::enable_if<__flag, _T>::type;
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -151,7 +151,7 @@ using access_mode = sycl::access_mode;
 template <typename _T>
 using __decay_t = ::std::decay_t<_T>;
 template <bool __flag, typename _T = void>
-using __enable_if_t = typename ::std::enable_if<__flag, _T>::type;
+using __enable_if_t = ::std::enable_if_t<__flag, _T>;
 
 // function to simplify zip_iterator creation
 template <typename... T>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -31,9 +31,9 @@ namespace unseq_backend
 {
 // helpers to encapsulate void and other types
 template <typename _Tp>
-using void_type = typename ::std::enable_if<::std::is_void<_Tp>::value, _Tp>::type;
+using void_type = ::std::enable_if_t<::std::is_void<_Tp>::value, _Tp>;
 template <typename _Tp>
-using non_void_type = typename ::std::enable_if<!::std::is_void<_Tp>::value, _Tp>::type;
+using non_void_type = ::std::enable_if_t<!::std::is_void<_Tp>::value, _Tp>;
 
 #if _USE_GROUP_ALGOS && _ONEDPL_SYCL_INTEL_COMPILER
 //This optimization depends on Intel(R) oneAPI DPC++ Compiler implementation such as support of binary operators from std namespace.
@@ -565,8 +565,8 @@ struct __global_scan_functor
             // an initial value precedes the first group for the exclusive scan
             __item_idx += __shift;
             auto __bin_op_result = __binary_op(__wg_sums_acc[__wg_sums_idx], __out_acc[__item_idx]);
-            using __out_type = typename ::std::decay<decltype(__out_acc[__item_idx])>::type;
-            using __in_type = typename ::std::decay<decltype(__bin_op_result)>::type;
+            using __out_type = ::std::decay_t<decltype(__out_acc[__item_idx])>;
+            using __in_type = ::std::decay_t<decltype(__bin_op_result)>;
             __out_acc[__item_idx] =
                 static_cast<typename __internal::__get_tuple_type<__in_type, __out_type>::__type>(__bin_op_result);
         }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -49,21 +49,21 @@ using __has_known_identity =
         __dpl_sycl::__has_known_identity<_BinaryOp, _Tp>,
         ::std::conjunction<
             ::std::is_arithmetic<_Tp>,
-            ::std::disjunction<::std::is_same<typename ::std::decay<_BinaryOp>::type, ::std::plus<_Tp>>,
-                               ::std::is_same<typename ::std::decay<_BinaryOp>::type, ::std::plus<void>>,
-                               ::std::is_same<typename ::std::decay<_BinaryOp>::type, __dpl_sycl::__plus<_Tp>>,
-                               ::std::is_same<typename ::std::decay<_BinaryOp>::type, __dpl_sycl::__plus<void>>,
-                               ::std::is_same<typename ::std::decay<_BinaryOp>::type, __dpl_sycl::__minimum<_Tp>>,
-                               ::std::is_same<typename ::std::decay<_BinaryOp>::type, __dpl_sycl::__minimum<void>>,
-                               ::std::is_same<typename ::std::decay<_BinaryOp>::type, __dpl_sycl::__maximum<_Tp>>,
-                               ::std::is_same<typename ::std::decay<_BinaryOp>::type, __dpl_sycl::__maximum<void>>>>>;
+            ::std::disjunction<::std::is_same<::std::decay_t<_BinaryOp>, ::std::plus<_Tp>>,
+                               ::std::is_same<::std::decay_t<_BinaryOp>, ::std::plus<void>>,
+                               ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__plus<_Tp>>,
+                               ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__plus<void>>,
+                               ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__minimum<_Tp>>,
+                               ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__minimum<void>>,
+                               ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__maximum<_Tp>>,
+                               ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__maximum<void>>>>>;
 #    else  //_ONEDPL_LIBSYCL_VERSION >= 50200
     typename ::std::conjunction<
         ::std::is_arithmetic<_Tp>,
-        ::std::disjunction<::std::is_same<typename ::std::decay<_BinaryOp>::type, ::std::plus<_Tp>>,
-                           ::std::is_same<typename ::std::decay<_BinaryOp>::type, ::std::plus<void>>,
-                           ::std::is_same<typename ::std::decay<_BinaryOp>::type, __dpl_sycl::__plus<_Tp>>,
-                           ::std::is_same<typename ::std::decay<_BinaryOp>::type, __dpl_sycl::__plus<void>>>>;
+        ::std::disjunction<::std::is_same<::std::decay_t<_BinaryOp>, ::std::plus<_Tp>>,
+                           ::std::is_same<::std::decay_t<_BinaryOp>, ::std::plus<void>>,
+                           ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__plus<_Tp>>,
+                           ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__plus<void>>>>;
 #    endif //_ONEDPL_LIBSYCL_VERSION >= 50200
 
 #else //_USE_GROUP_ALGOS && _ONEDPL_SYCL_INTEL_COMPILER
@@ -76,7 +76,7 @@ using __has_known_identity = std::false_type;
 template <typename _BinaryOp, typename _Tp>
 struct __known_identity_for_plus
 {
-    static_assert(std::is_same_v<typename std::decay<_BinaryOp>::type, std::plus<_Tp>>);
+    static_assert(std::is_same_v<std::decay_t<_BinaryOp>, std::plus<_Tp>>);
     static constexpr _Tp value = 0;
 };
 
@@ -472,8 +472,8 @@ struct __copy_by_mask
             auto __out_idx = get<N>(__in_acc[__item_idx]) - 1;
 
             using __tuple_type = typename __internal::__get_tuple_type<
-                typename ::std::decay<decltype(get<0>(__in_acc[__item_idx]))>::type,
-                typename ::std::decay<decltype(__out_acc[__out_idx])>::type>::__type;
+                ::std::decay_t<decltype(get<0>(__in_acc[__item_idx]))>,
+                ::std::decay_t<decltype(__out_acc[__out_idx])>>::__type;
 
             // calculation of position for copy
             if (__item_idx >= __size_per_wg)
@@ -516,7 +516,7 @@ struct __partition_by_mask
         if (__item_idx < __n)
         {
             using ::std::get;
-            using __in_type = typename ::std::decay<decltype(get<0>(__in_acc[__item_idx]))>::type;
+            using __in_type = ::std::decay_t<decltype(get<0>(__in_acc[__item_idx]))>;
             auto __wg_sums_idx = __item_idx / __size_per_wg;
             bool __not_first_wg = __item_idx >= __size_per_wg;
             if (get<1>(__in_acc[__item_idx]) &&
@@ -524,7 +524,7 @@ struct __partition_by_mask
             {
                 auto __out_idx = get<1>(__in_acc[__item_idx]) - 1;
                 using __tuple_type = typename __internal::__get_tuple_type<
-                    __in_type, typename ::std::decay<decltype(get<0>(__out_acc[__out_idx]))>::type>::__type;
+                    __in_type, ::std::decay_t<decltype(get<0>(__out_acc[__out_idx]))>>::__type;
 
                 if (__not_first_wg)
                     __out_idx = __binary_op(__out_idx, __wg_sums_acc[__wg_sums_idx - 1]);
@@ -534,7 +534,7 @@ struct __partition_by_mask
             {
                 auto __out_idx = __item_idx - get<1>(__in_acc[__item_idx]);
                 using __tuple_type = typename __internal::__get_tuple_type<
-                    __in_type, typename ::std::decay<decltype(get<1>(__out_acc[__out_idx]))>::type>::__type;
+                    __in_type, ::std::decay_t<decltype(get<1>(__out_acc[__out_idx]))>>::__type;
 
                 if (__not_first_wg)
                     __out_idx -= __wg_sums_acc[__wg_sums_idx - 1];

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -53,7 +53,7 @@ template <typename _T, sycl::access::mode _AccMode = sycl::access::mode::read,
           sycl::access::placeholder _Placeholder = sycl::access::placeholder::true_t>
 class all_view
 {
-    using __return_t = typename ::std::conditional<_AccMode == sycl::access::mode::read, const _T, _T>::type;
+    using __return_t = ::std::conditional_t<_AccMode == sycl::access::mode::read, const _T, _T>;
     using __diff_type = typename ::std::iterator_traits<_T*>::difference_type;
     using __accessor_t = sycl::accessor<_T, 1, _AccMode, _Target, _Placeholder>;
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -201,9 +201,9 @@ struct is_temp_buff : ::std::false_type
 };
 
 template <typename _Iter>
-struct is_temp_buff<_Iter, typename ::std::enable_if<!is_hetero_it<_Iter>::value && !::std::is_pointer<_Iter>::value &&
-                                                         !is_passed_directly_it<_Iter>::value,
-                                                     void>::type> : ::std::true_type
+struct is_temp_buff<_Iter, ::std::enable_if_t<!is_hetero_it<_Iter>::value && !::std::is_pointer<_Iter>::value &&
+                                                  !is_passed_directly_it<_Iter>::value,
+                                              void>> : ::std::true_type
 {
 };
 
@@ -500,8 +500,7 @@ struct __get_sycl_range
 
     // for raw pointers and direct pass objects (for example, counting_iterator, iterator of USM-containers)
     template <typename _Iter>
-    typename ::std::enable_if<is_passed_directly_it<_Iter>::value,
-                              __range_holder<oneapi::dpl::__ranges::guard_view<_Iter>>>::type
+    ::std::enable_if_t<is_passed_directly_it<_Iter>::value, __range_holder<oneapi::dpl::__ranges::guard_view<_Iter>>>
     operator()(_Iter __first, _Iter __last)
     {
         assert(__first < __last);
@@ -513,8 +512,8 @@ struct __get_sycl_range
     template <typename _Iter>
     auto
     operator()(_Iter __first, _Iter __last) ->
-        typename ::std::enable_if<is_hetero_it<_Iter>::value,
-                                  __range_holder<oneapi::dpl::__ranges::all_view<val_t<_Iter>, AccMode>>>::type
+        ::std::enable_if_t<is_hetero_it<_Iter>::value,
+                                  __range_holder<oneapi::dpl::__ranges::all_view<val_t<_Iter>, AccMode>>>
     {
         assert(__first < __last);
         using value_type = val_t<_Iter>;
@@ -533,8 +532,8 @@ struct __get_sycl_range
     template <typename _Iter>
     auto
     operator()(_Iter __first, _Iter __last) ->
-        typename ::std::enable_if<is_temp_buff<_Iter>::value && !is_zip<_Iter>::value && !is_permutation<_Iter>::value,
-                                  __buffer_holder<val_t<_Iter>, AccMode>>::type
+        ::std::enable_if_t<is_temp_buff<_Iter>::value && !is_zip<_Iter>::value && !is_permutation<_Iter>::value,
+                           __buffer_holder<val_t<_Iter>, AccMode>>
     {
         static_assert(!oneapi::dpl::__internal::is_const_iterator<_Iter>::value || AccMode == sycl::access::mode::read,
                       "Should be non-const iterator for a modifying algorithm.");

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -173,7 +173,7 @@ struct is_zip : ::std::false_type
 };
 
 template <typename Iter> // for iterators defined as direct pass
-struct is_zip<Iter, typename ::std::enable_if<Iter::is_zip::value, void>::type> : ::std::true_type
+struct is_zip<Iter, ::std::enable_if_t<Iter::is_zip::value, void>> : ::std::true_type
 {
 };
 
@@ -183,7 +183,7 @@ struct is_permutation : ::std::false_type
 };
 
 template <typename Iter> // for permutation_iterators
-struct is_permutation<Iter, typename ::std::enable_if<Iter::is_permutation::value, void>::type> : ::std::true_type
+struct is_permutation<Iter, ::std::enable_if_t<Iter::is_permutation::value, void>> : ::std::true_type
 {
 };
 
@@ -428,7 +428,7 @@ struct __get_sycl_range
 
   private:
     template <typename _R, typename _Map, typename _Size,
-              typename ::std::enable_if<oneapi::dpl::__internal::__is_functor<_Map>, int>::type = 0>
+              ::std::enable_if_t<oneapi::dpl::__internal::__is_functor<_Map>, int> = 0>
     static auto
     __get_permutation_view(_R __r, _Map __m, _Size __s)
     {
@@ -437,7 +437,7 @@ struct __get_sycl_range
 
     template <
         typename _R, typename _Map, typename _Size,
-        typename ::std::enable_if<oneapi::dpl::__internal::__is_random_access_iterator<_Map>::value, int>::type = 0>
+        ::std::enable_if_t<oneapi::dpl::__internal::__is_random_access_iterator<_Map>::value, int> = 0>
     auto
     __get_permutation_view(_R __r, _Map __m, _Size __s)
     {
@@ -447,7 +447,7 @@ struct __get_sycl_range
 
   public:
     //specialization for permutation_iterator using sycl_iterator as source
-    template <typename _It, typename _Map, typename ::std::enable_if<is_hetero_it<_It>::value, int>::type = 0>
+    template <typename _It, typename _Map, ::std::enable_if_t<is_hetero_it<_It>::value, int> = 0>
     auto
     operator()(oneapi::dpl::permutation_iterator<_It, _Map> __first,
                oneapi::dpl::permutation_iterator<_It, _Map> __last)
@@ -466,7 +466,7 @@ struct __get_sycl_range
     // TODO Add specialization for general case, e.g., permutation_iterator using host
     // or another fancy iterator.
     //specialization for permutation_iterator using USM pointer as source
-    template <typename _It, typename _Map, typename ::std::enable_if<!is_hetero_it<_It>::value, int>::type = 0>
+    template <typename _It, typename _Map, ::std::enable_if_t<!is_hetero_it<_It>::value, int> = 0>
     auto
     operator()(oneapi::dpl::permutation_iterator<_It, _Map> __first,
                oneapi::dpl::permutation_iterator<_It, _Map> __last)

--- a/include/oneapi/dpl/pstl/iterator_defs.h
+++ b/include/oneapi/dpl/pstl/iterator_defs.h
@@ -67,8 +67,8 @@ struct __is_random_access_iterator_impl<_IteratorType,
 /* iterator */
 template <typename _IteratorType, typename... _OtherIteratorTypes>
 struct __is_random_access_iterator
-    : ::std::conditional<__is_random_access_iterator_impl<_IteratorType>::value,
-                         __is_random_access_iterator<_OtherIteratorTypes...>, ::std::false_type>::type
+    : ::std::conditional_t<__is_random_access_iterator_impl<_IteratorType>::value,
+                           __is_random_access_iterator<_OtherIteratorTypes...>, ::std::false_type>
 {
 };
 

--- a/include/oneapi/dpl/pstl/iterator_defs.h
+++ b/include/oneapi/dpl/pstl/iterator_defs.h
@@ -84,7 +84,7 @@ struct is_hetero_iterator : ::std::false_type
 };
 
 template <typename Iter> // for heterogeneous iterators
-struct is_hetero_iterator<Iter, typename ::std::enable_if<Iter::is_hetero::value, void>::type> : ::std::true_type
+struct is_hetero_iterator<Iter, ::std::enable_if_t<Iter::is_hetero::value, void>> : ::std::true_type
 {
 };
 // struct for checking if iterator should be passed directly to device or not
@@ -94,13 +94,13 @@ struct is_passed_directly : ::std::false_type
 };
 
 template <typename Iter> // for iterators defined as direct pass
-struct is_passed_directly<Iter, typename ::std::enable_if<Iter::is_passed_directly::value, void>::type>
+struct is_passed_directly<Iter, ::std::enable_if_t<Iter::is_passed_directly::value, void>>
     : ::std::true_type
 {
 };
 
 template <typename Iter> // for pointers to objects on device
-struct is_passed_directly<Iter, typename ::std::enable_if<::std::is_pointer<Iter>::value, void>::type>
+struct is_passed_directly<Iter, ::std::enable_if_t<::std::is_pointer<Iter>::value, void>>
     : ::std::true_type
 {
 };

--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -570,10 +570,10 @@ template <typename SourceIterator, typename _Permutation>
 class permutation_iterator
 {
   public:
-    typedef typename std::conditional<
+    typedef std::conditional_t<
         !__internal::__is_functor<_Permutation>, _Permutation,
         transform_iterator<counting_iterator<typename ::std::iterator_traits<SourceIterator>::difference_type>,
-                           _Permutation>>::type IndexMap;
+                           _Permutation>> IndexMap;
     typedef typename ::std::iterator_traits<SourceIterator>::difference_type difference_type;
     typedef typename ::std::iterator_traits<SourceIterator>::value_type value_type;
     typedef typename ::std::iterator_traits<SourceIterator>::pointer pointer;

--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -83,7 +83,7 @@ class zip_forward_iterator
     typedef typename ::std::tuple<_Types...> __it_types;
 
   public:
-    typedef typename ::std::make_signed<::std::size_t>::type difference_type;
+    typedef ::std::make_signed_t<::std::size_t> difference_type;
     typedef ::std::tuple<typename ::std::iterator_traits<_Types>::value_type...> value_type;
     typedef ::std::tuple<typename ::std::iterator_traits<_Types>::reference...> reference;
     typedef ::std::tuple<typename ::std::iterator_traits<_Types>::pointer...> pointer;
@@ -153,7 +153,7 @@ class counting_iterator
     static_assert(::std::is_integral<_Ip>::value, "Cannot instantiate counting_iterator with a non-integer type");
 
   public:
-    typedef typename ::std::make_signed<_Ip>::type difference_type;
+    typedef ::std::make_signed_t<_Ip> difference_type;
     typedef _Ip value_type;
     typedef const _Ip* pointer;
     // There is no storage behind the iterator, so we return a value instead of reference.
@@ -269,7 +269,7 @@ class zip_iterator
     typedef oneapi::dpl::__internal::tuple<_Types...> __it_types;
 
   public:
-    typedef typename ::std::make_signed<::std::size_t>::type difference_type;
+    typedef ::std::make_signed_t<::std::size_t> difference_type;
     typedef oneapi::dpl::__internal::tuple<typename ::std::iterator_traits<_Types>::value_type...> value_type;
     typedef oneapi::dpl::__internal::tuple<typename ::std::iterator_traits<_Types>::reference...> reference;
     typedef ::std::tuple<typename ::std::iterator_traits<_Types>::pointer...> pointer;

--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -421,7 +421,7 @@ class transform_iterator
   public:
     typedef typename ::std::iterator_traits<_Iter>::difference_type difference_type;
     typedef decltype(__my_unary_func_(::std::declval<typename ::std::iterator_traits<_Iter>::reference>())) reference;
-    typedef typename ::std::remove_reference<reference>::type value_type;
+    typedef ::std::remove_reference_t<reference> value_type;
     typedef typename ::std::iterator_traits<_Iter>::pointer pointer;
     typedef typename ::std::iterator_traits<_Iter>::iterator_category iterator_category;
 

--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -584,19 +584,19 @@ class permutation_iterator
 
     permutation_iterator() = default;
 
-    template <typename _T = _Permutation, typename ::std::enable_if<!__internal::__is_functor<_T>, int>::type = 0>
+    template <typename _T = _Permutation, ::std::enable_if_t<!__internal::__is_functor<_T>, int> = 0>
     permutation_iterator(SourceIterator input1, _Permutation input2) : my_source_it(input1), my_index(input2)
     {
     }
 
-    template <typename _T = _Permutation, typename ::std::enable_if<__internal::__is_functor<_T>, int>::type = 0>
+    template <typename _T = _Permutation, ::std::enable_if_t<__internal::__is_functor<_T>, int> = 0>
     permutation_iterator(SourceIterator input1, _Permutation __f, difference_type __idx = 0)
         : my_source_it(input1), my_index(counting_iterator<difference_type>(__idx), __f)
     {
     }
 
   private:
-    template <typename _T = _Permutation, typename ::std::enable_if<__internal::__is_functor<_T>, int>::type = 0>
+    template <typename _T = _Permutation, ::std::enable_if_t<__internal::__is_functor<_T>, int> = 0>
     permutation_iterator(SourceIterator input1, IndexMap input2) : my_source_it(input1), my_index(input2)
     {
     }

--- a/include/oneapi/dpl/pstl/memory_impl.h
+++ b/include/oneapi/dpl/pstl/memory_impl.h
@@ -118,7 +118,7 @@ struct __op_uninitialized_copy<_ExecutionPolicy>
     void
     operator()(_SourceT&& __source, _TargetT& __target) const
     {
-        using _TargetValueType = typename ::std::decay<_TargetT>::type;
+        using _TargetValueType = ::std::decay_t<_TargetT>;
 
         ::new (::std::addressof(__target)) _TargetValueType(::std::forward<_SourceT>(__source));
     }
@@ -135,7 +135,7 @@ struct __op_uninitialized_move<_ExecutionPolicy>
     void
     operator()(_SourceT&& __source, _TargetT& __target) const
     {
-        using _TargetValueType = typename ::std::decay<_TargetT>::type;
+        using _TargetValueType = ::std::decay_t<_TargetT>;
 
         ::new (::std::addressof(__target)) _TargetValueType(::std::move(__source));
     }
@@ -154,7 +154,7 @@ struct __op_uninitialized_fill<_SourceT, _ExecutionPolicy>
     void
     operator()(_TargetT& __target) const
     {
-        using _TargetValueType = typename ::std::decay<_TargetT>::type;
+        using _TargetValueType = ::std::decay_t<_TargetT>;
 
         ::new (::std::addressof(__target)) _TargetValueType(__source);
     }
@@ -171,7 +171,7 @@ struct __op_destroy<_ExecutionPolicy>
     void
     operator()(_TargetT& __target) const
     {
-        using _TargetValueType = typename ::std::decay<_TargetT>::type;
+        using _TargetValueType = ::std::decay_t<_TargetT>;
         __target.~_TargetValueType();
     }
 };
@@ -187,7 +187,7 @@ struct __op_uninitialized_default_construct<_ExecutionPolicy>
     void
     operator()(_TargetT& __target) const
     {
-        using _TargetValueType = typename ::std::decay<_TargetT>::type;
+        using _TargetValueType = ::std::decay_t<_TargetT>;
 
         ::new (::std::addressof(__target)) _TargetValueType;
     }
@@ -204,7 +204,7 @@ struct __op_uninitialized_value_construct<_ExecutionPolicy>
     void
     operator()(_TargetT& __target) const
     {
-        using _TargetValueType = typename ::std::decay<_TargetT>::type;
+        using _TargetValueType = ::std::decay_t<_TargetT>;
 
         ::new (::std::addressof(__target)) _TargetValueType();
     }

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -194,7 +194,7 @@ __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __la
 template <typename _Tp, typename _BinaryOperation>
 using is_arithmetic_udop =
     ::std::integral_constant<bool, ::std::is_arithmetic<_Tp>::value &&
-                                       !::std::is_same<_BinaryOperation, ::std::plus<_Tp>>::value>;
+                                       !::std::is_same_v<_BinaryOperation, ::std::plus<_Tp>>>;
 
 // [restriction] - T shall be DefaultConstructible.
 // [violation] - default ctor of T shall set the identity value for binary_op.

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -200,7 +200,7 @@ using is_arithmetic_udop =
 // [violation] - default ctor of T shall set the identity value for binary_op.
 template <class _RandomAccessIterator, class _OutputIterator, class _UnaryOperation, class _Tp, class _BinaryOperation,
           class _Inclusive>
-typename ::std::enable_if<!is_arithmetic_udop<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>::type
+::std::enable_if_t<!is_arithmetic_udop<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>
 __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __last, _OutputIterator __result,
                        _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op, _Inclusive,
                        /*is_vector=*/::std::true_type) noexcept
@@ -217,7 +217,7 @@ __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __la
 
 template <class _RandomAccessIterator, class _OutputIterator, class _UnaryOperation, class _Tp, class _BinaryOperation,
           class _Inclusive>
-typename ::std::enable_if<is_arithmetic_udop<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>::type
+::std::enable_if_t<is_arithmetic_udop<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>
 __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __last, _OutputIterator __result,
                        _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op, _Inclusive,
                        /*is_vector=*/::std::true_type) noexcept

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -447,14 +447,14 @@ class __task : public tbb::task
     __task*
     make_continuation(_Fn&& __f)
     {
-        return new (allocate_continuation()) __func_task<typename ::std::decay<_Fn>::type>(::std::forward<_Fn>(__f));
+        return new (allocate_continuation()) __func_task<::std::decay_t<_Fn>>(::std::forward<_Fn>(__f));
     }
 
     template <typename _Fn>
     __task*
     make_child_of(__task* parent, _Fn&& __f)
     {
-        return new (parent->allocate_child()) __func_task<typename ::std::decay<_Fn>::type>(::std::forward<_Fn>(__f));
+        return new (parent->allocate_child()) __func_task<::std::decay_t<_Fn>>(::std::forward<_Fn>(__f));
     }
 
     template <typename _Fn>
@@ -462,7 +462,7 @@ class __task : public tbb::task
     make_additional_child_of(tbb::task* parent, _Fn&& __f)
     {
         return new (tbb::task::allocate_additional_child_of(*parent))
-            __func_task<typename ::std::decay<_Fn>::type>(::std::forward<_Fn>(__f));
+            __func_task<::std::decay_t<_Fn>>(::std::forward<_Fn>(__f));
     }
 
     inline void
@@ -547,8 +547,7 @@ class __task : public tbb::detail::d1::task
     {
         assert(_M_execute_data != nullptr);
         tbb::detail::d1::small_object_allocator __alloc{};
-        auto __t = __alloc.new_object<__func_task<typename ::std::decay<_Fn>::type>>(*_M_execute_data,
-                                                                                     ::std::forward<_Fn>(__f));
+        auto __t = __alloc.new_object<__func_task<::std::decay_t<_Fn>>>(*_M_execute_data, ::std::forward<_Fn>(__f));
         __t->_M_allocator = __alloc;
         return __t;
     }

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -58,8 +58,8 @@ struct __serial_move_merge
                _RandomAccessIterator2 __ye, _RandomAccessIterator3 __zs, _Compare __comp, _MoveValueX __move_value_x,
                _MoveValueY __move_value_y, _MoveSequenceX __move_sequence_x, _MoveSequenceY __move_sequence_y)
     {
-        constexpr bool __same_move_val = ::std::is_same<_MoveValueX, _MoveValueY>::value;
-        constexpr bool __same_move_seq = ::std::is_same<_MoveSequenceX, _MoveSequenceY>::value;
+        constexpr bool __same_move_val = ::std::is_same_v<_MoveValueX, _MoveValueY>;
+        constexpr bool __same_move_seq = ::std::is_same_v<_MoveSequenceX, _MoveSequenceY>;
 
         auto __n = _M_nmerge;
         assert(__n > 0);

--- a/include/oneapi/dpl/pstl/parallel_impl.h
+++ b/include/oneapi/dpl/pstl/parallel_impl.h
@@ -40,7 +40,7 @@ __parallel_find(_ExecutionPolicy&& __exec, _Index __first, _Index __last, _Brick
     const _DifferenceType __n = __last - __first;
     _DifferenceType __initial_dist = _IsFirst::value ? __n : -1;
 
-    constexpr auto __comp = typename ::std::conditional<_IsFirst::value, __pstl_less, __pstl_greater>::type{};
+    constexpr auto __comp = ::std::conditional_t<_IsFirst::value, __pstl_less, __pstl_greater>{};
 
     ::std::atomic<_DifferenceType> __extremum(__initial_dist);
     // TODO: find out what is better here: parallel_for or parallel_reduce

--- a/include/oneapi/dpl/pstl/ranges/nanorange.hpp
+++ b/include/oneapi/dpl/pstl/ranges/nanorange.hpp
@@ -5508,9 +5508,9 @@ namespace common_iterator_
 template <typename I, typename S>
 class common_iterator
 {
-    static_assert(input_or_output_iterator<I>, "");
-    static_assert(sentinel_for<S, I>, "");
-    static_assert(!same_as<I, S>, "");
+    static_assert(input_or_output_iterator<I>);
+    static_assert(sentinel_for<S, I>);
+    static_assert(!same_as<I, S>);
 
     template <typename II, typename SS>
     friend class common_iterator;
@@ -5739,8 +5739,8 @@ template <typename D>
 class view_interface : public view_base
 {
 
-    static_assert(::std::is_class<D>::value, "");
-    static_assert(same_as<D, ::std::remove_cv_t<D>>, "");
+    static_assert(::std::is_class<D>::value);
+    static_assert(same_as<D, ::std::remove_cv_t<D>>);
 
   private:
     constexpr D&
@@ -6039,7 +6039,7 @@ class subrange : public view_interface<subrange<I, S, K>>
 {
     static_assert(input_or_output_iterator<I>);
     static_assert(sentinel_for<S, I>);
-    static_assert(K == subrange_kind::sized || !sized_sentinel_for<S, I>, "");
+    static_assert(K == subrange_kind::sized || !sized_sentinel_for<S, I>);
 
   private:
     static constexpr bool StoreSize = K == subrange_kind::sized && !sized_sentinel_for<S, I>;
@@ -7770,7 +7770,7 @@ namespace counted_iterator_
 template <typename I>
 class counted_iterator
 {
-    static_assert(input_or_output_iterator<I>, "");
+    static_assert(input_or_output_iterator<I>);
 
     template <typename I2>
     friend class counted_iterator;
@@ -15321,7 +15321,7 @@ template <typename R>
 class ref_view : public view_interface<ref_view<R>>
 {
 
-    static_assert(range<R> && ::std::is_object<R>::value, "");
+    static_assert(range<R> && ::std::is_object<R>::value);
 
     R* r_ = nullptr;
 
@@ -15475,7 +15475,7 @@ template <typename V>
 class common_view : public view_interface<common_view<V>>
 {
 
-    static_assert(view<V> && !common_range<V>, "");
+    static_assert(view<V> && !common_range<V>);
 
     template <typename VV>
     using random_and_sized_t = ::std::integral_constant<bool, random_access_range<VV> && sized_range<VV>>;
@@ -16420,7 +16420,7 @@ namespace empty_view_
 template <typename T>
 class empty_view : view_interface<empty_view<T>>
 {
-    static_assert(::std::is_object<T>::value, "");
+    static_assert(::std::is_object<T>::value);
 
   public:
     static constexpr T*

--- a/include/oneapi/dpl/pstl/ranges/nanorange.hpp
+++ b/include/oneapi/dpl/pstl/ranges/nanorange.hpp
@@ -527,8 +527,7 @@ namespace detail
 {
 
 template <typename T, typename U>
-constexpr bool same_decayed_v =
-    ::std::is_same<T, ::std::decay_t<T>>::value&& ::std::is_same<U, ::std::decay_t<U>>::value;
+constexpr bool same_decayed_v = ::std::is_same_v<T, ::std::decay_t<T>>&& ::std::is_same_v<U, ::std::decay_t<U>>;
 
 template <typename T, typename U>
 using ternary_return_t = ::std::decay_t<decltype(false ? ::std::declval<T>() : ::std::declval<U>())>;
@@ -1828,8 +1827,8 @@ struct legacy_iterator_category : iterator_category<T>
 };
 
 template <typename T>
-struct legacy_iterator_category<
-    T, ::std::enable_if_t<::std::is_same<iterator_category_t<T>, contiguous_iterator_tag>::value>>
+struct legacy_iterator_category<T,
+                                ::std::enable_if_t<::std::is_same_v<iterator_category_t<T>, contiguous_iterator_tag>>>
 {
     using type = random_access_iterator_tag;
 };

--- a/include/oneapi/dpl/pstl/tuple_impl.h
+++ b/include/oneapi/dpl/pstl/tuple_impl.h
@@ -91,7 +91,7 @@ struct __lvref_or_val
 template <typename _Tp>
 struct __lvref_or_val<_Tp, false>
 {
-    using __type = typename ::std::remove_reference<_Tp>::type;
+    using __type = ::std::remove_reference_t<_Tp>;
 };
 
 template <typename T>

--- a/include/oneapi/dpl/pstl/tuple_impl.h
+++ b/include/oneapi/dpl/pstl/tuple_impl.h
@@ -328,12 +328,12 @@ struct tuple<T1, T...>
     tuple() = default;
     tuple(const tuple& other) = default;
     tuple(tuple&& other) = default;
-    template <typename _U1, typename... _U, typename = typename ::std::enable_if<(sizeof...(_U) == sizeof...(T))>::type>
+    template <typename _U1, typename... _U, typename = ::std::enable_if_t<(sizeof...(_U) == sizeof...(T))>>
     tuple(const tuple<_U1, _U...>& other) : holder(other.template get<0>()), next(other.next)
     {
     }
 
-    template <typename _U1, typename... _U, typename = typename ::std::enable_if<(sizeof...(_U) == sizeof...(T))>::type>
+    template <typename _U1, typename... _U, typename = ::std::enable_if_t<(sizeof...(_U) == sizeof...(T))>>
     tuple(tuple<_U1, _U...>&& other) : holder(std::move(other).template get<0>()), next(std::move(other.next))
     {
     }

--- a/include/oneapi/dpl/pstl/tuple_impl.h
+++ b/include/oneapi/dpl/pstl/tuple_impl.h
@@ -339,10 +339,10 @@ struct tuple<T1, T...>
     }
 
     template <typename _U1, typename... _U,
-              typename = typename ::std::enable_if<
+              typename = ::std::enable_if_t<
                   (sizeof...(_U) == sizeof...(T) &&
                    oneapi::dpl::__internal::__conjunction<::std::is_constructible<T1, _U1&&>,
-                                                          ::std::is_constructible<T, _U&&>...>::value)>::type>
+                                                          ::std::is_constructible<T, _U&&>...>::value)>>
     tuple(_U1&& _value, _U&&... _next) : holder(::std::forward<_U1>(_value)), next(::std::forward<_U>(_next)...)
     {
     }

--- a/include/oneapi/dpl/pstl/tuple_impl.h
+++ b/include/oneapi/dpl/pstl/tuple_impl.h
@@ -163,7 +163,7 @@ template <>
 struct get_impl<0>
 {
     template <typename... T>
-    using ret_type = typename ::std::tuple_element<0, oneapi::dpl::__internal::tuple<T...>>::type;
+    using ret_type = ::std::tuple_element_t<0, oneapi::dpl::__internal::tuple<T...>>;
 
     template <typename... T>
     constexpr ret_type<T...>&
@@ -645,27 +645,27 @@ using __decay_with_tuple_specialization_t = typename __decay_with_tuple_speciali
 namespace std
 {
 template <size_t _Idx, typename... _Tp>
-constexpr typename ::std::tuple_element<_Idx, oneapi::dpl::__internal::tuple<_Tp...>>::type&
+constexpr ::std::tuple_element_t<_Idx, oneapi::dpl::__internal::tuple<_Tp...>>&
 get(oneapi::dpl::__internal::tuple<_Tp...>& __a)
 {
     return __a.template get<_Idx>();
 }
 
 template <size_t _Idx, typename... _Tp>
-constexpr typename ::std::tuple_element<_Idx, oneapi::dpl::__internal::tuple<_Tp...>>::type const&
+constexpr ::std::tuple_element_t<_Idx, oneapi::dpl::__internal::tuple<_Tp...>> const&
 get(const oneapi::dpl::__internal::tuple<_Tp...>& __a)
 {
     return __a.template get<_Idx>();
 }
 template <size_t _Idx, typename... _Tp>
-constexpr typename ::std::tuple_element<_Idx, oneapi::dpl::__internal::tuple<_Tp...>>::type&&
+constexpr ::std::tuple_element_t<_Idx, oneapi::dpl::__internal::tuple<_Tp...>>&&
 get(oneapi::dpl::__internal::tuple<_Tp...>&& __a)
 {
     return ::std::move(__a).template get<_Idx>();
 }
 
 template <size_t _Idx, typename... _Tp>
-constexpr typename ::std::tuple_element<_Idx, oneapi::dpl::__internal::tuple<_Tp...>>::type const&&
+constexpr ::std::tuple_element_t<_Idx, oneapi::dpl::__internal::tuple<_Tp...>> const&&
 get(const oneapi::dpl::__internal::tuple<_Tp...>&& __a)
 {
     return ::std::move(__a).template get<_Idx>();

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -473,7 +473,7 @@ __simd_adjacent_find(_Index __first, _Index __last, _BinaryPredicate __pred, boo
 // It was created to reduce the code inside ::std::enable_if
 template <typename _Tp, typename _BinaryOperation>
 using is_arithmetic_plus = ::std::integral_constant<
-    bool, ::std::is_arithmetic<_Tp>::value&& ::std::is_same<_BinaryOperation, ::std::plus<_Tp>>::value>;
+    bool, ::std::is_arithmetic<_Tp>::value&& ::std::is_same_v<_BinaryOperation, ::std::plus<_Tp>>>;
 
 template <typename _DifferenceType, typename _Tp, typename _BinaryOperation, typename _UnaryOperation>
 ::std::enable_if_t<is_arithmetic_plus<_Tp, _BinaryOperation>::value, _Tp>

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -476,7 +476,7 @@ using is_arithmetic_plus = ::std::integral_constant<
     bool, ::std::is_arithmetic<_Tp>::value&& ::std::is_same<_BinaryOperation, ::std::plus<_Tp>>::value>;
 
 template <typename _DifferenceType, typename _Tp, typename _BinaryOperation, typename _UnaryOperation>
-typename ::std::enable_if<is_arithmetic_plus<_Tp, _BinaryOperation>::value, _Tp>::type
+::std::enable_if_t<is_arithmetic_plus<_Tp, _BinaryOperation>::value, _Tp>
 __simd_transform_reduce(_DifferenceType __n, _Tp __init, _BinaryOperation, _UnaryOperation __f) noexcept
 {
     _ONEDPL_PRAGMA_SIMD_REDUCTION(+ : __init)
@@ -486,7 +486,7 @@ __simd_transform_reduce(_DifferenceType __n, _Tp __init, _BinaryOperation, _Unar
 }
 
 template <typename _Size, typename _Tp, typename _BinaryOperation, typename _UnaryOperation>
-typename ::std::enable_if<!is_arithmetic_plus<_Tp, _BinaryOperation>::value, _Tp>::type
+::std::enable_if_t<!is_arithmetic_plus<_Tp, _BinaryOperation>::value, _Tp>
 __simd_transform_reduce(_Size __n, _Tp __init, _BinaryOperation __binary_op, _UnaryOperation __f) noexcept
 {
     const _Size __block_size = __lane_size / sizeof(_Tp);
@@ -543,7 +543,7 @@ __simd_transform_reduce(_Size __n, _Tp __init, _BinaryOperation __binary_op, _Un
 // Exclusive scan for "+" and arithmetic types
 template <class _InputIterator, class _Size, class _OutputIterator, class _UnaryOperation, class _Tp,
           class _BinaryOperation>
-typename ::std::enable_if<is_arithmetic_plus<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>::type
+::std::enable_if_t<is_arithmetic_plus<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>
 __simd_scan(_InputIterator __first, _Size __n, _OutputIterator __result, _UnaryOperation __unary_op, _Tp __init,
             _BinaryOperation, /*Inclusive*/ ::std::false_type)
 {
@@ -581,7 +581,7 @@ struct _Combiner
 // Exclusive scan for other binary operations and types
 template <class _InputIterator, class _Size, class _OutputIterator, class _UnaryOperation, class _Tp,
           class _BinaryOperation>
-typename ::std::enable_if<!is_arithmetic_plus<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>::type
+::std::enable_if_t<!is_arithmetic_plus<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>
 __simd_scan(_InputIterator __first, _Size __n, _OutputIterator __result, _UnaryOperation __unary_op, _Tp __init,
             _BinaryOperation __binary_op, /*Inclusive*/ ::std::false_type)
 {
@@ -604,7 +604,7 @@ __simd_scan(_InputIterator __first, _Size __n, _OutputIterator __result, _UnaryO
 // Inclusive scan for "+" and arithmetic types
 template <class _InputIterator, class _Size, class _OutputIterator, class _UnaryOperation, class _Tp,
           class _BinaryOperation>
-typename ::std::enable_if<is_arithmetic_plus<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>::type
+::std::enable_if_t<is_arithmetic_plus<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>
 __simd_scan(_InputIterator __first, _Size __n, _OutputIterator __result, _UnaryOperation __unary_op, _Tp __init,
             _BinaryOperation, /*Inclusive*/ ::std::true_type)
 {
@@ -621,7 +621,7 @@ __simd_scan(_InputIterator __first, _Size __n, _OutputIterator __result, _UnaryO
 // Inclusive scan for other binary operations and types
 template <class _InputIterator, class _Size, class _OutputIterator, class _UnaryOperation, class _Tp,
           class _BinaryOperation>
-typename ::std::enable_if<!is_arithmetic_plus<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>::type
+::std::enable_if_t<!is_arithmetic_plus<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>
 __simd_scan(_InputIterator __first, _Size __n, _OutputIterator __result, _UnaryOperation __unary_op, _Tp __init,
             _BinaryOperation __binary_op, ::std::true_type)
 {

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -527,18 +527,18 @@ using __is_const_callable_object =
 struct __next_to_last
 {
     template <typename _Iterator>
-    typename ::std::enable_if<::std::is_base_of<::std::random_access_iterator_tag,
-                                                typename ::std::iterator_traits<_Iterator>::iterator_category>::value,
-                              _Iterator>::type
+    ::std::enable_if_t<::std::is_base_of<::std::random_access_iterator_tag,
+                                         typename ::std::iterator_traits<_Iterator>::iterator_category>::value,
+                       _Iterator>
     operator()(_Iterator __it, _Iterator __last, typename ::std::iterator_traits<_Iterator>::difference_type __n)
     {
         return __n > __last - __it ? __last : __it + __n;
     }
 
     template <typename _Iterator>
-    typename ::std::enable_if<!::std::is_base_of<::std::random_access_iterator_tag,
-                                                 typename ::std::iterator_traits<_Iterator>::iterator_category>::value,
-                              _Iterator>::type
+    ::std::enable_if_t<!::std::is_base_of<::std::random_access_iterator_tag,
+                                          typename ::std::iterator_traits<_Iterator>::iterator_category>::value,
+                       _Iterator>
     operator()(_Iterator __it, _Iterator __last, typename ::std::iterator_traits<_Iterator>::difference_type __n)
     {
         for (; --__n >= 0 && __it != __last; ++__it)

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -399,7 +399,7 @@ __pstl_right_bound(_Buffer& __a, _Index __first, _Index __last, const _Value& __
 template <typename _IntType, typename _Acc>
 struct _ReverseCounter
 {
-    typedef typename ::std::make_signed<_IntType>::type difference_type;
+    typedef ::std::make_signed_t<_IntType> difference_type;
 
     _IntType __my_cn;
 

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -50,7 +50,7 @@ namespace __internal
 
 template <typename Iterator>
 using is_const_iterator =
-    typename ::std::is_const<typename ::std::remove_pointer<typename ::std::iterator_traits<Iterator>::pointer>::type>;
+    typename ::std::is_const<::std::remove_pointer_t<typename ::std::iterator_traits<Iterator>::pointer>>;
 
 template <typename _Fp>
 auto

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -449,7 +449,7 @@ struct _ReverseCounter
 
     class __private_class;
 
-    operator typename ::std::conditional<decltype(__check_braces<_Acc>(0))::value, sycl::id<1>, __private_class>::type()
+    operator ::std::conditional_t<decltype(__check_braces<_Acc>(0))::value, sycl::id<1>, __private_class>()
     {
         return sycl::id<1>(__my_cn);
     }
@@ -561,7 +561,7 @@ struct __conjunction<_B1> : _B1
 };
 
 template <typename _B1, typename... _Bs>
-struct __conjunction<_B1, _Bs...> : ::std::conditional<!bool(_B1::value), _B1, __conjunction<_Bs...>>::type
+struct __conjunction<_B1, _Bs...> : ::std::conditional_t<!bool(_B1::value), _B1, __conjunction<_Bs...>>
 {
 };
 

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -95,7 +95,7 @@ struct pipeline_base
 };
 
 template <typename Range>
-struct pipeline_base<Range, typename ::std::enable_if<is_pipeline_object<Range>::value>::type>
+struct pipeline_base<Range, ::std::enable_if_t<is_pipeline_object<Range>::value>>
 {
     using type = typename pipeline_base<::std::decay_t<decltype(::std::declval<Range>().base())>>::type;
 };
@@ -116,7 +116,7 @@ struct pipeline_base_range
 
 // use ::std::conditional to understand what class to inherit from
 template <typename Range>
-struct pipeline_base_range<Range, typename ::std::enable_if<is_pipeline_object<Range>::value, void>::type>
+struct pipeline_base_range<Range, ::std::enable_if_t<is_pipeline_object<Range>::value, void>>
 {
     Range rng;
 
@@ -456,7 +456,7 @@ struct permutation_view_simple;
 
 //permutation view: specialization for an index map functor
 template <typename _R, typename _M>
-struct permutation_view_simple<_R, _M, typename ::std::enable_if<oneapi::dpl::__internal::__is_functor<_M>>::type>
+struct permutation_view_simple<_R, _M, ::std::enable_if_t<oneapi::dpl::__internal::__is_functor<_M>>>
 {
     using value_type = typename ::std::decay_t<_R>::value_type;
     using _Size = oneapi::dpl::__internal::__difference_t<_R>;
@@ -495,7 +495,7 @@ struct permutation_view_simple<_R, _M, typename ::std::enable_if<oneapi::dpl::__
 
 //permutation view: specialization for a map view (a viewable range concept)
 template <typename _R, typename _M>
-struct permutation_view_simple<_R, _M, typename ::std::enable_if<is_map_view<_M>::value>::type>
+struct permutation_view_simple<_R, _M, ::std::enable_if_t<is_map_view<_M>::value>>
 {
     using value_type = typename ::std::decay_t<_R>::value_type;
 

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -97,7 +97,7 @@ struct pipeline_base
 template <typename Range>
 struct pipeline_base<Range, typename ::std::enable_if<is_pipeline_object<Range>::value>::type>
 {
-    using type = typename pipeline_base<typename ::std::decay<decltype(::std::declval<Range>().base())>::type>::type;
+    using type = typename pipeline_base<::std::decay_t<decltype(::std::declval<Range>().base())>>::type;
 };
 
 //pipeline_base_range

--- a/test/general/test_policies.pass.cpp
+++ b/test/general/test_policies.pass.cpp
@@ -89,7 +89,7 @@ main()
     test_policy_instance(device_policy<class Kernel_24>(sycl::queue(dpcpp_default))); // conversion to sycl::queue
     test_policy_instance(device_policy<>{});
     class Kernel_25;
-    static_assert(std::is_same<device_policy<Kernel_25>::kernel_name, Kernel_25>::value, "wrong result for kernel_name (device_policy)");
+    static_assert(std::is_same_v<device_policy<Kernel_25>::kernel_name, Kernel_25>, "wrong result for kernel_name (device_policy)");
 
 #if ONEDPL_FPGA_DEVICE
     static_assert(is_execution_policy<fpga_policy</*unroll_factor =*/ 1, class Kernel_0>>::value, "wrong result for is_execution_policy<fpga_policy>");
@@ -109,7 +109,7 @@ main()
     test_policy_instance(fpga_policy</*unroll_factor =*/ 2, class Kernel_42>(sycl::device{TestUtils::default_selector}));
     test_policy_instance(fpga_policy</*unroll_factor =*/ 4, class Kernel_43>(dpcpp_fpga));
     test_policy_instance(fpga_policy</*unroll_factor =*/ 8, class Kernel_44>{});
-    static_assert(std::is_same<fpga_policy</*unroll_factor =*/ 8, Kernel_25>::kernel_name, Kernel_25>::value, "wrong result for kernel_name (fpga_policy)");
+    static_assert(std::is_same_v<fpga_policy</*unroll_factor =*/ 8, Kernel_25>::kernel_name, Kernel_25>, "wrong result for kernel_name (fpga_policy)");
     static_assert(fpga_policy</*unroll_factor =*/ 16, class Kernel_45>::unroll_factor == 16, "wrong unroll_factor");
 #endif // ONEDPL_FPGA_DEVICE
 

--- a/test/general/type_requirements.pass.cpp
+++ b/test/general/type_requirements.pass.cpp
@@ -23,8 +23,8 @@
 
 template <typename... Args>
 void CheckTuple() {
-    static_assert(::std::is_trivially_copyable<oneapi::dpl::__internal::tuple<Args...>>::value, "");
-    static_assert(::std::is_standard_layout<oneapi::dpl::__internal::tuple<Args...>>::value, "");
+    static_assert(::std::is_trivially_copyable<oneapi::dpl::__internal::tuple<Args...>>::value);
+    static_assert(::std::is_standard_layout<oneapi::dpl::__internal::tuple<Args...>>::value);
 };
 
 #endif

--- a/test/general/version.pass.cpp
+++ b/test/general/version.pass.cpp
@@ -22,15 +22,15 @@
 #include "support/utils.h"
 
 #if !__has_include(<execution>)
-static_assert(_PSTL_VERSION == 11000, "");
-static_assert(_PSTL_VERSION_MAJOR == 11, "");
-static_assert(_PSTL_VERSION_MINOR == 00, "");
-static_assert(_PSTL_VERSION_PATCH == 0, "");
+static_assert(_PSTL_VERSION == 11000);
+static_assert(_PSTL_VERSION_MAJOR == 11);
+static_assert(_PSTL_VERSION_MINOR == 00);
+static_assert(_PSTL_VERSION_PATCH == 0);
 #endif
 
-static_assert(ONEDPL_VERSION_MAJOR == 2022, "");
-static_assert(ONEDPL_VERSION_MINOR == 3, "");
-static_assert(ONEDPL_VERSION_PATCH == 0, "");
+static_assert(ONEDPL_VERSION_MAJOR == 2022);
+static_assert(ONEDPL_VERSION_MINOR == 3);
+static_assert(ONEDPL_VERSION_PATCH == 0);
 
 int main() {
 

--- a/test/parallel_api/algorithm/alg.merge/inplace_merge.pass.cpp
+++ b/test/parallel_api/algorithm/alg.merge/inplace_merge.pass.cpp
@@ -28,7 +28,7 @@ struct test_one_policy
     // inplace_merge works with bidirectional iterators at least
     template <typename Policy, typename BiDirIt1, typename Size, typename Generator1, typename Generator2,
               typename Compare>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt1>::value, void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt1>::value, void>
     operator()(Policy&& exec, BiDirIt1 first1, BiDirIt1 last1, BiDirIt1 first2, BiDirIt1 last2, Size n, Size m,
                Generator1 generator1, Generator2 generator2, Compare comp)
     {
@@ -39,7 +39,7 @@ struct test_one_policy
     }
 
     template <typename Policy, typename BiDirIt1, typename Size, typename Generator1, typename Generator2>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt1>::value, void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt1>::value, void>
     operator()(Policy&& exec, BiDirIt1 first1, BiDirIt1 last1, BiDirIt1 first2, BiDirIt1 last2, Size n, Size m,
                Generator1 generator1, Generator2 generator2)
     {
@@ -64,14 +64,14 @@ struct test_one_policy
     }
 
     template <typename Policy, typename BiDirIt1, typename Size, typename Generator1, typename Generator2>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt1>::value, void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt1>::value, void>
     operator()(Policy&& /* exec */, BiDirIt1 /* first1 */, BiDirIt1 /* last1 */, BiDirIt1 /* first2 */, BiDirIt1 /* last2 */, Size /* n */, Size /* m */,
                Generator1 /* generator1 */, Generator2 /* generator2 */)
     {
     }
     template <typename Policy, typename BiDirIt1, typename Size, typename Generator1, typename Generator2,
               typename Compare>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt1>::value, void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt1>::value, void>
     operator()(Policy&& /* exec */, BiDirIt1 /* first1 */, BiDirIt1 /* last1 */, BiDirIt1 /* first2 */, BiDirIt1 /* last2 */, Size /* n */, Size /* m */,
                Generator1 /* generator1 */, Generator2 /* generator2 */, Compare /* comp */)
     {

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition.pass.cpp
@@ -61,8 +61,8 @@ is_equal(Iterator first, Iterator last, Iterator d_first)
 }
 
 template <typename Iterator>
-typename ::std::enable_if<!::std::is_trivial<typename ::std::iterator_traits<Iterator>::value_type>::value, bool>::type
-is_equal(Iterator /* first */, Iterator /* last */, Iterator /* d_first */)
+::std::enable_if_t<!::std::is_trivial<typename ::std::iterator_traits<Iterator>::value_type>::value, bool>
+    is_equal(Iterator /* first */, Iterator /* last */, Iterator /* d_first */)
 {
     return true;
 }
@@ -71,7 +71,7 @@ template<typename T>
 struct test_partition
 {
     template <typename Policy, typename BiDirIt, typename Size, typename UnaryOp, typename Generator>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt>::value, void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt>::value, void>
     operator()(Policy&& exec, BiDirIt first, BiDirIt last, BiDirIt /* exp_first */, BiDirIt /* exp_last */, Size /* n */,
                UnaryOp unary_op, Generator generator)
     {
@@ -82,7 +82,7 @@ struct test_partition
     }
 
     template <typename Policy, typename BiDirIt, typename Size, typename UnaryOp, typename Generator>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt>::value, void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt>::value, void>
     operator()(Policy&& /* exec */, BiDirIt /* first */, BiDirIt /* last */, BiDirIt /* exp_first */, BiDirIt /* exp_last */, Size /* n */,
                UnaryOp /* unary_op */, Generator /* generator */)
     {

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition.pass.cpp
@@ -54,7 +54,7 @@ struct DataType
 };
 
 template <typename Iterator>
-typename ::std::enable_if<::std::is_trivial<typename ::std::iterator_traits<Iterator>::value_type>::value, bool>::type
+::std::enable_if_t<::std::is_trivial<typename ::std::iterator_traits<Iterator>::value_type>::value, bool>
 is_equal(Iterator first, Iterator last, Iterator d_first)
 {
     return ::std::equal(first, last, d_first);

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/stable_partition.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/stable_partition.pass.cpp
@@ -54,15 +54,15 @@ struct DataType
 };
 
 template <typename Iterator>
-typename ::std::enable_if<::std::is_trivial<typename ::std::iterator_traits<Iterator>::value_type>::value, bool>::type
+::std::enable_if_t<::std::is_trivial<typename ::std::iterator_traits<Iterator>::value_type>::value, bool>
 is_equal(Iterator first, Iterator last, Iterator d_first)
 {
     return ::std::equal(first, last, d_first);
 }
 
 template <typename Iterator>
-typename ::std::enable_if<!::std::is_trivial<typename ::std::iterator_traits<Iterator>::value_type>::value, bool>::type
-is_equal(Iterator /* first */, Iterator /* last */, Iterator /* d_first */)
+::std::enable_if_t<!::std::is_trivial<typename ::std::iterator_traits<Iterator>::value_type>::value, bool>
+    is_equal(Iterator /* first */, Iterator /* last */, Iterator /* d_first */)
 {
     return true;
 }
@@ -71,7 +71,7 @@ template <typename T>
 struct test_stable_partition
 {
     template <typename Policy, typename BiDirIt, typename Size, typename UnaryOp, typename Generator>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt>::value, void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt>::value, void>
     operator()(Policy&& exec, BiDirIt first, BiDirIt last, BiDirIt exp_first, BiDirIt exp_last, Size /* n */,
                UnaryOp unary_op, Generator generator)
     {
@@ -86,7 +86,7 @@ struct test_stable_partition
     }
 
     template <typename Policy, typename BiDirIt, typename Size, typename UnaryOp, typename Generator>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt>::value, void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt>::value, void>
     operator()(Policy&& /* exec */, BiDirIt /* first */, BiDirIt /* last */, BiDirIt /* exp_first */, BiDirIt /* exp_last */, Size /* n */,
                UnaryOp /* unary_op */, Generator /* generator */)
     {

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse.pass.cpp
@@ -29,14 +29,14 @@ struct test_one_policy
 {
 #if _PSTL_ICC_18_VC141_TEST_SIMD_LAMBDA_RELEASE_BROKEN // dummy specialization by policy type, in case of broken configuration
     template <typename Iterator1, typename Iterator2>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value, void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value, void>
     operator()(oneapi::dpl::execution::unsequenced_policy, Iterator1 data_b, Iterator1 data_e, Iterator2 actual_b,
                Iterator2 actual_e)
     {
     }
 
     template <typename Iterator1, typename Iterator2>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value, void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value, void>
     operator()(oneapi::dpl::execution::parallel_unsequenced_policy, Iterator1 data_b, Iterator1 data_e, Iterator2 actual_b,
                Iterator2 actual_e)
     {
@@ -44,7 +44,7 @@ struct test_one_policy
 #endif
 
     template <typename ExecutionPolicy, typename Iterator1, typename Iterator2>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::bidirectional_iterator_tag, Iterator1>::value>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::bidirectional_iterator_tag, Iterator1>::value>
     operator()(ExecutionPolicy&& exec, Iterator1 data_b, Iterator1 data_e, Iterator2 actual_b, Iterator2 actual_e)
     {
         using namespace std;
@@ -59,7 +59,7 @@ struct test_one_policy
     }
 
     template <typename ExecutionPolicy, typename Iterator1, typename Iterator2>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, Iterator1>::value>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, Iterator1>::value>
     operator()(ExecutionPolicy&& /* exec */, Iterator1 /* data_b */, Iterator1 /* data_e */, Iterator2 /* actual_b */, Iterator2 /* actual_e */)
     {
     }

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse_copy.pass.cpp
@@ -55,7 +55,7 @@ template<typename T1, typename T2>
 struct test_one_policy
 {
     template <typename ExecutionPolicy, typename Iterator1, typename Iterator2>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::bidirectional_iterator_tag, Iterator1>::value>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::bidirectional_iterator_tag, Iterator1>::value>
     operator()(ExecutionPolicy&& exec, Iterator1 data_b, Iterator1 data_e, Iterator2 actual_b, Iterator2 actual_e)
     {
         using namespace std;
@@ -72,7 +72,7 @@ struct test_one_policy
     }
 
     template <typename ExecutionPolicy, typename Iterator1, typename Iterator2>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, Iterator1>::value>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, Iterator1>::value>
     operator()(ExecutionPolicy&& /* exec */, Iterator1 /* data_b */, Iterator1 /* data_e */, Iterator2 /* actual_b */, Iterator2 /* actual_e*/)
     {
     }

--- a/test/parallel_api/algorithm/alg.modifying.operations/replace.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/replace.pass.cpp
@@ -84,7 +84,7 @@ struct test_replace
     }
 
     template <typename T, typename Iterator1>
-    typename ::std::enable_if<::std::is_same<T, copy_int>::value, bool>::type_t
+    ::std::enable_if_t<::std::is_same<T, copy_int>::value, bool>
     check(Iterator1 b, Iterator1 e)
     {
         return ::std::all_of(b, e, [](const copy_int& elem) { return elem.copied_times == 0; });

--- a/test/parallel_api/algorithm/alg.modifying.operations/replace.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/replace.pass.cpp
@@ -84,7 +84,7 @@ struct test_replace
     }
 
     template <typename T, typename Iterator1>
-    ::std::enable_if_t<::std::is_same<T, copy_int>::value, bool>
+    ::std::enable_if_t<::std::is_same_v<T, copy_int>, bool>
     check(Iterator1 b, Iterator1 e)
     {
         return ::std::all_of(b, e, [](const copy_int& elem) { return elem.copied_times == 0; });

--- a/test/parallel_api/algorithm/alg.modifying.operations/rotate.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/rotate.pass.cpp
@@ -101,11 +101,11 @@ struct test_one_policy
     }
 
     template <typename ExecutionPolicy, typename Iterator, typename Size>
-    typename ::std::enable_if<
+    ::std::enable_if_t<
         is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
         !::std::is_same<ExecutionPolicy, oneapi::dpl::execution::sequenced_policy>::value &&
         ::std::is_same<typename ::std::iterator_traits<Iterator>::value_type, wrapper<float32_t>>::value,
-        bool>::type
+        bool>
     check_move(ExecutionPolicy&& /* exec */, Iterator b, Iterator e, Size shift)
     {
         bool result = all_of(b, e, [](wrapper<float32_t>& a) {
@@ -117,11 +117,11 @@ struct test_one_policy
     }
 
     template <typename ExecutionPolicy, typename Iterator, typename Size>
-    typename ::std::enable_if<
+    ::std::enable_if_t<
         !(is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
         !::std::is_same<ExecutionPolicy, oneapi::dpl::execution::sequenced_policy>::value &&
         ::std::is_same<typename ::std::iterator_traits<Iterator>::value_type, wrapper<float32_t>>::value),
-        bool>::type
+        bool>
     check_move(ExecutionPolicy&& /* exec */, Iterator /* b */, Iterator /* e */, Size /* shift */)
     {
         return true;

--- a/test/parallel_api/algorithm/alg.modifying.operations/rotate.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/rotate.pass.cpp
@@ -103,8 +103,8 @@ struct test_one_policy
     template <typename ExecutionPolicy, typename Iterator, typename Size>
     ::std::enable_if_t<
         is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
-        !::std::is_same<ExecutionPolicy, oneapi::dpl::execution::sequenced_policy>::value &&
-        ::std::is_same<typename ::std::iterator_traits<Iterator>::value_type, wrapper<float32_t>>::value,
+        !::std::is_same_v<ExecutionPolicy, oneapi::dpl::execution::sequenced_policy> &&
+        ::std::is_same_v<typename ::std::iterator_traits<Iterator>::value_type, wrapper<float32_t>>,
         bool>
     check_move(ExecutionPolicy&& /* exec */, Iterator b, Iterator e, Size shift)
     {
@@ -119,8 +119,8 @@ struct test_one_policy
     template <typename ExecutionPolicy, typename Iterator, typename Size>
     ::std::enable_if_t<
         !(is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
-        !::std::is_same<ExecutionPolicy, oneapi::dpl::execution::sequenced_policy>::value &&
-        ::std::is_same<typename ::std::iterator_traits<Iterator>::value_type, wrapper<float32_t>>::value),
+        !::std::is_same_v<ExecutionPolicy, oneapi::dpl::execution::sequenced_policy> &&
+        ::std::is_same_v<typename ::std::iterator_traits<Iterator>::value_type, wrapper<float32_t>>),
         bool>
     check_move(ExecutionPolicy&& /* exec */, Iterator /* b */, Iterator /* e */, Size /* shift */)
     {

--- a/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
@@ -148,27 +148,21 @@ struct shift_left_algo
 struct shift_right_algo
 {
     template <typename Policy, typename It>
-    typename ::std::enable_if<TestUtils::is_base_of_iterator_category<::std::bidirectional_iterator_tag, 
-                            It>::value,
-                            It>::type
+    ::std::enable_if_t<TestUtils::is_base_of_iterator_category<::std::bidirectional_iterator_tag, It>::value, It>
     operator()(Policy&& exec, It first, It last, typename ::std::iterator_traits<It>::difference_type n)
     {
         return oneapi::dpl::shift_right(::std::forward<Policy>(exec), first, last, n);
     }
     //skip the test for non-bidirectional iterator (forward iterator, etc)
     template <typename Policy, typename It>
-    typename ::std::enable_if<!TestUtils::is_base_of_iterator_category<::std::bidirectional_iterator_tag, 
-                            It>::value,
-                            It>::type
+    ::std::enable_if_t<!TestUtils::is_base_of_iterator_category<::std::bidirectional_iterator_tag, It>::value, It>
     operator()(Policy&& exec, It first, It last, typename ::std::iterator_traits<It>::difference_type n)
     {
         return first;
     }
 
     template <typename It, typename ItExp>
-    typename ::std::enable_if<TestUtils::is_base_of_iterator_category<::std::bidirectional_iterator_tag, 
-                            It>::value,
-                            void>::type
+    ::std::enable_if_t<TestUtils::is_base_of_iterator_category<::std::bidirectional_iterator_tag, It>::value, void>
     check(It res, It first, typename ::std::iterator_traits<It>::difference_type m, ItExp first_exp,
         typename ::std::iterator_traits<It>::difference_type n)
     {
@@ -188,9 +182,7 @@ struct shift_right_algo
     }
     //skip the check for non-bidirectional iterator (forward iterator, etc)
     template <typename It, typename ItExp>
-    typename ::std::enable_if<!TestUtils::is_base_of_iterator_category<::std::bidirectional_iterator_tag, 
-                            It>::value,
-                            void>::type
+    ::std::enable_if_t<!TestUtils::is_base_of_iterator_category<::std::bidirectional_iterator_tag, It>::value, void>
     check(It res, It first, typename ::std::iterator_traits<It>::difference_type m, ItExp first_exp,
         typename ::std::iterator_traits<It>::difference_type n)
     {

--- a/test/parallel_api/algorithm/alg.nonmodifying/nth_element.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/nth_element.pass.cpp
@@ -113,7 +113,7 @@ struct test_with_compare
     // nth_element works only with random access iterators
     template <typename Policy, typename Iterator1, typename Size, typename Generator1, typename Generator2,
               typename Compare>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value, void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value, void>
     operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator1 first2, Iterator1 last2, Size n, Size m,
                Generator1 generator1, Generator2 generator2, Compare comp)
     {
@@ -136,7 +136,7 @@ struct test_with_compare
 
     template <typename Policy, typename Iterator1, typename Size, typename Generator1, typename Generator2,
               typename Compare>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value, void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value, void>
     operator()(Policy&& /* exec */, Iterator1 /* first1 */, Iterator1 /* last1 */, Iterator1 /* first2 */, Iterator1 /* last2 */, Size /* n */, Size /* m */,
                Generator1 /* generator1 */, Generator2 /* generator2 */, Compare /* comp */)
     {

--- a/test/parallel_api/algorithm/alg.nonmodifying/nth_element.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/nth_element.pass.cpp
@@ -76,8 +76,9 @@ struct test_without_compare
 {
     // nth_element works only with random access iterators
     template <typename Policy, typename Iterator1, typename Size, typename Generator1, typename Generator2>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value &&
-                              can_use_default_less_operator<Type>::value, void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value &&
+                           can_use_default_less_operator<Type>::value,
+                       void>
     operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator1 first2, Iterator1 last2, Size n, Size m,
                Generator1 generator1, Generator2 generator2)
     {
@@ -99,8 +100,9 @@ struct test_without_compare
     }
 
     template <typename Policy, typename Iterator1, typename Size, typename Generator1, typename Generator2>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value ||
-                              !can_use_default_less_operator<Type>::value, void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value ||
+                           !can_use_default_less_operator<Type>::value,
+                       void>
     operator()(Policy&& /* exec */, Iterator1 /* first1 */, Iterator1 /* last1 */, Iterator1 /* first2 */, Iterator1 /* last2 */, Size /* n */, Size /* m */,
                Generator1 /* generator1 */, Generator2 /* generator2 */)
     {

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
@@ -56,7 +56,7 @@ DEFINE_TEST(test_binary_search)
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     typename ::std::enable_if<
-        oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<Policy>::type>::value &&
+        oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
         void>::type
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
@@ -95,7 +95,7 @@ DEFINE_TEST(test_binary_search)
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     typename ::std::enable_if<
 #if TEST_DPCPP_BACKEND_PRESENT
-        !oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<Policy>::type>::value &&
+        !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
         void>::type

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
@@ -55,10 +55,9 @@ DEFINE_TEST(test_binary_search)
 #if TEST_DPCPP_BACKEND_PRESENT
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    typename ::std::enable_if<
-        oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
-            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-        void>::type
+    ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
+                           is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
+                       void>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {
@@ -93,12 +92,12 @@ DEFINE_TEST(test_binary_search)
 
     // specialization for host execution policies
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    typename ::std::enable_if<
+    ::std::enable_if_t<
 #if TEST_DPCPP_BACKEND_PRESENT
         !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-        void>::type
+        void>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {
@@ -118,8 +117,7 @@ DEFINE_TEST(test_binary_search)
 
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-                              void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value, void>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
@@ -51,7 +51,7 @@ DEFINE_TEST(test_lower_bound)
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     typename ::std::enable_if<
-        oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<Policy>::type>::value &&
+        oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
         void>::type
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
@@ -90,7 +90,7 @@ DEFINE_TEST(test_lower_bound)
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     typename ::std::enable_if<
 #if TEST_DPCPP_BACKEND_PRESENT
-        !oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<Policy>::type>::value &&
+        !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
         void>::type

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
@@ -50,10 +50,9 @@ DEFINE_TEST(test_lower_bound)
 #if TEST_DPCPP_BACKEND_PRESENT
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    typename ::std::enable_if<
-        oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
-            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-        void>::type
+    ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
+                           is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
+                       void>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {
@@ -88,12 +87,12 @@ DEFINE_TEST(test_lower_bound)
 
     // specialization for host execution policies
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    typename ::std::enable_if<
+    ::std::enable_if_t<
 #if TEST_DPCPP_BACKEND_PRESENT
         !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-        void>::type
+        void>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {
@@ -112,8 +111,7 @@ DEFINE_TEST(test_lower_bound)
 
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-                              void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value, void>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
@@ -58,7 +58,7 @@ DEFINE_TEST(test_upper_bound)
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     typename ::std::enable_if<
-        oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<Policy>::type>::value &&
+        oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
         void>::type
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
@@ -97,7 +97,7 @@ DEFINE_TEST(test_upper_bound)
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     typename ::std::enable_if<
 #if TEST_DPCPP_BACKEND_PRESENT
-        !oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<Policy>::type>::value &&
+        !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
         void>::type

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
@@ -57,10 +57,9 @@ DEFINE_TEST(test_upper_bound)
 #if TEST_DPCPP_BACKEND_PRESENT
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    typename ::std::enable_if<
-        oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
-            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-        void>::type
+    ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
+                           is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
+                       void>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {
@@ -95,12 +94,12 @@ DEFINE_TEST(test_upper_bound)
 
     // specialization for host execution policies
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    typename ::std::enable_if<
+    ::std::enable_if_t<
 #if TEST_DPCPP_BACKEND_PRESENT
         !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-        void>::type
+        void>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {
@@ -119,8 +118,7 @@ DEFINE_TEST(test_upper_bound)
 
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-                              void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value, void>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {

--- a/test/parallel_api/algorithm/alg.sorting/alg.heap.operations/is_heap.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.heap.operations/is_heap.pass.cpp
@@ -48,7 +48,7 @@ template <typename T>
 struct test_is_heap
 {
     template <typename Policy, typename Iterator>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>
     operator()(Policy&& exec, Iterator first, Iterator last)
     {
         using namespace std;
@@ -59,7 +59,7 @@ struct test_is_heap
 
     // is_heap works only with random access iterators
     template <typename Policy, typename Iterator>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>
     operator()(Policy&& /* exec */, Iterator /* first */, Iterator /* last */)
     {
     }
@@ -69,7 +69,7 @@ template <typename T>
 struct test_is_heap_predicate
 {
     template <typename Policy, typename Iterator, typename Predicate>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>
     operator()(Policy&& exec, Iterator first, Iterator last, Predicate pred)
     {
         using namespace std;
@@ -80,7 +80,7 @@ struct test_is_heap_predicate
 
     // is_heap works only with random access iterators
     template <typename Policy, typename Iterator, typename Predicate>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>
     operator()(Policy&& /* exec */, Iterator /* first */, Iterator /* last */, Predicate /* pred */)
     {
     }
@@ -90,7 +90,7 @@ template <typename T>
 struct test_is_heap_until
 {
     template <typename Policy, typename Iterator>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>
     operator()(Policy&& exec, Iterator first, Iterator last)
     {
         using namespace std;
@@ -101,7 +101,7 @@ struct test_is_heap_until
 
     // is_heap, is_heap_until works only with random access iterators
     template <typename Policy, typename Iterator>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>
     operator()(Policy&& /* exec */, Iterator /* first */, Iterator /* last */)
     {
     }
@@ -111,7 +111,7 @@ template <typename T>
 struct test_is_heap_until_predicate
 {
     template <typename Policy, typename Iterator, typename Predicate>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>
     operator()(Policy&& exec, Iterator first, Iterator last, Predicate pred)
     {
         using namespace std;
@@ -122,7 +122,7 @@ struct test_is_heap_until_predicate
 
     // is_heap, is_heap_until works only with random access iterators
     template <typename Policy, typename Iterator, typename Predicate>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>
     operator()(Policy&& /* exec */, Iterator /* first */, Iterator /* last */, Predicate /* pred */)
     {
     }

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/max.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/max.pass.cpp
@@ -56,8 +56,8 @@ ONEDPL_TEST_NUM_MAIN
     {
     constexpr int x = 1;
     constexpr int y = 0;
-    static_assert(dpl::max(x, y) == x, "" );
-    static_assert(dpl::max(y, x) == x, "" );
+    static_assert(dpl::max(x, y) == x);
+    static_assert(dpl::max(y, x) == x);
     }
 #endif
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/max_comp.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/max_comp.pass.cpp
@@ -58,8 +58,8 @@ ONEDPL_TEST_NUM_MAIN
     {
     constexpr int x = 1;
     constexpr int y = 0;
-    static_assert(dpl::max(x, y, dpl::greater<int>()) == y, "");
-    static_assert(dpl::max(y, x, dpl::greater<int>()) == y, "");
+    static_assert(dpl::max(x, y, dpl::greater<int>()) == y);
+    static_assert(dpl::max(y, x, dpl::greater<int>()) == y);
     }
 #endif
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/max_init_list.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/max_init_list.pass.cpp
@@ -48,9 +48,9 @@ ONEDPL_TEST_NUM_MAIN
     assert(i == 3);
 #if TEST_STD_VER >= 14
     {
-    static_assert(dpl::max({1, 3, 2}) == 3, "");
-    static_assert(dpl::max({2, 1, 3}) == 3, "");
-    static_assert(dpl::max({3, 2, 1}) == 3, "");
+    static_assert(dpl::max({1, 3, 2}) == 3);
+    static_assert(dpl::max({2, 1, 3}) == 3);
+    static_assert(dpl::max({3, 2, 1}) == 3);
     }
 #endif
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/max_init_list_comp.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/max_init_list_comp.pass.cpp
@@ -44,9 +44,9 @@ ONEDPL_TEST_NUM_MAIN
     assert(i == 1);
 #if TEST_STD_VER >= 14
     {
-    static_assert(dpl::max({1, 3, 2}, dpl::greater<int>()) == 1, "");
-    static_assert(dpl::max({2, 1, 3}, dpl::greater<int>()) == 1, "");
-    static_assert(dpl::max({3, 2, 1}, dpl::greater<int>()) == 1, "");
+    static_assert(dpl::max({1, 3, 2}, dpl::greater<int>()) == 1);
+    static_assert(dpl::max({2, 1, 3}, dpl::greater<int>()) == 1);
+    static_assert(dpl::max({3, 2, 1}, dpl::greater<int>()) == 1);
     }
 #endif
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/min.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/min.pass.cpp
@@ -56,8 +56,8 @@ ONEDPL_TEST_NUM_MAIN
     {
     constexpr int x = 1;
     constexpr int y = 0;
-    static_assert(dpl::min(x, y) == y, "" );
-    static_assert(dpl::min(y, x) == y, "" );
+    static_assert(dpl::min(x, y) == y);
+    static_assert(dpl::min(y, x) == y);
     }
 #endif
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/min_comp.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/min_comp.pass.cpp
@@ -58,8 +58,8 @@ ONEDPL_TEST_NUM_MAIN
     {
     constexpr int x = 1;
     constexpr int y = 0;
-    static_assert(dpl::min(x, y, dpl::greater<int>()) == x, "" );
-    static_assert(dpl::min(y, x, dpl::greater<int>()) == x, "" );
+    static_assert(dpl::min(x, y, dpl::greater<int>()) == x);
+    static_assert(dpl::min(y, x, dpl::greater<int>()) == x);
     }
 #endif
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/min_init_list.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/min_init_list.pass.cpp
@@ -48,9 +48,9 @@ ONEDPL_TEST_NUM_MAIN
     assert(i == 1);
 #if TEST_STD_VER >= 14
     {
-    static_assert(dpl::min({1, 3, 2}) == 1, "");
-    static_assert(dpl::min({2, 1, 3}) == 1, "");
-    static_assert(dpl::min({3, 2, 1}) == 1, "");
+    static_assert(dpl::min({1, 3, 2}) == 1);
+    static_assert(dpl::min({2, 1, 3}) == 1);
+    static_assert(dpl::min({3, 2, 1}) == 1);
     }
 #endif
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/min_init_list_comp.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/min_init_list_comp.pass.cpp
@@ -44,9 +44,9 @@ ONEDPL_TEST_NUM_MAIN
     assert(i == 3);
 #if TEST_STD_VER >= 14
     {
-    static_assert(dpl::min({1, 3, 2}, dpl::greater<int>()) == 3, "");
-    static_assert(dpl::min({2, 1, 3}, dpl::greater<int>()) == 3, "");
-    static_assert(dpl::min({3, 2, 1}, dpl::greater<int>()) == 3, "");
+    static_assert(dpl::min({1, 3, 2}, dpl::greater<int>()) == 3);
+    static_assert(dpl::min({2, 1, 3}, dpl::greater<int>()) == 3);
+    static_assert(dpl::min({3, 2, 1}, dpl::greater<int>()) == 3);
     }
 #endif
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.set.operations/includes.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.set.operations/includes.pass.cpp
@@ -72,7 +72,7 @@ template <typename T>
 struct test_with_compare
 {
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    typename ::std::enable_if<!TestUtils::isReverse<InputIterator1>::value, void>::type
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value, void>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2,
                Compare comp)
     {
@@ -84,7 +84,7 @@ struct test_with_compare
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    typename ::std::enable_if<TestUtils::isReverse<InputIterator1>::value, void>::type
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value, void>
     operator()(Policy&& /* exec */, InputIterator1 /* first1 */, InputIterator1 /* last1 */, InputIterator2 /* first2 */, InputIterator2 /* last2 */,
                Compare /* comp */)
     {

--- a/test/parallel_api/algorithm/alg.sorting/alg.set.operations/includes.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.set.operations/includes.pass.cpp
@@ -50,8 +50,7 @@ template <typename T>
 struct test_without_compare
 {
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    typename ::std::enable_if<!TestUtils::isReverse<InputIterator1>::value &&
-                              can_use_default_less_operator<T>::value, void>::type
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value && can_use_default_less_operator<T>::value, void>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2)
     {
         auto expect_res = ::std::includes(first1, last1, first2, last2);
@@ -61,8 +60,7 @@ struct test_without_compare
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    typename ::std::enable_if<TestUtils::isReverse<InputIterator1>::value ||
-                              !can_use_default_less_operator<T>::value, void>::type
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value || !can_use_default_less_operator<T>::value, void>
     operator()(Policy&& /* exec */, InputIterator1 /* first1 */, InputIterator1 /* last1 */, InputIterator2 /* first2 */, InputIterator2 /* last2 */)
     {
     }

--- a/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_common.h
+++ b/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_common.h
@@ -85,7 +85,7 @@ template <typename Type>
 struct test_set_union
 {
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    typename ::std::enable_if<!TestUtils::isReverse<InputIterator1>::value, void>::type
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value, void>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2,
                Compare comp)
     {
@@ -101,7 +101,7 @@ struct test_set_union
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    typename ::std::enable_if<!TestUtils::isReverse<InputIterator1>::value, void>::type
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value, void>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2)
     {
         auto sequences = init(first1, last1, first2, last2);
@@ -115,13 +115,13 @@ struct test_set_union
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    typename ::std::enable_if<TestUtils::isReverse<InputIterator1>::value, void>::type
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value, void>
     operator()(Policy&&, InputIterator1, InputIterator1, InputIterator2, InputIterator2)
     {
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    typename ::std::enable_if<TestUtils::isReverse<InputIterator1>::value, void>::type
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value, void>
     operator()(Policy&&, InputIterator1, InputIterator1, InputIterator2, InputIterator2, Compare)
     {
     }
@@ -131,7 +131,7 @@ template <typename Type>
 struct test_set_intersection
 {
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    typename ::std::enable_if<!TestUtils::isReverse<InputIterator1>::value, void>::type
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value, void>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2,
                Compare comp)
     {
@@ -146,7 +146,7 @@ struct test_set_intersection
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    typename ::std::enable_if<!TestUtils::isReverse<InputIterator1>::value, void>::type
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value, void>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2)
     {
         auto sequences = init(first1, last1, first2, last2);
@@ -160,13 +160,13 @@ struct test_set_intersection
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    typename ::std::enable_if<TestUtils::isReverse<InputIterator1>::value, void>::type
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value, void>
     operator()(Policy&&, InputIterator1, InputIterator1, InputIterator2, InputIterator2)
     {
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    typename ::std::enable_if<TestUtils::isReverse<InputIterator1>::value, void>::type
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value, void>
     operator()(Policy&&, InputIterator1, InputIterator1, InputIterator2, InputIterator2, Compare)
     {
     }
@@ -176,7 +176,7 @@ template <typename Type>
 struct test_set_difference
 {
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    typename ::std::enable_if<!TestUtils::isReverse<InputIterator1>::value, void>::type
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value, void>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2,
                Compare comp)
     {
@@ -191,7 +191,7 @@ struct test_set_difference
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    typename ::std::enable_if<!TestUtils::isReverse<InputIterator1>::value, void>::type
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value, void>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2)
     {
         auto sequences = init(first1, last1, first2, last2);
@@ -207,13 +207,13 @@ struct test_set_difference
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    typename ::std::enable_if<TestUtils::isReverse<InputIterator1>::value, void>::type
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value, void>
     operator()(Policy&&, InputIterator1, InputIterator1, InputIterator2, InputIterator2)
     {
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    typename ::std::enable_if<TestUtils::isReverse<InputIterator1>::value, void>::type
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value, void>
     operator()(Policy&&, InputIterator1, InputIterator1, InputIterator2, InputIterator2, Compare)
     {
     }
@@ -223,7 +223,7 @@ template <typename Type>
 struct test_set_symmetric_difference
 {
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    typename ::std::enable_if<!TestUtils::isReverse<InputIterator1>::value, void>::type
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value, void>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2,
                Compare comp)
     {
@@ -239,7 +239,7 @@ struct test_set_symmetric_difference
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    typename ::std::enable_if<!TestUtils::isReverse<InputIterator1>::value, void>::type
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value, void>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2)
     {
         auto sequences = init(first1, last1, first2, last2);
@@ -255,13 +255,13 @@ struct test_set_symmetric_difference
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    typename ::std::enable_if<TestUtils::isReverse<InputIterator1>::value, void>::type
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value, void>
     operator()(Policy&&, InputIterator1, InputIterator1, InputIterator2, InputIterator2)
     {
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    typename ::std::enable_if<TestUtils::isReverse<InputIterator1>::value, void>::type
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value, void>
     operator()(Policy&&, InputIterator1, InputIterator1, InputIterator2, InputIterator2, Compare)
     {
     }

--- a/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
@@ -58,8 +58,7 @@ template <typename Type>
 struct test_brick_partial_sort
 {
     template <typename Policy, typename InputIterator, typename Compare>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value,
-                            void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value, void>
     operator()(Policy&& exec, InputIterator first, InputIterator last, InputIterator exp_first, InputIterator exp_last,
                InputIterator tmp_first, InputIterator tmp_last, Compare compare)
     {
@@ -102,16 +101,16 @@ struct test_brick_partial_sort
     }
 
     template <typename Policy, typename InputIterator, typename Compare>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value,
-                            void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value, void>
     operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, InputIterator /* exp_first */,
                InputIterator /* exp_last */, InputIterator /* tmp_first */, InputIterator /* tmp_last */, Compare /* compare */)
     {
     }
 
     template <typename Policy, typename InputIterator>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value &&
-                              can_use_default_less_operator<Type>::value, void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value &&
+                           can_use_default_less_operator<Type>::value,
+                       void>
     operator()(Policy&& exec, InputIterator first, InputIterator last, InputIterator exp_first, InputIterator exp_last,
                InputIterator tmp_first, InputIterator tmp_last)
     {
@@ -131,8 +130,9 @@ struct test_brick_partial_sort
     }
 
     template <typename Policy, typename InputIterator>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value ||
-                              !can_use_default_less_operator<Type>::value, void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value ||
+                           !can_use_default_less_operator<Type>::value,
+                       void>
     operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, InputIterator /* exp_first */,
                InputIterator /* exp_last */, InputIterator /* tmp_first */, InputIterator /* tmp_last */)
     {

--- a/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
@@ -304,10 +304,11 @@ template <typename T>
 struct test_sort_op
 {
     template <typename Policy, typename InputIterator, typename OutputIterator, typename OutputIterator2, typename Size,
-              typename ...Compare>
-    typename ::std::enable_if<TestUtils::is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value
-                          && (TestUtils::can_use_default_less_operator<T>::value || sizeof...(Compare) > 0),
-                              void>::type
+              typename... Compare>
+    ::std::enable_if_t<
+        TestUtils::is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value &&
+            (TestUtils::can_use_default_less_operator<T>::value || sizeof...(Compare) > 0),
+        void>
     operator()(Policy&& exec, OutputIterator tmp_first, OutputIterator tmp_last, OutputIterator2 expected_first,
                OutputIterator2 expected_last, InputIterator first, InputIterator last, Size n, Compare ...compare)
     {
@@ -316,10 +317,11 @@ struct test_sort_op
     }
 
     template <typename Policy, typename InputIterator, typename OutputIterator, typename OutputIterator2, typename Size,
-              typename ...Compare>
-    typename ::std::enable_if<!TestUtils::is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value
-                          || !(TestUtils::can_use_default_less_operator<T>::value || sizeof...(Compare) > 0),
-                              void>::type
+              typename... Compare>
+    ::std::enable_if_t<
+        !TestUtils::is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value ||
+            !(TestUtils::can_use_default_less_operator<T>::value || sizeof...(Compare) > 0),
+        void>
     operator()(Policy&& /* exec */, OutputIterator /* tmp_first */, OutputIterator /* tmp_last */,
                OutputIterator2 /* expected_first */, OutputIterator2 /* expected_last */, InputIterator /* first */,
                InputIterator /* last */, Size /* n */, Compare .../*compare*/)

--- a/test/parallel_api/experimental/for_loop.pass.cpp
+++ b/test/parallel_api/experimental/for_loop.pass.cpp
@@ -108,7 +108,7 @@ test_body_for_loop_strided(Policy&& exec, Iterator first, Iterator last, Iterato
 
     ::std::experimental::for_loop_strided(exec, first, last, loop_stride, [&flip](Iterator iter) { flip(*iter); });
 
-    typename ::std::make_signed<Size>::type idx = 0;
+    ::std::make_signed_t<Size> idx = 0;
     for (auto iter = expected_first; iter != expected_last; ::std::advance(iter, single_stride), ++idx)
     {
         if (idx % loop_stride != 0)
@@ -238,7 +238,7 @@ test_body_for_loop_strided_neg(Policy&& exec, Iterator first, Iterator /* last *
 {
     assert(loop_stride < 0);
 
-    using Ssize = typename ::std::make_signed<Size>::type;
+    using Ssize = ::std::make_signed_t<Size>;
 
     // Test negative stride value with non-forward iterators on range (first - 1, first)
     auto new_first = first;

--- a/test/parallel_api/experimental/for_loop.pass.cpp
+++ b/test/parallel_api/experimental/for_loop.pass.cpp
@@ -230,9 +230,9 @@ struct test_for_loop_impl
 };
 
 template <typename Policy, typename Iterator, typename Size, typename S>
-typename ::std::enable_if<
+::std::enable_if_t<
     !::std::is_same<typename ::std::iterator_traits<Iterator>::iterator_category, ::std::forward_iterator_tag>::value,
-    void>::type
+    void>
 test_body_for_loop_strided_neg(Policy&& exec, Iterator first, Iterator /* last */, Iterator expected_first,
                                Iterator /* expected_last */, Size n, S loop_stride)
 {
@@ -256,9 +256,9 @@ test_body_for_loop_strided_neg(Policy&& exec, Iterator first, Iterator /* last *
 }
 
 template <typename Policy, typename Iterator, typename Size, typename S>
-typename ::std::enable_if<
+::std::enable_if_t<
     ::std::is_same<typename ::std::iterator_traits<Iterator>::iterator_category, ::std::forward_iterator_tag>::value,
-    void>::type
+    void>
 test_body_for_loop_strided_neg(Policy&& /* exec */, Iterator /* first */, Iterator /* last */, Iterator /* expected_first */,
                                Iterator /* expected_last */, Size /* n */, S /* loop_stride */)
 {

--- a/test/parallel_api/experimental/for_loop.pass.cpp
+++ b/test/parallel_api/experimental/for_loop.pass.cpp
@@ -231,8 +231,7 @@ struct test_for_loop_impl
 
 template <typename Policy, typename Iterator, typename Size, typename S>
 ::std::enable_if_t<
-    !::std::is_same<typename ::std::iterator_traits<Iterator>::iterator_category, ::std::forward_iterator_tag>::value,
-    void>
+    !::std::is_same_v<typename ::std::iterator_traits<Iterator>::iterator_category, ::std::forward_iterator_tag>, void>
 test_body_for_loop_strided_neg(Policy&& exec, Iterator first, Iterator /* last */, Iterator expected_first,
                                Iterator /* expected_last */, Size n, S loop_stride)
 {
@@ -257,8 +256,7 @@ test_body_for_loop_strided_neg(Policy&& exec, Iterator first, Iterator /* last *
 
 template <typename Policy, typename Iterator, typename Size, typename S>
 ::std::enable_if_t<
-    ::std::is_same<typename ::std::iterator_traits<Iterator>::iterator_category, ::std::forward_iterator_tag>::value,
-    void>
+    ::std::is_same_v<typename ::std::iterator_traits<Iterator>::iterator_category, ::std::forward_iterator_tag>, void>
 test_body_for_loop_strided_neg(Policy&& /* exec */, Iterator /* first */, Iterator /* last */, Iterator /* expected_first */,
                                Iterator /* expected_last */, Size /* n */, S /* loop_stride */)
 {

--- a/test/parallel_api/experimental/for_loop_induction.pass.cpp
+++ b/test/parallel_api/experimental/for_loop_induction.pass.cpp
@@ -80,7 +80,7 @@ test_body_induction_strided(Policy&& exec, Iterator first, Iterator last, Iterat
         const T ind_init = n % 97;
         T lval_ind = ind_init;
 
-        using Ssize = typename ::std::make_signed<Size>::type;
+        using Ssize = ::std::make_signed_t<Size>;
 
         ::std::experimental::for_loop_n_strided(::std::forward<Policy>(exec), Ssize(0), Ssize(n), loop_stride,
                                               ::std::experimental::induction(lval_ind),

--- a/test/parallel_api/experimental/for_loop_induction.pass.cpp
+++ b/test/parallel_api/experimental/for_loop_induction.pass.cpp
@@ -96,7 +96,7 @@ test_body_induction_strided(Policy&& exec, Iterator first, Iterator last, Iterat
 
         // Negative strides are not allowed with forward iterators
         if (loop_stride < 0 &&
-            ::std::is_same<typename ::std::iterator_traits<Iterator>::iterator_category, ::std::forward_iterator_tag>::value)
+            ::std::is_same_v<typename ::std::iterator_traits<Iterator>::iterator_category, ::std::forward_iterator_tag>)
             continue;
 
         auto new_first = first;

--- a/test/parallel_api/experimental/for_loop_reduction.pass.cpp
+++ b/test/parallel_api/experimental/for_loop_reduction.pass.cpp
@@ -127,8 +127,7 @@ struct test_body_predefined
 struct test_body_predefined_bits
 {
     template <typename Policy, typename Iterator, typename Size>
-    typename ::std::enable_if<!::std::is_floating_point<typename ::std::iterator_traits<Iterator>::value_type>::value,
-                            void>::type
+    ::std::enable_if_t<!::std::is_floating_point<typename ::std::iterator_traits<Iterator>::value_type>::value, void>
     operator()(Policy&& exec, Iterator first, Iterator last, Iterator /*expected_first*/, Iterator /*expected_last*/,
                Size /* n */)
     {
@@ -162,8 +161,7 @@ struct test_body_predefined_bits
     }
 
     template <typename Policy, typename Iterator, typename Size>
-    typename ::std::enable_if<::std::is_floating_point<typename ::std::iterator_traits<Iterator>::value_type>::value,
-                            void>::type
+    ::std::enable_if_t<::std::is_floating_point<typename ::std::iterator_traits<Iterator>::value_type>::value, void>
     operator()(Policy&& /* exec */, Iterator /* first */, Iterator /* last */, Iterator /*expected_first*/, Iterator /*expected_last*/,
                Size /* n */)
     {

--- a/test/parallel_api/iterator/iterators.pass.cpp
+++ b/test/parallel_api/iterator/iterators.pass.cpp
@@ -274,8 +274,8 @@ struct test_transform_iterator {
         auto test_lambda = [](T2& x){ return x + 1; };
         auto new_transform_iterator = oneapi::dpl::make_transform_iterator(in2.begin(), test_lambda);
         EXPECT_TRUE(_it1.base() == in1.begin(), "wrong result from transform_iterator::base");
-        static_assert(::std::is_same<decltype(new_transform_iterator.functor()), decltype(test_lambda)>::value,
-            "wrong result from transform_iterator::functor");
+        static_assert(::std::is_same_v<decltype(new_transform_iterator.functor()), decltype(test_lambda)>,
+                      "wrong result from transform_iterator::functor");
         test_random_iterator(_it2);
     }
 };

--- a/test/parallel_api/numeric/numeric.ops/adjacent_difference.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/adjacent_difference.pass.cpp
@@ -62,7 +62,7 @@ compare(const wrapper<T>& a, const wrapper<T>& b)
 }
 
 template <typename Iterator1, typename Iterator2, typename T, typename Function>
-typename ::std::enable_if<!::std::is_floating_point<T>::value, bool>::type
+::std::enable_if_t<!::std::is_floating_point<T>::value, bool>
 compute_and_check(Iterator1 first, Iterator1 last, Iterator2 d_first, T, Function f)
 {
     using T2 = typename ::std::iterator_traits<Iterator2>::value_type;
@@ -89,7 +89,7 @@ compute_and_check(Iterator1 first, Iterator1 last, Iterator2 d_first, T, Functio
 // we don't want to check equality here
 // because we can't be sure it will be strictly equal for floating point types
 template <typename Iterator1, typename Iterator2, typename T, typename Function>
-typename ::std::enable_if<::std::is_floating_point<T>::value, bool>::type
+::std::enable_if_t<::std::is_floating_point<T>::value, bool>
 compute_and_check(Iterator1 /* first */, Iterator1 /* last */, Iterator2 /* d_first */, T, Function)
 {
     return true;

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
@@ -113,10 +113,9 @@ DEFINE_TEST_2(test_exclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
 #if TEST_DPCPP_BACKEND_PRESENT
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    typename ::std::enable_if<
-        oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
-            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-        void>::type
+    ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
+                           is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
+                       void>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 val_res_first, Iterator3 val_res_last, Size n)
     {
@@ -184,12 +183,12 @@ DEFINE_TEST_2(test_exclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
 
     // specialization for host execution policies
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    typename ::std::enable_if<
+    ::std::enable_if_t<
 #if TEST_DPCPP_BACKEND_PRESENT
         !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif // TEST_DPCPP_BACKEND_PRESENT
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-        void>::type
+        void>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 val_res_first, Iterator3 val_res_last, Size n)
     {
@@ -226,8 +225,7 @@ DEFINE_TEST_2(test_exclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
 
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-                              void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value, void>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 val_res_first, Iterator3 val_res_last, Size n)
     {

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
@@ -114,7 +114,7 @@ DEFINE_TEST_2(test_exclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     typename ::std::enable_if<
-        oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<Policy>::type>::value &&
+        oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
         void>::type
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
@@ -186,7 +186,7 @@ DEFINE_TEST_2(test_exclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     typename ::std::enable_if<
 #if TEST_DPCPP_BACKEND_PRESENT
-        !oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<Policy>::type>::value &&
+        !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif // TEST_DPCPP_BACKEND_PRESENT
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
         void>::type

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -110,10 +110,9 @@ DEFINE_TEST_2(test_inclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
 #if TEST_DPCPP_BACKEND_PRESENT
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    typename ::std::enable_if<
-        oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
-            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-        void>::type
+    ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
+                           is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
+                       void>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 val_res_first, Iterator3 val_res_last, Size n)
     {
@@ -163,12 +162,12 @@ DEFINE_TEST_2(test_inclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
 
     // specialization for host execution policies
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    typename ::std::enable_if<
+    ::std::enable_if_t<
 #if TEST_DPCPP_BACKEND_PRESENT
         !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-        void>::type
+        void>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 val_res_first, Iterator3 val_res_last, Size n)
     {
@@ -194,8 +193,7 @@ DEFINE_TEST_2(test_inclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
 
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-                              void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value, void>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 val_res_first, Iterator3 val_res_last, Size n)
     {

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -111,7 +111,7 @@ DEFINE_TEST_2(test_inclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     typename ::std::enable_if<
-        oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<Policy>::type>::value &&
+        oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
         void>::type
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
@@ -165,7 +165,7 @@ DEFINE_TEST_2(test_inclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     typename ::std::enable_if<
 #if TEST_DPCPP_BACKEND_PRESENT
-        !oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<Policy>::type>::value &&
+        !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
         void>::type

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -127,11 +127,10 @@ DEFINE_TEST_2(test_reduce_by_segment, BinaryPredicate, BinaryOperation)
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4,
               typename Size>
-    typename ::std::enable_if<
-        oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
-            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value &&
-            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator4>::value,
-        void>::type
+    ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
+                           is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value &&
+                           is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator4>::value,
+                       void>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 key_res_first, Iterator3 key_res_last, Iterator4 val_res_first, Iterator4 val_res_last, Size n)
     {
@@ -192,13 +191,13 @@ DEFINE_TEST_2(test_reduce_by_segment, BinaryPredicate, BinaryOperation)
     // specialization for host execution policies
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4,
               typename Size>
-    typename ::std::enable_if<
+    ::std::enable_if_t<
 #if TEST_DPCPP_BACKEND_PRESENT
-        !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
+            !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value &&
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator4>::value,
-        void>::type
+        void>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 key_res_first, Iterator3 key_res_last, Iterator4 val_res_first, Iterator4 val_res_last, Size n)
     {
@@ -232,9 +231,9 @@ DEFINE_TEST_2(test_reduce_by_segment, BinaryPredicate, BinaryOperation)
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4,
               typename Size>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value ||
-                                  !is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator4>::value,
-                              void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value ||
+                           !is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator4>::value,
+                       void>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 key_res_first, Iterator3 key_res_last, Iterator4 val_res_first, Iterator4 val_res_last, Size n)
     {

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -128,7 +128,7 @@ DEFINE_TEST_2(test_reduce_by_segment, BinaryPredicate, BinaryOperation)
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4,
               typename Size>
     typename ::std::enable_if<
-        oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<Policy>::type>::value &&
+        oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value &&
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator4>::value,
         void>::type
@@ -194,7 +194,7 @@ DEFINE_TEST_2(test_reduce_by_segment, BinaryPredicate, BinaryOperation)
               typename Size>
     typename ::std::enable_if<
 #if TEST_DPCPP_BACKEND_PRESENT
-        !oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<Policy>::type>::value &&
+        !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value &&
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator4>::value,

--- a/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
@@ -124,7 +124,7 @@ struct test_inclusive_scan_with_binary_op
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T,
               typename BinaryOp>
-    typename ::std::enable_if<!TestUtils::isReverse<Iterator1>::value, void>::type
+    ::std::enable_if_t<!TestUtils::isReverse<Iterator1>::value, void>
     operator()(Policy&& exec, Iterator1 in_first, Iterator1 in_last, Iterator2 out_first, Iterator2 out_last,
                Iterator3 expected_first, Iterator3 /* expected_last */, Size n, T init, BinaryOp binary_op, T trash)
     {
@@ -140,7 +140,7 @@ struct test_inclusive_scan_with_binary_op
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T,
               typename BinaryOp>
-    typename ::std::enable_if<!TestUtils::isReverse<Iterator1>::value, void>::type
+    ::std::enable_if_t<!TestUtils::isReverse<Iterator1>::value, void>
     operator()(Policy&& exec, Iterator1 in_first, Iterator1 in_last, Iterator2 out_first, Iterator2 out_last,
                Iterator3 expected_first, Iterator3 /* expected_last */, Size n, BinaryOp binary_op, T trash)
     {
@@ -156,7 +156,7 @@ struct test_inclusive_scan_with_binary_op
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T,
               typename BinaryOp>
-    typename ::std::enable_if<TestUtils::isReverse<Iterator1>::value, void>::type
+    ::std::enable_if_t<TestUtils::isReverse<Iterator1>::value, void>
     operator()(Policy&& /* exec */, Iterator1 /* in_first */, Iterator1 /* in_last */, Iterator2 /* out_first */, Iterator2 /* out_last */,
                Iterator3 /* expected_first */, Iterator3 /* expected_last */, Size /* n */, BinaryOp /* binary_op */, T /* trash */)
     {
@@ -164,7 +164,7 @@ struct test_inclusive_scan_with_binary_op
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T,
               typename BinaryOp>
-    typename ::std::enable_if<TestUtils::isReverse<Iterator1>::value, void>::type
+    ::std::enable_if_t<TestUtils::isReverse<Iterator1>::value, void>
     operator()(Policy&& /* exec */, Iterator1 /* in_first */, Iterator1 /* in_last */, Iterator2 /* out_first */, Iterator2 /* out_last */,
                Iterator3 /* expected_first */, Iterator3 /* expected_last */, Size /* n */, T /* init */, BinaryOp /* binary_op */, T /* trash */)
     {
@@ -176,7 +176,7 @@ struct test_exclusive_scan_with_binary_op
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T,
               typename BinaryOp>
-    typename ::std::enable_if<!TestUtils::isReverse<Iterator1>::value, void>::type
+    ::std::enable_if_t<!TestUtils::isReverse<Iterator1>::value, void>
     operator()(Policy&& exec, Iterator1 in_first, Iterator1 in_last, Iterator2 out_first, Iterator2 out_last,
                Iterator3 expected_first, Iterator3 /* expected_last */, Size n, T init, BinaryOp binary_op, T trash)
     {
@@ -193,7 +193,7 @@ struct test_exclusive_scan_with_binary_op
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T,
               typename BinaryOp>
-    typename ::std::enable_if<TestUtils::isReverse<Iterator1>::value, void>::type
+    ::std::enable_if_t<TestUtils::isReverse<Iterator1>::value, void>
     operator()(Policy&& /* exec */, Iterator1 /* in_first */, Iterator1 /* in_last */, Iterator2 /* out_first */, Iterator2 /* out_last */,
                Iterator3 /* expected_first */, Iterator3 /* expected_last */, Size /* n */, T /* init */, BinaryOp /* binary_op */, T /* trash */)
     {

--- a/test/parallel_api/numeric/numeric.ops/scan_2.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan_2.pass.cpp
@@ -146,7 +146,7 @@ DEFINE_TEST_1(test_scan_non_inplace, TestingAlgoritm)
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     typename ::std::enable_if<
-        oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<Policy>::type>::value &&
+        oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value,
         void>::type
     operator()(Policy&& exec,
@@ -194,7 +194,7 @@ DEFINE_TEST_1(test_scan_non_inplace, TestingAlgoritm)
     // specialization for host execution policies
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     typename ::std::enable_if<
-        !oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<Policy>::type>::value &&
+        !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value,
         void>::type
     operator()(Policy&& exec,
@@ -234,7 +234,7 @@ DEFINE_TEST_1(test_scan_inplace, TestingAlgoritm)
     // specialization for host execution policies
     template <typename Policy, typename Iterator1, typename Size>
     typename ::std::enable_if<
-        !oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<Policy>::type>::value &&
+        !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value,
         void>::type
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Size n)
@@ -258,7 +258,7 @@ DEFINE_TEST_1(test_scan_inplace, TestingAlgoritm)
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Size>
     typename ::std::enable_if<
-        oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<Policy>::type>::value &&
+        oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value,
         void>::type
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last,

--- a/test/parallel_api/numeric/numeric.ops/scan_2.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan_2.pass.cpp
@@ -145,10 +145,10 @@ DEFINE_TEST_1(test_scan_non_inplace, TestingAlgoritm)
 
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
-    typename ::std::enable_if<
+    ::std::enable_if_t<
         oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value,
-        void>::type
+        void>
     operator()(Policy&& exec,
                Iterator1 keys_first, Iterator1 keys_last,
                Iterator2 vals_first, Iterator2 vals_last,
@@ -193,10 +193,10 @@ DEFINE_TEST_1(test_scan_non_inplace, TestingAlgoritm)
 
     // specialization for host execution policies
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
-    typename ::std::enable_if<
+    ::std::enable_if_t<
         !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value,
-        void>::type
+        void>
     operator()(Policy&& exec,
                Iterator1 keys_first, Iterator1 keys_last,
                Iterator2 vals_first, Iterator2 vals_last,
@@ -233,10 +233,10 @@ DEFINE_TEST_1(test_scan_inplace, TestingAlgoritm)
 
     // specialization for host execution policies
     template <typename Policy, typename Iterator1, typename Size>
-    typename ::std::enable_if<
+    ::std::enable_if_t<
         !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value,
-        void>::type
+        void>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Size n)
     {
         using KeyT = typename ::std::iterator_traits<Iterator1>::value_type;
@@ -257,10 +257,10 @@ DEFINE_TEST_1(test_scan_inplace, TestingAlgoritm)
 
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Size>
-    typename ::std::enable_if<
+    ::std::enable_if_t<
         oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value,
-        void>::type
+        void>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last,
                Size n)
     {

--- a/test/parallel_api/numeric/numeric.ops/scan_2.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan_2.pass.cpp
@@ -218,7 +218,7 @@ DEFINE_TEST_1(test_scan_non_inplace, TestingAlgoritm)
 
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value, void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value, void>
     operator()(Policy&& exec,
                Iterator1 keys_first, Iterator1 keys_last,
                Iterator2 vals_first, Iterator2 vals_last,
@@ -289,7 +289,7 @@ DEFINE_TEST_1(test_scan_inplace, TestingAlgoritm)
 
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Size>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value, void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value, void>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Size n)
     {
     }

--- a/test/parallel_api/numeric/numeric.ops/transform_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/transform_scan.pass.cpp
@@ -45,7 +45,7 @@ struct test_transform_exclusive_scan
 {
     template <typename Policy, typename InputIterator, typename OutputIterator, typename Size, typename UnaryOp,
               typename T, typename BinaryOp>
-    typename ::std::enable_if<!TestUtils::isReverse<InputIterator>::value, void>::type
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator>::value, void>
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
                OutputIterator out_last, OutputIterator expected_first, OutputIterator /* expected_last */, Size n,
                UnaryOp unary_op, T init, BinaryOp binary_op, T trash)
@@ -61,7 +61,7 @@ struct test_transform_exclusive_scan
 
     template <typename Policy, typename InputIterator, typename OutputIterator, typename Size, typename UnaryOp,
               typename T, typename BinaryOp>
-    typename ::std::enable_if<TestUtils::isReverse<InputIterator>::value, void>::type
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator>::value, void>
     operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, OutputIterator /* out_first */,
                OutputIterator /* out_last */, OutputIterator /* expected_first */, OutputIterator /* expected_last */, Size /* n */,
                UnaryOp /* unary_op */, T /* init */, BinaryOp /* binary_op */, T /* trash */)
@@ -74,7 +74,7 @@ struct test_transform_inclusive_scan_init
 {
     template <typename Policy, typename InputIterator, typename OutputIterator, typename Size, typename UnaryOp,
               typename T, typename BinaryOp>
-    typename ::std::enable_if<!TestUtils::isReverse<InputIterator>::value, void>::type
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator>::value, void>
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
                OutputIterator out_last, OutputIterator expected_first, OutputIterator /* expected_last */, Size n,
                UnaryOp unary_op, T init, BinaryOp binary_op, T trash)
@@ -90,7 +90,7 @@ struct test_transform_inclusive_scan_init
 
     template <typename Policy, typename InputIterator, typename OutputIterator, typename Size, typename UnaryOp,
               typename T, typename BinaryOp>
-    typename ::std::enable_if<TestUtils::isReverse<InputIterator>::value, void>::type
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator>::value, void>
     operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, OutputIterator /* out_first */,
                OutputIterator /* out_last */, OutputIterator /* expected_first */, OutputIterator /* expected_last */, Size /* n */,
                UnaryOp /* unary_op */, T /* init */, BinaryOp /* binary_op */, T /* trash */)
@@ -103,7 +103,7 @@ struct test_transform_inclusive_scan
 {
     template <typename Policy, typename InputIterator, typename OutputIterator, typename Size, typename UnaryOp,
               typename T, typename BinaryOp>
-    typename ::std::enable_if<!TestUtils::isReverse<InputIterator>::value, void>::type
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator>::value, void>
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
                OutputIterator out_last, OutputIterator expected_first, OutputIterator /* expected_last */, Size n,
                UnaryOp unary_op, T /* init */, BinaryOp binary_op, T trash)
@@ -122,7 +122,7 @@ struct test_transform_inclusive_scan
 
     template <typename Policy, typename InputIterator, typename OutputIterator, typename Size, typename UnaryOp,
               typename T, typename BinaryOp>
-    typename ::std::enable_if<TestUtils::isReverse<InputIterator>::value, void>::type
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator>::value, void>
     operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, OutputIterator /* out_first */,
                OutputIterator /* out_last */, OutputIterator /* expected_first */, OutputIterator /* expected_last */, Size /* n */,
                UnaryOp /* unary_op */, T /* init */, BinaryOp /* binary_op */, T /* trash */)

--- a/test/support/iterator_utils.h
+++ b/test/support/iterator_utils.h
@@ -291,8 +291,7 @@ struct non_const_wrapper_tagged : non_const_wrapper
     }
 
     template <typename Policy, typename InputIterator, typename OutputIterator>
-    typename ::std::enable_if<IsPositiveCondition == is_same_iterator_category<OutputIterator, IteratorTag>::value,
-                            void>::type
+    ::std::enable_if_t<IsPositiveCondition == is_same_iterator_category<OutputIterator, IteratorTag>::value, void>
     operator()(Policy&& exec, InputIterator input_iter, OutputIterator out_iter)
     {
         Op()(exec, input_iter, out_iter);
@@ -305,8 +304,7 @@ struct non_const_wrapper_tagged : non_const_wrapper
     }
 
     template <typename Policy, typename InputIterator, typename OutputIterator>
-    typename ::std::enable_if<IsPositiveCondition != is_same_iterator_category<OutputIterator, IteratorTag>::value,
-                            void>::type
+    ::std::enable_if_t<IsPositiveCondition != is_same_iterator_category<OutputIterator, IteratorTag>::value, void>
     operator()(Policy&& /*exec*/, InputIterator /*input_iter*/, OutputIterator /*out_iter*/)
     {
     }
@@ -341,9 +339,9 @@ struct iterator_invoker
 
     // A single iterator version which is used for non_const testcases
     template <typename Policy, typename Op, typename Iterator>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
-                                ::std::is_base_of<non_const_wrapper, Op>::value,
-                            void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag,
+                                                    Iterator>::value&& ::std::is_base_of<non_const_wrapper, Op>::value,
+                       void>
     operator()(Policy&& exec, Op op, Iterator iter)
     {
         op(::std::forward<Policy>(exec), make_iterator<Iterator>()(iter));
@@ -351,9 +349,9 @@ struct iterator_invoker
 
     // A version with 2 iterators which is used for non_const testcases
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value &&
-                                ::std::is_base_of<non_const_wrapper, Op>::value,
-                            void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value&& ::std::
+                           is_base_of<non_const_wrapper, Op>::value,
+                       void>
     operator()(Policy&& exec, Op op, InputIterator input_iter, OutputIterator out_iter)
     {
         op(::std::forward<Policy>(exec), make_iterator<InputIterator>()(input_iter),
@@ -361,8 +359,7 @@ struct iterator_invoker
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::bidirectional_iterator_tag,
-                                            Iterator>::value, void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::bidirectional_iterator_tag, Iterator>::value, void>
     operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n,
         Iterator expected, Rest&&... rest)
     {
@@ -378,9 +375,9 @@ struct iterator_invoker
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
-                                !::std::is_base_of<non_const_wrapper, Op>::value,
-                            void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
+                           !::std::is_base_of<non_const_wrapper, Op>::value,
+                       void>
     operator()(Policy&& exec, Op op, Iterator inputBegin, Iterator inputEnd, Rest&&... rest)
     {
         invoke_if<Iterator>()(::std::distance(inputBegin, inputEnd) <= sizeLimit, op, exec,
@@ -389,8 +386,7 @@ struct iterator_invoker
     }
 
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator, typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value,
-                            void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value, void>
     operator()(Policy&& exec, Op op, InputIterator inputBegin, InputIterator inputEnd, OutputIterator outputBegin,
                Rest&&... rest)
     {
@@ -400,8 +396,7 @@ struct iterator_invoker
     }
 
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator, typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value,
-                            void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value, void>
     operator()(Policy&& exec, Op op, InputIterator inputBegin, InputIterator inputEnd, OutputIterator outputBegin,
                OutputIterator outputEnd, Rest&&... rest)
     {
@@ -413,8 +408,7 @@ struct iterator_invoker
 
     template <typename Policy, typename Op, typename InputIterator1, typename InputIterator2, typename OutputIterator,
               typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value,
-                            void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value, void>
     operator()(Policy&& exec, Op op, InputIterator1 inputBegin1, InputIterator1 inputEnd1, InputIterator2 inputBegin2,
                InputIterator2 inputEnd2, OutputIterator outputBegin, OutputIterator outputEnd, Rest&&... rest)
     {
@@ -437,9 +431,9 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
 
     // A single iterator version which is used for non_const testcases
     template <typename Policy, typename Op, typename Iterator>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
-                                ::std::is_base_of<non_const_wrapper, Op>::value,
-                            void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag,
+                                                    Iterator>::value&& ::std::is_base_of<non_const_wrapper, Op>::value,
+                       void>
     operator()(Policy&& exec, Op op, Iterator iter)
     {
         op(::std::forward<Policy>(exec), make_iterator<Iterator>()(iter));
@@ -447,9 +441,9 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
 
     // A version with 2 iterators which is used for non_const testcases
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value &&
-                                ::std::is_base_of<non_const_wrapper, Op>::value,
-                            void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value&& ::std::
+                           is_base_of<non_const_wrapper, Op>::value,
+                       void>
     operator()(Policy&& exec, Op op, InputIterator input_iter, OutputIterator out_iter)
     {
         op(::std::forward<Policy>(exec), make_iterator<InputIterator>()(input_iter),
@@ -482,9 +476,9 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
-                                !::std::is_base_of<non_const_wrapper, Op>::value,
-                            void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
+                           !::std::is_base_of<non_const_wrapper, Op>::value,
+                       void>
     operator()(Policy&& exec, Op op, Iterator inputBegin, Iterator inputEnd, Rest&&... rest)
     {
         if (::std::distance(inputBegin, inputEnd) <= sizeLimit)
@@ -493,8 +487,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     }
 
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator, typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value,
-                            void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value, void>
     operator()(Policy&& exec, Op op, InputIterator inputBegin, InputIterator inputEnd, OutputIterator outputBegin,
                Rest&&... rest)
     {
@@ -504,8 +497,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     }
 
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator, typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value,
-                            void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value, void>
     operator()(Policy&& exec, Op op, InputIterator inputBegin, InputIterator inputEnd, OutputIterator outputBegin,
                OutputIterator outputEnd, Rest&&... rest)
     {
@@ -517,8 +509,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
 
     template <typename Policy, typename Op, typename InputIterator1, typename InputIterator2, typename OutputIterator,
               typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value,
-                            void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value, void>
     operator()(Policy&& exec, Op op, InputIterator1 inputBegin1, InputIterator1 inputEnd1, InputIterator2 inputBegin2,
                InputIterator2 inputEnd2, OutputIterator outputBegin, OutputIterator outputEnd, Rest&&... rest)
     {

--- a/test/support/iterator_utils.h
+++ b/test/support/iterator_utils.h
@@ -230,8 +230,7 @@ struct iterator_traits_
 };
 
 template <typename Iter> // For iterators
-struct iterator_traits_<Iter,
-                        typename ::std::enable_if<!::std::is_void<typename Iter::iterator_category>::value, void>::type>
+struct iterator_traits_<Iter, ::std::enable_if_t<!::std::is_void<typename Iter::iterator_category>::value, void>>
 {
     typedef typename Iter::iterator_category iterator_category;
 };
@@ -285,7 +284,7 @@ template <typename Op, typename IteratorTag, bool IsPositiveCondition = true>
 struct non_const_wrapper_tagged : non_const_wrapper
 {
     template <typename Policy, typename Iterator>
-    typename ::std::enable_if<IsPositiveCondition == is_same_iterator_category<Iterator, IteratorTag>::value, void>::type
+    ::std::enable_if_t<IsPositiveCondition == is_same_iterator_category<Iterator, IteratorTag>::value, void>
     operator()(Policy&& exec, Iterator iter)
     {
         Op()(exec, iter);
@@ -300,7 +299,7 @@ struct non_const_wrapper_tagged : non_const_wrapper
     }
 
     template <typename Policy, typename Iterator>
-    typename ::std::enable_if<IsPositiveCondition != is_same_iterator_category<Iterator, IteratorTag>::value, void>::type
+    ::std::enable_if_t<IsPositiveCondition != is_same_iterator_category<Iterator, IteratorTag>::value, void>
     operator()(Policy&& /*exec*/, Iterator /*iter*/)
     {
     }
@@ -371,7 +370,7 @@ struct iterator_invoker
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>
     operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n, Rest&&... rest)
     {
         invoke_if<Iterator>()(n <= sizeLimit, op, exec, make_iterator<Iterator>()(begin), n,
@@ -458,7 +457,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>
     operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n, Rest&&... rest)
     {
         if (n <= sizeLimit)
@@ -466,7 +465,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>
     operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n, Iterator expected,
         Rest&&... rest)
     {
@@ -475,7 +474,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    typename ::std::enable_if<is_same_iterator_category<Iterator, ::std::bidirectional_iterator_tag>::value, void>::type
+    ::std::enable_if_t<is_same_iterator_category<Iterator, ::std::bidirectional_iterator_tag>::value, void>
     operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n, Iterator expected, Rest&&... rest)
     {
         if (n <= sizeLimit)

--- a/test/support/reduce_serial_impl.h
+++ b/test/support/reduce_serial_impl.h
@@ -22,8 +22,8 @@ reduce_by_segment_serial(RandAccessItKeysIn keys, RandAccessItValsIn vals,
     if (n < 1)
         return 0;
     
-    using ValT = typename ::std::decay<decltype(vals[0])>::type;
-    using KeyT = typename ::std::decay<decltype(keys[0])>::type;
+    using ValT = ::std::decay_t<decltype(vals[0])>;
+    using KeyT = ::std::decay_t<decltype(keys[0])>;
     KeyT tmp_key = keys[0];
     ValT tmp_val = vals[0];
     Size segment_count = 0;

--- a/test/support/test_complex.h
+++ b/test/support/test_complex.h
@@ -69,7 +69,7 @@ run_test()
 // Example:
 //     template <class T>
 //     void
-//     test(T x, typename std::enable_if<std::is_integral<T>::value>::type* = 0)
+//     test(T x, ::std::enable_if_t<std::is_integral<T>::value>* = 0)
 //     {
 //         static_assert((std::is_same<decltype(dpl::conj(x)), dpl::complex<double>>::value), "");
 // 

--- a/test/support/test_complex.h
+++ b/test/support/test_complex.h
@@ -27,6 +27,7 @@
 #include <cassert>
 
 #if !_PSTL_MSVC_LESS_THAN_CPP20_COMPLEX_CONSTEXPR_BROKEN
+#    define STD_COMPLEX_TESTS_STATIC_ASSERT(arg) static_assert(arg)
 #    define STD_COMPLEX_TESTS_STATIC_ASSERT(arg, msg) static_assert(arg, msg)
 #else
 #    define STD_COMPLEX_TESTS_STATIC_ASSERT(arg, msg) assert(arg)
@@ -71,7 +72,7 @@ run_test()
 //     void
 //     test(T x, ::std::enable_if_t<std::is_integral<T>::value>* = 0)
 //     {
-//         static_assert((std::is_same_v<decltype(dpl::conj(x)), dpl::complex<double>>), "");
+//         static_assert((std::is_same_v<decltype(dpl::conj(x)), dpl::complex<double>>));
 // 
 //         // HERE IS THE CODE WHICH CALL WE SHOULD AVOID IF DOUBLE IS NOT SUPPORTED ON DEVICE
 //         assert(dpl::conj(x) == dpl::conj(dpl::complex<double>(x, 0)));

--- a/test/support/test_complex.h
+++ b/test/support/test_complex.h
@@ -71,7 +71,7 @@ run_test()
 //     void
 //     test(T x, ::std::enable_if_t<std::is_integral<T>::value>* = 0)
 //     {
-//         static_assert((std::is_same<decltype(dpl::conj(x)), dpl::complex<double>>::value), "");
+//         static_assert((std::is_same_v<decltype(dpl::conj(x)), dpl::complex<double>>), "");
 // 
 //         // HERE IS THE CODE WHICH CALL WE SHOULD AVOID IF DOUBLE IS NOT SUPPORTED ON DEVICE
 //         assert(dpl::conj(x) == dpl::conj(dpl::complex<double>(x, 0)));

--- a/test/support/test_macros.h
+++ b/test/support/test_macros.h
@@ -236,11 +236,11 @@
 #define LIBCPP_ASSERT_NOT_NOEXCEPT(...) ASSERT_NOT_NOEXCEPT(__VA_ARGS__)
 #define LIBCPP_ONLY(...) __VA_ARGS__
 #else
-#define LIBCPP_ASSERT(...) static_assert(true, "")
-#define LIBCPP_STATIC_ASSERT(...) static_assert(true, "")
-#define LIBCPP_ASSERT_NOEXCEPT(...) static_assert(true, "")
-#define LIBCPP_ASSERT_NOT_NOEXCEPT(...) static_assert(true, "")
-#define LIBCPP_ONLY(...) static_assert(true, "")
+#define LIBCPP_ASSERT(...) static_assert(true)
+#define LIBCPP_STATIC_ASSERT(...) static_assert(true)
+#define LIBCPP_ASSERT_NOEXCEPT(...) static_assert(true)
+#define LIBCPP_ASSERT_NOT_NOEXCEPT(...) static_assert(true)
+#define LIBCPP_ONLY(...) static_assert(true)
 #endif
 
 #define TEST_IGNORE_NODISCARD (void)

--- a/test/support/test_macros.h
+++ b/test/support/test_macros.h
@@ -253,7 +253,7 @@ struct is_same<T, T> { enum {value = 1}; };
 } // namespace test_macros_detail
 
 #define ASSERT_SAME_TYPE(...) \
-    static_assert((test_macros_detail::is_same<__VA_ARGS__>::value), \
+    static_assert((test_macros_detail::is_same_v<__VA_ARGS__>), \
                  "Types differ unexpectedly")
 
 #ifndef TEST_HAS_NO_EXCEPTIONS

--- a/test/support/utils_invoke.h
+++ b/test/support/utils_invoke.h
@@ -35,7 +35,7 @@ template <typename Op, ::std::size_t CallNumber>
 struct unique_kernel_name;
 
 template <typename Policy, int idx>
-using new_kernel_name = unique_kernel_name<typename ::std::decay<Policy>::type, idx>;
+using new_kernel_name = unique_kernel_name<::std::decay_t<Policy>, idx>;
 
 /**
  * make_policy functions test wrappers

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -96,10 +96,10 @@ template <typename _NewKernelName, typename _Policy,
           oneapi::dpl::__internal::__enable_if_fpga_execution_policy<_Policy, int> = 0>
 auto
 make_new_policy(_Policy&& __policy)
-    -> decltype(TestUtils::make_fpga_policy<::std::decay<_Policy>::type::unroll_factor, _NewKernelName>(
+    -> decltype(TestUtils::make_fpga_policy<::std::decay_t<_Policy>::unroll_factor, _NewKernelName>(
         ::std::forward<_Policy>(__policy)))
 {
-    return TestUtils::make_fpga_policy<::std::decay<_Policy>::type::unroll_factor, _NewKernelName>(
+    return TestUtils::make_fpga_policy<::std::decay_t<_Policy>::unroll_factor, _NewKernelName>(
         ::std::forward<_Policy>(__policy));
 }
 #endif

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -373,36 +373,28 @@ test4buffers(int mult = kDefaultMultValue)
 }
 
 template <sycl::usm::alloc alloc_type, typename TestName>
-typename ::std::enable_if<
-    ::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value,
-    void>::type
+::std::enable_if_t<::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value, void>
 test1buffer()
 {
     test1buffer<alloc_type, typename TestName::UsedValueType, TestName>();
 }
 
 template <sycl::usm::alloc alloc_type, typename TestName>
-typename ::std::enable_if<
-    ::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value,
-    void>::type
+::std::enable_if_t<::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value, void>
 test2buffers()
 {
     test2buffers<alloc_type, typename TestName::UsedValueType, TestName>();
 }
 
 template <sycl::usm::alloc alloc_type, typename TestName>
-typename ::std::enable_if<
-    ::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value,
-    void>::type
+::std::enable_if_t<::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value, void>
 test3buffers(int mult = kDefaultMultValue)
 {
     test3buffers<alloc_type, typename TestName::UsedValueType, TestName>(mult);
 }
 
 template <sycl::usm::alloc alloc_type, typename TestName>
-typename ::std::enable_if<
-    ::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value,
-    void>::type
+::std::enable_if_t<::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value, void>
 test4buffers(int mult = kDefaultMultValue)
 {
     test4buffers<alloc_type, typename TestName::UsedValueType, TestName>(mult);

--- a/test/support/utils_test_base.h
+++ b/test/support/utils_test_base.h
@@ -404,14 +404,14 @@ void update_data(TTestDataTransfer& helper, Args&& ...args)
 
 //--------------------------------------------------------------------------------------------------------------------//
 template <typename T, typename TestName, typename TestBaseData>
-typename ::std::enable_if<::std::is_base_of<test_base<T>, TestName>::value, TestName>::type
+::std::enable_if_t<::std::is_base_of<test_base<T>, TestName>::value, TestName>
 create_test_obj(TestBaseData& data)
 {
     return TestName(data);
 }
 
 template <typename T, typename TestName, typename TestBaseData>
-typename ::std::enable_if<!::std::is_base_of<test_base<T>, TestName>::value, TestName>::type
+::std::enable_if_t<!::std::is_base_of<test_base<T>, TestName>::value, TestName>
 create_test_obj(TestBaseData&)
 {
     return TestName();
@@ -420,7 +420,6 @@ create_test_obj(TestBaseData&)
 //--------------------------------------------------------------------------------------------------------------------//
 // Used with algorithms that have two input sequences and one output sequences
 template <typename T, typename TestName>
-//typename ::std::enable_if<::std::is_base_of<test_base<T>, TestName>::value, void>::type
 void
 test_algo_three_sequences()
 {
@@ -459,7 +458,6 @@ test_algo_three_sequences()
 //--------------------------------------------------------------------------------------------------------------------//
 // Used with algorithms that have two input sequences and two output sequencess
 template <typename T, typename TestName>
-//typename ::std::enable_if<::std::is_base_of<test_base<T>, TestName>::value, void>::type
 void
 test_algo_four_sequences()
 {

--- a/test/support/utils_test_base.h
+++ b/test/support/utils_test_base.h
@@ -447,9 +447,7 @@ test_algo_three_sequences()
 
 //--------------------------------------------------------------------------------------------------------------------//
 template <typename TestName>
-typename ::std::enable_if<
-    ::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value,
-    void>::type
+::std::enable_if_t<::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value, void>
 test_algo_three_sequences()
 {
     test_algo_three_sequences<typename TestName::UsedValueType, TestName>();
@@ -488,9 +486,7 @@ test_algo_four_sequences()
 
 //--------------------------------------------------------------------------------------------------------------------//
 template <typename TestName>
-typename ::std::enable_if<
-    ::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value,
-    void>::type
+::std::enable_if_t<::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value, void>
 test_algo_four_sequences()
 {
     test_algo_four_sequences<typename TestName::UsedValueType, TestName>();

--- a/test/xpu_api/numerics/c.math/abs1.pass.cpp
+++ b/test/xpu_api/numerics/c.math/abs1.pass.cpp
@@ -18,7 +18,7 @@
 template<class T>
 struct correct_size_int
 {
-    typedef typename std::conditional<sizeof(T) < sizeof(int), int, T>::type type;
+    typedef std::conditional_t<sizeof(T) < sizeof(int), int, T> type;
 };
 
 template <class Source, class Result>
@@ -48,9 +48,7 @@ ONEDPL_TEST_NUM_MAIN
 {
     // On some systems char is unsigned.
     // If that is the case, we should just test signed char twice.
-    typedef std::conditional<
-        std::is_signed<char>::value, char, signed char
-    >::type SignedChar;
+    ::std::conditional_t<std::is_signed<char>::value, char, signed char> SignedChar;
 
     // All types less than or equal to and not greater than int are promoted to int.
     test_abs<short int, int>();

--- a/test/xpu_api/numerics/c.math/abs1.pass.cpp
+++ b/test/xpu_api/numerics/c.math/abs1.pass.cpp
@@ -28,7 +28,7 @@ void test_abs()
     Source pos_val = 5;
     Result res = 5;
 
-    static_assert(::std::is_same<decltype(dpl::abs(neg_val)), Result>::value);
+    static_assert(::std::is_same_v<decltype(dpl::abs(neg_val)), Result>);
 
     assert(dpl::abs(neg_val) == res);
     assert(dpl::abs(pos_val) == res);

--- a/test/xpu_api/numerics/c.math/cmath.pass.cpp
+++ b/test/xpu_api/numerics/c.math/cmath.pass.cpp
@@ -78,25 +78,25 @@ void test_abs()
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wabsolute-value"
 #endif
-    static_assert((std::is_same<decltype(dpl::abs((float)0)), float>::value), "");
-    static_assert((std::is_same<decltype(dpl::abs((int)0)), int>::value), "");
-    static_assert((std::is_same<decltype(dpl::abs((long)0)), long>::value), "");
-    static_assert((std::is_same<decltype(dpl::abs((long long)0)), long long>::value), "");
-    static_assert((std::is_same<decltype(dpl::abs((unsigned char)0)), int>::value), "");
-    static_assert((std::is_same<decltype(dpl::abs((unsigned short)0)), int>::value), "");
-    static_assert((std::is_same<decltype(dpl::abs((signed char)0)), int>::value), "");
-    static_assert((std::is_same<decltype(dpl::abs((short)0)), int>::value), "");
-    static_assert((std::is_same<decltype(dpl::abs((unsigned char)0)), int>::value), "");
-    static_assert((std::is_same<decltype(dpl::abs((char)0)), int>::value), "");
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::abs(Ambiguous())), Ambiguous>::value), ""))
+    static_assert((std::is_same_v<decltype(dpl::abs((float)0)), float>), "");
+    static_assert((std::is_same_v<decltype(dpl::abs((int)0)), int>), "");
+    static_assert((std::is_same_v<decltype(dpl::abs((long)0)), long>), "");
+    static_assert((std::is_same_v<decltype(dpl::abs((long long)0)), long long>), "");
+    static_assert((std::is_same_v<decltype(dpl::abs((unsigned char)0)), int>), "");
+    static_assert((std::is_same_v<decltype(dpl::abs((unsigned short)0)), int>), "");
+    static_assert((std::is_same_v<decltype(dpl::abs((signed char)0)), int>), "");
+    static_assert((std::is_same_v<decltype(dpl::abs((short)0)), int>), "");
+    static_assert((std::is_same_v<decltype(dpl::abs((unsigned char)0)), int>), "");
+    static_assert((std::is_same_v<decltype(dpl::abs((char)0)), int>), "");
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::abs(Ambiguous())), Ambiguous>), ""))
 
     static_assert(!has_abs<unsigned>::value, "");
     static_assert(!has_abs<unsigned long>::value, "");
     static_assert(!has_abs<unsigned long long>::value, "");
     static_assert(!has_abs<size_t>::value, "");
 
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::abs((double)0)), double>::value), ""))
-    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::abs((long double)0)), long double>::value), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::abs((double)0)), double>), ""))
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::abs((long double)0)), long double>), ""))
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif
@@ -107,76 +107,76 @@ void test_abs()
 ONEDPL_TEST_DECLARE
 void test_ceil()
 {
-    static_assert((std::is_same<decltype(dpl::ceil((float)0)), float>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::ceil((float)0)), float>), "");
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::ceil((bool)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::ceil((unsigned short)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::ceil((int)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::ceil((unsigned int)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::ceil((long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::ceil((unsigned long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::ceil((long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::ceil((unsigned long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::ceil((double)0)), double>::value), ""))
-    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::ceil((long double)0)), long double>::value), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::ceil(Ambiguous())), Ambiguous>::value), "");
+        static_assert((std::is_same_v<decltype(dpl::ceil((bool)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::ceil((unsigned short)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::ceil((int)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::ceil((unsigned int)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::ceil((long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::ceil((unsigned long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::ceil((long long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::ceil((unsigned long long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::ceil((double)0)), double>), ""))
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::ceil((long double)0)), long double>), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::ceil(Ambiguous())), Ambiguous>), "");
                       assert(dpl::ceil(0) == 0))
 }
 
 ONEDPL_TEST_DECLARE
 void test_exp()
 {
-    static_assert((std::is_same<decltype(dpl::exp((float)0)), float>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::exp((float)0)), float>), "");
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::exp((bool)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::exp((unsigned short)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::exp((int)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::exp((unsigned int)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::exp((long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::exp((unsigned long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::exp((long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::exp((unsigned long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::exp((double)0)), double>::value), ""))
-    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::exp((long double)0)), long double>::value), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::exp(Ambiguous())), Ambiguous>::value), "");
+        static_assert((std::is_same_v<decltype(dpl::exp((bool)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::exp((unsigned short)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::exp((int)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::exp((unsigned int)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::exp((long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::exp((unsigned long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::exp((long long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::exp((unsigned long long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::exp((double)0)), double>), ""))
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::exp((long double)0)), long double>), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::exp(Ambiguous())), Ambiguous>), "");
                       assert(dpl::exp(0) == 1))
 }
 
 ONEDPL_TEST_DECLARE
 void test_fabs()
 {
-    static_assert((std::is_same<decltype(dpl::fabs((float)0)), float>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::fabs((float)0)), float>), "");
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::fabs((bool)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fabs((unsigned short)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fabs((int)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fabs((unsigned int)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fabs((long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fabs((unsigned long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fabs((long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fabs((unsigned long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fabs((double)0)), double>::value), ""))
-    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::fabs((long double)0)), long double>::value), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::fabs(Ambiguous())), Ambiguous>::value), "");
+        static_assert((std::is_same_v<decltype(dpl::fabs((bool)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fabs((unsigned short)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fabs((int)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fabs((unsigned int)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fabs((long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fabs((unsigned long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fabs((long long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fabs((unsigned long long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fabs((double)0)), double>), ""))
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::fabs((long double)0)), long double>), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::fabs(Ambiguous())), Ambiguous>), "");
                       assert(dpl::fabs(-1) == 1));
 }
 
 ONEDPL_TEST_DECLARE
 void test_floor()
 {
-    static_assert((std::is_same<decltype(dpl::floor((float)0)), float>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::floor((float)0)), float>), "");
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::floor((bool)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::floor((unsigned short)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::floor((int)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::floor((unsigned int)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::floor((long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::floor((unsigned long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::floor((long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::floor((unsigned long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::floor((double)0)), double>::value), ""))
-    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::floor((long double)0)), long double>::value), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::floor(Ambiguous())), Ambiguous>::value), "");
+        static_assert((std::is_same_v<decltype(dpl::floor((bool)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::floor((unsigned short)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::floor((int)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::floor((unsigned int)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::floor((long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::floor((unsigned long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::floor((long long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::floor((unsigned long long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::floor((double)0)), double>), ""))
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::floor((long double)0)), long double>), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::floor(Ambiguous())), Ambiguous>), "");
                       assert(dpl::floor(1) == 1))
 }
 
@@ -186,19 +186,19 @@ void test_isgreater()
 #ifdef isgreater
 #error isgreater defined
 #endif
-    static_assert((std::is_same<decltype(dpl::isgreater((float)0, (float)0)), bool>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::isgreater((float)0, (float)0)), bool>), "");
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::isgreater((float)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isgreater((double)0, (float)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isgreater((double)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isgreater(0, (double)0)), bool>::value), ""))
+        static_assert((std::is_same_v<decltype(dpl::isgreater((float)0, (double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isgreater((double)0, (float)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isgreater((double)0, (double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isgreater(0, (double)0)), bool>), ""))
     IF_LONG_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::isgreater((float)0, (long double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isgreater((double)0, (long double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isgreater((long double)0, (float)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isgreater((long double)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isgreater((long double)0, (long double)0)), bool>::value), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::isgreater(Ambiguous(), Ambiguous())), Ambiguous>::value), "");
+        static_assert((std::is_same_v<decltype(dpl::isgreater((float)0, (long double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isgreater((double)0, (long double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isgreater((long double)0, (float)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isgreater((long double)0, (double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isgreater((long double)0, (long double)0)), bool>), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::isgreater(Ambiguous(), Ambiguous())), Ambiguous>), "");
                       assert(dpl::isgreater(-1.0, 0.F) == false))
 }
 
@@ -208,19 +208,19 @@ void test_isgreaterequal()
 #ifdef isgreaterequal
 #error isgreaterequal defined
 #endif
-    static_assert((std::is_same<decltype(dpl::isgreaterequal((float)0, (float)0)), bool>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::isgreaterequal((float)0, (float)0)), bool>), "");
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::isgreaterequal((float)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isgreaterequal((double)0, (float)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isgreaterequal((double)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isgreaterequal(0, (double)0)), bool>::value), ""))
+        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((float)0, (double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((double)0, (float)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((double)0, (double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isgreaterequal(0, (double)0)), bool>), ""))
     IF_LONG_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::isgreaterequal((float)0, (long double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isgreaterequal((double)0, (long double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isgreaterequal((long double)0, (float)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isgreaterequal((long double)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isgreaterequal((long double)0, (long double)0)), bool>::value), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::isgreaterequal(Ambiguous(), Ambiguous())), Ambiguous>::value), "");
+        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((float)0, (long double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((double)0, (long double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((long double)0, (float)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((long double)0, (double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((long double)0, (long double)0)), bool>), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::isgreaterequal(Ambiguous(), Ambiguous())), Ambiguous>), "");
                       assert(dpl::isgreaterequal(-1.0, 0.F) == false))
 }
 
@@ -236,25 +236,25 @@ void test_isinf()
 #pragma clang diagnostic ignored "-Wtautological-constant-compare"
 #endif
 
-    static_assert((std::is_same<decltype(dpl::isinf((float)0)), bool>::value), "");
-    static_assert((std::is_same<decltype(dpl::isinf(0)), bool>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::isinf((float)0)), bool>), "");
+    static_assert((std::is_same_v<decltype(dpl::isinf(0)), bool>), "");
 
     auto fnc = []()
     {
         typedef decltype(dpl::isinf((double)0)) DoubleRetType;
 #if !defined(__linux__) || defined(__clang__)
-        static_assert((std::is_same<DoubleRetType, bool>::value), "");
+        static_assert((std::is_same_v<DoubleRetType, bool>), "");
 #else
         // GLIBC < 2.23 defines 'isinf(double)' with a return type of 'int' in
         // all C++ dialects. The test should tolerate this when libc++ can't work
         // around it.
         // See: https://sourceware.org/bugzilla/show_bug.cgi?id=19439
-        static_assert((std::is_same<DoubleRetType, bool>::value || std::is_same<DoubleRetType, int>::value), "");
+        static_assert((std::is_same_v<DoubleRetType, bool> || std::is_same_v<DoubleRetType, int>), "");
 #endif
     };
     IF_DOUBLE_SUPPORT_L(fnc)
 
-    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::isinf((long double)0)), bool>::value), ""))
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::isinf((long double)0)), bool>), ""))
     IF_DOUBLE_SUPPORT(assert(dpl::isinf(-1.0) == false))
 #if !_PSTL_ICC_TEST_COMPLEX_ISINF_BROKEN
     assert(dpl::isinf(0) == false);
@@ -275,19 +275,19 @@ void test_isless()
 #ifdef isless
 #error isless defined
 #endif
-    static_assert((std::is_same<decltype(dpl::isless((float)0, (float)0)), bool>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::isless((float)0, (float)0)), bool>), "");
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::isless((float)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isless((double)0, (float)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isless((double)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isless(0, (double)0)), bool>::value), ""))
+        static_assert((std::is_same_v<decltype(dpl::isless((float)0, (double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isless((double)0, (float)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isless((double)0, (double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isless(0, (double)0)), bool>), ""))
     IF_LONG_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::isless((float)0, (long double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isless((double)0, (long double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isless((long double)0, (float)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isless((long double)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isless((long double)0, (long double)0)), bool>::value), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::isless(Ambiguous(), Ambiguous())), Ambiguous>::value), "");
+        static_assert((std::is_same_v<decltype(dpl::isless((float)0, (long double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isless((double)0, (long double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isless((long double)0, (float)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isless((long double)0, (double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isless((long double)0, (long double)0)), bool>), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::isless(Ambiguous(), Ambiguous())), Ambiguous>), "");
                       assert(dpl::isless(-1.0, 0.F) == true))
 }
 
@@ -297,19 +297,19 @@ void test_islessequal()
 #ifdef islessequal
 #error islessequal defined
 #endif
-    static_assert((std::is_same<decltype(dpl::islessequal((float)0, (float)0)), bool>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::islessequal((float)0, (float)0)), bool>), "");
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::islessequal((float)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::islessequal((double)0, (float)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::islessequal((double)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::islessequal(0, (double)0)), bool>::value), ""))
+        static_assert((std::is_same_v<decltype(dpl::islessequal((float)0, (double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::islessequal((double)0, (float)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::islessequal((double)0, (double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::islessequal(0, (double)0)), bool>), ""))
     IF_LONG_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::islessequal((float)0, (long double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::islessequal((double)0, (long double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::islessequal((long double)0, (float)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::islessequal((long double)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::islessequal((long double)0, (long double)0)), bool>::value), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::islessequal(Ambiguous(), Ambiguous())), Ambiguous>::value), "");
+        static_assert((std::is_same_v<decltype(dpl::islessequal((float)0, (long double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::islessequal((double)0, (long double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::islessequal((long double)0, (float)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::islessequal((long double)0, (double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::islessequal((long double)0, (long double)0)), bool>), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::islessequal(Ambiguous(), Ambiguous())), Ambiguous>), "");
                       assert(dpl::islessequal(-1.0, 0.F) == true));
 }
 
@@ -324,25 +324,25 @@ void test_isnan()
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wtautological-constant-compare"
 #endif
-    static_assert((std::is_same<decltype(dpl::isnan((float)0)), bool>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::isnan((float)0)), bool>), "");
 
     auto fnc = []()
     {
         typedef decltype(dpl::isnan((double)0)) DoubleRetType;
 #if !defined(__linux__) || defined(__clang__)
-        static_assert((std::is_same<DoubleRetType, bool>::value), "");
+        static_assert((std::is_same_v<DoubleRetType, bool>), "");
 #else
         // GLIBC < 2.23 defines 'isinf(double)' with a return type of 'int' in
         // all C++ dialects. The test should tolerate this when libc++ can't work
         // around it.
         // See: https://sourceware.org/bugzilla/show_bug.cgi?id=19439
-        static_assert((std::is_same<DoubleRetType, bool>::value || std::is_same<DoubleRetType, int>::value), "");
+        static_assert((std::is_same_v<DoubleRetType, bool> || std::is_same_v<DoubleRetType, int>), "");
 #endif
     };
     IF_DOUBLE_SUPPORT_L(fnc)
 
-    static_assert((std::is_same<decltype(dpl::isnan(0)), bool>::value), "");
-    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::isnan((long double)0)), bool>::value), ""))
+    static_assert((std::is_same_v<decltype(dpl::isnan(0)), bool>), "");
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::isnan((long double)0)), bool>), ""))
     IF_DOUBLE_SUPPORT(assert(dpl::isnan(-1.0) == false))
 #if !_PSTL_ICC_TEST_COMPLEX_ISNAN_BROKEN
     assert(dpl::isnan(0) == false);
@@ -363,142 +363,142 @@ void test_isunordered()
 #ifdef isunordered
 #error isunordered defined
 #endif
-    static_assert((std::is_same<decltype(dpl::isunordered((float)0, (float)0)), bool>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::isunordered((float)0, (float)0)), bool>), "");
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::isunordered((float)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isunordered((double)0, (float)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isunordered((double)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isunordered(0, (double)0)), bool>::value), ""))
+        static_assert((std::is_same_v<decltype(dpl::isunordered((float)0, (double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isunordered((double)0, (float)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isunordered((double)0, (double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isunordered(0, (double)0)), bool>), ""))
     IF_LONG_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::isunordered((float)0, (long double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isunordered((double)0, (long double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isunordered((long double)0, (float)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isunordered((long double)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isunordered((long double)0, (long double)0)), bool>::value), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::isunordered(Ambiguous(), Ambiguous())), Ambiguous>::value), "");
+        static_assert((std::is_same_v<decltype(dpl::isunordered((float)0, (long double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isunordered((double)0, (long double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isunordered((long double)0, (float)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isunordered((long double)0, (double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isunordered((long double)0, (long double)0)), bool>), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::isunordered(Ambiguous(), Ambiguous())), Ambiguous>), "");
                       assert(dpl::isunordered(-1.0, 0.F) == false));
 }
 
 ONEDPL_TEST_DECLARE
 void test_copysign()
 {
-    static_assert((std::is_same<decltype(dpl::copysign((float)0, (float)0)), float>::value), "");
-    static_assert((std::is_same<decltype(dpl::copysign((float)0, (unsigned int)0)), double>::value), "");
-    static_assert((std::is_same<decltype(dpl::copysignf(0,0)), float>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::copysign((float)0, (float)0)), float>), "");
+    static_assert((std::is_same_v<decltype(dpl::copysign((float)0, (unsigned int)0)), double>), "");
+    static_assert((std::is_same_v<decltype(dpl::copysignf(0, 0)), float>), "");
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::copysign((bool)0, (float)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::copysign((unsigned short)0, (double)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::copysign((double)0, (long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::copysign((int)0, (unsigned long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::copysign((double)0, (double)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::copysign((float)0, (double)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::copysign((int)0, (int)0)), double>::value), ""))
+        static_assert((std::is_same_v<decltype(dpl::copysign((bool)0, (float)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::copysign((unsigned short)0, (double)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::copysign((double)0, (long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::copysign((int)0, (unsigned long long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::copysign((double)0, (double)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::copysign((float)0, (double)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::copysign((int)0, (int)0)), double>), ""))
     IF_LONG_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::copysign((int)0, (long double)0)), long double>::value), "");
-        static_assert((std::is_same<decltype(dpl::copysign((long double)0, (unsigned long)0)), long double>::value), "");
-        static_assert((std::is_same<decltype(dpl::copysign((int)0, (long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::copysign((long double)0, (long double)0)), long double>::value), "");
-        static_assert((std::is_same<decltype(dpl::copysign((float)0, (long double)0)), long double>::value), "");
-        static_assert((std::is_same<decltype(dpl::copysign((double)0, (long double)0)), long double>::value), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::copysign(Ambiguous(), Ambiguous())), Ambiguous>::value), "");
+        static_assert((std::is_same_v<decltype(dpl::copysign((int)0, (long double)0)), long double>), "");
+        static_assert((std::is_same_v<decltype(dpl::copysign((long double)0, (unsigned long)0)), long double>), "");
+        static_assert((std::is_same_v<decltype(dpl::copysign((int)0, (long long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::copysign((long double)0, (long double)0)), long double>), "");
+        static_assert((std::is_same_v<decltype(dpl::copysign((float)0, (long double)0)), long double>), "");
+        static_assert((std::is_same_v<decltype(dpl::copysign((double)0, (long double)0)), long double>), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::copysign(Ambiguous(), Ambiguous())), Ambiguous>), "");
                       assert(dpl::copysign(1,1) == 1))
 }
 
 ONEDPL_TEST_DECLARE
 void test_fmax()
 {
-    static_assert((std::is_same<decltype(dpl::fmax((float)0, (float)0)), float>::value), "");
-    static_assert((std::is_same<decltype(dpl::fmax((float)0, (unsigned int)0)), double>::value), "");
-    static_assert((std::is_same<decltype(dpl::fmaxf(0,0)), float>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::fmax((float)0, (float)0)), float>), "");
+    static_assert((std::is_same_v<decltype(dpl::fmax((float)0, (unsigned int)0)), double>), "");
+    static_assert((std::is_same_v<decltype(dpl::fmaxf(0, 0)), float>), "");
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::fmax((bool)0, (float)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmax((unsigned short)0, (double)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmax((int)0, (long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmax((int)0, (unsigned long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmax((double)0, (long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmax((double)0, (double)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmax((float)0, (double)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmax((int)0, (int)0)), double>::value), ""))
+        static_assert((std::is_same_v<decltype(dpl::fmax((bool)0, (float)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmax((unsigned short)0, (double)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmax((int)0, (long long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmax((int)0, (unsigned long long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmax((double)0, (long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmax((double)0, (double)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmax((float)0, (double)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmax((int)0, (int)0)), double>), ""))
     IF_LONG_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::fmax((int)0, (long double)0)), long double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmax((long double)0, (unsigned long)0)), long double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmax((long double)0, (long double)0)), long double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmax((float)0, (long double)0)), long double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmax((double)0, (long double)0)), long double>::value), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::fmax(Ambiguous(), Ambiguous())), Ambiguous>::value), "");
+        static_assert((std::is_same_v<decltype(dpl::fmax((int)0, (long double)0)), long double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmax((long double)0, (unsigned long)0)), long double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmax((long double)0, (long double)0)), long double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmax((float)0, (long double)0)), long double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmax((double)0, (long double)0)), long double>), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::fmax(Ambiguous(), Ambiguous())), Ambiguous>), "");
                       assert(dpl::fmax(1,0) == 1))
 }
 
 ONEDPL_TEST_DECLARE
 void test_fmin()
 {
-    static_assert((std::is_same<decltype(dpl::fmin((float)0, (float)0)), float>::value), "");
-    static_assert((std::is_same<decltype(dpl::fminf(0, 0)), float>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::fmin((float)0, (float)0)), float>), "");
+    static_assert((std::is_same_v<decltype(dpl::fminf(0, 0)), float>), "");
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::fmin((bool)0, (float)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmin((unsigned short)0, (double)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmin((float)0, (unsigned int)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmin((double)0, (long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmin((int)0, (unsigned long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmin((double)0, (double)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmin((float)0, (double)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmin((int)0, (int)0)), double>::value), ""))
+        static_assert((std::is_same_v<decltype(dpl::fmin((bool)0, (float)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmin((unsigned short)0, (double)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmin((float)0, (unsigned int)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmin((double)0, (long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmin((int)0, (unsigned long long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmin((double)0, (double)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmin((float)0, (double)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmin((int)0, (int)0)), double>), ""))
     IF_LONG_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::fmin((int)0, (long double)0)), long double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmin((long double)0, (unsigned long)0)), long double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmin((int)0, (long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmin((long double)0, (long double)0)), long double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmin((float)0, (long double)0)), long double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmin((double)0, (long double)0)), long double>::value), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::fmin(Ambiguous(), Ambiguous())), Ambiguous>::value), "");
+        static_assert((std::is_same_v<decltype(dpl::fmin((int)0, (long double)0)), long double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmin((long double)0, (unsigned long)0)), long double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmin((int)0, (long long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmin((long double)0, (long double)0)), long double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmin((float)0, (long double)0)), long double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmin((double)0, (long double)0)), long double>), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::fmin(Ambiguous(), Ambiguous())), Ambiguous>), "");
                       assert(dpl::fmin(1,0) == 0))
 }
 
 ONEDPL_TEST_DECLARE
 void test_nan()
 {
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::nan("")), double>::value), ""))
-    static_assert((std::is_same<decltype(dpl::nanf("")), float>::value), "");
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::nan("")), double>), ""))
+    static_assert((std::is_same_v<decltype(dpl::nanf("")), float>), "");
 }
 
 ONEDPL_TEST_DECLARE
 void test_round()
 {
-    static_assert((std::is_same<decltype(dpl::round((float)0)), float>::value), "");
-    static_assert((std::is_same<decltype(dpl::roundf(0)), float>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::round((float)0)), float>), "");
+    static_assert((std::is_same_v<decltype(dpl::roundf(0)), float>), "");
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::round((bool)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::round((unsigned short)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::round((int)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::round((unsigned int)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::round((long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::round((unsigned long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::round((unsigned long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::round((double)0)), double>::value), ""))
+        static_assert((std::is_same_v<decltype(dpl::round((bool)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::round((unsigned short)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::round((int)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::round((unsigned int)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::round((long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::round((unsigned long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::round((unsigned long long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::round((double)0)), double>), ""))
     IF_LONG_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::round((long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::round((long double)0)), long double>::value), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::round(Ambiguous())), Ambiguous>::value), "");
+        static_assert((std::is_same_v<decltype(dpl::round((long long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::round((long double)0)), long double>), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::round(Ambiguous())), Ambiguous>), "");
                       assert(dpl::round(1) == 1))
 }
 
 ONEDPL_TEST_DECLARE
 void test_trunc()
 {
-    static_assert((std::is_same<decltype(dpl::trunc((float)0)), float>::value), "");
-    static_assert((std::is_same<decltype(dpl::truncf(0)), float>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::trunc((float)0)), float>), "");
+    static_assert((std::is_same_v<decltype(dpl::truncf(0)), float>), "");
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::trunc((bool)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::trunc((unsigned short)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::trunc((int)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::trunc((unsigned int)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::trunc((long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::trunc((unsigned long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::trunc((long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::trunc((unsigned long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::trunc((double)0)), double>::value), ""))
-    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::trunc((long double)0)), long double>::value), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::trunc(Ambiguous())), Ambiguous>::value), "");
+        static_assert((std::is_same_v<decltype(dpl::trunc((bool)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::trunc((unsigned short)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::trunc((int)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::trunc((unsigned int)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::trunc((long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::trunc((unsigned long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::trunc((long long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::trunc((unsigned long long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::trunc((double)0)), double>), ""))
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::trunc((long double)0)), long double>), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::trunc(Ambiguous())), Ambiguous>), "");
                       assert(dpl::trunc(1) == 1))
 }
 

--- a/test/xpu_api/numerics/c.math/cmath.pass.cpp
+++ b/test/xpu_api/numerics/c.math/cmath.pass.cpp
@@ -78,25 +78,25 @@ void test_abs()
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wabsolute-value"
 #endif
-    static_assert((std::is_same_v<decltype(dpl::abs((float)0)), float>), "");
-    static_assert((std::is_same_v<decltype(dpl::abs((int)0)), int>), "");
-    static_assert((std::is_same_v<decltype(dpl::abs((long)0)), long>), "");
-    static_assert((std::is_same_v<decltype(dpl::abs((long long)0)), long long>), "");
-    static_assert((std::is_same_v<decltype(dpl::abs((unsigned char)0)), int>), "");
-    static_assert((std::is_same_v<decltype(dpl::abs((unsigned short)0)), int>), "");
-    static_assert((std::is_same_v<decltype(dpl::abs((signed char)0)), int>), "");
-    static_assert((std::is_same_v<decltype(dpl::abs((short)0)), int>), "");
-    static_assert((std::is_same_v<decltype(dpl::abs((unsigned char)0)), int>), "");
-    static_assert((std::is_same_v<decltype(dpl::abs((char)0)), int>), "");
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::abs(Ambiguous())), Ambiguous>), ""))
+    static_assert((std::is_same_v<decltype(dpl::abs((float)0)), float>));
+    static_assert((std::is_same_v<decltype(dpl::abs((int)0)), int>));
+    static_assert((std::is_same_v<decltype(dpl::abs((long)0)), long>));
+    static_assert((std::is_same_v<decltype(dpl::abs((long long)0)), long long>));
+    static_assert((std::is_same_v<decltype(dpl::abs((unsigned char)0)), int>));
+    static_assert((std::is_same_v<decltype(dpl::abs((unsigned short)0)), int>));
+    static_assert((std::is_same_v<decltype(dpl::abs((signed char)0)), int>));
+    static_assert((std::is_same_v<decltype(dpl::abs((short)0)), int>));
+    static_assert((std::is_same_v<decltype(dpl::abs((unsigned char)0)), int>));
+    static_assert((std::is_same_v<decltype(dpl::abs((char)0)), int>));
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::abs(Ambiguous())), Ambiguous>)))
 
-    static_assert(!has_abs<unsigned>::value, "");
-    static_assert(!has_abs<unsigned long>::value, "");
-    static_assert(!has_abs<unsigned long long>::value, "");
-    static_assert(!has_abs<size_t>::value, "");
+    static_assert(!has_abs<unsigned>::value);
+    static_assert(!has_abs<unsigned long>::value);
+    static_assert(!has_abs<unsigned long long>::value);
+    static_assert(!has_abs<size_t>::value);
 
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::abs((double)0)), double>), ""))
-    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::abs((long double)0)), long double>), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::abs((double)0)), double>)))
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::abs((long double)0)), long double>)))
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif
@@ -107,76 +107,76 @@ void test_abs()
 ONEDPL_TEST_DECLARE
 void test_ceil()
 {
-    static_assert((std::is_same_v<decltype(dpl::ceil((float)0)), float>), "");
+    static_assert((std::is_same_v<decltype(dpl::ceil((float)0)), float>));
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::ceil((bool)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::ceil((unsigned short)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::ceil((int)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::ceil((unsigned int)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::ceil((long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::ceil((unsigned long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::ceil((long long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::ceil((unsigned long long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::ceil((double)0)), double>), ""))
-    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::ceil((long double)0)), long double>), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::ceil(Ambiguous())), Ambiguous>), "");
+        static_assert((std::is_same_v<decltype(dpl::ceil((bool)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::ceil((unsigned short)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::ceil((int)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::ceil((unsigned int)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::ceil((long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::ceil((unsigned long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::ceil((long long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::ceil((unsigned long long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::ceil((double)0)), double>)))
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::ceil((long double)0)), long double>)))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::ceil(Ambiguous())), Ambiguous>));
                       assert(dpl::ceil(0) == 0))
 }
 
 ONEDPL_TEST_DECLARE
 void test_exp()
 {
-    static_assert((std::is_same_v<decltype(dpl::exp((float)0)), float>), "");
+    static_assert((std::is_same_v<decltype(dpl::exp((float)0)), float>));
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::exp((bool)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::exp((unsigned short)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::exp((int)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::exp((unsigned int)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::exp((long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::exp((unsigned long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::exp((long long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::exp((unsigned long long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::exp((double)0)), double>), ""))
-    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::exp((long double)0)), long double>), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::exp(Ambiguous())), Ambiguous>), "");
+        static_assert((std::is_same_v<decltype(dpl::exp((bool)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::exp((unsigned short)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::exp((int)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::exp((unsigned int)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::exp((long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::exp((unsigned long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::exp((long long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::exp((unsigned long long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::exp((double)0)), double>)))
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::exp((long double)0)), long double>)))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::exp(Ambiguous())), Ambiguous>));
                       assert(dpl::exp(0) == 1))
 }
 
 ONEDPL_TEST_DECLARE
 void test_fabs()
 {
-    static_assert((std::is_same_v<decltype(dpl::fabs((float)0)), float>), "");
+    static_assert((std::is_same_v<decltype(dpl::fabs((float)0)), float>));
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::fabs((bool)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fabs((unsigned short)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fabs((int)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fabs((unsigned int)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fabs((long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fabs((unsigned long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fabs((long long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fabs((unsigned long long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fabs((double)0)), double>), ""))
-    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::fabs((long double)0)), long double>), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::fabs(Ambiguous())), Ambiguous>), "");
+        static_assert((std::is_same_v<decltype(dpl::fabs((bool)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fabs((unsigned short)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fabs((int)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fabs((unsigned int)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fabs((long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fabs((unsigned long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fabs((long long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fabs((unsigned long long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fabs((double)0)), double>)))
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::fabs((long double)0)), long double>)))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::fabs(Ambiguous())), Ambiguous>));
                       assert(dpl::fabs(-1) == 1));
 }
 
 ONEDPL_TEST_DECLARE
 void test_floor()
 {
-    static_assert((std::is_same_v<decltype(dpl::floor((float)0)), float>), "");
+    static_assert((std::is_same_v<decltype(dpl::floor((float)0)), float>));
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::floor((bool)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::floor((unsigned short)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::floor((int)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::floor((unsigned int)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::floor((long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::floor((unsigned long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::floor((long long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::floor((unsigned long long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::floor((double)0)), double>), ""))
-    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::floor((long double)0)), long double>), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::floor(Ambiguous())), Ambiguous>), "");
+        static_assert((std::is_same_v<decltype(dpl::floor((bool)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::floor((unsigned short)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::floor((int)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::floor((unsigned int)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::floor((long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::floor((unsigned long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::floor((long long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::floor((unsigned long long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::floor((double)0)), double>)))
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::floor((long double)0)), long double>)))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::floor(Ambiguous())), Ambiguous>));
                       assert(dpl::floor(1) == 1))
 }
 
@@ -186,19 +186,19 @@ void test_isgreater()
 #ifdef isgreater
 #error isgreater defined
 #endif
-    static_assert((std::is_same_v<decltype(dpl::isgreater((float)0, (float)0)), bool>), "");
+    static_assert((std::is_same_v<decltype(dpl::isgreater((float)0, (float)0)), bool>));
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::isgreater((float)0, (double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isgreater((double)0, (float)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isgreater((double)0, (double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isgreater(0, (double)0)), bool>), ""))
+        static_assert((std::is_same_v<decltype(dpl::isgreater((float)0, (double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isgreater((double)0, (float)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isgreater((double)0, (double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isgreater(0, (double)0)), bool>)))
     IF_LONG_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::isgreater((float)0, (long double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isgreater((double)0, (long double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isgreater((long double)0, (float)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isgreater((long double)0, (double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isgreater((long double)0, (long double)0)), bool>), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::isgreater(Ambiguous(), Ambiguous())), Ambiguous>), "");
+        static_assert((std::is_same_v<decltype(dpl::isgreater((float)0, (long double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isgreater((double)0, (long double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isgreater((long double)0, (float)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isgreater((long double)0, (double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isgreater((long double)0, (long double)0)), bool>)))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::isgreater(Ambiguous(), Ambiguous())), Ambiguous>));
                       assert(dpl::isgreater(-1.0, 0.F) == false))
 }
 
@@ -208,19 +208,19 @@ void test_isgreaterequal()
 #ifdef isgreaterequal
 #error isgreaterequal defined
 #endif
-    static_assert((std::is_same_v<decltype(dpl::isgreaterequal((float)0, (float)0)), bool>), "");
+    static_assert((std::is_same_v<decltype(dpl::isgreaterequal((float)0, (float)0)), bool>));
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((float)0, (double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((double)0, (float)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((double)0, (double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isgreaterequal(0, (double)0)), bool>), ""))
+        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((float)0, (double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((double)0, (float)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((double)0, (double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isgreaterequal(0, (double)0)), bool>)))
     IF_LONG_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((float)0, (long double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((double)0, (long double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((long double)0, (float)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((long double)0, (double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((long double)0, (long double)0)), bool>), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::isgreaterequal(Ambiguous(), Ambiguous())), Ambiguous>), "");
+        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((float)0, (long double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((double)0, (long double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((long double)0, (float)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((long double)0, (double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((long double)0, (long double)0)), bool>)))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::isgreaterequal(Ambiguous(), Ambiguous())), Ambiguous>));
                       assert(dpl::isgreaterequal(-1.0, 0.F) == false))
 }
 
@@ -236,25 +236,25 @@ void test_isinf()
 #pragma clang diagnostic ignored "-Wtautological-constant-compare"
 #endif
 
-    static_assert((std::is_same_v<decltype(dpl::isinf((float)0)), bool>), "");
-    static_assert((std::is_same_v<decltype(dpl::isinf(0)), bool>), "");
+    static_assert((std::is_same_v<decltype(dpl::isinf((float)0)), bool>));
+    static_assert((std::is_same_v<decltype(dpl::isinf(0)), bool>));
 
     auto fnc = []()
     {
         typedef decltype(dpl::isinf((double)0)) DoubleRetType;
 #if !defined(__linux__) || defined(__clang__)
-        static_assert((std::is_same_v<DoubleRetType, bool>), "");
+        static_assert((std::is_same_v<DoubleRetType, bool>));
 #else
         // GLIBC < 2.23 defines 'isinf(double)' with a return type of 'int' in
         // all C++ dialects. The test should tolerate this when libc++ can't work
         // around it.
         // See: https://sourceware.org/bugzilla/show_bug.cgi?id=19439
-        static_assert((std::is_same_v<DoubleRetType, bool> || std::is_same_v<DoubleRetType, int>), "");
+        static_assert((std::is_same_v<DoubleRetType, bool> || std::is_same_v<DoubleRetType, int>));
 #endif
     };
     IF_DOUBLE_SUPPORT_L(fnc)
 
-    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::isinf((long double)0)), bool>), ""))
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::isinf((long double)0)), bool>)))
     IF_DOUBLE_SUPPORT(assert(dpl::isinf(-1.0) == false))
 #if !_PSTL_ICC_TEST_COMPLEX_ISINF_BROKEN
     assert(dpl::isinf(0) == false);
@@ -275,19 +275,19 @@ void test_isless()
 #ifdef isless
 #error isless defined
 #endif
-    static_assert((std::is_same_v<decltype(dpl::isless((float)0, (float)0)), bool>), "");
+    static_assert((std::is_same_v<decltype(dpl::isless((float)0, (float)0)), bool>));
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::isless((float)0, (double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isless((double)0, (float)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isless((double)0, (double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isless(0, (double)0)), bool>), ""))
+        static_assert((std::is_same_v<decltype(dpl::isless((float)0, (double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isless((double)0, (float)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isless((double)0, (double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isless(0, (double)0)), bool>)))
     IF_LONG_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::isless((float)0, (long double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isless((double)0, (long double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isless((long double)0, (float)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isless((long double)0, (double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isless((long double)0, (long double)0)), bool>), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::isless(Ambiguous(), Ambiguous())), Ambiguous>), "");
+        static_assert((std::is_same_v<decltype(dpl::isless((float)0, (long double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isless((double)0, (long double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isless((long double)0, (float)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isless((long double)0, (double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isless((long double)0, (long double)0)), bool>)))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::isless(Ambiguous(), Ambiguous())), Ambiguous>));
                       assert(dpl::isless(-1.0, 0.F) == true))
 }
 
@@ -297,19 +297,19 @@ void test_islessequal()
 #ifdef islessequal
 #error islessequal defined
 #endif
-    static_assert((std::is_same_v<decltype(dpl::islessequal((float)0, (float)0)), bool>), "");
+    static_assert((std::is_same_v<decltype(dpl::islessequal((float)0, (float)0)), bool>));
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::islessequal((float)0, (double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::islessequal((double)0, (float)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::islessequal((double)0, (double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::islessequal(0, (double)0)), bool>), ""))
+        static_assert((std::is_same_v<decltype(dpl::islessequal((float)0, (double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::islessequal((double)0, (float)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::islessequal((double)0, (double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::islessequal(0, (double)0)), bool>)))
     IF_LONG_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::islessequal((float)0, (long double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::islessequal((double)0, (long double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::islessequal((long double)0, (float)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::islessequal((long double)0, (double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::islessequal((long double)0, (long double)0)), bool>), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::islessequal(Ambiguous(), Ambiguous())), Ambiguous>), "");
+        static_assert((std::is_same_v<decltype(dpl::islessequal((float)0, (long double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::islessequal((double)0, (long double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::islessequal((long double)0, (float)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::islessequal((long double)0, (double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::islessequal((long double)0, (long double)0)), bool>)))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::islessequal(Ambiguous(), Ambiguous())), Ambiguous>));
                       assert(dpl::islessequal(-1.0, 0.F) == true));
 }
 
@@ -324,25 +324,25 @@ void test_isnan()
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wtautological-constant-compare"
 #endif
-    static_assert((std::is_same_v<decltype(dpl::isnan((float)0)), bool>), "");
+    static_assert((std::is_same_v<decltype(dpl::isnan((float)0)), bool>));
 
     auto fnc = []()
     {
         typedef decltype(dpl::isnan((double)0)) DoubleRetType;
 #if !defined(__linux__) || defined(__clang__)
-        static_assert((std::is_same_v<DoubleRetType, bool>), "");
+        static_assert((std::is_same_v<DoubleRetType, bool>));
 #else
         // GLIBC < 2.23 defines 'isinf(double)' with a return type of 'int' in
         // all C++ dialects. The test should tolerate this when libc++ can't work
         // around it.
         // See: https://sourceware.org/bugzilla/show_bug.cgi?id=19439
-        static_assert((std::is_same_v<DoubleRetType, bool> || std::is_same_v<DoubleRetType, int>), "");
+        static_assert((std::is_same_v<DoubleRetType, bool> || std::is_same_v<DoubleRetType, int>));
 #endif
     };
     IF_DOUBLE_SUPPORT_L(fnc)
 
-    static_assert((std::is_same_v<decltype(dpl::isnan(0)), bool>), "");
-    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::isnan((long double)0)), bool>), ""))
+    static_assert((std::is_same_v<decltype(dpl::isnan(0)), bool>));
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::isnan((long double)0)), bool>)))
     IF_DOUBLE_SUPPORT(assert(dpl::isnan(-1.0) == false))
 #if !_PSTL_ICC_TEST_COMPLEX_ISNAN_BROKEN
     assert(dpl::isnan(0) == false);
@@ -363,142 +363,142 @@ void test_isunordered()
 #ifdef isunordered
 #error isunordered defined
 #endif
-    static_assert((std::is_same_v<decltype(dpl::isunordered((float)0, (float)0)), bool>), "");
+    static_assert((std::is_same_v<decltype(dpl::isunordered((float)0, (float)0)), bool>));
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::isunordered((float)0, (double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isunordered((double)0, (float)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isunordered((double)0, (double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isunordered(0, (double)0)), bool>), ""))
+        static_assert((std::is_same_v<decltype(dpl::isunordered((float)0, (double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isunordered((double)0, (float)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isunordered((double)0, (double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isunordered(0, (double)0)), bool>)))
     IF_LONG_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::isunordered((float)0, (long double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isunordered((double)0, (long double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isunordered((long double)0, (float)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isunordered((long double)0, (double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isunordered((long double)0, (long double)0)), bool>), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::isunordered(Ambiguous(), Ambiguous())), Ambiguous>), "");
+        static_assert((std::is_same_v<decltype(dpl::isunordered((float)0, (long double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isunordered((double)0, (long double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isunordered((long double)0, (float)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isunordered((long double)0, (double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isunordered((long double)0, (long double)0)), bool>)))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::isunordered(Ambiguous(), Ambiguous())), Ambiguous>));
                       assert(dpl::isunordered(-1.0, 0.F) == false));
 }
 
 ONEDPL_TEST_DECLARE
 void test_copysign()
 {
-    static_assert((std::is_same_v<decltype(dpl::copysign((float)0, (float)0)), float>), "");
-    static_assert((std::is_same_v<decltype(dpl::copysign((float)0, (unsigned int)0)), double>), "");
-    static_assert((std::is_same_v<decltype(dpl::copysignf(0, 0)), float>), "");
+    static_assert((std::is_same_v<decltype(dpl::copysign((float)0, (float)0)), float>));
+    static_assert((std::is_same_v<decltype(dpl::copysign((float)0, (unsigned int)0)), double>));
+    static_assert((std::is_same_v<decltype(dpl::copysignf(0, 0)), float>));
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::copysign((bool)0, (float)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::copysign((unsigned short)0, (double)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::copysign((double)0, (long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::copysign((int)0, (unsigned long long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::copysign((double)0, (double)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::copysign((float)0, (double)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::copysign((int)0, (int)0)), double>), ""))
+        static_assert((std::is_same_v<decltype(dpl::copysign((bool)0, (float)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::copysign((unsigned short)0, (double)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::copysign((double)0, (long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::copysign((int)0, (unsigned long long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::copysign((double)0, (double)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::copysign((float)0, (double)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::copysign((int)0, (int)0)), double>)))
     IF_LONG_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::copysign((int)0, (long double)0)), long double>), "");
-        static_assert((std::is_same_v<decltype(dpl::copysign((long double)0, (unsigned long)0)), long double>), "");
-        static_assert((std::is_same_v<decltype(dpl::copysign((int)0, (long long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::copysign((long double)0, (long double)0)), long double>), "");
-        static_assert((std::is_same_v<decltype(dpl::copysign((float)0, (long double)0)), long double>), "");
-        static_assert((std::is_same_v<decltype(dpl::copysign((double)0, (long double)0)), long double>), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::copysign(Ambiguous(), Ambiguous())), Ambiguous>), "");
+        static_assert((std::is_same_v<decltype(dpl::copysign((int)0, (long double)0)), long double>));
+        static_assert((std::is_same_v<decltype(dpl::copysign((long double)0, (unsigned long)0)), long double>));
+        static_assert((std::is_same_v<decltype(dpl::copysign((int)0, (long long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::copysign((long double)0, (long double)0)), long double>));
+        static_assert((std::is_same_v<decltype(dpl::copysign((float)0, (long double)0)), long double>));
+        static_assert((std::is_same_v<decltype(dpl::copysign((double)0, (long double)0)), long double>)))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::copysign(Ambiguous(), Ambiguous())), Ambiguous>));
                       assert(dpl::copysign(1,1) == 1))
 }
 
 ONEDPL_TEST_DECLARE
 void test_fmax()
 {
-    static_assert((std::is_same_v<decltype(dpl::fmax((float)0, (float)0)), float>), "");
-    static_assert((std::is_same_v<decltype(dpl::fmax((float)0, (unsigned int)0)), double>), "");
-    static_assert((std::is_same_v<decltype(dpl::fmaxf(0, 0)), float>), "");
+    static_assert((std::is_same_v<decltype(dpl::fmax((float)0, (float)0)), float>));
+    static_assert((std::is_same_v<decltype(dpl::fmax((float)0, (unsigned int)0)), double>));
+    static_assert((std::is_same_v<decltype(dpl::fmaxf(0, 0)), float>));
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::fmax((bool)0, (float)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmax((unsigned short)0, (double)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmax((int)0, (long long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmax((int)0, (unsigned long long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmax((double)0, (long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmax((double)0, (double)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmax((float)0, (double)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmax((int)0, (int)0)), double>), ""))
+        static_assert((std::is_same_v<decltype(dpl::fmax((bool)0, (float)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fmax((unsigned short)0, (double)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fmax((int)0, (long long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fmax((int)0, (unsigned long long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fmax((double)0, (long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fmax((double)0, (double)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fmax((float)0, (double)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fmax((int)0, (int)0)), double>)))
     IF_LONG_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::fmax((int)0, (long double)0)), long double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmax((long double)0, (unsigned long)0)), long double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmax((long double)0, (long double)0)), long double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmax((float)0, (long double)0)), long double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmax((double)0, (long double)0)), long double>), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::fmax(Ambiguous(), Ambiguous())), Ambiguous>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmax((int)0, (long double)0)), long double>));
+        static_assert((std::is_same_v<decltype(dpl::fmax((long double)0, (unsigned long)0)), long double>));
+        static_assert((std::is_same_v<decltype(dpl::fmax((long double)0, (long double)0)), long double>));
+        static_assert((std::is_same_v<decltype(dpl::fmax((float)0, (long double)0)), long double>));
+        static_assert((std::is_same_v<decltype(dpl::fmax((double)0, (long double)0)), long double>)))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::fmax(Ambiguous(), Ambiguous())), Ambiguous>));
                       assert(dpl::fmax(1,0) == 1))
 }
 
 ONEDPL_TEST_DECLARE
 void test_fmin()
 {
-    static_assert((std::is_same_v<decltype(dpl::fmin((float)0, (float)0)), float>), "");
-    static_assert((std::is_same_v<decltype(dpl::fminf(0, 0)), float>), "");
+    static_assert((std::is_same_v<decltype(dpl::fmin((float)0, (float)0)), float>));
+    static_assert((std::is_same_v<decltype(dpl::fminf(0, 0)), float>));
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::fmin((bool)0, (float)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmin((unsigned short)0, (double)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmin((float)0, (unsigned int)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmin((double)0, (long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmin((int)0, (unsigned long long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmin((double)0, (double)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmin((float)0, (double)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmin((int)0, (int)0)), double>), ""))
+        static_assert((std::is_same_v<decltype(dpl::fmin((bool)0, (float)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fmin((unsigned short)0, (double)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fmin((float)0, (unsigned int)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fmin((double)0, (long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fmin((int)0, (unsigned long long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fmin((double)0, (double)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fmin((float)0, (double)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fmin((int)0, (int)0)), double>)))
     IF_LONG_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::fmin((int)0, (long double)0)), long double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmin((long double)0, (unsigned long)0)), long double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmin((int)0, (long long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmin((long double)0, (long double)0)), long double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmin((float)0, (long double)0)), long double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmin((double)0, (long double)0)), long double>), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::fmin(Ambiguous(), Ambiguous())), Ambiguous>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmin((int)0, (long double)0)), long double>));
+        static_assert((std::is_same_v<decltype(dpl::fmin((long double)0, (unsigned long)0)), long double>));
+        static_assert((std::is_same_v<decltype(dpl::fmin((int)0, (long long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fmin((long double)0, (long double)0)), long double>));
+        static_assert((std::is_same_v<decltype(dpl::fmin((float)0, (long double)0)), long double>));
+        static_assert((std::is_same_v<decltype(dpl::fmin((double)0, (long double)0)), long double>)))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::fmin(Ambiguous(), Ambiguous())), Ambiguous>));
                       assert(dpl::fmin(1,0) == 0))
 }
 
 ONEDPL_TEST_DECLARE
 void test_nan()
 {
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::nan("")), double>), ""))
-    static_assert((std::is_same_v<decltype(dpl::nanf("")), float>), "");
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::nan("")), double>)))
+    static_assert((std::is_same_v<decltype(dpl::nanf("")), float>));
 }
 
 ONEDPL_TEST_DECLARE
 void test_round()
 {
-    static_assert((std::is_same_v<decltype(dpl::round((float)0)), float>), "");
-    static_assert((std::is_same_v<decltype(dpl::roundf(0)), float>), "");
+    static_assert((std::is_same_v<decltype(dpl::round((float)0)), float>));
+    static_assert((std::is_same_v<decltype(dpl::roundf(0)), float>));
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::round((bool)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::round((unsigned short)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::round((int)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::round((unsigned int)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::round((long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::round((unsigned long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::round((unsigned long long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::round((double)0)), double>), ""))
+        static_assert((std::is_same_v<decltype(dpl::round((bool)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::round((unsigned short)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::round((int)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::round((unsigned int)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::round((long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::round((unsigned long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::round((unsigned long long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::round((double)0)), double>)))
     IF_LONG_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::round((long long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::round((long double)0)), long double>), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::round(Ambiguous())), Ambiguous>), "");
+        static_assert((std::is_same_v<decltype(dpl::round((long long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::round((long double)0)), long double>)))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::round(Ambiguous())), Ambiguous>));
                       assert(dpl::round(1) == 1))
 }
 
 ONEDPL_TEST_DECLARE
 void test_trunc()
 {
-    static_assert((std::is_same_v<decltype(dpl::trunc((float)0)), float>), "");
-    static_assert((std::is_same_v<decltype(dpl::truncf(0)), float>), "");
+    static_assert((std::is_same_v<decltype(dpl::trunc((float)0)), float>));
+    static_assert((std::is_same_v<decltype(dpl::truncf(0)), float>));
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::trunc((bool)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::trunc((unsigned short)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::trunc((int)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::trunc((unsigned int)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::trunc((long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::trunc((unsigned long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::trunc((long long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::trunc((unsigned long long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::trunc((double)0)), double>), ""))
-    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::trunc((long double)0)), long double>), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::trunc(Ambiguous())), Ambiguous>), "");
+        static_assert((std::is_same_v<decltype(dpl::trunc((bool)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::trunc((unsigned short)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::trunc((int)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::trunc((unsigned int)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::trunc((long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::trunc((unsigned long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::trunc((long long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::trunc((unsigned long long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::trunc((double)0)), double>)))
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::trunc((long double)0)), long double>)))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::trunc(Ambiguous())), Ambiguous>));
                       assert(dpl::trunc(1) == 1))
 }
 

--- a/test/xpu_api/numerics/complex.number/cases.h
+++ b/test/xpu_api/numerics/complex.number/cases.h
@@ -234,14 +234,14 @@ template <typename T>
 constexpr auto __tol = std::numeric_limits<T>::epsilon() * 1e5;
 
 template <typename X, typename Y>
-typename std::enable_if<!std::numeric_limits<X>::is_integer || !std::numeric_limits<Y>::is_integer, void>::type
+::std::enable_if_t<!std::numeric_limits<X>::is_integer || !std::numeric_limits<Y>::is_integer, void>
 is_about(X x, Y y, const X eps = __tol<X>)
 {
     assert(std::fabs(x - y) <= eps);
 }
 
 template <typename T>
-typename std::enable_if<!std::numeric_limits<T>::is_integer, void>::type
+::std::enable_if_t<!std::numeric_limits<T>::is_integer, void>
 is_about(const dpl::complex<T>& x, const dpl::complex<T>& y, const T eps = __tol<T>)
 {
     return is_about(::std::abs(y - x), T(0.), eps);

--- a/test/xpu_api/numerics/complex.number/cmplx.over/arg.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/arg.pass.cpp
@@ -22,7 +22,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<std::is_integral<T>::value>* = 0)
 {
-    static_assert((std::is_same_v<decltype(dpl::arg(x)), double>), "");
+    static_assert((std::is_same_v<decltype(dpl::arg(x)), double>));
     assert(dpl::arg(x) == dpl::arg(dpl::complex<double>(static_cast<double>(x), 0)));
 }
 
@@ -30,7 +30,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<!std::is_integral<T>::value>* = 0)
 {
-    static_assert((std::is_same_v<decltype(dpl::arg(x)), T>), "");
+    static_assert((std::is_same_v<decltype(dpl::arg(x)), T>));
     assert(dpl::arg(x) == dpl::arg(dpl::complex<T>(x, 0)));
 }
 

--- a/test/xpu_api/numerics/complex.number/cmplx.over/arg.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/arg.pass.cpp
@@ -20,7 +20,7 @@
 
 template <class T>
 void
-test(T x, typename std::enable_if<std::is_integral<T>::value>::type* = 0)
+test(T x, ::std::enable_if_t<std::is_integral<T>::value>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::arg(x)), double>::value), "");
     assert(dpl::arg(x) == dpl::arg(dpl::complex<double>(static_cast<double>(x), 0)));
@@ -28,7 +28,7 @@ test(T x, typename std::enable_if<std::is_integral<T>::value>::type* = 0)
 
 template <class T>
 void
-test(T x, typename std::enable_if<!std::is_integral<T>::value>::type* = 0)
+test(T x, ::std::enable_if_t<!std::is_integral<T>::value>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::arg(x)), T>::value), "");
     assert(dpl::arg(x) == dpl::arg(dpl::complex<T>(x, 0)));

--- a/test/xpu_api/numerics/complex.number/cmplx.over/arg.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/arg.pass.cpp
@@ -22,7 +22,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<std::is_integral<T>::value>* = 0)
 {
-    static_assert((std::is_same<decltype(dpl::arg(x)), double>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::arg(x)), double>), "");
     assert(dpl::arg(x) == dpl::arg(dpl::complex<double>(static_cast<double>(x), 0)));
 }
 
@@ -30,7 +30,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<!std::is_integral<T>::value>* = 0)
 {
-    static_assert((std::is_same<decltype(dpl::arg(x)), T>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::arg(x)), T>), "");
     assert(dpl::arg(x) == dpl::arg(dpl::complex<T>(x, 0)));
 }
 

--- a/test/xpu_api/numerics/complex.number/cmplx.over/conj.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/conj.pass.cpp
@@ -36,8 +36,7 @@ test(T x, ::std::enable_if_t<std::is_floating_point<T>::value>* = 0)
 
 template <class T>
 void
-test(T x, typename std::enable_if<!std::is_integral<T>::value &&
-                                  !std::is_floating_point<T>::value>::type* = 0)
+test(T x, ::std::enable_if_t<!std::is_integral<T>::value && !std::is_floating_point<T>::value>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::conj(x)), dpl::complex<T>>::value), "");
     assert(dpl::conj(x) == dpl::conj(dpl::complex<T>(x, 0)));

--- a/test/xpu_api/numerics/complex.number/cmplx.over/conj.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/conj.pass.cpp
@@ -22,7 +22,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<std::is_integral<T>::value>* = 0)
 {
-    static_assert((std::is_same_v<decltype(dpl::conj(x)), dpl::complex<double>>), "");
+    static_assert((std::is_same_v<decltype(dpl::conj(x)), dpl::complex<double>>));
     assert(dpl::conj(x) == dpl::conj(dpl::complex<double>(x, 0)));
 }
 
@@ -30,7 +30,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<std::is_floating_point<T>::value>* = 0)
 {
-    static_assert((std::is_same_v<decltype(dpl::conj(x)), dpl::complex<T>>), "");
+    static_assert((std::is_same_v<decltype(dpl::conj(x)), dpl::complex<T>>));
     assert(dpl::conj(x) == dpl::conj(dpl::complex<T>(x, 0)));
 }
 
@@ -38,7 +38,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<!std::is_integral<T>::value && !std::is_floating_point<T>::value>* = 0)
 {
-    static_assert((std::is_same_v<decltype(dpl::conj(x)), dpl::complex<T>>), "");
+    static_assert((std::is_same_v<decltype(dpl::conj(x)), dpl::complex<T>>));
     assert(dpl::conj(x) == dpl::conj(dpl::complex<T>(x, 0)));
 }
 

--- a/test/xpu_api/numerics/complex.number/cmplx.over/conj.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/conj.pass.cpp
@@ -22,7 +22,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<std::is_integral<T>::value>* = 0)
 {
-    static_assert((std::is_same<decltype(dpl::conj(x)), dpl::complex<double> >::value), "");
+    static_assert((std::is_same_v<decltype(dpl::conj(x)), dpl::complex<double>>), "");
     assert(dpl::conj(x) == dpl::conj(dpl::complex<double>(x, 0)));
 }
 
@@ -30,7 +30,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<std::is_floating_point<T>::value>* = 0)
 {
-    static_assert((std::is_same<decltype(dpl::conj(x)), dpl::complex<T>>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::conj(x)), dpl::complex<T>>), "");
     assert(dpl::conj(x) == dpl::conj(dpl::complex<T>(x, 0)));
 }
 
@@ -38,7 +38,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<!std::is_integral<T>::value && !std::is_floating_point<T>::value>* = 0)
 {
-    static_assert((std::is_same<decltype(dpl::conj(x)), dpl::complex<T>>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::conj(x)), dpl::complex<T>>), "");
     assert(dpl::conj(x) == dpl::conj(dpl::complex<T>(x, 0)));
 }
 

--- a/test/xpu_api/numerics/complex.number/cmplx.over/conj.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/conj.pass.cpp
@@ -20,7 +20,7 @@
 
 template <class T>
 void
-test(T x, typename std::enable_if<std::is_integral<T>::value>::type* = 0)
+test(T x, ::std::enable_if_t<std::is_integral<T>::value>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::conj(x)), dpl::complex<double> >::value), "");
     assert(dpl::conj(x) == dpl::conj(dpl::complex<double>(x, 0)));
@@ -28,7 +28,7 @@ test(T x, typename std::enable_if<std::is_integral<T>::value>::type* = 0)
 
 template <class T>
 void
-test(T x, typename std::enable_if<std::is_floating_point<T>::value>::type* = 0)
+test(T x, ::std::enable_if_t<std::is_floating_point<T>::value>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::conj(x)), dpl::complex<T>>::value), "");
     assert(dpl::conj(x) == dpl::conj(dpl::complex<T>(x, 0)));

--- a/test/xpu_api/numerics/complex.number/cmplx.over/imag.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/imag.pass.cpp
@@ -20,26 +20,26 @@ template <class T, int x>
 void
 test(::std::enable_if_t<std::is_integral<T>::value>* = 0)
 {
-    static_assert((std::is_same_v<decltype(dpl::imag(T(x))), double>), "");
+    static_assert((std::is_same_v<decltype(dpl::imag(T(x))), double>));
     assert(dpl::imag(x) == 0);
 
     constexpr T val {x};
-    STD_COMPLEX_TESTS_STATIC_ASSERT(dpl::imag(val) == 0, "");
+    STD_COMPLEX_TESTS_STATIC_ASSERT(dpl::imag(val) == 0);
     constexpr dpl::complex<T> t{val, val};
-    STD_COMPLEX_TESTS_STATIC_ASSERT(t.imag() == x, "" );
+    STD_COMPLEX_TESTS_STATIC_ASSERT(t.imag() == x);
 }
 
 template <class T, int x>
 void
 test(::std::enable_if_t<!std::is_integral<T>::value>* = 0)
 {
-    static_assert((std::is_same_v<decltype(dpl::imag(T(x))), T>), "");
+    static_assert((std::is_same_v<decltype(dpl::imag(T(x))), T>));
     assert(dpl::imag(x) == 0);
 
     constexpr T val {x};
-    STD_COMPLEX_TESTS_STATIC_ASSERT(dpl::imag(val) == 0, "");
+    STD_COMPLEX_TESTS_STATIC_ASSERT(dpl::imag(val) == 0);
     constexpr dpl::complex<T> t{val, val};
-    STD_COMPLEX_TESTS_STATIC_ASSERT(t.imag() == x, "" );
+    STD_COMPLEX_TESTS_STATIC_ASSERT(t.imag() == x);
 }
 
 template <class T>

--- a/test/xpu_api/numerics/complex.number/cmplx.over/imag.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/imag.pass.cpp
@@ -18,7 +18,7 @@
 
 template <class T, int x>
 void
-test(typename std::enable_if<std::is_integral<T>::value>::type* = 0)
+test(::std::enable_if_t<std::is_integral<T>::value>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::imag(T(x))), double>::value), "");
     assert(dpl::imag(x) == 0);
@@ -31,7 +31,7 @@ test(typename std::enable_if<std::is_integral<T>::value>::type* = 0)
 
 template <class T, int x>
 void
-test(typename std::enable_if<!std::is_integral<T>::value>::type* = 0)
+test(::std::enable_if_t<!std::is_integral<T>::value>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::imag(T(x))), T>::value), "");
     assert(dpl::imag(x) == 0);

--- a/test/xpu_api/numerics/complex.number/cmplx.over/imag.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/imag.pass.cpp
@@ -20,7 +20,7 @@ template <class T, int x>
 void
 test(::std::enable_if_t<std::is_integral<T>::value>* = 0)
 {
-    static_assert((std::is_same<decltype(dpl::imag(T(x))), double>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::imag(T(x))), double>), "");
     assert(dpl::imag(x) == 0);
 
     constexpr T val {x};
@@ -33,7 +33,7 @@ template <class T, int x>
 void
 test(::std::enable_if_t<!std::is_integral<T>::value>* = 0)
 {
-    static_assert((std::is_same<decltype(dpl::imag(T(x))), T>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::imag(T(x))), T>), "");
     assert(dpl::imag(x) == 0);
 
     constexpr T val {x};

--- a/test/xpu_api/numerics/complex.number/cmplx.over/norm.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/norm.pass.cpp
@@ -20,7 +20,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<std::is_integral<T>::value>* = 0)
 {
-    static_assert((std::is_same_v<decltype(dpl::norm(x)), double>), "");
+    static_assert((std::is_same_v<decltype(dpl::norm(x)), double>));
     assert(dpl::norm(x) == dpl::norm(dpl::complex<double>(static_cast<double>(x), 0)));
 }
 
@@ -28,7 +28,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<!std::is_integral<T>::value>* = 0)
 {
-    static_assert((std::is_same_v<decltype(dpl::norm(x)), T>), "");
+    static_assert((std::is_same_v<decltype(dpl::norm(x)), T>));
     assert(dpl::norm(x) == dpl::norm(dpl::complex<T>(x, 0)));
 }
 

--- a/test/xpu_api/numerics/complex.number/cmplx.over/norm.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/norm.pass.cpp
@@ -18,7 +18,7 @@
 
 template <class T>
 void
-test(T x, typename std::enable_if<std::is_integral<T>::value>::type* = 0)
+test(T x, ::std::enable_if_t<std::is_integral<T>::value>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::norm(x)), double>::value), "");
     assert(dpl::norm(x) == dpl::norm(dpl::complex<double>(static_cast<double>(x), 0)));
@@ -26,7 +26,7 @@ test(T x, typename std::enable_if<std::is_integral<T>::value>::type* = 0)
 
 template <class T>
 void
-test(T x, typename std::enable_if<!std::is_integral<T>::value>::type* = 0)
+test(T x, ::std::enable_if_t<!std::is_integral<T>::value>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::norm(x)), T>::value), "");
     assert(dpl::norm(x) == dpl::norm(dpl::complex<T>(x, 0)));

--- a/test/xpu_api/numerics/complex.number/cmplx.over/norm.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/norm.pass.cpp
@@ -20,7 +20,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<std::is_integral<T>::value>* = 0)
 {
-    static_assert((std::is_same<decltype(dpl::norm(x)), double>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::norm(x)), double>), "");
     assert(dpl::norm(x) == dpl::norm(dpl::complex<double>(static_cast<double>(x), 0)));
 }
 
@@ -28,7 +28,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<!std::is_integral<T>::value>* = 0)
 {
-    static_assert((std::is_same<decltype(dpl::norm(x)), T>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::norm(x)), T>), "");
     assert(dpl::norm(x) == dpl::norm(dpl::complex<T>(x, 0)));
 }
 

--- a/test/xpu_api/numerics/complex.number/cmplx.over/pow.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/pow.pass.cpp
@@ -39,7 +39,7 @@ void
 test(T x, const dpl::complex<U>& y)
 {
     typedef decltype(promote(x) + promote(dpl::real(y))) V;
-    static_assert((std::is_same_v<decltype(dpl::pow(x, y)), dpl::complex<V>>), "");
+    static_assert((std::is_same_v<decltype(dpl::pow(x, y)), dpl::complex<V>>));
     is_about(dpl::pow(x, y), dpl::pow(dpl::complex<V>(x, 0), dpl::complex<V>(y)));
 }
 
@@ -48,7 +48,7 @@ void
 test(const dpl::complex<T>& x, U y)
 {
     typedef decltype(promote(dpl::real(x)) + promote(y)) V;
-    static_assert((std::is_same_v<decltype(dpl::pow(x, y)), dpl::complex<V>>), "");
+    static_assert((std::is_same_v<decltype(dpl::pow(x, y)), dpl::complex<V>>));
     is_about(dpl::pow(x, y), dpl::pow(dpl::complex<V>(x), dpl::complex<V>(y, 0)));
 }
 
@@ -57,7 +57,7 @@ void
 test(const dpl::complex<T>& x, const dpl::complex<U>& y)
 {
     typedef decltype(promote(dpl::real(x)) + promote(dpl::real(y))) V;
-    static_assert((std::is_same_v<decltype(dpl::pow(x, y)), dpl::complex<V>>), "");
+    static_assert((std::is_same_v<decltype(dpl::pow(x, y)), dpl::complex<V>>));
     assert(dpl::pow(x, y) == dpl::pow(dpl::complex<V>(x), dpl::complex<V>(y)));
 }
 

--- a/test/xpu_api/numerics/complex.number/cmplx.over/pow.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/pow.pass.cpp
@@ -39,7 +39,7 @@ void
 test(T x, const dpl::complex<U>& y)
 {
     typedef decltype(promote(x) + promote(dpl::real(y))) V;
-    static_assert((std::is_same<decltype(dpl::pow(x, y)), dpl::complex<V> >::value), "");
+    static_assert((std::is_same_v<decltype(dpl::pow(x, y)), dpl::complex<V>>), "");
     is_about(dpl::pow(x, y), dpl::pow(dpl::complex<V>(x, 0), dpl::complex<V>(y)));
 }
 
@@ -48,7 +48,7 @@ void
 test(const dpl::complex<T>& x, U y)
 {
     typedef decltype(promote(dpl::real(x)) + promote(y)) V;
-    static_assert((std::is_same<decltype(dpl::pow(x, y)), dpl::complex<V> >::value), "");
+    static_assert((std::is_same_v<decltype(dpl::pow(x, y)), dpl::complex<V>>), "");
     is_about(dpl::pow(x, y), dpl::pow(dpl::complex<V>(x), dpl::complex<V>(y, 0)));
 }
 
@@ -57,7 +57,7 @@ void
 test(const dpl::complex<T>& x, const dpl::complex<U>& y)
 {
     typedef decltype(promote(dpl::real(x)) + promote(dpl::real(y))) V;
-    static_assert((std::is_same<decltype(dpl::pow(x, y)), dpl::complex<V> >::value), "");
+    static_assert((std::is_same_v<decltype(dpl::pow(x, y)), dpl::complex<V>>), "");
     assert(dpl::pow(x, y) == dpl::pow(dpl::complex<V>(x), dpl::complex<V>(y)));
 }
 

--- a/test/xpu_api/numerics/complex.number/cmplx.over/pow.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/pow.pass.cpp
@@ -28,7 +28,7 @@
 
 template <class T>
 double
-promote(T, typename std::enable_if<std::is_integral<T>::value>::type* = 0);
+promote(T, ::std::enable_if_t<std::is_integral<T>::value>* = 0);
 
 float promote(float);
 double promote(double);
@@ -63,7 +63,7 @@ test(const dpl::complex<T>& x, const dpl::complex<U>& y)
 
 template <class T, class U>
 void
-test(typename std::enable_if<std::is_integral<T>::value>::type* = 0, typename std::enable_if<!std::is_integral<U>::value>::type* = 0)
+test(::std::enable_if_t<std::is_integral<T>::value>* = 0, ::std::enable_if_t<!std::is_integral<U>::value>* = 0)
 {
     test(T(3), dpl::complex<U>(4, 5));
     test(dpl::complex<U>(3, 4), T(5));
@@ -71,7 +71,7 @@ test(typename std::enable_if<std::is_integral<T>::value>::type* = 0, typename st
 
 template <class T, class U>
 void
-test(typename std::enable_if<!std::is_integral<T>::value>::type* = 0, typename std::enable_if<!std::is_integral<U>::value>::type* = 0)
+test(::std::enable_if_t<!std::is_integral<T>::value>* = 0, ::std::enable_if_t<!std::is_integral<U>::value>* = 0)
 {
     test(T(3), dpl::complex<U>(4, 5));
     test(dpl::complex<T>(3, 4), U(5));

--- a/test/xpu_api/numerics/complex.number/cmplx.over/proj.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/proj.pass.cpp
@@ -22,7 +22,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<std::is_integral<T>::value>* = 0)
 {
-    static_assert((std::is_same_v<decltype(dpl::proj(x)), dpl::complex<double>>), "");
+    static_assert((std::is_same_v<decltype(dpl::proj(x)), dpl::complex<double>>));
     assert(dpl::proj(x) == dpl::proj(dpl::complex<double>(x, 0)));
 }
 
@@ -30,7 +30,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<std::is_floating_point<T>::value>* = 0)
 {
-    static_assert((std::is_same_v<decltype(dpl::proj(x)), dpl::complex<T>>), "");
+    static_assert((std::is_same_v<decltype(dpl::proj(x)), dpl::complex<T>>));
     assert(dpl::proj(x) == dpl::proj(dpl::complex<T>(x, 0)));
 }
 
@@ -38,7 +38,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<!std::is_integral<T>::value && !std::is_floating_point<T>::value>* = 0)
 {
-    static_assert((std::is_same_v<decltype(dpl::proj(x)), dpl::complex<T>>), "");
+    static_assert((std::is_same_v<decltype(dpl::proj(x)), dpl::complex<T>>));
     assert(dpl::proj(x) == dpl::proj(dpl::complex<T>(x, 0)));
 }
 

--- a/test/xpu_api/numerics/complex.number/cmplx.over/proj.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/proj.pass.cpp
@@ -22,7 +22,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<std::is_integral<T>::value>* = 0)
 {
-    static_assert((std::is_same<decltype(dpl::proj(x)), dpl::complex<double> >::value), "");
+    static_assert((std::is_same_v<decltype(dpl::proj(x)), dpl::complex<double>>), "");
     assert(dpl::proj(x) == dpl::proj(dpl::complex<double>(x, 0)));
 }
 
@@ -30,7 +30,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<std::is_floating_point<T>::value>* = 0)
 {
-    static_assert((std::is_same<decltype(dpl::proj(x)), dpl::complex<T> >::value), "");
+    static_assert((std::is_same_v<decltype(dpl::proj(x)), dpl::complex<T>>), "");
     assert(dpl::proj(x) == dpl::proj(dpl::complex<T>(x, 0)));
 }
 
@@ -38,7 +38,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<!std::is_integral<T>::value && !std::is_floating_point<T>::value>* = 0)
 {
-    static_assert((std::is_same<decltype(dpl::proj(x)), dpl::complex<T> >::value), "");
+    static_assert((std::is_same_v<decltype(dpl::proj(x)), dpl::complex<T>>), "");
     assert(dpl::proj(x) == dpl::proj(dpl::complex<T>(x, 0)));
 }
 

--- a/test/xpu_api/numerics/complex.number/cmplx.over/proj.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/proj.pass.cpp
@@ -20,7 +20,7 @@
 
 template <class T>
 void
-test(T x, typename std::enable_if<std::is_integral<T>::value>::type* = 0)
+test(T x, ::std::enable_if_t<std::is_integral<T>::value>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::proj(x)), dpl::complex<double> >::value), "");
     assert(dpl::proj(x) == dpl::proj(dpl::complex<double>(x, 0)));
@@ -28,7 +28,7 @@ test(T x, typename std::enable_if<std::is_integral<T>::value>::type* = 0)
 
 template <class T>
 void
-test(T x, typename std::enable_if<std::is_floating_point<T>::value>::type* = 0)
+test(T x, ::std::enable_if_t<std::is_floating_point<T>::value>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::proj(x)), dpl::complex<T> >::value), "");
     assert(dpl::proj(x) == dpl::proj(dpl::complex<T>(x, 0)));

--- a/test/xpu_api/numerics/complex.number/cmplx.over/proj.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/proj.pass.cpp
@@ -36,8 +36,7 @@ test(T x, ::std::enable_if_t<std::is_floating_point<T>::value>* = 0)
 
 template <class T>
 void
-test(T x, typename std::enable_if<!std::is_integral<T>::value &&
-                                  !std::is_floating_point<T>::value>::type* = 0)
+test(T x, ::std::enable_if_t<!std::is_integral<T>::value && !std::is_floating_point<T>::value>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::proj(x)), dpl::complex<T> >::value), "");
     assert(dpl::proj(x) == dpl::proj(dpl::complex<T>(x, 0)));

--- a/test/xpu_api/numerics/complex.number/cmplx.over/real.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/real.pass.cpp
@@ -20,26 +20,26 @@ template <class T, int x>
 void
 test(::std::enable_if_t<std::is_integral<T>::value>* = 0)
 {
-    static_assert((std::is_same_v<decltype(dpl::real(T(x))), double>), "");
+    static_assert((std::is_same_v<decltype(dpl::real(T(x))), double>));
     assert(dpl::real(x) == x);
 
     constexpr T val {x};
-    STD_COMPLEX_TESTS_STATIC_ASSERT(dpl::real(val) == val, "");
+    STD_COMPLEX_TESTS_STATIC_ASSERT(dpl::real(val) == val);
     constexpr dpl::complex<T> t{val, val};
-    STD_COMPLEX_TESTS_STATIC_ASSERT(t.real() == x, "" );
+    STD_COMPLEX_TESTS_STATIC_ASSERT(t.real() == x );
 }
 
 template <class T, int x>
 void
 test(::std::enable_if_t<!std::is_integral<T>::value>* = 0)
 {
-    static_assert((std::is_same_v<decltype(dpl::real(T(x))), T>), "");
+    static_assert((std::is_same_v<decltype(dpl::real(T(x))), T>));
     assert(dpl::real(x) == x);
 
     constexpr T val {x};
-    STD_COMPLEX_TESTS_STATIC_ASSERT(dpl::real(val) == val, "");
+    STD_COMPLEX_TESTS_STATIC_ASSERT(dpl::real(val) == val);
     constexpr dpl::complex<T> t{val, val};
-    STD_COMPLEX_TESTS_STATIC_ASSERT(t.real() == x, "" );
+    STD_COMPLEX_TESTS_STATIC_ASSERT(t.real() == x);
 }
 
 template <class T>

--- a/test/xpu_api/numerics/complex.number/cmplx.over/real.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/real.pass.cpp
@@ -18,7 +18,7 @@
 
 template <class T, int x>
 void
-test(typename std::enable_if<std::is_integral<T>::value>::type* = 0)
+test(::std::enable_if_t<std::is_integral<T>::value>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::real(T(x))), double>::value), "");
     assert(dpl::real(x) == x);
@@ -31,7 +31,7 @@ test(typename std::enable_if<std::is_integral<T>::value>::type* = 0)
 
 template <class T, int x>
 void
-test(typename std::enable_if<!std::is_integral<T>::value>::type* = 0)
+test(::std::enable_if_t<!std::is_integral<T>::value>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::real(T(x))), T>::value), "");
     assert(dpl::real(x) == x);

--- a/test/xpu_api/numerics/complex.number/cmplx.over/real.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/real.pass.cpp
@@ -20,7 +20,7 @@ template <class T, int x>
 void
 test(::std::enable_if_t<std::is_integral<T>::value>* = 0)
 {
-    static_assert((std::is_same<decltype(dpl::real(T(x))), double>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::real(T(x))), double>), "");
     assert(dpl::real(x) == x);
 
     constexpr T val {x};
@@ -33,7 +33,7 @@ template <class T, int x>
 void
 test(::std::enable_if_t<!std::is_integral<T>::value>* = 0)
 {
-    static_assert((std::is_same<decltype(dpl::real(T(x))), T>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::real(T(x))), T>), "");
     assert(dpl::real(x) == x);
 
     constexpr T val {x};

--- a/test/xpu_api/numerics/complex.number/complex.literals/literals.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.literals/literals.pass.cpp
@@ -16,12 +16,12 @@ ONEDPL_TEST_NUM_MAIN
     using namespace std::literals::complex_literals;
 
 //  Make sure the types are right
-    IF_LONG_DOUBLE_SUPPORT(static_assert ( std::is_same<decltype( 3.0il ), dpl::complex<long double>>::value, "" ))
-    IF_LONG_DOUBLE_SUPPORT(static_assert ( std::is_same<decltype( 3il   ), dpl::complex<long double>>::value, "" ))
-    IF_DOUBLE_SUPPORT(static_assert(std::is_same<decltype(3.0i), dpl::complex<double>>::value, ""))
-    IF_DOUBLE_SUPPORT(static_assert(std::is_same<decltype(3i), dpl::complex<double>>::value, ""))
-    static_assert ( std::is_same<decltype( 3.0if ), dpl::complex<float>>::value, "" );
-    static_assert ( std::is_same<decltype( 3if   ), dpl::complex<float>>::value, "" );
+    IF_LONG_DOUBLE_SUPPORT(static_assert ( std::is_same_v<decltype( 3.0il ), dpl::complex<long double>>, "" ))
+    IF_LONG_DOUBLE_SUPPORT(static_assert ( std::is_same_v<decltype( 3il   ), dpl::complex<long double>>, "" ))
+    IF_DOUBLE_SUPPORT(static_assert(std::is_same_v<decltype(3.0i), dpl::complex<double>>, ""))
+    IF_DOUBLE_SUPPORT(static_assert(std::is_same_v<decltype(3i), dpl::complex<double>>, ""))
+    static_assert ( std::is_same_v<decltype( 3.0if ), dpl::complex<float>>, "" );
+    static_assert ( std::is_same_v<decltype( 3if   ), dpl::complex<float>>, "" );
 
     IF_LONG_DOUBLE_SUPPORT(dpl::complex<long double> c1 = 3.0il;
                            assert(c1 == dpl::complex<long double>(0, 3.0));

--- a/test/xpu_api/numerics/complex.number/complex.literals/literals.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.literals/literals.pass.cpp
@@ -16,12 +16,12 @@ ONEDPL_TEST_NUM_MAIN
     using namespace std::literals::complex_literals;
 
 //  Make sure the types are right
-    IF_LONG_DOUBLE_SUPPORT(static_assert ( std::is_same_v<decltype( 3.0il ), dpl::complex<long double>>, "" ))
-    IF_LONG_DOUBLE_SUPPORT(static_assert ( std::is_same_v<decltype( 3il   ), dpl::complex<long double>>, "" ))
-    IF_DOUBLE_SUPPORT(static_assert(std::is_same_v<decltype(3.0i), dpl::complex<double>>, ""))
-    IF_DOUBLE_SUPPORT(static_assert(std::is_same_v<decltype(3i), dpl::complex<double>>, ""))
-    static_assert ( std::is_same_v<decltype( 3.0if ), dpl::complex<float>>, "" );
-    static_assert ( std::is_same_v<decltype( 3if   ), dpl::complex<float>>, "" );
+    IF_LONG_DOUBLE_SUPPORT(static_assert ( std::is_same_v<decltype( 3.0il ), dpl::complex<long double>>))
+    IF_LONG_DOUBLE_SUPPORT(static_assert ( std::is_same_v<decltype( 3il   ), dpl::complex<long double>>))
+    IF_DOUBLE_SUPPORT(static_assert(std::is_same_v<decltype(3.0i), dpl::complex<double>>))
+    IF_DOUBLE_SUPPORT(static_assert(std::is_same_v<decltype(3i), dpl::complex<double>>))
+    static_assert ( std::is_same_v<decltype( 3.0if ), dpl::complex<float>>);
+    static_assert ( std::is_same_v<decltype( 3if   ), dpl::complex<float>>);
 
     IF_LONG_DOUBLE_SUPPORT(dpl::complex<long double> c1 = 3.0il;
                            assert(c1 == dpl::complex<long double>(0, 3.0));

--- a/test/xpu_api/numerics/complex.number/complex/types.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex/types.pass.cpp
@@ -23,7 +23,7 @@ void
 test()
 {
     typedef dpl::complex<T> C;
-    static_assert((std::is_same<typename C::value_type, T>::value), "");
+    static_assert((std::is_same_v<typename C::value_type, T>), "");
 }
 
 ONEDPL_TEST_NUM_MAIN

--- a/test/xpu_api/numerics/complex.number/complex/types.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex/types.pass.cpp
@@ -23,7 +23,7 @@ void
 test()
 {
     typedef dpl::complex<T> C;
-    static_assert((std::is_same_v<typename C::value_type, T>), "");
+    static_assert((std::is_same_v<typename C::value_type, T>));
 }
 
 ONEDPL_TEST_NUM_MAIN

--- a/test/xpu_api/numerics/numeric.ops/numeric.ops.gcd/xpu_gcd.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/numeric.ops.gcd/xpu_gcd.pass.cpp
@@ -30,8 +30,8 @@ test0(int in1, int in2, int out)
 {
     auto value1 = static_cast<Input1>(in1);
     auto value2 = static_cast<Input2>(in2);
-    static_assert(oneapi::dpl::is_same<Output, decltype(oneapi::dpl::gcd(value1, value2))>::value, "");
-    static_assert(oneapi::dpl::is_same<Output, decltype(oneapi::dpl::gcd(value2, value1))>::value, "");
+    static_assert(oneapi::dpl::is_same_v<Output, decltype(oneapi::dpl::gcd(value1, value2))>, "");
+    static_assert(oneapi::dpl::is_same_v<Output, decltype(oneapi::dpl::gcd(value2, value1))>, "");
     return (static_cast<Output>(out) == oneapi::dpl::gcd(value1, value2));
 }
 

--- a/test/xpu_api/numerics/numeric.ops/numeric.ops.gcd/xpu_gcd.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/numeric.ops.gcd/xpu_gcd.pass.cpp
@@ -30,8 +30,8 @@ test0(int in1, int in2, int out)
 {
     auto value1 = static_cast<Input1>(in1);
     auto value2 = static_cast<Input2>(in2);
-    static_assert(oneapi::dpl::is_same_v<Output, decltype(oneapi::dpl::gcd(value1, value2))>, "");
-    static_assert(oneapi::dpl::is_same_v<Output, decltype(oneapi::dpl::gcd(value2, value1))>, "");
+    static_assert(oneapi::dpl::is_same_v<Output, decltype(oneapi::dpl::gcd(value1, value2))>);
+    static_assert(oneapi::dpl::is_same_v<Output, decltype(oneapi::dpl::gcd(value2, value1))>);
     return (static_cast<Output>(out) == oneapi::dpl::gcd(value1, value2));
 }
 

--- a/test/xpu_api/numerics/numeric.ops/numeric.ops.lcm/xpu_lcm.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/numeric.ops.lcm/xpu_lcm.pass.cpp
@@ -33,8 +33,8 @@ test0(int in1, int in2, int out)
 {
     auto value1 = static_cast<Input1>(in1);
     auto value2 = static_cast<Input2>(in2);
-    static_assert(is_same<Output, decltype(lcm(value1, value2))>::value, "");
-    static_assert(is_same<Output, decltype(lcm(value2, value1))>::value, "");
+    static_assert(is_same<Output, decltype(lcm(value1, value2))>::value);
+    static_assert(is_same<Output, decltype(lcm(value2, value1))>::value);
     return static_cast<Output>(out) == lcm(value1, value2);
 }
 

--- a/test/xpu_api/random/interface_tests/distributions_methods.pass.cpp
+++ b/test/xpu_api/random/interface_tests/distributions_methods.pass.cpp
@@ -139,8 +139,7 @@ check_params(oneapi::dpl::extreme_value_distribution<T>& distr)
 }
 
 template <typename Distr>
-::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::uniform_int_distribution<typename Distr::result_type>>::value,
-                   void>
+::std::enable_if_t<::std::is_same_v<Distr, oneapi::dpl::uniform_int_distribution<typename Distr::result_type>>, void>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{0, 10};
@@ -148,8 +147,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::uniform_real_distribution<typename Distr::result_type>>::value,
-                   void>
+::std::enable_if_t<::std::is_same_v<Distr, oneapi::dpl::uniform_real_distribution<typename Distr::result_type>>, void>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{1.5, 3.0};
@@ -157,8 +155,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::exponential_distribution<typename Distr::result_type>>::value,
-                   void>
+::std::enable_if_t<::std::is_same_v<Distr, oneapi::dpl::exponential_distribution<typename Distr::result_type>>, void>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{1.5};
@@ -166,7 +163,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::bernoulli_distribution<typename Distr::result_type>>::value, void>
+::std::enable_if_t<::std::is_same_v<Distr, oneapi::dpl::bernoulli_distribution<typename Distr::result_type>>, void>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{0.5};
@@ -174,7 +171,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::geometric_distribution<typename Distr::result_type>>::value, void>
+::std::enable_if_t<::std::is_same_v<Distr, oneapi::dpl::geometric_distribution<typename Distr::result_type>>, void>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{0.5};
@@ -182,7 +179,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::weibull_distribution<typename Distr::result_type>>::value, void>
+::std::enable_if_t<::std::is_same_v<Distr, oneapi::dpl::weibull_distribution<typename Distr::result_type>>, void>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{1.5, 3.0};
@@ -190,7 +187,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::lognormal_distribution<typename Distr::result_type>>::value, void>
+::std::enable_if_t<::std::is_same_v<Distr, oneapi::dpl::lognormal_distribution<typename Distr::result_type>>, void>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{1.5, 3.5};
@@ -198,7 +195,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::normal_distribution<typename Distr::result_type>>::value, void>
+::std::enable_if_t<::std::is_same_v<Distr, oneapi::dpl::normal_distribution<typename Distr::result_type>>, void>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{1.5, 3.5};
@@ -206,7 +203,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::cauchy_distribution<typename Distr::result_type>>::value, void>
+::std::enable_if_t<::std::is_same_v<Distr, oneapi::dpl::cauchy_distribution<typename Distr::result_type>>, void>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{1.5, 3.5};
@@ -214,8 +211,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::extreme_value_distribution<typename Distr::result_type>>::value,
-                   void>
+::std::enable_if_t<::std::is_same_v<Distr, oneapi::dpl::extreme_value_distribution<typename Distr::result_type>>, void>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{1.5, 3.5};

--- a/test/xpu_api/random/interface_tests/distributions_methods.pass.cpp
+++ b/test/xpu_api/random/interface_tests/distributions_methods.pass.cpp
@@ -139,8 +139,8 @@ check_params(oneapi::dpl::extreme_value_distribution<T>& distr)
 }
 
 template <typename Distr>
-typename ::std::enable_if<::std::is_same<Distr,
-        oneapi::dpl::uniform_int_distribution<typename Distr::result_type>>::value, void>::type
+::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::uniform_int_distribution<typename Distr::result_type>>::value,
+                   void>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{0, 10};
@@ -148,8 +148,8 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-typename ::std::enable_if<::std::is_same<Distr, 
-        oneapi::dpl::uniform_real_distribution<typename Distr::result_type>>::value, void>::type
+::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::uniform_real_distribution<typename Distr::result_type>>::value,
+                   void>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{1.5, 3.0};
@@ -157,8 +157,8 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-typename ::std::enable_if<::std::is_same<Distr, 
-        oneapi::dpl::exponential_distribution<typename Distr::result_type>>::value, void>::type
+::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::exponential_distribution<typename Distr::result_type>>::value,
+                   void>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{1.5};
@@ -166,8 +166,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-typename ::std::enable_if<::std::is_same<Distr, 
-        oneapi::dpl::bernoulli_distribution<typename Distr::result_type>>::value, void>::type
+::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::bernoulli_distribution<typename Distr::result_type>>::value, void>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{0.5};
@@ -175,8 +174,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-typename ::std::enable_if<::std::is_same<Distr, 
-        oneapi::dpl::geometric_distribution<typename Distr::result_type>>::value, void>::type
+::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::geometric_distribution<typename Distr::result_type>>::value, void>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{0.5};
@@ -184,8 +182,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-typename ::std::enable_if<::std::is_same<Distr, 
-        oneapi::dpl::weibull_distribution<typename Distr::result_type>>::value, void>::type
+::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::weibull_distribution<typename Distr::result_type>>::value, void>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{1.5, 3.0};
@@ -193,8 +190,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-typename ::std::enable_if<::std::is_same<Distr, 
-        oneapi::dpl::lognormal_distribution<typename Distr::result_type>>::value, void>::type
+::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::lognormal_distribution<typename Distr::result_type>>::value, void>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{1.5, 3.5};
@@ -202,8 +198,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-typename ::std::enable_if<::std::is_same<Distr, 
-        oneapi::dpl::normal_distribution<typename Distr::result_type>>::value, void>::type
+::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::normal_distribution<typename Distr::result_type>>::value, void>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{1.5, 3.5};
@@ -211,8 +206,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-typename ::std::enable_if<::std::is_same<Distr, 
-        oneapi::dpl::cauchy_distribution<typename Distr::result_type>>::value, void>::type
+::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::cauchy_distribution<typename Distr::result_type>>::value, void>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{1.5, 3.5};
@@ -220,8 +214,8 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-typename ::std::enable_if<::std::is_same<Distr, 
-        oneapi::dpl::extreme_value_distribution<typename Distr::result_type>>::value, void>::type
+::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::extreme_value_distribution<typename Distr::result_type>>::value,
+                   void>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{1.5, 3.5};


### PR DESCRIPTION
In this PR we try to make oneDPL code a little bit clear:
- use ```::std::decay_t<X>`` instead of ```typename ::std::decay<X>::type```;
- use ```::std::enable_if_t<X>``` instead of ```typename ::std::enable_if<X>::type```;
- use ```::std::remove_reference_t<X>``` instead of ```typename ::std::remove_reference<X>::type```;
- use ```::std::make_signed_t<X>``` instead of ```typename ::std::make_signed<X>::type```.