### PR TITLE
Support USM memory for synchronous reductions

### DIFF
--- a/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
+++ b/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
@@ -139,8 +139,13 @@ __pattern_transform_reduce_async(_ExecutionPolicy&& __exec, _RandomAccessIterato
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _RandomAccessIterator2>();
     auto __buf2 = __keep2(__first2, __first2 + __n);
 
+<<<<<<< HEAD
     return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp,
                                                                           ::std::true_type /*is_commutative*/>(
+=======
+    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce_async<
+        _RepackedTp, _BinaryOperation1, _Functor, ::std::true_type /*is_commutative*/>(
+>>>>>>> 54d359e8 (Add USM memory support for the reduction result)
         ::std::forward<_ExecutionPolicy>(__exec), __binary_op1, _Functor{__binary_op2},
         unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
         __buf1.all_view(), __buf2.all_view());
@@ -166,8 +171,13 @@ __pattern_transform_reduce_async(_ExecutionPolicy&& __exec, _ForwardIterator __f
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _ForwardIterator>();
     auto __buf = __keep(__first, __last);
 
+<<<<<<< HEAD
     return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp,
                                                                           ::std::true_type /*is_commutative*/>(
+=======
+    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce_async<_RepackedTp, _BinaryOperation, _Functor,
+                                                                                ::std::true_type /*is_commutative*/>(
+>>>>>>> 54d359e8 (Add USM memory support for the reduction result)
         ::std::forward<_ExecutionPolicy>(__exec), __binary_op, _Functor{__unary_op},
         unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
         __buf.all_view());

--- a/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
+++ b/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
@@ -139,13 +139,8 @@ __pattern_transform_reduce_async(_ExecutionPolicy&& __exec, _RandomAccessIterato
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _RandomAccessIterator2>();
     auto __buf2 = __keep2(__first2, __first2 + __n);
 
-<<<<<<< HEAD
-    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp,
-                                                                          ::std::true_type /*is_commutative*/>(
-=======
-    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce_async<
-        _RepackedTp, _BinaryOperation1, _Functor, ::std::true_type /*is_commutative*/>(
->>>>>>> 54d359e8 (Add USM memory support for the reduction result)
+    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce_async<_RepackedTp,
+                                                                                ::std::true_type /*is_commutative*/>(
         ::std::forward<_ExecutionPolicy>(__exec), __binary_op1, _Functor{__binary_op2},
         unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
         __buf1.all_view(), __buf2.all_view());
@@ -171,13 +166,8 @@ __pattern_transform_reduce_async(_ExecutionPolicy&& __exec, _ForwardIterator __f
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _ForwardIterator>();
     auto __buf = __keep(__first, __last);
 
-<<<<<<< HEAD
-    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp,
-                                                                          ::std::true_type /*is_commutative*/>(
-=======
-    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce_async<_RepackedTp, _BinaryOperation, _Functor,
+    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce_async<_RepackedTp,
                                                                                 ::std::true_type /*is_commutative*/>(
->>>>>>> 54d359e8 (Add USM memory support for the reduction result)
         ::std::forward<_ExecutionPolicy>(__exec), __binary_op, _Functor{__unary_op},
         unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
         __buf.all_view());

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -396,12 +396,11 @@ __pattern_min_element(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __
     auto __buf = __keep(__first, __last);
 
     auto __ret_idx =
-        oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_ReduceValueType,
+        oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce_sync<_ReduceValueType,
                                                                        ::std::false_type /*is_commutative*/>(
             ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
             unseq_backend::__no_init_value{}, // no initial value
-            __buf.all_view())
-            .get();
+            __buf.all_view());
 
     return __first + ::std::get<0>(__ret_idx);
 }
@@ -465,12 +464,11 @@ __pattern_minmax_element(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
     auto __buf = __keep(__first, __last);
 
-    auto __ret = oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_ReduceValueType,
+    auto __ret = oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce_sync<_ReduceValueType,
                                                                                 ::std::false_type /*is_commutative*/>(
                      ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
                      unseq_backend::__no_init_value{}, // no initial value
-                     __buf.all_view())
-                     .get();
+                     __buf.all_view());
 
     return ::std::make_pair<_Iterator, _Iterator>(__first + ::std::get<0>(__ret), __first + ::std::get<1>(__ret));
 }
@@ -562,12 +560,11 @@ __pattern_count(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, 
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
     auto __buf = __keep(__first, __last);
 
-    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_ReduceValueType,
+    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce_sync<_ReduceValueType,
                                                                           ::std::true_type /*is_commutative*/>(
                ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
                unseq_backend::__no_init_value{}, // no initial value
-               __buf.all_view())
-        .get();
+               __buf.all_view());
 }
 
 //------------------------------------------------------------------------
@@ -1018,12 +1015,11 @@ __pattern_is_partitioned(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
     auto __buf = __keep(__first, __last);
 
-    auto __res = oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_ReduceValueType,
+    auto __res = oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce_sync<_ReduceValueType,
                                                                                 ::std::false_type /*is_commutative*/>(
                      ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
                      unseq_backend::__no_init_value{}, // no initial value
-                     __buf.all_view())
-                     .get();
+                     __buf.all_view());
 
     return __broken != __reduce_fn(_ReduceValueType{__all_true}, __res);
 }
@@ -1307,12 +1303,11 @@ __pattern_lexicographical_compare(_ExecutionPolicy&& __exec, _Iterator1 __first1
     auto __buf2 = __keep2(__first2, __first2 + __shared_size);
 
     auto __ret_idx =
-        oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_ReduceValueType,
+        oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce_sync<_ReduceValueType,
                                                                        ::std::false_type /*is_commutative*/>(
             ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
             unseq_backend::__no_init_value{}, // no initial value
-            __buf1.all_view(), __buf2.all_view())
-            .get();
+            __buf1.all_view(), __buf2.all_view());
 
     return __ret_idx ? __ret_idx == 1 : (__last1 - __first1) < (__last2 - __first2);
 }

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -388,7 +388,11 @@ __pattern_min_element(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __
     // not commutative.
     auto __reduce_fn = [__comp](_ReduceValueType __a, _ReduceValueType __b) {
         using ::std::get;
-        return __comp(get<1>(__b), get<1>(__a)) ? __b : __a;
+        if (__comp(get<1>(__b), get<1>(__a)))
+        {
+            return __b;
+        }
+        return __a;
     };
     auto __transform_fn = [](auto __gidx, auto __acc) { return _ReduceValueType{__gidx, __acc[__gidx]}; };
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -401,7 +401,7 @@ __pattern_min_element(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __
 
     auto __ret_idx =
         oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce_sync<_ReduceValueType,
-                                                                       ::std::false_type /*is_commutative*/>(
+                                                                            ::std::false_type /*is_commutative*/>(
             ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
             unseq_backend::__no_init_value{}, // no initial value
             __buf.all_view());
@@ -468,11 +468,12 @@ __pattern_minmax_element(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
     auto __buf = __keep(__first, __last);
 
-    auto __ret = oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce_sync<_ReduceValueType,
-                                                                                ::std::false_type /*is_commutative*/>(
-                     ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
-                     unseq_backend::__no_init_value{}, // no initial value
-                     __buf.all_view());
+    auto __ret =
+        oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce_sync<_ReduceValueType,
+                                                                            ::std::false_type /*is_commutative*/>(
+            ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
+            unseq_backend::__no_init_value{}, // no initial value
+            __buf.all_view());
 
     return ::std::make_pair<_Iterator, _Iterator>(__first + ::std::get<0>(__ret), __first + ::std::get<1>(__ret));
 }
@@ -565,10 +566,10 @@ __pattern_count(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, 
     auto __buf = __keep(__first, __last);
 
     return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce_sync<_ReduceValueType,
-                                                                          ::std::true_type /*is_commutative*/>(
-               ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
-               unseq_backend::__no_init_value{}, // no initial value
-               __buf.all_view());
+                                                                               ::std::true_type /*is_commutative*/>(
+        ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
+        unseq_backend::__no_init_value{}, // no initial value
+        __buf.all_view());
 }
 
 //------------------------------------------------------------------------
@@ -1019,11 +1020,12 @@ __pattern_is_partitioned(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
     auto __buf = __keep(__first, __last);
 
-    auto __res = oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce_sync<_ReduceValueType,
-                                                                                ::std::false_type /*is_commutative*/>(
-                     ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
-                     unseq_backend::__no_init_value{}, // no initial value
-                     __buf.all_view());
+    auto __res =
+        oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce_sync<_ReduceValueType,
+                                                                            ::std::false_type /*is_commutative*/>(
+            ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
+            unseq_backend::__no_init_value{}, // no initial value
+            __buf.all_view());
 
     return __broken != __reduce_fn(_ReduceValueType{__all_true}, __res);
 }
@@ -1308,7 +1310,7 @@ __pattern_lexicographical_compare(_ExecutionPolicy&& __exec, _Iterator1 __first1
 
     auto __ret_idx =
         oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce_sync<_ReduceValueType,
-                                                                       ::std::false_type /*is_commutative*/>(
+                                                                            ::std::false_type /*is_commutative*/>(
             ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
             unseq_backend::__no_init_value{}, // no initial value
             __buf1.all_view(), __buf2.all_view());

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -319,12 +319,11 @@ __pattern_count(_ExecutionPolicy&& __exec, _Range&& __rng, _Predicate __predicat
         return (__predicate(__acc[__gidx]) ? 1 : 0);
     };
 
-    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_ReduceValueType,
+    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce_sync<_ReduceValueType,
                                                                           ::std::true_type /*is_commutative*/>(
                ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
                unseq_backend::__no_init_value{}, // no initial value
-               ::std::forward<_Range>(__rng))
-        .get();
+               ::std::forward<_Range>(__rng));
 }
 
 //------------------------------------------------------------------------
@@ -558,12 +557,11 @@ __pattern_min_element(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp
     auto __transform_fn = [](auto __gidx, auto __acc) { return _ReduceValueType{__gidx, __acc[__gidx]}; };
 
     auto __ret_idx =
-        oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_ReduceValueType,
+        oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce_sync<_ReduceValueType,
                                                                        ::std::false_type /*is_commutative*/>(
             ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
             unseq_backend::__no_init_value{}, // no initial value
-            ::std::forward<_Range>(__rng))
-            .get();
+            ::std::forward<_Range>(__rng));
 
     using ::std::get;
     return get<0>(__ret_idx);
@@ -614,12 +612,11 @@ __pattern_minmax_element(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __c
     };
 
     _ReduceValueType __ret =
-        oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_ReduceValueType,
+        oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce_sync<_ReduceValueType,
                                                                        ::std::false_type /*is_commutative*/>(
             ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
             unseq_backend::__no_init_value{}, // no initial value
-            ::std::forward<_Range>(__rng))
-            .get();
+            ::std::forward<_Range>(__rng));
 
     using ::std::get;
     return ::std::make_pair(get<0>(__ret), get<1>(__ret));

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -552,7 +552,11 @@ __pattern_min_element(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp
     // not commutative.
     auto __reduce_fn = [__comp](_ReduceValueType __a, _ReduceValueType __b) {
         using ::std::get;
-        return __comp(get<1>(__b), get<1>(__a)) ? __b : __a;
+        if (__comp(get<1>(__b), get<1>(__a)))
+        {
+            return __b;
+        }
+        return __a;
     };
     auto __transform_fn = [](auto __gidx, auto __acc) { return _ReduceValueType{__gidx, __acc[__gidx]}; };
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -320,10 +320,10 @@ __pattern_count(_ExecutionPolicy&& __exec, _Range&& __rng, _Predicate __predicat
     };
 
     return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce_sync<_ReduceValueType,
-                                                                          ::std::true_type /*is_commutative*/>(
-               ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
-               unseq_backend::__no_init_value{}, // no initial value
-               ::std::forward<_Range>(__rng));
+                                                                               ::std::true_type /*is_commutative*/>(
+        ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
+        unseq_backend::__no_init_value{}, // no initial value
+        ::std::forward<_Range>(__rng));
 }
 
 //------------------------------------------------------------------------
@@ -562,7 +562,7 @@ __pattern_min_element(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp
 
     auto __ret_idx =
         oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce_sync<_ReduceValueType,
-                                                                       ::std::false_type /*is_commutative*/>(
+                                                                            ::std::false_type /*is_commutative*/>(
             ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
             unseq_backend::__no_init_value{}, // no initial value
             ::std::forward<_Range>(__rng));
@@ -617,7 +617,7 @@ __pattern_minmax_element(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __c
 
     _ReduceValueType __ret =
         oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce_sync<_ReduceValueType,
-                                                                       ::std::false_type /*is_commutative*/>(
+                                                                            ::std::false_type /*is_commutative*/>(
             ::std::forward<_ExecutionPolicy>(__exec), __reduce_fn, __transform_fn,
             unseq_backend::__no_init_value{}, // no initial value
             ::std::forward<_Range>(__rng));

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
@@ -107,7 +107,7 @@ __parallel_transform_reduce_sync(_ExecutionPolicy&& __exec, _ReduceOp __reduce_o
         __device_policy, __reduce_op, __transform_op, __init, ::std::forward<_Ranges>(__rngs)...);
 }
 
-template <typename _Tp, typename _ReduceOp, typename _TransformOp, typename _Commutative, typename _ExecutionPolicy,
+template <typename _Tp, typename _Commutative, typename _ExecutionPolicy, typename _ReduceOp, typename _TransformOp,
           typename _InitType, oneapi::dpl::__internal::__enable_if_fpga_execution_policy<_ExecutionPolicy, int> = 0,
           typename... _Ranges>
 auto

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
@@ -96,14 +96,29 @@ template <typename _Tp, typename _Commutative, typename _ExecutionPolicy, typena
           typename _InitType, oneapi::dpl::__internal::__enable_if_fpga_execution_policy<_ExecutionPolicy, int> = 0,
           typename... _Ranges>
 auto
-__parallel_transform_reduce(_ExecutionPolicy&& __exec, _ReduceOp __reduce_op, _TransformOp __transform_op,
-                            _InitType __init, _Ranges&&... __rngs)
+__parallel_transform_reduce_sync(_ExecutionPolicy&& __exec, _ReduceOp __reduce_op, _TransformOp __transform_op,
+                                 _InitType __init, _Ranges&&... __rngs)
 {
     // workaround until we implement more performant version for patterns
     using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
     using __kernel_name = typename _Policy::kernel_name;
     auto __device_policy = oneapi::dpl::execution::make_device_policy<__kernel_name>(__exec.queue());
-    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_Tp, _Commutative>(
+    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce_sync<_Tp, _Commutative>(
+        __device_policy, __reduce_op, __transform_op, __init, ::std::forward<_Ranges>(__rngs)...);
+}
+
+template <typename _Tp, typename _ReduceOp, typename _TransformOp, typename _Commutative, typename _ExecutionPolicy,
+          typename _InitType, oneapi::dpl::__internal::__enable_if_fpga_execution_policy<_ExecutionPolicy, int> = 0,
+          typename... _Ranges>
+auto
+__parallel_transform_reduce_async(_ExecutionPolicy&& __exec, _ReduceOp __reduce_op, _TransformOp __transform_op,
+                                  _InitType __init, _Ranges&&... __rngs)
+{
+    // workaround until we implement more performant version for patterns
+    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using __kernel_name = typename _Policy::kernel_name;
+    auto __device_policy = oneapi::dpl::execution::make_device_policy<__kernel_name>(__exec.queue());
+    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce_async<_Tp, _Commutative>(
         __device_policy, __reduce_op, __transform_op, __init, ::std::forward<_Ranges>(__rngs)...);
 }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -68,11 +68,11 @@ __work_group_reduce_kernel(const _NDItemId __item_id, const _Size __n, const _Si
 
 // Device kernel that transforms and reduces __n elements to the number of work groups preliminary results.
 template <typename _Tp, typename _NDItemId, typename _Size, typename _TransformPattern, typename _ReducePattern,
-          typename _AccLocal, typename _Tmp, typename... _Acc>
+          typename _AccLocal, typename _Temp, typename... _Acc>
 void
 __device_reduce_kernel(const _NDItemId __item_id, const _Size __n, const _Size __n_items,
                        _TransformPattern __transform_pattern, _ReducePattern __reduce_pattern,
-                       const _AccLocal& __local_mem, const _Tmp& __temp_acc, const _Acc&... __acc)
+                       const _AccLocal& __local_mem, const _Temp& __temp_acc, const _Acc&... __acc)
 {
     auto __local_idx = __item_id.get_local_id(0);
     auto __group_idx = __item_id.get_group(0);
@@ -156,11 +156,11 @@ struct __parallel_transform_reduce_device_kernel_submitter<_Tp, __work_group_siz
                                                            __internal::__optional_kernel_name<_KernelName...>>
 {
     template <typename _ExecutionPolicy, typename _Size, typename _ReduceOp, typename _TransformOp, typename _InitType,
-              oneapi::dpl::__internal::__enable_if_device_execution_policy<_ExecutionPolicy, int> = 0,
+              typename _Temp, oneapi::dpl::__internal::__enable_if_device_execution_policy<_ExecutionPolicy, int> = 0,
               typename... _Ranges>
     auto
     operator()(_ExecutionPolicy&& __exec, _Size __n, _ReduceOp __reduce_op, _TransformOp __transform_op,
-               _InitType __init, sycl::buffer<_Tp>& __temp, _Ranges&&... __rngs) const
+               _InitType __init, _Temp& __temp, _Ranges&&... __rngs) const
     {
         auto __transform_pattern =
             unseq_backend::transform_reduce<_ExecutionPolicy, __iters_per_work_item, _ReduceOp, _TransformOp>{
@@ -173,14 +173,14 @@ struct __parallel_transform_reduce_device_kernel_submitter<_Tp, __work_group_siz
         _Size __n_items = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __iters_per_work_item);
 
         return __exec.queue().submit([&, __n, __n_items](sycl::handler& __cgh) {
-            oneapi::dpl::__ranges::__require_access(__cgh, __rngs...); // get an access to data under SYCL buffer
-            sycl::accessor __temp_acc{__temp, __cgh, sycl::write_only, __dpl_sycl::__no_init{}};
+            // get an access to data under SYCL buffer
+            oneapi::dpl::__ranges::__require_access(__cgh, __temp, __rngs...);
             __dpl_sycl::__local_accessor<_Tp> __temp_local(sycl::range<1>(__work_group_size), __cgh);
             __cgh.parallel_for<_KernelName...>(
                 sycl::nd_range<1>(sycl::range<1>(__n_groups * __work_group_size), sycl::range<1>(__work_group_size)),
                 [=](sycl::nd_item<1> __item_id) {
                     __device_reduce_kernel<_Tp>(__item_id, __n, __n_items, __transform_pattern, __reduce_pattern,
-                                                __temp_local, __temp_acc, __rngs...);
+                                                __temp_local, __temp, __rngs...);
                 });
         });
     }
@@ -198,10 +198,11 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<_Tp, __work_group
                                                                __internal::__optional_kernel_name<_KernelName...>>
 {
     template <typename _ExecutionPolicy, typename _Size, typename _ReduceOp, typename _TransformOp, typename _InitType,
-              typename _Res, oneapi::dpl::__internal::__enable_if_device_execution_policy<_ExecutionPolicy, int> = 0>
+              typename _Res, typename _Temp,
+              oneapi::dpl::__internal::__enable_if_device_execution_policy<_ExecutionPolicy, int> = 0>
     auto
     operator()(_ExecutionPolicy&& __exec, sycl::event& __reduce_event, _Size __n, _ReduceOp __reduce_op,
-               _TransformOp __transform_op, _InitType __init, _Res& __res, sycl::buffer<_Tp>& __temp) const
+               _TransformOp __transform_op, _InitType __init, _Res& __res, _Temp& __temp) const
     {
         using _NoOpFunctor = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;
         auto __transform_pattern =
@@ -224,15 +225,14 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<_Tp, __work_group
 
         return __exec.queue().submit([&, __n, __n_items](sycl::handler& __cgh) {
             __cgh.depends_on(__reduce_event);
-            oneapi::dpl::__ranges::__require_access(__cgh, __res); // get an access to data under SYCL buffer
-            sycl::accessor __temp_acc{__temp, __cgh, sycl::read_only};
+            oneapi::dpl::__ranges::__require_access(__cgh, __temp, __res); // get an access to data under SYCL buffer
             __dpl_sycl::__local_accessor<_Tp> __temp_local(sycl::range<1>(__work_group_size2), __cgh);
 
             __cgh.parallel_for<_KernelName...>(
                 sycl::nd_range<1>(sycl::range<1>(__work_group_size2), sycl::range<1>(__work_group_size2)),
                 [=](sycl::nd_item<1> __item_id) {
                     __work_group_reduce_kernel<_Tp>(__item_id, __n, __n_items, __transform_pattern, __reduce_pattern,
-                                                    __init, __temp_local, __res, __temp_acc);
+                                                    __init, __temp_local, __res, __temp);
                 });
         });
     }
@@ -241,10 +241,12 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<_Tp, __work_group
 template <typename _Tp, ::std::uint16_t __work_group_size, ::std::uint8_t __iters_per_work_item_device_kernel,
           ::std::uint8_t __iters_per_work_item_work_group_kernel, typename _ExecutionPolicy, typename _Size,
           typename _ReduceOp, typename _TransformOp, typename _InitType, typename _Res,
-          oneapi::dpl::__internal::__enable_if_device_execution_policy<_ExecutionPolicy, int> = 0, typename... _Ranges>
+          typename _Temp, oneapi::dpl::__internal::__enable_if_device_execution_policy<_ExecutionPolicy, int> = 0,
+          typename... _Ranges>
 auto
 __parallel_transform_reduce_mid_impl(_ExecutionPolicy&& __exec, _Size __n, _ReduceOp __reduce_op,
-                                     _TransformOp __transform_op, _InitType __init, _Res& __res, _Ranges&&... __rngs)
+                                     _TransformOp __transform_op, _InitType __init, _Res& __res, _Temp& __temp,
+                                     _Ranges&&... __rngs)
 {
     using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
     using _CustomName = typename _Policy::kernel_name;
@@ -260,7 +262,6 @@ __parallel_transform_reduce_mid_impl(_ExecutionPolicy&& __exec, _Size __n, _Redu
     // number of buffer elements processed within workgroup
     constexpr _Size __size_per_work_group = __iters_per_work_item_device_kernel * __work_group_size;
     const _Size __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __size_per_work_group);
-    sycl::buffer<_Tp> __temp{sycl::range<1>(__n_groups)};
 
     sycl::event __reduce_event =
         __parallel_transform_reduce_device_kernel_submitter<_Tp, __work_group_size, __iters_per_work_item_device_kernel,
@@ -377,7 +378,118 @@ struct __parallel_transform_reduce_impl
     }
 }; // struct __parallel_transform_reduce_impl
 
-// General caller of the reduce pattern.
+// Use a single work group to reduce small arrays (__work_group_size * __iters_per_work_item).
+template <typename _Tp, typename _Commutative, typename _ExecutionPolicy, typename _ReduceOp, typename _TransformOp,
+          typename _InitType, typename _Res,
+          oneapi::dpl::__internal::__enable_if_device_execution_policy<_ExecutionPolicy, int> = 0, typename... _Ranges>
+auto
+__parallel_transform_reduce_small_caller(_ExecutionPolicy&& __exec, _ReduceOp __reduce_op, _TransformOp __transform_op,
+                                         _InitType __init, _Res& __res, _Ranges&&... __rngs)
+{
+    auto __n = oneapi::dpl::__ranges::__get_first_range_size(__rngs...);
+    assert(__n > 0);
+    assert(__n <= 8192);
+
+    if (__n <= 256)
+    {
+            return __parallel_transform_reduce_small_impl<_Tp, 256, 1>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                   __reduce_op, __transform_op, __init, __res,
+                                                                   ::std::forward<_Ranges>(__rngs)...);
+    }
+    else if (__n <= 512)
+    {
+            return __parallel_transform_reduce_small_impl<_Tp, 256, 2>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                   __reduce_op, __transform_op, __init, __res,
+                                                                   ::std::forward<_Ranges>(__rngs)...);
+    }
+    else if (__n <= 1024)
+    {
+            return __parallel_transform_reduce_small_impl<_Tp, 256, 4>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                   __reduce_op, __transform_op, __init, __res,
+                                                                   ::std::forward<_Ranges>(__rngs)...);
+    }
+    else if (__n <= 2048)
+    {
+            return __parallel_transform_reduce_small_impl<_Tp, 256, 8>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                   __reduce_op, __transform_op, __init, __res,
+                                                                   ::std::forward<_Ranges>(__rngs)...);
+    }
+    else if (__n <= 4096)
+    {
+            return __parallel_transform_reduce_small_impl<_Tp, 256, 16>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                    __reduce_op, __transform_op, __init, __res,
+                                                                    ::std::forward<_Ranges>(__rngs)...);
+    }
+    else
+    {
+            return __parallel_transform_reduce_small_impl<_Tp, 256, 32>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                    __reduce_op, __transform_op, __init, __res,
+                                                                    ::std::forward<_Ranges>(__rngs)...);
+    }
+}
+
+// Use two-step tree reduction.
+// First step reduces __work_group_size * __iters_per_work_item_device_kernel elements.
+// Second step reduces __work_group_size * __iters_per_work_item_work_group_kernel elements.
+template <typename _Tp, typename _ReduceOp, typename _TransformOp, typename _Commutative, typename _ExecutionPolicy,
+          typename _InitType, typename _Res, typename _Temp,
+          oneapi::dpl::__internal::__enable_if_device_execution_policy<_ExecutionPolicy, int> = 0, typename... _Ranges>
+auto
+__parallel_transform_reduce_mid_caller(_ExecutionPolicy&& __exec, _ReduceOp __reduce_op, _TransformOp __transform_op,
+                                       _InitType __init, _Res& __res, _Temp& __temp, _Ranges&&... __rngs)
+{
+    auto __n = oneapi::dpl::__ranges::__get_first_range_size(__rngs...);
+    assert(__n > 0);
+    assert(__n <= 67108864);
+
+    if (__n <= 2097152)
+    {
+            return __parallel_transform_reduce_mid_impl<_Tp, 256, 32, 1>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                     __reduce_op, __transform_op, __init, __res, __temp,
+                                                                     ::std::forward<_Ranges>(__rngs)...);
+    }
+    else if (__n <= 4194304)
+    {
+            return __parallel_transform_reduce_mid_impl<_Tp, 256, 32, 2>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                     __reduce_op, __transform_op, __init, __res, __temp,
+                                                                     ::std::forward<_Ranges>(__rngs)...);
+    }
+    else if (__n <= 8388608)
+    {
+            return __parallel_transform_reduce_mid_impl<_Tp, 256, 32, 4>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                     __reduce_op, __transform_op, __init, __res, __temp,
+                                                                     ::std::forward<_Ranges>(__rngs)...);
+    }
+    else if (__n <= 16777216)
+    {
+            return __parallel_transform_reduce_mid_impl<_Tp, 256, 32, 8>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                     __reduce_op, __transform_op, __init, __res, __temp,
+                                                                     ::std::forward<_Ranges>(__rngs)...);
+    }
+    else if (__n <= 33554432)
+    {
+            return __parallel_transform_reduce_mid_impl<_Tp, 256, 32, 16>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                      __reduce_op, __transform_op, __init, __res,
+                                                                      __temp, ::std::forward<_Ranges>(__rngs)...);
+    }
+    else
+    {
+            return __parallel_transform_reduce_mid_impl<_Tp, 256, 32, 32>(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                                      __reduce_op, __transform_op, __init, __res,
+                                                                      __temp, ::std::forward<_Ranges>(__rngs)...);
+    }
+}
+
+// Use a wrapped policy for the buffer implementation
+template <typename _Name>
+class __reduce_wrapper
+{
+};
+
+// Synchronous pattern. The general implementation uses buffers. Using USM memory can be beneficial since it reduces
+// the overheads of managing migratable memory. USM host memory is further beneficial on GPUs utilizing L0. Other
+// runtimes show significant overheads for pinning the host memory.
+//
 // The binary operator must be associative but commutativity is only required by some of the algorithms using
 // __parallel_transform_reduce. This is provided by the _Commutative parameter. The current implementation uses a
 // generic implementation that processes elements in order. However, future improvements might be possible utilizing
