### PR TITLE
[oneDPL] Radix sort one wg: Add unique kernel name for case that partially uses global memory

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
@@ -40,11 +40,14 @@ struct __subgroup_radix_sort
         using __block_size_t = ::std::integral_constant<::std::uint16_t, __block_size>;
         using __call_0_t = ::std::integral_constant<::std::uint16_t, 0>;
         using __call_1_t = ::std::integral_constant<::std::uint16_t, 1>;
+        using __call_2_t = ::std::integral_constant<::std::uint16_t, 2>;
 
         using _SortKernelLoc = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
             __radix_sort_one_wg_kernel<_KernelNameBase, __wg_size_t, __block_size_t, __call_0_t>>;
-        using _SortKernelGlob = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
+        using _SortKernelPartGlob = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
             __radix_sort_one_wg_kernel<_KernelNameBase, __wg_size_t, __block_size_t, __call_1_t>>;
+        using _SortKernelGlob = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
+            __radix_sort_one_wg_kernel<_KernelNameBase, __wg_size_t, __block_size_t, __call_2_t>>;
 
         using _KeyT = oneapi::dpl::__internal::__value_t<_RangeIn>;
         //check SLM size
@@ -53,8 +56,9 @@ struct __subgroup_radix_sort
             return __one_group_submitter<_SortKernelLoc>()(__q, ::std::forward<_RangeIn>(__src), __proj,
                                                            ::std::true_type{} /*SLM*/, ::std::true_type{} /*SLM*/);
         if (__SLM_available.second)
-            return __one_group_submitter<_SortKernelGlob>()(__q, ::std::forward<_RangeIn>(__src), __proj,
-                                                            ::std::false_type{} /*No SLM*/, ::std::true_type{} /*SLM*/);
+            return __one_group_submitter<_SortKernelPartGlob>()(__q, ::std::forward<_RangeIn>(__src), __proj,
+                                                                ::std::false_type{} /*No SLM*/,
+                                                                ::std::true_type{} /*SLM*/);
         return __one_group_submitter<_SortKernelGlob>()(__q, ::std::forward<_RangeIn>(__src), __proj,
                                                             ::std::false_type{} /*No SLM*/, ::std::false_type{} /*No SLM*/);
     }


### PR DESCRIPTION
This PR fixes a duplicate kernel name bug that arose with the recent changes to the one workgroup sort implementation. We now have three unique kernel types based on available SLM that each require a name: a case where we use an SLM buffer and SLM counter, no SLM buffer and SLM counter, and no SLM used at all. The current implementation only provides two kernel names which results in a compile error when compiled without unnamed lambdas enabled. This fix adds a new kernel name for the case where we have no SLM buffer and an SLM counter.