### PR TITLE
[oneDPL] + a fix for the oneDPL merge (merge Path)

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1362,38 +1362,38 @@ __find_start_point(const _Rng1& __rng1, const _Rng2& __rng2, _Index __i_elem, _I
 {
     _Index1 __start1 = 0;
     _Index2 __start2 = 0;
-    if (__i_elem < __n1) //a condition to specify upper or lower part of the merge matrix to be processed
+    if (__i_elem < __n2) //a condition to specify upper or lower part of the merge matrix to be processed
     {
         auto __q = __i_elem;                            //diagonal index
-        auto __n_diag = ::std::min<_Index2>(__q, __n2); //diagonal size
+        auto __n_diag = ::std::min<_Index2>(__q, __n1); //diagonal size
 
         //searching for the first '1', a lower bound for a diagonal [0, 0,..., 0, 1, 1,.... 1, 1]
         oneapi::dpl::counting_iterator<_Index> __diag_it(0);
         auto __res = ::std::lower_bound(__diag_it, __diag_it + __n_diag, 1/*value to find*/,
-            [&__rng1, &__rng2, __q, __comp](const auto& __i_diag, const auto& __value) mutable
+            [&__rng2, &__rng1, __q, __comp](const auto& __i_diag, const auto& __value) mutable
             {
-                auto __zero_or_one = __comp(__rng1[__q - __i_diag - 1], __rng2[__i_diag]);
+                auto __zero_or_one = __comp(__rng2[__q - __i_diag - 1], __rng1[__i_diag]);
                 return __zero_or_one < __value;
             });
-        __start1 = __q - *__res;
-        __start2 = *__res;
+        __start1 = *__res;
+        __start2 = __q - *__res;
     }
     else
     {
-        auto __q = __i_elem - __n1;                            //diagonal index
-        auto __n_diag = ::std::min<_Index1>(__n2 - __q, __n1); //diagonal size
+        auto __q = __i_elem - __n2;                            //diagonal index
+        auto __n_diag = ::std::min<_Index1>(__n1 - __q, __n2); //diagonal size
 
         //searching for the first '1', a lower bound for a diagonal [0, 0,..., 0, 1, 1,.... 1, 1]
         oneapi::dpl::counting_iterator<_Index> __diag_it(0);
         auto __res = ::std::lower_bound(__diag_it, __diag_it + __n_diag, 1/*value to find*/,
-            [&__rng1, &__rng2, __n1, __q, __comp](const auto& __i_diag, const auto& __value) mutable
+            [&__rng2, &__rng1, __n2, __q, __comp](const auto& __i_diag, const auto& __value) mutable
             {
-                auto __zero_or_one = __comp(__rng1[__n1 - __i_diag - 1], __rng2[__q + __i_diag]);
+                auto __zero_or_one = __comp(__rng2[__n2 - __i_diag - 1], __rng1[__q + __i_diag]);
                 return __zero_or_one < __value;
             });
 
-        __start1 = __n1 - *__res;
-        __start2 = __q + *__res;
+        __start1 = __q + *__res;
+        __start2 = __n2 - *__res;
     }
     return std::make_pair(__start1, __start2);
 }


### PR DESCRIPTION
[oneDPL] + a fix for the oneDPL merge (merge Path).
There was a kind of mess with ranges order to be merged, r1 and r2. 
A "merge" matrix was define for r2 and r1, but real merging for r1 and r2.
Actually a "merge" matrix has been "transposed" for the fix.