### PR TITLE
Lazy initialization of queue inside dpcpp_default policy

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -51,12 +51,14 @@ class device_policy
     {
     }
     explicit device_policy(sycl::queue q_) : q(q_) {}
-    explicit device_policy(sycl::device d_) : q(d_) {}
-    operator sycl::queue() const { return q; }
+    explicit device_policy(sycl::device d_) { q.emplace(d_); }
+    operator sycl::queue() const { return queue(); }
     sycl::queue
     queue() const
     {
-        return q;
+        if (!q)
+            q.emplace();
+        return *q;
     }
 
     // For internal use only
@@ -78,7 +80,7 @@ class device_policy
     }
 
   private:
-    sycl::queue q;
+    mutable ::std::optional<sycl::queue> q;
 };
 
 #if _ONEDPL_FPGA_DEVICE

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -106,9 +106,9 @@ class fpga_policy : public device_policy<KernelName>
         if (!this->q)
             this->q.emplace(
 #    if _ONEDPL_FPGA_EMU
-              __dpl_sycl::__fpga_emulator_selector()
+                __dpl_sycl::__fpga_emulator_selector()
 #    else
-              __dpl_sycl::__fpga_selector()
+                __dpl_sycl::__fpga_selector()
 #    endif // _ONEDPL_FPGA_EMU
             );
         return *this->q;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -55,15 +55,17 @@ class device_policy
 
     device_policy(const device_policy& other) : q(other.queue()) {}
     device_policy(device_policy&& other) : q(other.queue()) {}
-    device_policy& operator=(const device_policy& other)
+    device_policy&
+    operator=(const device_policy& other)
     {
-      q = other.queue();
-      return *this;
+        q = other.queue();
+        return *this;
     }
-    device_policy& operator=(device_policy&& other)
+    device_policy&
+    operator=(device_policy&& other)
     {
-      q.swap(other.q);
-      return *this;
+        q.swap(other.q);
+        return *this;
     }
 
     explicit device_policy(sycl::queue q_) : q(q_) {}

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -100,7 +100,7 @@ class fpga_policy : public device_policy<KernelName>
 #    else
               __dpl_sycl::__fpga_selector()
 #    endif // _ONEDPL_FPGA_EMU
-              ))
+                  ))
     {
     }
 


### PR DESCRIPTION
There are a few potential issues with oneDPL's global `sycl::queue`, including:

- Requirement that a SYCL device is available whenever oneDPL is included as mentioned in #1060
- Static initialization order fiasco with regard to queues being defined in other translation units

To address the issue, this PR lazily initializes the `sycl::queue` inside the `dpcpp_default` execution policy on first use.