@@ -391,117 +503,6 @@ struct __parallel_transform_reduce_impl
 // Mid-sized arrays use two tree reductions with independent __iters_per_work_item.
 // Big arrays are processed with a recursive tree reduction. __work_group_size * __iters_per_work_item elements are
 // reduced in each step.
-template <typename _Tp, typename _Commutative, typename _ExecutionPolicy, typename _ReduceOp, typename _TransformOp,
-          typename _InitType, typename _Res,
-          oneapi::dpl::__internal::__enable_if_device_execution_policy<_ExecutionPolicy, int> = 0, typename... _Ranges>
-auto
-__parallel_transform_reduce_caller(_ExecutionPolicy&& __exec, _ReduceOp __reduce_op, _TransformOp __transform_op,
-                                   _InitType __init, _Res& __res, _Ranges&&... __rngs)
-{
-    auto __n = oneapi::dpl::__ranges::__get_first_range_size(__rngs...);
-    assert(__n > 0);
-
-    // Get the work group size adjusted to the local memory limit.
-    // Pessimistically double the memory requirement to take into account memory used by compiled kernel.
-    // TODO: find a way to generalize getting of reliable work-group size.
-    ::std::size_t __work_group_size = oneapi::dpl::__internal::__slm_adjusted_work_group_size(__exec, sizeof(_Tp) * 2);
-
-    // Use single work group implementation if array < __work_group_size * __iters_per_work_item.
-    if (__work_group_size >= 256)
-    {
-        if (__n <= 256)
-        {
-            return __parallel_transform_reduce_small_impl<_Tp, 256, 1>(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                                       __reduce_op, __transform_op, __init, __res,
-                                                                       ::std::forward<_Ranges>(__rngs)...);
-        }
-        else if (__n <= 512)
-        {
-            return __parallel_transform_reduce_small_impl<_Tp, 256, 2>(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                                       __reduce_op, __transform_op, __init, __res,
-                                                                       ::std::forward<_Ranges>(__rngs)...);
-        }
-        else if (__n <= 1024)
-        {
-            return __parallel_transform_reduce_small_impl<_Tp, 256, 4>(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                                       __reduce_op, __transform_op, __init, __res,
-                                                                       ::std::forward<_Ranges>(__rngs)...);
-        }
-        else if (__n <= 2048)
-        {
-            return __parallel_transform_reduce_small_impl<_Tp, 256, 8>(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                                       __reduce_op, __transform_op, __init, __res,
-                                                                       ::std::forward<_Ranges>(__rngs)...);
-        }
-        else if (__n <= 4096)
-        {
-            return __parallel_transform_reduce_small_impl<_Tp, 256, 16>(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                                        __reduce_op, __transform_op, __init, __res,
-                                                                        ::std::forward<_Ranges>(__rngs)...);
-        }
-        else if (__n <= 8192)
-        {
-            return __parallel_transform_reduce_small_impl<_Tp, 256, 32>(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                                        __reduce_op, __transform_op, __init, __res,
-                                                                        ::std::forward<_Ranges>(__rngs)...);
-        }
-
-        // Use two-step tree reduction.
-        // First step reduces __work_group_size * __iters_per_work_item_device_kernel elements.
-        // Second step reduces __work_group_size * __iters_per_work_item_work_group_kernel elements.
-        else if (__n <= 2097152)
-        {
-            return __parallel_transform_reduce_mid_impl<_Tp, 256, 32, 1>(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                                         __reduce_op, __transform_op, __init, __res,
-                                                                         ::std::forward<_Ranges>(__rngs)...);
-        }
-        else if (__n <= 4194304)
-        {
-            return __parallel_transform_reduce_mid_impl<_Tp, 256, 32, 2>(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                                         __reduce_op, __transform_op, __init, __res,
-                                                                         ::std::forward<_Ranges>(__rngs)...);
-        }
-        else if (__n <= 8388608)
-        {
-            return __parallel_transform_reduce_mid_impl<_Tp, 256, 32, 4>(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                                         __reduce_op, __transform_op, __init, __res,
-                                                                         ::std::forward<_Ranges>(__rngs)...);
-        }
-        else if (__n <= 16777216)
-        {
-            return __parallel_transform_reduce_mid_impl<_Tp, 256, 32, 8>(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                                         __reduce_op, __transform_op, __init, __res,
-                                                                         ::std::forward<_Ranges>(__rngs)...);
-        }
-        else if (__n <= 33554432)
-        {
-            return __parallel_transform_reduce_mid_impl<_Tp, 256, 32, 16>(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                                          __reduce_op, __transform_op, __init, __res,
-                                                                          ::std::forward<_Ranges>(__rngs)...);
-        }
-        else if (__n <= 67108864)
-        {
-            return __parallel_transform_reduce_mid_impl<_Tp, 256, 32, 32>(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                                          __reduce_op, __transform_op, __init, __res,
-                                                                          ::std::forward<_Ranges>(__rngs)...);
-        }
-    }
-
-    // Otherwise use a recursive tree reduction.
-    return __parallel_transform_reduce_impl<_Tp, 32>::submit(::std::forward<_ExecutionPolicy>(__exec), __n,
-                                                             __work_group_size, __reduce_op, __transform_op, __init,
-                                                             __res, ::std::forward<_Ranges>(__rngs)...);
-}
-
-// Use a wrapped policy for the buffer implementation
-template <typename _Name>
-class __reduce_wrapper
-{
-};
-
-// Synchronous pattern. The general implementation uses buffers. Using USM memory can be beneficial since it reduces
-// the overheads of managing migratable memory. USM host memory is further beneficial on GPUs utilizing L0. Other
-// runtimes show significant overheads for pinning the host memory.
 template <typename _Tp, typename _ReduceOp, typename _TransformOp, typename _Commutative, typename _ExecutionPolicy,
           typename _InitType, oneapi::dpl::__internal::__enable_if_device_execution_policy<_ExecutionPolicy, int> = 0,
           typename... _Ranges>
