### PR TITLE
Fix places where std::plus<T> used without std::plus<void>

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -76,7 +76,8 @@ using __has_known_identity = std::false_type;
 template <typename _BinaryOp, typename _Tp>
 struct __known_identity_for_plus
 {
-    static_assert(std::is_same_v<typename std::decay<_BinaryOp>::type, std::plus<_Tp>>);
+    static_assert(std::is_same_v<typename std::decay<_BinaryOp>::type, std::plus<_Tp>> ||
+                  std::is_same_v<typename std::decay<_BinaryOp>::type, std::plus<void>>);
     static constexpr _Tp value = 0;
 };
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -77,7 +77,9 @@ template <typename _BinaryOp, typename _Tp>
 struct __known_identity_for_plus
 {
     static_assert(std::is_same_v<typename std::decay<_BinaryOp>::type, std::plus<_Tp>> ||
-                  std::is_same_v<typename std::decay<_BinaryOp>::type, std::plus<void>>);
+                  std::is_same_v<typename std::decay<_BinaryOp>::type, std::plus<void>> ||
+                  std::is_same_v<typename ::std::decay<_BinaryOp>::type, __dpl_sycl::__plus<_Tp>> ||
+                  std::is_same_v<typename ::std::decay<_BinaryOp>::type, __dpl_sycl::__plus<void>>);
     static constexpr _Tp value = 0;
 };
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -76,10 +76,10 @@ using __has_known_identity = std::false_type;
 template <typename _BinaryOp, typename _Tp>
 struct __known_identity_for_plus
 {
-    static_assert(std::is_same_v<typename std::decay<_BinaryOp>::type, std::plus<_Tp>> ||
-                  std::is_same_v<typename std::decay<_BinaryOp>::type, std::plus<void>> ||
-                  std::is_same_v<typename ::std::decay<_BinaryOp>::type, __dpl_sycl::__plus<_Tp>> ||
-                  std::is_same_v<typename ::std::decay<_BinaryOp>::type, __dpl_sycl::__plus<void>>);
+    static_assert(::std::is_same_v<::std::decay_t<_BinaryOp>, ::std::plus<_Tp>> ||
+                  ::std::is_same_v<::std::decay_t<_BinaryOp>, ::std::plus<void>> ||
+                  ::std::is_same_v<::std::decay_t<_BinaryOp>, __dpl_sycl::__plus<_Tp>> ||
+                  ::std::is_same_v<::std::decay_t<_BinaryOp>, __dpl_sycl::__plus<void>>);
     static constexpr _Tp value = 0;
 };
 

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -27,6 +27,10 @@
 
 #include "parallel_backend.h"
 
