### PR TITLE
[KT] Fix an error in the async free memory in esimd radix sort

### DIFF
--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
@@ -713,7 +713,7 @@ __onesweep(sycl::queue __q, _Range&& __rng, ::std::size_t __n)
     }
 
     __event_chain = __q.submit(
-        [&](sycl::handler& __cgh)
+        [__event_chain, __p_temp_memory, __q](sycl::handler& __cgh)
         {
             __cgh.depends_on(__event_chain);
             __cgh.host_task([&]() { sycl::free(__p_temp_memory, __q); });


### PR DESCRIPTION
Introduced in https://github.com/oneapi-src/oneDPL/pull/1057