### PR TITLE
[Dynamic Selection] Addressing comments for dynamic_selection.h and auto_tune

### DIFF
--- a/include/oneapi/dpl/internal/dynamic_selection.h
+++ b/include/oneapi/dpl/internal/dynamic_selection.h
@@ -125,7 +125,7 @@ namespace internal {
   auto submit(T&& t, Function&&f, Args&&... args) {
     if constexpr(internal::has_get_policy<T>::value == true) {
       // t is a selection
-      return t.get_policy().submit(std::forward<T>(t), std::forward<Function>(f), std::forward<Args>(args)...);
+      return submit(std::forward<T>(t).get_policy(), std::forward<Function>(f), std::forward<Args>(args)...);
     } else if constexpr(internal::has_submit<T, Function, Args...>::value == true) {
       // t is a policy and policy has optional submit(f, args...)
       return std::forward<T>(t).submit(std::forward<Function>(f), std::forward<Args>(args)...);
@@ -134,7 +134,6 @@ namespace internal {
       return submit(std::forward<T>(t), t.select(f, args...), std::forward<Function>(f), std::forward<Args>(args)...);
     }
   }
-
   template<typename T, typename Function, typename... Args>
   auto submit_and_wait(T&& t, Function&&f, Args&&... args) {
     if constexpr (internal::has_get_policy<T>::value == true) {

--- a/include/oneapi/dpl/internal/dynamic_selection.h
+++ b/include/oneapi/dpl/internal/dynamic_selection.h
@@ -125,7 +125,7 @@ namespace internal {
   auto submit(T&& t, Function&&f, Args&&... args) {
     if constexpr(internal::has_get_policy<T>::value == true) {
       // t is a selection
-      return submit(std::forward<T>(t).get_policy(), std::forward<Function>(f), std::forward<Args>(args)...);
+      return submit(t.get_policy(), std::forward<T>(t), std::forward<Function>(f), std::forward<Args>(args)...);
     } else if constexpr(internal::has_submit<T, Function, Args...>::value == true) {
       // t is a policy and policy has optional submit(f, args...)
       return std::forward<T>(t).submit(std::forward<Function>(f), std::forward<Args>(args)...);

--- a/include/oneapi/dpl/internal/dynamic_selection.h
+++ b/include/oneapi/dpl/internal/dynamic_selection.h
@@ -151,7 +151,7 @@ namespace internal {
       if constexpr ( internal::has_submit_and_wait<T, Function, Args...>::value == true) {
         // has the optional submit_and_wait(f, args...)
         return std::forward<T>(t).submit_and_wait(std::forward<Function>(f), std::forward<Args>(args)...);
-      } else if constexpr ( internal::has_submit_and_wait_handle<T, typename std::decay<T>::type::selection_type, Function, Args...>::value == true) {
+      } else if constexpr ( internal::has_submit_and_wait_handle<T, typename std::decay_t<T>::selection_type, Function, Args...>::value == true) {
         // has the optional submit_and_wait for a selection, so select and call
         return submit_and_wait(std::forward<T>(t).select(f, args...), std::forward<Function>(f), std::forward<Args>(args)...);
       } else {

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h
@@ -23,13 +23,6 @@
 namespace oneapi {
 namespace dpl {
 namespace experimental {
-/*#if _DS_BACKEND_SYCL != 0
-  template <typename Backend=sycl_backend, typename... KeyArgs>
-#else
-  template <typename Backend, typename... KeyArgs>
-#endif
-class auto_tune_policy;
-*/
   template <typename Backend=sycl_backend, typename... KeyArgs>
   class auto_tune_policy {
 

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h
@@ -23,40 +23,14 @@
 namespace oneapi {
 namespace dpl {
 namespace experimental {
-#if _DS_BACKEND_SYCL != 0
+/*#if _DS_BACKEND_SYCL != 0
   template <typename Backend=sycl_backend, typename... KeyArgs>
 #else
   template <typename Backend, typename... KeyArgs>
 #endif
 class auto_tune_policy;
-
-  namespace internal {
-    template <typename Backend, typename Resource, typename Tuner, typename... KeyArgs>
-    class auto_tune_selection_type {
-      using policy_t = auto_tune_policy<Backend, KeyArgs...>;
-      policy_t policy_;
-      using resource_with_offset_t = Resource;
-      resource_with_offset_t resource_;
-      using tuner_t = Tuner;
-      std::shared_ptr<tuner_t> tuner_;
-
-    public:
-      auto_tune_selection_type() : policy_(deferred_initialization) {}
-
-      auto_tune_selection_type(const policy_t& p, resource_with_offset_t r, std::shared_ptr<tuner_t> t)
-        : policy_(p), resource_(r), tuner_(t) {}
-
-      auto unwrap() { return ::oneapi::dpl::experimental::unwrap(resource_.r_); }
-
-      policy_t get_policy() { return policy_; };
-
-      void report(const execution_info::task_time_t&, const typename execution_info::task_time_t::value_type& v) const {
-        tuner_->add_new_timing(resource_, v);
-      }
-    };
-  }
-
-  template <typename Backend, typename... KeyArgs>
+*/
+  template <typename Backend=sycl_backend, typename... KeyArgs>
   class auto_tune_policy {
 
     static constexpr double never_resample = 0.0;
@@ -80,7 +54,7 @@ class auto_tune_policy;
     struct tuner_t {
       std::mutex m_;
 
-      std::chrono::high_resolution_clock::time_point t0_;
+      std::chrono::steady_clock::time_point t0_;
 
       timing_t best_timing_ = std::numeric_limits<timing_t>::max();
       resource_with_offset_t best_resource_;
@@ -94,7 +68,7 @@ class auto_tune_policy;
       double resample_time_ = 0;
 
       tuner_t(resource_with_offset_t br, size_type resources_size, double rt)
-        : t0_(std::chrono::high_resolution_clock::now()),
+        : t0_(std::chrono::steady_clock::now()),
           best_resource_(br),
           max_resource_to_profile_(resources_size),
           resample_time_(rt) {}
@@ -107,7 +81,7 @@ class auto_tune_policy;
         } else if (resample_time_ == never_resample) {
           return use_best_resource;
         } else {
-          auto now = std::chrono::high_resolution_clock::now();
+          auto now = std::chrono::steady_clock::now();
           auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(now-t0_).count();
           if (ms < resample_time_) {
             return use_best_resource;
@@ -141,12 +115,36 @@ class auto_tune_policy;
 
     };
 
+    template <typename Resource, typename Tuner>
+    class auto_tune_selection_type {
+      using policy_t = auto_tune_policy<Backend, KeyArgs...>;
+      policy_t policy_;
+      using resource_with_offset_t = Resource;
+      resource_with_offset_t resource_;
+      using tuner_t = Tuner;
+      std::shared_ptr<tuner_t> tuner_;
+
+    public:
+      auto_tune_selection_type() : policy_(deferred_initialization) {}
+
+      auto_tune_selection_type(const policy_t& p, resource_with_offset_t r, std::shared_ptr<tuner_t> t)
+        : policy_(p), resource_(r), tuner_(t) {}
+
+      auto unwrap() { return ::oneapi::dpl::experimental::unwrap(resource_.r_); }
+
+      policy_t get_policy() { return policy_; };
+
+      void report(const execution_info::task_time_t&, const typename execution_info::task_time_t::value_type& v) const {
+        tuner_->add_new_timing(resource_, v);
+      }
+    };
+
    public:
 
     // Needed by Policy Traits
     using resource_type = decltype(unwrap(std::declval<wrapped_resource_t>()));
     using wait_type = typename Backend::wait_type;
-    using selection_type = internal::auto_tune_selection_type<Backend, resource_with_offset_t, tuner_t, KeyArgs...>;
+    using selection_type = auto_tune_selection_type<resource_with_offset_t, tuner_t>;
 
     auto_tune_policy(double resample_time=never_resample) {
       if (resample_time != deferred_initialization) {

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h
@@ -25,25 +25,25 @@ namespace dpl {
 namespace experimental {
 #if _DS_BACKEND_SYCL != 0
   template <typename Backend=sycl_backend, typename... KeyArgs>
-#else 
+#else
   template <typename Backend, typename... KeyArgs>
 #endif
 class auto_tune_policy;
 
-  namespace internal { 
+  namespace internal {
     template <typename Backend, typename Resource, typename Tuner, typename... KeyArgs>
     class auto_tune_selection_type {
       using policy_t = auto_tune_policy<Backend, KeyArgs...>;
-      policy_t policy_; 
+      policy_t policy_;
       using resource_with_offset_t = Resource;
       resource_with_offset_t resource_;
       using tuner_t = Tuner;
       std::shared_ptr<tuner_t> tuner_;
 
     public:
-      auto_tune_selection_type() : policy_(deferred_initialization) {} 
+      auto_tune_selection_type() : policy_(deferred_initialization) {}
 
-      auto_tune_selection_type(const policy_t& p, resource_with_offset_t r, std::shared_ptr<tuner_t> t) 
+      auto_tune_selection_type(const policy_t& p, resource_with_offset_t r, std::shared_ptr<tuner_t> t)
         : policy_(p), resource_(r), tuner_(t) {}
 
       auto unwrap() { return ::oneapi::dpl::experimental::unwrap(resource_.r_); }
@@ -62,14 +62,14 @@ class auto_tune_policy;
     static constexpr double never_resample = 0.0;
     static constexpr int use_best_resource = -1;
 
-    using wrapped_resource_t = typename std::decay<Backend>::type::execution_resource_t;
+    using wrapped_resource_t = typename std::decay_t<Backend>::execution_resource_t;
     using size_type = typename std::vector<typename Backend::resource_type>::size_type;
 
     using timing_t = uint64_t;
 
     struct resource_with_offset_t {
       wrapped_resource_t r_;
-      size_type offset_; 
+      size_type offset_;
     };
 
     struct time_data_t {
@@ -93,9 +93,9 @@ class auto_tune_policy;
 
       double resample_time_ = 0;
 
-      tuner_t(resource_with_offset_t br, size_type resources_size, double rt) 
-        : t0_(std::chrono::high_resolution_clock::now()), 
-          best_resource_(br), 
+      tuner_t(resource_with_offset_t br, size_type resources_size, double rt)
+        : t0_(std::chrono::high_resolution_clock::now()),
+          best_resource_(br),
           max_resource_to_profile_(resources_size),
           resample_time_(rt) {}
 
@@ -117,7 +117,7 @@ class auto_tune_policy;
           }
         }
       }
- 
+
       // called to add new profile info
       void add_new_timing(resource_with_offset_t r, timing_t t) {
         std::unique_lock<std::mutex> l(m_);
@@ -137,7 +137,7 @@ class auto_tune_policy;
           best_timing_ = new_value;
           best_resource_ = r;
         }
-      } 
+      }
 
     };
 
@@ -159,7 +159,7 @@ class auto_tune_policy;
         initialize(u, resample_time);
       }
     }
-   
+
     void initialize(double resample_time=never_resample) {
       if (!state_) {
         state_ = std::make_shared<state_t>();
@@ -184,11 +184,11 @@ class auto_tune_policy;
         auto t  = state_->tuner_by_key_[k];
         auto offset = t->get_resource_to_profile();
         if (offset == use_best_resource) {
-          return selection_type{*this, t->best_resource_, t}; 
+          return selection_type{*this, t->best_resource_, t};
         } else {
           auto r = state_->resources_with_offset_[offset];
-          return selection_type{*this, r, t}; 
-        } 
+          return selection_type{*this, r, t};
+        }
       } else {
          throw std::runtime_error("Called select before initialization\n");
       }

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/fixed_resource_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/fixed_resource_policy.h
@@ -28,7 +28,7 @@ namespace experimental {
     using backend_t = Backend;
     using resource_container_t = typename backend_t::resource_container_t;
     using execution_resource_t = typename backend_t::execution_resource_t;
-    using wrapped_resource_t = typename std::decay<Backend>::type::execution_resource_t;
+    using wrapped_resource_t = typename std::decay_t<Backend>::execution_resource_t;
 
   public:
     //policy traits

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/policy_traits.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/policy_traits.h
@@ -16,10 +16,10 @@ namespace experimental{
 
     template<typename Policy>
     struct policy_traits{
-        using selection_type = typename std::decay<Policy>::type::selection_type;  //selection type
-        using resource_type = typename std::decay<Policy>::type::resource_type; //resource type
+        using selection_type = typename std::decay_t<Policy>::selection_type;  //selection type
+        using resource_type = typename std::decay_t<Policy>::resource_type; //resource type
 
-        using wait_type = typename std::decay<Policy>::type::wait_type; //wait_type
+        using wait_type = typename std::decay_t<Policy>::wait_type; //wait_type
     };
 }
 }

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/round_robin_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/round_robin_policy.h
@@ -30,7 +30,7 @@ namespace experimental{
     using backend_t = Backend;
     using resource_container_t = typename backend_t::resource_container_t;
     using resource_container_size_t = typename resource_container_t::size_type;
-    using wrapped_resource_t = typename std::decay<Backend>::type::execution_resource_t;
+    using wrapped_resource_t = typename std::decay_t<Backend>::execution_resource_t;
 
     using execution_resource_t = typename backend_t::execution_resource_t;
 


### PR DESCRIPTION
1. std::decay<T>::type to std::decay_t<T>
2. Fixed definition of submit to not use policy's function directly
3. Checking use of forwards in submit and submit_and_wait
4. move internal namespace classes into auto_tune_policy as private types
5. change auto_tune to use steady_clock