+#if _ONEDPL_BACKEND_SYCL
+#    include "hetero/dpcpp/sycl_defs.h"
+#endif
+
 namespace oneapi
 {
 namespace dpl
@@ -193,9 +197,17 @@ __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __la
 // type is arithmetic and binary operation is a user defined operation.
 template <typename _Tp, typename _BinaryOperation>
 using is_arithmetic_udop =
-    ::std::integral_constant<bool, ::std::is_arithmetic<_Tp>::value &&
-                                       !::std::is_same<_BinaryOperation, ::std::plus<_Tp>>::value &&
-                                       !::std::is_same<_BinaryOperation, ::std::plus<void>>::value>;
+#if _ONEDPL_BACKEND_SYCL
+    ::std::integral_constant<bool, ::std::is_arithmetic_v<_Tp> &&
+                                       !::std::is_same_v<_BinaryOperation, ::std::plus<_Tp>> &&
+                                       !::std::is_same_v<_BinaryOperation, ::std::plus<void>> &&
+                                       !::std::is_same_v<_BinaryOperation, __dpl_sycl::__plus<_Tp>> &&
+                                       !::std::is_same_v<_BinaryOperation, __dpl_sycl::__plus<void>>>;
+#else
+    ::std::integral_constant<bool, ::std::is_arithmetic_v<_Tp> &&
+                                       !::std::is_same_v<_BinaryOperation, ::std::plus<_Tp>> &&
+                                       !::std::is_same_v<_BinaryOperation, ::std::plus<void>>>;
+#endif // _ONEDPL_BACKEND_SYCL
 
 // [restriction] - T shall be DefaultConstructible.
 // [violation] - default ctor of T shall set the identity value for binary_op.

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -194,7 +194,8 @@ __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __la
 template <typename _Tp, typename _BinaryOperation>
 using is_arithmetic_udop =
     ::std::integral_constant<bool, ::std::is_arithmetic<_Tp>::value &&
-                                       !::std::is_same<_BinaryOperation, ::std::plus<_Tp>>::value>;
+                                       !::std::is_same<_BinaryOperation, ::std::plus<_Tp>>::value &&
+                                       !::std::is_same<_BinaryOperation, ::std::plus<void>>::value>;
 
 // [restriction] - T shall be DefaultConstructible.
 // [violation] - default ctor of T shall set the identity value for binary_op.

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -27,10 +27,6 @@
 
 #include "parallel_backend.h"
 
-#if _ONEDPL_BACKEND_SYCL
-#    include "hetero/dpcpp/sycl_defs.h"
-#endif
-
 namespace oneapi
 {
 namespace dpl
@@ -196,18 +192,9 @@ __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __la
 
 // type is arithmetic and binary operation is a user defined operation.
 template <typename _Tp, typename _BinaryOperation>
-using is_arithmetic_udop =
-#if _ONEDPL_BACKEND_SYCL
-    ::std::integral_constant<bool, ::std::is_arithmetic_v<_Tp> &&
-                                       !::std::is_same_v<_BinaryOperation, ::std::plus<_Tp>> &&
-                                       !::std::is_same_v<_BinaryOperation, ::std::plus<void>> &&
-                                       !::std::is_same_v<_BinaryOperation, __dpl_sycl::__plus<_Tp>> &&
-                                       !::std::is_same_v<_BinaryOperation, __dpl_sycl::__plus<void>>>;
-#else
-    ::std::integral_constant<bool, ::std::is_arithmetic_v<_Tp> &&
-                                       !::std::is_same_v<_BinaryOperation, ::std::plus<_Tp>> &&
-                                       !::std::is_same_v<_BinaryOperation, ::std::plus<void>>>;
-#endif // _ONEDPL_BACKEND_SYCL
+using is_arithmetic_udop = ::std::integral_constant<bool, ::std::is_arithmetic_v<_Tp> &&
+                                                              !::std::is_same_v<_BinaryOperation, ::std::plus<_Tp>> &&
+                                                              !::std::is_same_v<_BinaryOperation, ::std::plus<void>>>;
 
 // [restriction] - T shall be DefaultConstructible.
 // [violation] - default ctor of T shall set the identity value for binary_op.

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -477,17 +477,17 @@ __simd_adjacent_find(_Index __first, _Index __last, _BinaryPredicate __pred, boo
 // It was created to reduce the code inside ::std::enable_if
 template <typename _Tp, typename _BinaryOperation>
 using is_arithmetic_plus =
-#   if _ONEDPL_BACKEND_SYCL
+#if _ONEDPL_BACKEND_SYCL
     ::std::integral_constant<bool, ::std::is_arithmetic_v<_Tp> &&
                                        (::std::is_same_v<_BinaryOperation, ::std::plus<_Tp>> ||
                                         ::std::is_same_v<_BinaryOperation, ::std::plus<void>> ||
                                         ::std::is_same_v<_BinaryOperation, __dpl_sycl::__plus<_Tp>> ||
                                         ::std::is_same_v<_BinaryOperation, __dpl_sycl::__plus<void>>)>;
-#   else
+#else
     ::std::integral_constant<bool, ::std::is_arithmetic_v<_Tp>::value &&
                                        (::std::is_same_v<_BinaryOperation, ::std::plus<_Tp>> ||
                                         ::std::is_same_v<_BinaryOperation, ::std::plus<void>>)>;
-#   endif // _ONEDPL_BACKEND_SYCL
+#endif // _ONEDPL_BACKEND_SYCL
 
 template <typename _DifferenceType, typename _Tp, typename _BinaryOperation, typename _UnaryOperation>
 typename ::std::enable_if<is_arithmetic_plus<_Tp, _BinaryOperation>::value, _Tp>::type

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -472,8 +472,9 @@ __simd_adjacent_find(_Index __first, _Index __last, _BinaryPredicate __pred, boo
 
 // It was created to reduce the code inside ::std::enable_if
 template <typename _Tp, typename _BinaryOperation>
-using is_arithmetic_plus = ::std::integral_constant<
-    bool, ::std::is_arithmetic<_Tp>::value&& ::std::is_same<_BinaryOperation, ::std::plus<_Tp>>::value>;
+using is_arithmetic_plus = ::std::integral_constant<bool, ::std::is_arithmetic<_Tp>::value &&
+                                       (::std::is_same<_BinaryOperation, ::std::plus<_Tp>>::value ||
+                                        ::std::is_same<_BinaryOperation, ::std::plus<void>>::value)>;
 
 template <typename _DifferenceType, typename _Tp, typename _BinaryOperation, typename _UnaryOperation>
 typename ::std::enable_if<is_arithmetic_plus<_Tp, _BinaryOperation>::value, _Tp>::type

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -20,10 +20,6 @@
 
 #include "utils.h"
 
-#if _ONEDPL_BACKEND_SYCL
-#    include "hetero/dpcpp/sycl_defs.h"
-#endif
-
 // This header defines the minimum set of vector routines required
 // to support Parallel STL.
 namespace oneapi
@@ -476,18 +472,9 @@ __simd_adjacent_find(_Index __first, _Index __last, _BinaryPredicate __pred, boo
 
 // It was created to reduce the code inside ::std::enable_if
 template <typename _Tp, typename _BinaryOperation>
-using is_arithmetic_plus =
-#if _ONEDPL_BACKEND_SYCL
-    ::std::integral_constant<bool, ::std::is_arithmetic_v<_Tp> &&
-                                       (::std::is_same_v<_BinaryOperation, ::std::plus<_Tp>> ||
-                                        ::std::is_same_v<_BinaryOperation, ::std::plus<void>> ||
-                                        ::std::is_same_v<_BinaryOperation, __dpl_sycl::__plus<_Tp>> ||
-                                        ::std::is_same_v<_BinaryOperation, __dpl_sycl::__plus<void>>)>;
-#else
-    ::std::integral_constant<bool, ::std::is_arithmetic_v<_Tp> &&
-                                       (::std::is_same_v<_BinaryOperation, ::std::plus<_Tp>> ||
-                                        ::std::is_same_v<_BinaryOperation, ::std::plus<void>>)>;
-#endif // _ONEDPL_BACKEND_SYCL
+using is_arithmetic_plus = ::std::integral_constant<bool, ::std::is_arithmetic_v<_Tp> &&
+                                                              (::std::is_same_v<_BinaryOperation, ::std::plus<_Tp>> ||
+                                                               ::std::is_same_v<_BinaryOperation, ::std::plus<void>>)>;
 
 template <typename _DifferenceType, typename _Tp, typename _BinaryOperation, typename _UnaryOperation>
 typename ::std::enable_if<is_arithmetic_plus<_Tp, _BinaryOperation>::value, _Tp>::type

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -484,7 +484,7 @@ using is_arithmetic_plus =
                                         ::std::is_same_v<_BinaryOperation, __dpl_sycl::__plus<_Tp>> ||
                                         ::std::is_same_v<_BinaryOperation, __dpl_sycl::__plus<void>>)>;
 #else
-    ::std::integral_constant<bool, ::std::is_arithmetic_v<_Tp>::value &&
+    ::std::integral_constant<bool, ::std::is_arithmetic_v<_Tp> &&
                                        (::std::is_same_v<_BinaryOperation, ::std::plus<_Tp>> ||
                                         ::std::is_same_v<_BinaryOperation, ::std::plus<void>>)>;
 #endif // _ONEDPL_BACKEND_SYCL

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -20,6 +20,10 @@
 
 #include "utils.h"
 
+#if _ONEDPL_BACKEND_SYCL
+#    include "hetero/dpcpp/sycl_defs.h"
+#endif
+
 // This header defines the minimum set of vector routines required
 // to support Parallel STL.
 namespace oneapi
@@ -473,9 +477,17 @@ __simd_adjacent_find(_Index __first, _Index __last, _BinaryPredicate __pred, boo
 // It was created to reduce the code inside ::std::enable_if
 template <typename _Tp, typename _BinaryOperation>
 using is_arithmetic_plus =
-    ::std::integral_constant<bool, ::std::is_arithmetic<_Tp>::value &&
-                                       (::std::is_same<_BinaryOperation, ::std::plus<_Tp>>::value ||
-                                        ::std::is_same<_BinaryOperation, ::std::plus<void>>::value)>;
+#   if _ONEDPL_BACKEND_SYCL
+    ::std::integral_constant<bool, ::std::is_arithmetic_v<_Tp> &&
+                                       (::std::is_same_v<_BinaryOperation, ::std::plus<_Tp>> ||
+                                        ::std::is_same_v<_BinaryOperation, ::std::plus<void>> ||
+                                        ::std::is_same_v<_BinaryOperation, __dpl_sycl::__plus<_Tp>> ||
+                                        ::std::is_same_v<_BinaryOperation, __dpl_sycl::__plus<void>>)>;
+#   else
+    ::std::integral_constant<bool, ::std::is_arithmetic_v<_Tp>::value &&
+                                       (::std::is_same_v<_BinaryOperation, ::std::plus<_Tp>> ||
+                                        ::std::is_same_v<_BinaryOperation, ::std::plus<void>>)>;
+#   endif // _ONEDPL_BACKEND_SYCL
 
 template <typename _DifferenceType, typename _Tp, typename _BinaryOperation, typename _UnaryOperation>
 typename ::std::enable_if<is_arithmetic_plus<_Tp, _BinaryOperation>::value, _Tp>::type

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -472,7 +472,8 @@ __simd_adjacent_find(_Index __first, _Index __last, _BinaryPredicate __pred, boo
 
 // It was created to reduce the code inside ::std::enable_if
 template <typename _Tp, typename _BinaryOperation>
-using is_arithmetic_plus = ::std::integral_constant<bool, ::std::is_arithmetic<_Tp>::value &&
+using is_arithmetic_plus =
+    ::std::integral_constant<bool, ::std::is_arithmetic<_Tp>::value &&
                                        (::std::is_same<_BinaryOperation, ::std::plus<_Tp>>::value ||
                                         ::std::is_same<_BinaryOperation, ::std::plus<void>>::value)>;
 


### PR DESCRIPTION
In this PR we fix some places where ```std::plus<T>``` used ```without std::plus<void>```