@@ -509,23 +510,26 @@ auto
 __parallel_transform_reduce_sync(_ExecutionPolicy&& __exec, _ReduceOp __reduce_op, _TransformOp __transform_op,
                                  _InitType __init, _Ranges&&... __rngs)
 {
+    auto __n = oneapi::dpl::__ranges::__get_first_range_size(__rngs...);
+    assert(__n > 0);
+    using _Size = typename ::std::decay<decltype(__n)>::type;
+
     auto __queue = __exec.queue();
     auto __device = __queue.get_device();
-    bool __supports_usm_device = __device.has(sycl::aspect::usm_device_allocations);
-    bool __supports_usm_host = __device.has(sycl::aspect::usm_host_allocations);
-    bool __is_gpu = __device.is_gpu();
-    bool __is_level_zero = __device.get_backend() == sycl::backend::ext_oneapi_level_zero;
-    bool __use_usm_host = (__supports_usm_host && __is_gpu && __is_level_zero);
 
-    __supports_usm_device = 1;
-    __use_usm_host = 0;
-
-    bool __use_usm = (__use_usm_host || __supports_usm_device);
+    // Get the work group size adjusted to the local memory limit.
+    // Pessimistically double the memory requirement to take into account memory used by compiled kernel.
+    // TODO: find a way to generalize getting of reliable work-group size.
+    ::std::size_t __work_group_size = oneapi::dpl::__internal::__slm_adjusted_work_group_size(__exec, sizeof(_Tp) * 2);
 
     // Use USM device memory if supported or USM host memory if executed on a L0 GPU.
-    if (__use_usm)
+    if (__device.has(sycl::aspect::usm_device_allocations))
     {
         sycl::usm::alloc __usm_kind = sycl::usm::alloc::device;
+        bool __supports_usm_host = __device.has(sycl::aspect::usm_host_allocations);
+        bool __is_gpu = __device.is_gpu();
+        bool __is_level_zero = __device.get_backend() == sycl::backend::ext_oneapi_level_zero;
+        bool __use_usm_host = (__supports_usm_host && __is_gpu && __is_level_zero);
         if (__use_usm_host)
             __usm_kind = sycl::usm::alloc::host;
         oneapi::dpl::__par_backend_hetero::__internal::__buffer<_ExecutionPolicy, _Tp, _Tp*> __res_usm(__exec, 1,
@@ -533,12 +537,37 @@ __parallel_transform_reduce_sync(_ExecutionPolicy&& __exec, _ReduceOp __reduce_o
         auto __keep = oneapi::dpl::__ranges::__get_sycl_range<
             __par_backend_hetero::access_mode::write,
             oneapi::dpl::__par_backend_hetero::__internal::__buffer<_ExecutionPolicy, _Tp, _Tp*>>();
-        auto __buf = __keep(__res_usm.get(), __res_usm.get() + 1);
-        auto __res = __buf.all_view();
-        __parallel_transform_reduce_caller<_Tp, _ReduceOp, _TransformOp, _Commutative>(
-            ::std::forward<_ExecutionPolicy>(__exec), __reduce_op, __transform_op, __init, __res,
-            ::std::forward<_Ranges>(__rngs)...)
-            .wait();
+        auto __buf_temp = __keep(__res_usm.get(), __res_usm.get() + 1);
+        auto __res = __buf_temp.all_view();
+        if (__work_group_size > 256 && __n <= 8192)
+        {
+            __parallel_transform_reduce_small_caller<_Tp, _ReduceOp, _TransformOp, _Commutative>(
+                ::std::forward<_ExecutionPolicy>(__exec), __reduce_op, __transform_op, __init, __res,
+                ::std::forward<_Ranges>(__rngs)...)
+                .wait();
+        }
+        else if (__work_group_size > 256 && __n <= 67108864)
+        {
+            const _Size __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__n, 32 * 256);
+            oneapi::dpl::__par_backend_hetero::__internal::__buffer<_ExecutionPolicy, _Tp, _Tp*> __temp_usm(
+                __exec, __n_groups, sycl::usm::alloc::device);
+            auto __keep_temp = oneapi::dpl::__ranges::__get_sycl_range<
+                __par_backend_hetero::access_mode::read_write,
+                oneapi::dpl::__par_backend_hetero::__internal::__buffer<_ExecutionPolicy, _Tp, _Tp*>>();
+            auto __buf_temp = __keep_temp(__temp_usm.get(), __temp_usm.get() + 1);
+            auto __temp = __buf_temp.all_view();
+            __parallel_transform_reduce_mid_caller<_Tp, _ReduceOp, _TransformOp, _Commutative>(
+                ::std::forward<_ExecutionPolicy>(__exec), __reduce_op, __transform_op, __init, __res, __temp,
+                ::std::forward<_Ranges>(__rngs)...)
+                .wait();
+        }
+        else
+        {
+            __parallel_transform_reduce_impl<_Tp, 32>::submit(::std::forward<_ExecutionPolicy>(__exec), __n,
+                                                              __work_group_size, __reduce_op, __transform_op, __init,
+                                                              __res, ::std::forward<_Ranges>(__rngs)...)
+                .wait();
+        }
         if (__use_usm_host)
             return __res_usm.get()[0];
         else
@@ -554,10 +583,31 @@ __parallel_transform_reduce_sync(_ExecutionPolicy&& __exec, _ReduceOp __reduce_o
 
         sycl::buffer<_Tp> __res_buffer(sycl::range<1>(1));
         auto __res = oneapi::dpl::__ranges::all_view<_Tp, __par_backend_hetero::access_mode::write>(__res_buffer);
-        __parallel_transform_reduce_caller<_Tp, _ReduceOp, _TransformOp, _Commutative>(
-            oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__reduce_wrapper>(
-                ::std::forward<_ExecutionPolicy>(__exec)),
-            __reduce_op, __transform_op, __init, __res, ::std::forward<_Ranges>(__rngs)...);
+        if (__work_group_size > 256 && __n <= 8192)
+        {
+            __parallel_transform_reduce_small_caller<_Tp, _ReduceOp, _TransformOp, _Commutative>(
+                oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__reduce_wrapper>(
+                    ::std::forward<_ExecutionPolicy>(__exec)),
+                __reduce_op, __transform_op, __init, __res, ::std::forward<_Ranges>(__rngs)...);
+        }
+        else if (__work_group_size > 256 && __n <= 67108864)
+        {
+            const _Size __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__n, 32 * 256);
+            sycl::buffer<_Tp> __temp_buffer((sycl::range<1>(__n_groups)));
+            auto __temp =
+                oneapi::dpl::__ranges::all_view<_Tp, __par_backend_hetero::access_mode::read_write>(__temp_buffer);
+            __parallel_transform_reduce_mid_caller<_Tp, _ReduceOp, _TransformOp, _Commutative>(
+                oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__reduce_wrapper>(
+                    ::std::forward<_ExecutionPolicy>(__exec)),
+                __reduce_op, __transform_op, __init, __res, __temp, ::std::forward<_Ranges>(__rngs)...);
+        }
+        else
+        {
+            __parallel_transform_reduce_impl<_Tp, 32>::submit(
+                oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__reduce_wrapper>(
+                    ::std::forward<_ExecutionPolicy>(__exec)),
+                __n, __work_group_size, __reduce_op, __transform_op, __init, __res, ::std::forward<_Ranges>(__rngs)...);
+        }
 
         return __res_buffer.get_host_access(sycl::read_only)[0];
     }
@@ -571,12 +621,43 @@ auto
 __parallel_transform_reduce_async(_ExecutionPolicy&& __exec, _ReduceOp __reduce_op, _TransformOp __transform_op,
                                   _InitType __init, _Ranges&&... __rngs)
 {
+    auto __n = oneapi::dpl::__ranges::__get_first_range_size(__rngs...);
+    assert(__n > 0);
+    using _Size = typename ::std::decay<decltype(__n)>::type;
+
+    // Get the work group size adjusted to the local memory limit.
+    // Pessimistically double the memory requirement to take into account memory used by compiled kernel.
+    // TODO: find a way to generalize getting of reliable work-group size.
+    ::std::size_t __work_group_size = oneapi::dpl::__internal::__slm_adjusted_work_group_size(__exec, sizeof(_Tp) * 2);
+
+    sycl::event __reduce_event;
     sycl::buffer<_Tp> __res_buffer(sycl::range<1>(1));
     auto __res = oneapi::dpl::__ranges::all_view<_Tp, __par_backend_hetero::access_mode::write>(__res_buffer);
-    sycl::event __reduce_event = __parallel_transform_reduce_caller<_Tp, _ReduceOp, _TransformOp, _Commutative>(
-        oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__reduce_wrapper>(
-            ::std::forward<_ExecutionPolicy>(__exec)),
-        __reduce_op, __transform_op, __init, __res, ::std::forward<_Ranges>(__rngs)...);
+    if (__work_group_size > 256 && __n <= 8192)
+    {
+        __reduce_event = __parallel_transform_reduce_small_caller<_Tp, _ReduceOp, _TransformOp, _Commutative>(
+            oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__reduce_wrapper>(
+                ::std::forward<_ExecutionPolicy>(__exec)),
+            __reduce_op, __transform_op, __init, __res, ::std::forward<_Ranges>(__rngs)...);
+    }
+    else if (__work_group_size > 256 && __n <= 67108864)
+    {
+        const _Size __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__n, 32 * 256);
+        sycl::buffer<_Tp> __temp_buffer((sycl::range<1>(__n_groups)));
+        auto __temp =
+            oneapi::dpl::__ranges::all_view<_Tp, __par_backend_hetero::access_mode::read_write>(__temp_buffer);
+        __reduce_event = __parallel_transform_reduce_mid_caller<_Tp, _ReduceOp, _TransformOp, _Commutative>(
+            oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__reduce_wrapper>(
+                ::std::forward<_ExecutionPolicy>(__exec)),
+            __reduce_op, __transform_op, __init, __res, __temp, ::std::forward<_Ranges>(__rngs)...);
+    }
+    else
+    {
+        __reduce_event = __parallel_transform_reduce_impl<_Tp, 32>::submit(
+            oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__reduce_wrapper>(
+                ::std::forward<_ExecutionPolicy>(__exec)),
+            __n, __work_group_size, __reduce_op, __transform_op, __init, __res, ::std::forward<_Ranges>(__rngs)...);
+    }
 
     return __future(__reduce_event, __res_buffer);
 }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -428,13 +428,13 @@ struct __sycl_usm_free
     }
 };
 
-template <typename _ExecutionPolicy, typename _T, sycl::usm::alloc __alloc_t>
+template <typename _ExecutionPolicy, typename _T>
 struct __sycl_usm_alloc
 {
     _ExecutionPolicy __exec;
 
     _T*
-    operator()(::std::size_t __elements) const
+    operator()(::std::size_t __elements, sycl::usm::alloc __alloc_t) const
     {
         const auto& __queue = __exec.queue();
         return (_T*)sycl::malloc(sizeof(_T) * __elements, __queue.get_device(), __queue.get_context(), __alloc_t);
@@ -448,13 +448,12 @@ struct __buffer<_ExecutionPolicy, _T, _BValueT*>
   private:
     using __exec_policy_t = __decay_t<_ExecutionPolicy>;
     using __container_t = ::std::unique_ptr<_T, __sycl_usm_free<__exec_policy_t, _T>>;
-    using __alloc_t = sycl::usm::alloc;
 
     __container_t __container;
 
   public:
-    __buffer(_ExecutionPolicy __exec, ::std::size_t __n_elements)
-        : __container(__sycl_usm_alloc<__exec_policy_t, _T, __alloc_t::shared>{__exec}(__n_elements),
+    __buffer(_ExecutionPolicy __exec, ::std::size_t __n_elements, sycl::usm::alloc __alloc_t)
+        : __container(__sycl_usm_alloc<__exec_policy_t, _T>{__exec}(__n_elements, __alloc_t),
                       __sycl_usm_free<__exec_policy_t, _T>{__exec})
     {
     }

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -57,12 +57,11 @@ __pattern_transform_reduce(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __f
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _RandomAccessIterator2>();
     auto __buf2 = __keep2(__first2, __first2 + __n);
 
-    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp,
-                                                                          ::std::true_type /*is_commutative*/>(
-               ::std::forward<_ExecutionPolicy>(__exec), __binary_op1, _Functor{__binary_op2},
-               unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
-               __buf1.all_view(), __buf2.all_view())
-        .get();
+    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce_sync<_RepackedTp, _BinaryOperation1, _Functor,
+                                                                               ::std::true_type /*is_commutative*/>(
+        ::std::forward<_ExecutionPolicy>(__exec), __binary_op1, _Functor{__binary_op2},
+        unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
+        __buf1.all_view(), __buf2.all_view());
 }
 
 //------------------------------------------------------------------------
@@ -85,12 +84,11 @@ __pattern_transform_reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, 
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _ForwardIterator>();
     auto __buf = __keep(__first, __last);
 
-    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp,
-                                                                          ::std::true_type /*is_commutative*/>(
-               ::std::forward<_ExecutionPolicy>(__exec), __binary_op, _Functor{__unary_op},
-               unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
-               __buf.all_view())
-        .get();
+    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce_sync<_RepackedTp, _BinaryOperation, _Functor,
+                                                                               ::std::true_type /*is_commutative*/>(
+        ::std::forward<_ExecutionPolicy>(__exec), __binary_op, _Functor{__unary_op},
+        unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
+        __buf.all_view());
 }
 
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -57,7 +57,7 @@ __pattern_transform_reduce(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __f
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _RandomAccessIterator2>();
     auto __buf2 = __keep2(__first2, __first2 + __n);
 
-    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce_sync<_RepackedTp, _BinaryOperation1, _Functor,
+    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce_sync<_RepackedTp,
                                                                                ::std::true_type /*is_commutative*/>(
         ::std::forward<_ExecutionPolicy>(__exec), __binary_op1, _Functor{__binary_op2},
         unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
@@ -84,7 +84,7 @@ __pattern_transform_reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, 
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _ForwardIterator>();
     auto __buf = __keep(__first, __last);
 
-    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce_sync<_RepackedTp, _BinaryOperation, _Functor,
+    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce_sync<_RepackedTp,
                                                                                ::std::true_type /*is_commutative*/>(
         ::std::forward<_ExecutionPolicy>(__exec), __binary_op, _Functor{__unary_op},
         unseq_backend::__init_value<_RepackedTp>{__init}, // initial value

--- a/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
@@ -49,12 +49,11 @@ __pattern_transform_reduce(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&
     using _Functor = unseq_backend::walk_n<_ExecutionPolicy, _BinaryOperation2>;
     using _RepackedTp = oneapi::dpl::__par_backend_hetero::__repacked_tuple_t<_Tp>;
 
-    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp,
-                                                                          ::std::true_type /*is_commutative*/>(
-               ::std::forward<_ExecutionPolicy>(__exec), __binary_op1, _Functor{__binary_op2},
-               unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
-               ::std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2))
-        .get();
+    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce_sync<_RepackedTp, _BinaryOperation1, _Functor,
+                                                                               ::std::true_type /*is_commutative*/>(
+        ::std::forward<_ExecutionPolicy>(__exec), __binary_op1, _Functor{__binary_op2},
+        unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
+        ::std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2));
 }
 
 //------------------------------------------------------------------------
@@ -72,12 +71,11 @@ __pattern_transform_reduce(_ExecutionPolicy&& __exec, _Range&& __rng, _Tp __init
     using _Functor = unseq_backend::walk_n<_ExecutionPolicy, _UnaryOperation>;
     using _RepackedTp = oneapi::dpl::__par_backend_hetero::__repacked_tuple_t<_Tp>;
 
-    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp,
-                                                                          ::std::true_type /*is_commutative*/>(
-               ::std::forward<_ExecutionPolicy>(__exec), __binary_op, _Functor{__unary_op},
-               unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
-               ::std::forward<_Range>(__rng))
-        .get();
+    return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce_sync<_RepackedTp, _BinaryOperation, _Functor,
+                                                                               ::std::true_type /*is_commutative*/>(
+        ::std::forward<_ExecutionPolicy>(__exec), __binary_op, _Functor{__unary_op},
+        unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
+        ::std::forward<_Range>(__rng));
 }
 
 //------------------------------------------------------------------------


### PR DESCRIPTION
This patch aims at reducing the overheads of using buffers for the result and temporary memory in the reduce pattern on supported devices. Synchronous calls to the pattern will use the following versions:
1. USM host memory for the result on L0 GPUs. L0 provides a low-overhead implementation of host memory. The kernel can then directly write the result via PCIe (eliminates the L0 call to zeCommandListAppendMemoryCopy). Potential temporary memory uses USM device memory. Other backends and platforms show high costs for pinning host memory.
2. USM device memory for the result and temporary memory on all other devices supporting USM device memory.
3. Buffers for the result and temporary memory as a fallback.

The asynchronous version continues to use a single-element return buffer that is wrapped in a future-like object since the proposed solution in #874 is currently blocked by a compiler issue in 2023.2.

This also reverts back the changes of using the ternary conditional operator introduced in #1026 since it shows slowdowns for `max_element`.