### PR TITLE
[KT] Align names with the rest oneDPL code

### DIFF
--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort.h
@@ -27,11 +27,11 @@ namespace oneapi::dpl::experimental::kt::esimd::__impl
 {
 
 // TODO: allow calling it only for all_view (accessor) and guard_view (USM) ranges, views::subrange and sycl_iterator
-template <bool _IsAscending, ::std::uint8_t _RadixBits, typename _KernelParam, typename _Range>
+template <bool __is_ascending, ::std::uint8_t __radix_bits, typename _KernelParam, typename _Range>
 sycl::event
 __radix_sort(sycl::queue __q, _Range&& __rng, _KernelParam __param)
 {
-    static_assert(_RadixBits == 8);
+    static_assert(__radix_bits == 8);
 
     static_assert(32 <= __param.data_per_workitem && __param.data_per_workitem <= 512 &&
                   __param.data_per_workitem % 32 == 0);
@@ -48,14 +48,14 @@ __radix_sort(sycl::queue __q, _Range&& __rng, _KernelParam __param)
     if (__n <= __one_wg_cap)
     {
         // TODO: support different RadixBits values (only 7 or 8 are currently supported), WorkGroupSize
-        return __one_wg<_KernelName, _IsAscending, _RadixBits, __data_per_workitem, __workgroup_size>(
+        return __one_wg<_KernelName, __is_ascending, __radix_bits, __data_per_workitem, __workgroup_size>(
             __q, ::std::forward<_Range>(__rng), __n);
     }
     else
     {
         // TODO: avoid kernel duplication (generate the output storage with the same type as input storage and use swap)
         // TODO: support different RadixBits, WorkGroupSize
-        return __onesweep<_KernelName, _IsAscending, _RadixBits, __data_per_workitem, __workgroup_size>(
+        return __onesweep<_KernelName, __is_ascending, __radix_bits, __data_per_workitem, __workgroup_size>(
             __q, ::std::forward<_Range>(__rng), __n);
     }
 }
@@ -65,17 +65,17 @@ __radix_sort(sycl::queue __q, _Range&& __rng, _KernelParam __param)
 namespace oneapi::dpl::experimental::kt::esimd
 {
 
-template <bool _IsAscending = true, ::std::uint8_t _RadixBits = 8, typename _KernelParam, typename _Range>
+template <bool __is_ascending = true, ::std::uint8_t __radix_bits = 8, typename _KernelParam, typename _Range>
 sycl::event
 radix_sort(sycl::queue __q, _Range&& __rng, _KernelParam __param = {})
 {
     if (__rng.size() < 2)
         return {};
 
-    return __impl::__radix_sort<_IsAscending, _RadixBits>(__q, ::std::forward<_Range>(__rng), __param);
+    return __impl::__radix_sort<__is_ascending, __radix_bits>(__q, ::std::forward<_Range>(__rng), __param);
 }
 
-template <bool _IsAscending = true, ::std::uint8_t _RadixBits = 8, typename _KernelParam, typename _Iterator>
+template <bool __is_ascending = true, ::std::uint8_t __radix_bits = 8, typename _KernelParam, typename _Iterator>
 sycl::event
 radix_sort(sycl::queue __q, _Iterator __first, _Iterator __last, _KernelParam __param = {})
 {
@@ -85,7 +85,7 @@ radix_sort(sycl::queue __q, _Iterator __first, _Iterator __last, _KernelParam __
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<oneapi::dpl::__par_backend_hetero::access_mode::read_write,
                                                           _Iterator>();
     auto __rng = __keep(__first, __last);
-    return __impl::__radix_sort<_IsAscending, _RadixBits>(__q, __rng.all_view(), __param);
+    return __impl::__radix_sort<__is_ascending, __radix_bits>(__q, __rng.all_view(), __param);
 }
 
 } // namespace oneapi::dpl::experimental::kt::esimd

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_onesweep.h
@@ -19,8 +19,8 @@
 
 namespace oneapi::dpl::experimental::kt::esimd::__impl
 {
-template <typename _KeyT, typename _InputT, ::std::uint32_t _RadixBits, ::std::uint32_t _STAGES, ::std::uint32_t _WORK_GROUPS,
-          ::std::uint32_t _WORK_GROUP_SIZE, bool _IsAscending>
+template <typename _KeyT, typename _InputT, ::std::uint32_t __radix_bits, ::std::uint32_t __stage_count, ::std::uint32_t __hist_work_group_count,
+          ::std::uint32_t __hist_work_group_size, bool __is_ascending>
 void
 __global_histogram(sycl::nd_item<1> __idx, size_t __n, const _InputT& __input, ::std::uint32_t* __p_global_offset)
 {
@@ -28,113 +28,113 @@ __global_histogram(sycl::nd_item<1> __idx, size_t __n, const _InputT& __input, :
     using namespace __dpl_esimd_ns;
     using namespace __dpl_esimd_ens;
 
-    using _bin_t = ::std::uint16_t;
-    using _hist_t = ::std::uint32_t;
-    using _global_hist_t = ::std::uint32_t;
+    using _BinT = ::std::uint16_t;
+    using _HistT = ::std::uint32_t;
+    using _GlobalHistT = ::std::uint32_t;
 
     slm_init(16384);
 
-    constexpr ::std::uint32_t _BIN_COUNT = 1 << _RadixBits;
-    constexpr ::std::uint32_t _DATA_PER_WORK_ITEM = 128;
-    constexpr ::std::uint32_t _DEVICE_WIDE_STEP = _WORK_GROUPS * _WORK_GROUP_SIZE * _DATA_PER_WORK_ITEM;
+    constexpr ::std::uint32_t __bin_count = 1 << __radix_bits;
+    constexpr ::std::uint32_t __hist_data_per_work_item = 128;
+    constexpr ::std::uint32_t __device_wide_step = __hist_work_group_count * __hist_work_group_size * __hist_data_per_work_item;
 
     // Cap the number of histograms to reduce in SLM per __input range read pass
     // due to excessive GRF usage for thread-local histograms
-    constexpr ::std::uint32_t _STAGES_PER_BLOCK = sizeof(_KeyT) < 4 ? sizeof(_KeyT) : 4;
-    constexpr ::std::uint32_t _STAGE_BLOCKS = oneapi::dpl::__internal::__dpl_ceiling_div(_STAGES, _STAGES_PER_BLOCK);
+    constexpr ::std::uint32_t __stages_per_block = sizeof(_KeyT) < 4 ? sizeof(_KeyT) : 4;
+    constexpr ::std::uint32_t __stage_block_count = oneapi::dpl::__internal::__dpl_ceiling_div(__stage_count, __stages_per_block);
 
-    constexpr ::std::uint32_t _HIST_BUFFER_SIZE = _STAGES * _BIN_COUNT;
-    constexpr ::std::uint32_t _HIST_DATA_PER_WORK_ITEM = _HIST_BUFFER_SIZE / _WORK_GROUP_SIZE;
+    constexpr ::std::uint32_t __hist_buffer_size = __stage_count * __bin_count;
+    constexpr ::std::uint32_t __group_hist_size = __hist_buffer_size / __hist_work_group_size;
 
-    static_assert(_DATA_PER_WORK_ITEM % _DATA_PER_STEP == 0);
-    static_assert(_BIN_COUNT * _STAGES_PER_BLOCK % _DATA_PER_STEP == 0);
+    static_assert(__hist_data_per_work_item % __data_per_step == 0);
+    static_assert(__bin_count * __stages_per_block % __data_per_step == 0);
 
-    simd<_KeyT, _DATA_PER_WORK_ITEM> __keys;
-    simd<_bin_t, _DATA_PER_WORK_ITEM> __bins;
+    simd<_KeyT, __hist_data_per_work_item> __keys;
+    simd<_BinT, __hist_data_per_work_item> __bins;
 
     const ::std::uint32_t __local_id = __idx.get_local_linear_id();
     const ::std::uint32_t __global_id = __idx.get_global_linear_id();
 
     // 0. Early exit for threads without work
-    if ((__global_id - __local_id) * _DATA_PER_WORK_ITEM > __n)
+    if ((__global_id - __local_id) * __hist_data_per_work_item > __n)
     {
         return;
     }
 
     // 1. Initialize group-local histograms in SLM
-    __utils::_BlockStoreSlm<_global_hist_t, _HIST_DATA_PER_WORK_ITEM>(
-        __local_id * _HIST_DATA_PER_WORK_ITEM * sizeof(_global_hist_t), 0);
+    __utils::__block_store_slm<_GlobalHistT, __group_hist_size>(
+        __local_id * __group_hist_size * sizeof(_GlobalHistT), 0);
     barrier();
 
 #pragma unroll
-    for (::std::uint32_t __stage_block = 0; __stage_block < _STAGE_BLOCKS; ++__stage_block)
+    for (::std::uint32_t __stage_block = 0; __stage_block < __stage_block_count; ++__stage_block)
     {
-        simd<_global_hist_t, _BIN_COUNT * _STAGES_PER_BLOCK> __state_hist_grf(0);
-        ::std::uint32_t __stage_block_start = __stage_block * _STAGES_PER_BLOCK;
+        simd<_GlobalHistT, __bin_count * __stages_per_block> __state_hist_grf(0);
+        ::std::uint32_t __stage_block_start = __stage_block * __stages_per_block;
 
-        for (::std::uint32_t __wi_offset = __global_id * _DATA_PER_WORK_ITEM; __wi_offset < __n; __wi_offset += _DEVICE_WIDE_STEP)
+        for (::std::uint32_t __wi_offset = __global_id * __hist_data_per_work_item; __wi_offset < __n; __wi_offset += __device_wide_step)
         {
             // 1. Read __keys
-            // TODO: avoid reading global memory twice when _STAGE_BLOCKS > 1 increasing _DATA_PER_WORK_ITEM
-            if (__wi_offset + _DATA_PER_WORK_ITEM < __n)
+            // TODO: avoid reading global memory twice when __stage_block_count > 1 increasing __hist_data_per_work_item
+            if (__wi_offset + __hist_data_per_work_item < __n)
             {
                 __utils::__copy_from(__input, __wi_offset, __keys);
             }
             else
             {
-                simd<::std::uint32_t, _DATA_PER_STEP> __lane_offsets(0, 1);
+                simd<::std::uint32_t, __data_per_step> __lane_offsets(0, 1);
 #pragma unroll
-                for (::std::uint32_t __step_offset = 0; __step_offset < _DATA_PER_WORK_ITEM; __step_offset += _DATA_PER_STEP)
+                for (::std::uint32_t __step_offset = 0; __step_offset < __hist_data_per_work_item; __step_offset += __data_per_step)
                 {
-                    simd<::std::uint32_t, _DATA_PER_STEP> __offsets = __lane_offsets + __step_offset + __wi_offset;
-                    simd_mask<_DATA_PER_STEP> __is_in_range = __offsets < __n;
-                    simd<_KeyT, _DATA_PER_STEP> data = __utils::__gather<_KeyT, _DATA_PER_STEP>(__input, __offsets, 0, __is_in_range);
-                    simd<_KeyT, _DATA_PER_STEP> sort_identities = __utils::__sort_identity<_KeyT, _IsAscending>();
-                    __keys.template select<_DATA_PER_STEP, 1>(__step_offset) = merge(data, sort_identities, __is_in_range);
+                    simd<::std::uint32_t, __data_per_step> __offsets = __lane_offsets + __step_offset + __wi_offset;
+                    simd_mask<__data_per_step> __is_in_range = __offsets < __n;
+                    simd<_KeyT, __data_per_step> data = __utils::__gather<_KeyT, __data_per_step>(__input, __offsets, 0, __is_in_range);
+                    simd<_KeyT, __data_per_step> sort_identities = __utils::__sort_identity<_KeyT, __is_ascending>();
+                    __keys.template select<__data_per_step, 1>(__step_offset) = merge(data, sort_identities, __is_in_range);
                 }
             }
             // 2. Calculate thread-local histogram in GRF
 #pragma unroll
-            for (::std::uint32_t __stage_local = 0; __stage_local < _STAGES_PER_BLOCK; ++__stage_local)
+            for (::std::uint32_t __stage_local = 0; __stage_local < __stages_per_block; ++__stage_local)
             {
-                constexpr _bin_t _MASK = _BIN_COUNT - 1;
+                constexpr _BinT __mask = __bin_count - 1;
                 ::std::uint32_t __stage_global = __stage_block_start + __stage_local;
-                __bins = __utils::__get_bucket<_MASK>(__utils::__order_preserving_cast<_IsAscending>(__keys),
-                                                 __stage_global * _RadixBits);
+                __bins = __utils::__get_bucket<__mask>(__utils::__order_preserving_cast<__is_ascending>(__keys),
+                                                 __stage_global * __radix_bits);
 #pragma unroll
-                for (::std::uint32_t __i = 0; __i < _DATA_PER_WORK_ITEM; ++__i)
+                for (::std::uint32_t __i = 0; __i < __hist_data_per_work_item; ++__i)
                 {
-                    ++__state_hist_grf[__stage_local * _BIN_COUNT + __bins[__i]];
+                    ++__state_hist_grf[__stage_local * __bin_count + __bins[__i]];
                 }
             }
         }
 
         // 3. Reduce thread-local histograms from GRF into group-local histograms in SLM
 #pragma unroll
-        for (::std::uint32_t __grf_offset = 0; __grf_offset < _BIN_COUNT * _STAGES_PER_BLOCK; __grf_offset += _DATA_PER_STEP)
+        for (::std::uint32_t __grf_offset = 0; __grf_offset < __bin_count * __stages_per_block; __grf_offset += __data_per_step)
         {
-            ::std::uint32_t slm_offset = __stage_block_start * _BIN_COUNT + __grf_offset;
-            simd<::std::uint32_t, _DATA_PER_STEP> __slm_byte_offsets(slm_offset * sizeof(_global_hist_t), sizeof(_global_hist_t));
-            lsc_slm_atomic_update<atomic_op::add, _global_hist_t, _DATA_PER_STEP>(
-                __slm_byte_offsets, __state_hist_grf.template select<_DATA_PER_STEP, 1>(__grf_offset), 1);
+            ::std::uint32_t slm_offset = __stage_block_start * __bin_count + __grf_offset;
+            simd<::std::uint32_t, __data_per_step> __slm_byte_offsets(slm_offset * sizeof(_GlobalHistT), sizeof(_GlobalHistT));
+            lsc_slm_atomic_update<atomic_op::add, _GlobalHistT, __data_per_step>(
+                __slm_byte_offsets, __state_hist_grf.template select<__data_per_step, 1>(__grf_offset), 1);
         }
         barrier();
     }
 
     // 4. Reduce group-local historgrams from SLM into global histograms in global memory
-    simd<_global_hist_t, _HIST_DATA_PER_WORK_ITEM> __group_hist =
-        __utils::_BlockLoadSlm<_global_hist_t, _HIST_DATA_PER_WORK_ITEM>(__local_id * _HIST_DATA_PER_WORK_ITEM *
-                                                                    sizeof(_global_hist_t));
-    simd<::std::uint32_t, _HIST_DATA_PER_WORK_ITEM> __byte_offsets(0, sizeof(_global_hist_t));
-    lsc_atomic_update<atomic_op::add>(__p_global_offset + __local_id * _HIST_DATA_PER_WORK_ITEM, __byte_offsets, __group_hist,
-                                      simd_mask<_HIST_DATA_PER_WORK_ITEM>(1));
+    simd<_GlobalHistT, __group_hist_size> __group_hist =
+        __utils::__block_load_slm<_GlobalHistT, __group_hist_size>(__local_id * __group_hist_size *
+                                                                    sizeof(_GlobalHistT));
+    simd<::std::uint32_t, __group_hist_size> __byte_offsets(0, sizeof(_GlobalHistT));
+    lsc_atomic_update<atomic_op::add>(__p_global_offset + __local_id * __group_hist_size, __byte_offsets, __group_hist,
+                                      simd_mask<__group_hist_size>(1));
 }
 
-template <::std::uint32_t _BITS>
+template <::std::uint32_t __bit_count>
 inline __dpl_esimd_ns::simd<::std::uint32_t, 32>
 __match_bins(__dpl_esimd_ns::simd<::std::uint32_t, 32> __bins, ::std::uint32_t __local_tid)
 {
-    //instruction count is 5*_BITS, so 40 for 8 bits.
+    //instruction count is 5*__bit_count, so 40 for 8 bits.
     //performance is about 2 u per __bit for processing size 512 (will call this 16 times)
     // per bits 5 inst * 16 segments * 4 stages = 320 instructions, * 8 threads = 2560, /1.6G = 1.6 us.
     // 8 bits is 12.8 us
@@ -142,12 +142,12 @@ __match_bins(__dpl_esimd_ns::simd<::std::uint32_t, 32> __bins, ::std::uint32_t _
     fence<fence_mask::sw_barrier>();
     simd<::std::uint32_t, 32> __matched_bins(0xffffffff);
 #pragma unroll
-    for (int __i = 0; __i < _BITS; __i++)
+    for (int __i = 0; __i < __bit_count; __i++)
     {
-        simd<::std::uint32_t, 32> __bit = (__bins >> __i) & 1;                                  // and
+        simd<::std::uint32_t, 32> __bit = (__bins >> __i) & 1;                                         // and
         simd<::std::uint32_t, 32> __x = __dpl_esimd_ns::merge<::std::uint32_t, 32>(0, -1, __bit != 0); // sel
-        ::std::uint32_t __ones = pack_mask(__bit != 0);                                         // mov
-        __matched_bins = __matched_bins & (__x ^ __ones);                                // bfn
+        ::std::uint32_t __ones = pack_mask(__bit != 0);                                                // mov
+        __matched_bins = __matched_bins & (__x ^ __ones);                                              // bfn
     }
     fence<fence_mask::sw_barrier>();
     return __matched_bins;
@@ -159,55 +159,54 @@ struct _slm_lookup_t
     ::std::uint32_t __slm;
     inline _slm_lookup_t(::std::uint32_t __slm) : __slm(__slm) {}
 
-    template <int _TABLE_SIZE>
+    template <int __table_size>
     inline void
-    setup(__dpl_esimd_ns::simd<_T, _TABLE_SIZE> __source) SYCL_ESIMD_FUNCTION
+    __setup(__dpl_esimd_ns::simd<_T, __table_size> __source) SYCL_ESIMD_FUNCTION
     {
-        __utils::_BlockStoreSlm<_T, _TABLE_SIZE>(__slm, __source);
+        __utils::__block_store_slm<_T, __table_size>(__slm, __source);
     }
 
-    template <int _N, typename _IDX>
+    template <int _N, typename _Idx>
     inline auto
-    lookup(_IDX __idx) SYCL_ESIMD_FUNCTION
+    __lookup(_Idx __idx) SYCL_ESIMD_FUNCTION
     {
-        return __utils::_VectorLoad<_T, 1, _N>(__slm + __dpl_esimd_ns::simd<::std::uint32_t, _N>(__idx) * sizeof(_T));
+        return __utils::__vector_load<_T, 1, _N>(__slm + __dpl_esimd_ns::simd<::std::uint32_t, _N>(__idx) * sizeof(_T));
     }
 
-    template <int _N, int _TABLE_SIZE, typename _IDX>
+    template <int _N, int __table_size, typename _Idx>
     inline auto
-    lookup(__dpl_esimd_ns::simd<_T, _TABLE_SIZE> __source, _IDX __idx) SYCL_ESIMD_FUNCTION
+    __lookup(__dpl_esimd_ns::simd<_T, __table_size> __source, _Idx __idx) SYCL_ESIMD_FUNCTION
     {
-        setup(__source);
-        return lookup<_N>(__idx);
+        __setup(__source);
+        return __lookup<_N>(__idx);
     }
 };
 
-template <bool _IsAscending, ::std::uint8_t _RadixBits, ::std::uint16_t _DataPerWorkItem,
-          ::std::uint16_t _WorkGroupSize, typename _KeyT, typename _InputT, typename _OutputT>
+template <bool __is_ascending, ::std::uint8_t __radix_bits, ::std::uint16_t __data_per_work_item,
+          ::std::uint16_t __work_group_size, typename _KeyT, typename _InputT, typename _OutputT>
 struct __radix_sort_onesweep_slm_reorder_kernel
 {
-    using _bin_t = ::std::uint16_t;
-    using _hist_t = ::std::uint16_t;
-    using _global_hist_t = ::std::uint32_t;
-    using _device_addr_t = ::std::uint32_t;
+    using _BinT = ::std::uint16_t;
+    using _HistT = ::std::uint16_t;
+    using _GlobalHistT = ::std::uint32_t;
+    using _DeviceAddrT = ::std::uint32_t;
 
-    static constexpr ::std::uint32_t _BIN_COUNT = 1 << _RadixBits;
-    static constexpr ::std::uint32_t _NBITS = sizeof(_KeyT) * 8;
-    static constexpr ::std::uint32_t _STAGES = oneapi::dpl::__internal::__dpl_ceiling_div(_NBITS, _RadixBits);
-    static constexpr _bin_t _MASK = _BIN_COUNT - 1;
-    static constexpr ::std::uint32_t _REORDER_SLM_SIZE = _DataPerWorkItem * sizeof(_KeyT) * _WorkGroupSize;
-    static constexpr ::std::uint32_t _BIN_HIST_SLM_SIZE = _BIN_COUNT * sizeof(_hist_t) * _WorkGroupSize;
-    static constexpr ::std::uint32_t _SUBGROUP_LOOKUP_SIZE = _BIN_COUNT * sizeof(_hist_t) * _WorkGroupSize;
-    static constexpr ::std::uint32_t _GLOBAL_LOOKUP_SIZE = _BIN_COUNT * sizeof(_global_hist_t);
-    static constexpr ::std::uint32_t _INCOMING_OFFSET_SLM_SIZE = (_BIN_COUNT+1)*sizeof(_hist_t);
-    static constexpr ::std::uint32_t _OFFSETS_SLM_SIZE = _BIN_HIST_SLM_SIZE + _GLOBAL_LOOKUP_SIZE + _INCOMING_OFFSET_SLM_SIZE;
+    static constexpr ::std::uint32_t __bin_count = 1 << __radix_bits;
+    static constexpr ::std::uint32_t __bit_count = sizeof(_KeyT) * 8;
+    static constexpr ::std::uint32_t __stage_count = oneapi::dpl::__internal::__dpl_ceiling_div(__bit_count, __radix_bits);
+    static constexpr _BinT __mask = __bin_count - 1;
+    static constexpr ::std::uint32_t __reorder_slm_size = __data_per_work_item * sizeof(_KeyT) * __work_group_size;
+    static constexpr ::std::uint32_t __bin_hist_slm_size = __bin_count * sizeof(_HistT) * __work_group_size;
+    static constexpr ::std::uint32_t __sub_group_lookup_size = __bin_count * sizeof(_HistT) * __work_group_size;
+    static constexpr ::std::uint32_t __global_lookup_size = __bin_count * sizeof(_GlobalHistT);
+    static constexpr ::std::uint32_t __incoming_offset_slm_size = (__bin_count+1)*sizeof(_HistT);
 
     // slm allocation:
-    // first stage, do subgroup ranks, need _WorkGroupSize*_BIN_COUNT*sizeof(_hist_t)
-    // then do rank roll up in workgroup, need _WorkGroupSize*_BIN_COUNT*sizeof(_hist_t) + _BIN_COUNT*sizeof(_hist_t) + _BIN_COUNT*sizeof(_global_hist_t)
-    // after all these is done, update ranks to workgroup ranks, need _SUBGROUP_LOOKUP_SIZE
-    // then shuffle keys to workgroup order in SLM, need _DataPerWorkItem * sizeof(_KeyT) * _WorkGroupSize
-    // then read reordered slm and look up global fix, need _GLOBAL_LOOKUP_SIZE on top
+    // first stage, do subgroup ranks, need __work_group_size*__bin_count*sizeof(_HistT)
+    // then do rank roll up in workgroup, need __work_group_size*__bin_count*sizeof(_HistT) + __bin_count*sizeof(_HistT) + __bin_count*sizeof(_GlobalHistT)
+    // after all these is done, update ranks to workgroup ranks, need __sub_group_lookup_size
+    // then shuffle keys to workgroup order in SLM, need __data_per_work_item * sizeof(_KeyT) * __work_group_size
+    // then read reordered slm and look up global fix, need __global_lookup_size on top
 
     const ::std::uint32_t __n;
     const ::std::uint32_t __stage;
@@ -222,72 +221,72 @@ struct __radix_sort_onesweep_slm_reorder_kernel
     }
 
     inline void
-    _LoadKeys(::std::uint32_t __io_offset, __dpl_esimd_ns::simd<_KeyT, _DataPerWorkItem>& __keys, _KeyT __default_key) const
+    __load_keys(::std::uint32_t __io_offset, __dpl_esimd_ns::simd<_KeyT, __data_per_work_item>& __keys, _KeyT __default_key) const
     {
         using namespace __dpl_esimd_ns;
         using namespace __dpl_esimd_ens;
 
-        static_assert(_DataPerWorkItem % _DATA_PER_STEP == 0);
+        static_assert(__data_per_work_item % __data_per_step == 0);
 
-        bool __is_full_block = (__io_offset + _DataPerWorkItem) < __n;
+        bool __is_full_block = (__io_offset + __data_per_work_item) < __n;
         if (__is_full_block)
         {
-            simd<::std::uint32_t, _DATA_PER_STEP> __lane_id(0, 1);
+            simd<::std::uint32_t, __data_per_step> __lane_id(0, 1);
 #pragma unroll
-            for (::std::uint32_t __s = 0; __s < _DataPerWorkItem; __s += _DATA_PER_STEP)
+            for (::std::uint32_t __s = 0; __s < __data_per_work_item; __s += __data_per_step)
             {
                 __dpl_esimd_ns::simd __offset = __io_offset + __s + __lane_id;
-                __keys.template select<_DATA_PER_STEP, 1>(__s) = __utils::__gather<_KeyT, _DATA_PER_STEP>(__input, __offset, 0);
+                __keys.template select<__data_per_step, 1>(__s) = __utils::__gather<_KeyT, __data_per_step>(__input, __offset, 0);
             }
         }
         else
         {
-            simd<::std::uint32_t, _DATA_PER_STEP> __lane_id(0, 1);
+            simd<::std::uint32_t, __data_per_step> __lane_id(0, 1);
 #pragma unroll
-            for (::std::uint32_t __s = 0; __s < _DataPerWorkItem; __s += _DATA_PER_STEP)
+            for (::std::uint32_t __s = 0; __s < __data_per_work_item; __s += __data_per_step)
             {
                 __dpl_esimd_ns::simd __offset = __io_offset + __s + __lane_id;
-                simd_mask<_DATA_PER_STEP> __m = __offset < __n;
-                __keys.template select<_DATA_PER_STEP, 1>(__s) = merge(__utils::__gather<_KeyT, _DATA_PER_STEP>(__input, __offset, 0, __m),
-                                                                  simd<_KeyT, _DATA_PER_STEP>(__default_key), __m);
+                simd_mask<__data_per_step> __m = __offset < __n;
+                __keys.template select<__data_per_step, 1>(__s) = merge(__utils::__gather<_KeyT, __data_per_step>(__input, __offset, 0, __m),
+                                                                  simd<_KeyT, __data_per_step>(__default_key), __m);
             }
         }
     }
 
     inline void
-    _ResetBinCounters(::std::uint32_t __slm_bin_hist_this_thread) const
+    __reset_bin_counters(::std::uint32_t __slm_bin_hist_this_thread) const
     {
-        __utils::_BlockStoreSlm<_hist_t, _BIN_COUNT>(__slm_bin_hist_this_thread, 0);
+        __utils::__block_store_slm<_HistT, __bin_count>(__slm_bin_hist_this_thread, 0);
     }
 
     inline auto
-    RankSLM(__dpl_esimd_ns::simd<_bin_t, _DataPerWorkItem> __bins, ::std::uint32_t __slm_counter_offset, ::std::uint32_t __local_tid) const
+    RankSLM(__dpl_esimd_ns::simd<_BinT, __data_per_work_item> __bins, ::std::uint32_t __slm_counter_offset, ::std::uint32_t __local_tid) const
     {
         using namespace __dpl_esimd_ns;
         using namespace __dpl_esimd_ens;
 
         constexpr int _BinsPerStep = 32;
-        static_assert(_DataPerWorkItem % _BinsPerStep == 0);
+        static_assert(__data_per_work_item % _BinsPerStep == 0);
 
-        constexpr ::std::uint32_t _BIN_COUNT = 1 << _RadixBits;
-        simd<::std::uint32_t, _DataPerWorkItem> __ranks;
-        __utils::_BlockStoreSlm<_hist_t, _BIN_COUNT>(__slm_counter_offset, 0);
+        constexpr ::std::uint32_t __bin_count = 1 << __radix_bits;
+        simd<::std::uint32_t, __data_per_work_item> __ranks;
+        __utils::__block_store_slm<_HistT, __bin_count>(__slm_counter_offset, 0);
         simd<::std::uint32_t, _BinsPerStep> __remove_right_lanes, __lane_id(0, 1);
         __remove_right_lanes = 0x7fffffff >> (_BinsPerStep - 1 - __lane_id);
 #pragma unroll
-        for (::std::uint32_t __s = 0; __s < _DataPerWorkItem; __s += _BinsPerStep)
+        for (::std::uint32_t __s = 0; __s < __data_per_work_item; __s += _BinsPerStep)
         {
             simd<::std::uint32_t, _BinsPerStep> __this_bins = __bins.template select<_BinsPerStep, 1>(__s);
-            simd<::std::uint32_t, _BinsPerStep> __matched_bins = __match_bins<_RadixBits>(__this_bins, __local_tid); // 40 insts
+            simd<::std::uint32_t, _BinsPerStep> __matched_bins = __match_bins<__radix_bits>(__this_bins, __local_tid); // 40 insts
             simd<::std::uint32_t, _BinsPerStep> __pre_rank, __this_round_rank;
-            __pre_rank = __utils::_VectorLoad<_hist_t, 1, _BinsPerStep>(__slm_counter_offset +
-                                                                 __this_bins * sizeof(_hist_t)); // 2 mad+load.__slm
+            __pre_rank = __utils::__vector_load<_HistT, 1, _BinsPerStep>(__slm_counter_offset +
+                                                                 __this_bins * sizeof(_HistT)); // 2 mad+load.__slm
             auto __matched_left_lanes = __matched_bins & __remove_right_lanes;
             __this_round_rank = cbit(__matched_left_lanes);
             auto __this_round_count = cbit(__matched_bins);
             auto __rank_after = __pre_rank + __this_round_rank;
             auto __is_leader = __this_round_rank == __this_round_count - 1;
-            __utils::_VectorStore<_hist_t, 1, _BinsPerStep>(__slm_counter_offset + __this_bins * sizeof(_hist_t), __rank_after + 1,
+            __utils::__vector_store<_HistT, 1, _BinsPerStep>(__slm_counter_offset + __this_bins * sizeof(_HistT), __rank_after + 1,
                                                        __is_leader);
             __ranks.template select<_BinsPerStep, 1>(__s) = __rank_after;
         }
@@ -295,9 +294,9 @@ struct __radix_sort_onesweep_slm_reorder_kernel
     }
 
     inline void
-    _UpdateGroupRank(::std::uint32_t __local_tid, ::std::uint32_t __wg_id, __dpl_esimd_ns::simd<_hist_t, _BIN_COUNT>& __subgroup_offset,
-                    __dpl_esimd_ns::simd<_global_hist_t, _BIN_COUNT>& __global_fix, _global_hist_t* __p_global_bin_prev_group,
-                    _global_hist_t* __p_global_bin_this_group) const
+    __update_group_rank(::std::uint32_t __local_tid, ::std::uint32_t __wg_id, __dpl_esimd_ns::simd<_HistT, __bin_count>& __subgroup_offset,
+                    __dpl_esimd_ns::simd<_GlobalHistT, __bin_count>& __global_fix, _GlobalHistT* __p_global_bin_prev_group,
+                    _GlobalHistT* __p_global_bin_this_group) const
     {
         using namespace __dpl_esimd_ns;
         using namespace __dpl_esimd_ens;
@@ -307,88 +306,88 @@ struct __radix_sort_onesweep_slm_reorder_kernel
         then last row do exclusive scan as group incoming __offset
         then every thread add local sum with sum of previous group and incoming __offset
         */
-        constexpr ::std::uint32_t _HIST_STRIDE = sizeof(_hist_t) * _BIN_COUNT;
-        const ::std::uint32_t __slm_bin_hist_this_thread = __local_tid * _HIST_STRIDE;
-        const ::std::uint32_t __slm_bin_hist_group_incoming = _WorkGroupSize * _HIST_STRIDE;
-        const ::std::uint32_t __slm_bin_hist_global_incoming = __slm_bin_hist_group_incoming + _HIST_STRIDE;
-        constexpr ::std::uint32_t _GLOBAL_ACCUMULATED = 0x40000000;
-        constexpr ::std::uint32_t _HIST_UPDATED = 0x80000000;
-        constexpr ::std::uint32_t _GLOBAL_OFFSET_MASK = 0x3fffffff;
+        constexpr ::std::uint32_t __hist_stride = sizeof(_HistT) * __bin_count;
+        const ::std::uint32_t __slm_bin_hist_this_thread = __local_tid * __hist_stride;
+        const ::std::uint32_t __slm_bin_hist_group_incoming = __work_group_size * __hist_stride;
+        const ::std::uint32_t __slm_bin_hist_global_incoming = __slm_bin_hist_group_incoming + __hist_stride;
+        constexpr ::std::uint32_t __global_accumulated = 0x40000000;
+        constexpr ::std::uint32_t __hist_updated = 0x80000000;
+        constexpr ::std::uint32_t __global_offset_mask = 0x3fffffff;
         {
             barrier();
-            constexpr ::std::uint32_t _BIN_SUMMARY_GROUP_SIZE = 8;
-            constexpr ::std::uint32_t _BIN_WIDTH = _BIN_COUNT / _BIN_SUMMARY_GROUP_SIZE;
+            constexpr ::std::uint32_t __bin_summary_group_size = 8;
+            constexpr ::std::uint32_t __bin_width = __bin_count / __bin_summary_group_size;
 
-            static_assert(_BIN_COUNT % _BIN_WIDTH == 0);
+            static_assert(__bin_count % __bin_width == 0);
 
-            simd<_hist_t, _BIN_WIDTH> __thread_grf_hist_summary(0);
-            if (__local_tid < _BIN_SUMMARY_GROUP_SIZE)
+            simd<_HistT, __bin_width> __thread_grf_hist_summary(0);
+            if (__local_tid < __bin_summary_group_size)
             {
-                ::std::uint32_t __slm_bin_hist_summary_offset = __local_tid * _BIN_WIDTH * sizeof(_hist_t);
-                for (::std::uint32_t __s = 0; __s < _WorkGroupSize; __s++, __slm_bin_hist_summary_offset += _HIST_STRIDE)
+                ::std::uint32_t __slm_bin_hist_summary_offset = __local_tid * __bin_width * sizeof(_HistT);
+                for (::std::uint32_t __s = 0; __s < __work_group_size; __s++, __slm_bin_hist_summary_offset += __hist_stride)
                 {
-                    __thread_grf_hist_summary += __utils::_BlockLoadSlm<_hist_t, _BIN_WIDTH>(__slm_bin_hist_summary_offset);
-                    __utils::_BlockStoreSlm(__slm_bin_hist_summary_offset, __thread_grf_hist_summary);
+                    __thread_grf_hist_summary += __utils::__block_load_slm<_HistT, __bin_width>(__slm_bin_hist_summary_offset);
+                    __utils::__block_store_slm(__slm_bin_hist_summary_offset, __thread_grf_hist_summary);
                 }
 
-                __utils::_BlockStoreSlm(__slm_bin_hist_group_incoming + __local_tid * _BIN_WIDTH * sizeof(_hist_t),
-                                     __utils::__scan<_hist_t, _hist_t>(__thread_grf_hist_summary));
+                __utils::__block_store_slm(__slm_bin_hist_group_incoming + __local_tid * __bin_width * sizeof(_HistT),
+                                     __utils::__scan<_HistT, _HistT>(__thread_grf_hist_summary));
                 if (__wg_id != 0)
-                    __utils::_BlockStore<::std::uint32_t, _BIN_WIDTH>(__p_global_bin_this_group + __local_tid * _BIN_WIDTH,
-                                                           __thread_grf_hist_summary | _HIST_UPDATED);
+                    __utils::__block_store<::std::uint32_t, __bin_width>(__p_global_bin_this_group + __local_tid * __bin_width,
+                                                           __thread_grf_hist_summary | __hist_updated);
             }
             barrier();
-            if (__local_tid == _BIN_SUMMARY_GROUP_SIZE + 1)
+            if (__local_tid == __bin_summary_group_size + 1)
             {
                 // this thread to group scan
-                simd<_hist_t, _BIN_COUNT> __grf_hist_summary;
-                simd<_hist_t, _BIN_COUNT + 1> __grf_hist_summary_scan;
-                __grf_hist_summary = __utils::_BlockLoadSlm<_hist_t, _BIN_COUNT>(__slm_bin_hist_group_incoming);
+                simd<_HistT, __bin_count> __grf_hist_summary;
+                simd<_HistT, __bin_count + 1> __grf_hist_summary_scan;
+                __grf_hist_summary = __utils::__block_load_slm<_HistT, __bin_count>(__slm_bin_hist_group_incoming);
                 __grf_hist_summary_scan[0] = 0;
-                __grf_hist_summary_scan.template select<_BIN_WIDTH, 1>(1) =
-                    __grf_hist_summary.template select<_BIN_WIDTH, 1>(0);
+                __grf_hist_summary_scan.template select<__bin_width, 1>(1) =
+                    __grf_hist_summary.template select<__bin_width, 1>(0);
 #pragma unroll
-                for (::std::uint32_t __i = _BIN_WIDTH; __i < _BIN_COUNT; __i += _BIN_WIDTH)
+                for (::std::uint32_t __i = __bin_width; __i < __bin_count; __i += __bin_width)
                 {
-                    __grf_hist_summary_scan.template select<_BIN_WIDTH, 1>(__i + 1) =
-                        __grf_hist_summary.template select<_BIN_WIDTH, 1>(__i) + __grf_hist_summary_scan[__i];
+                    __grf_hist_summary_scan.template select<__bin_width, 1>(__i + 1) =
+                        __grf_hist_summary.template select<__bin_width, 1>(__i) + __grf_hist_summary_scan[__i];
                 }
-                __utils::_BlockStoreSlm<_hist_t, _BIN_COUNT>(__slm_bin_hist_group_incoming,
-                                                        __grf_hist_summary_scan.template select<_BIN_COUNT, 1>());
+                __utils::__block_store_slm<_HistT, __bin_count>(__slm_bin_hist_group_incoming,
+                                                        __grf_hist_summary_scan.template select<__bin_count, 1>());
             }
-            else if (__local_tid < _BIN_SUMMARY_GROUP_SIZE)
+            else if (__local_tid < __bin_summary_group_size)
             {
                 // these threads to global sync and update
-                simd<_global_hist_t, _BIN_WIDTH> __prev_group_hist_sum(0), __prev_group_hist;
-                simd_mask<_BIN_WIDTH> __is_not_accumulated(1);
+                simd<_GlobalHistT, __bin_width> __prev_group_hist_sum(0), __prev_group_hist;
+                simd_mask<__bin_width> __is_not_accumulated(1);
                 do
                 {
                     do
                     {
                         __prev_group_hist =
-                            lsc_block_load<_global_hist_t, _BIN_WIDTH, lsc_data_size::default_size, cache_hint::uncached,
-                                           cache_hint::cached>(__p_global_bin_prev_group + __local_tid * _BIN_WIDTH);
+                            lsc_block_load<_GlobalHistT, __bin_width, lsc_data_size::default_size, cache_hint::uncached,
+                                           cache_hint::cached>(__p_global_bin_prev_group + __local_tid * __bin_width);
                         fence<fence_mask::sw_barrier>();
-                    } while (((__prev_group_hist & _HIST_UPDATED) == 0).any() && __wg_id != 0);
+                    } while (((__prev_group_hist & __hist_updated) == 0).any() && __wg_id != 0);
                     __prev_group_hist_sum.merge(__prev_group_hist_sum + __prev_group_hist, __is_not_accumulated);
-                    __is_not_accumulated = (__prev_group_hist_sum & _GLOBAL_ACCUMULATED) == 0;
-                    __p_global_bin_prev_group -= _BIN_COUNT;
+                    __is_not_accumulated = (__prev_group_hist_sum & __global_accumulated) == 0;
+                    __p_global_bin_prev_group -= __bin_count;
                 } while (__is_not_accumulated.any() && __wg_id != 0);
-                __prev_group_hist_sum &= _GLOBAL_OFFSET_MASK;
-                simd<_global_hist_t, _BIN_WIDTH> after_group_hist_sum = __prev_group_hist_sum + __thread_grf_hist_summary;
-                __utils::_BlockStore<::std::uint32_t, _BIN_WIDTH>(__p_global_bin_this_group + __local_tid * _BIN_WIDTH,
-                                                       after_group_hist_sum | _HIST_UPDATED | _GLOBAL_ACCUMULATED);
+                __prev_group_hist_sum &= __global_offset_mask;
+                simd<_GlobalHistT, __bin_width> after_group_hist_sum = __prev_group_hist_sum + __thread_grf_hist_summary;
+                __utils::__block_store<::std::uint32_t, __bin_width>(__p_global_bin_this_group + __local_tid * __bin_width,
+                                                       after_group_hist_sum | __hist_updated | __global_accumulated);
 
-                __utils::_BlockStoreSlm<::std::uint32_t, _BIN_WIDTH>(
-                    __slm_bin_hist_global_incoming + __local_tid * _BIN_WIDTH * sizeof(_global_hist_t), __prev_group_hist_sum);
+                __utils::__block_store_slm<::std::uint32_t, __bin_width>(
+                    __slm_bin_hist_global_incoming + __local_tid * __bin_width * sizeof(_GlobalHistT), __prev_group_hist_sum);
             }
             barrier();
         }
-        auto __group_incoming = __utils::_BlockLoadSlm<_hist_t, _BIN_COUNT>(__slm_bin_hist_group_incoming);
-        __global_fix = __utils::_BlockLoadSlm<_global_hist_t, _BIN_COUNT>(__slm_bin_hist_global_incoming) - __group_incoming;
+        auto __group_incoming = __utils::__block_load_slm<_HistT, __bin_count>(__slm_bin_hist_group_incoming);
+        __global_fix = __utils::__block_load_slm<_GlobalHistT, __bin_count>(__slm_bin_hist_global_incoming) - __group_incoming;
         if (__local_tid > 0)
         {
-            __subgroup_offset = __group_incoming + __utils::_BlockLoadSlm<_hist_t, _BIN_COUNT>((__local_tid - 1) * _HIST_STRIDE);
+            __subgroup_offset = __group_incoming + __utils::__block_load_slm<_HistT, __bin_count>((__local_tid - 1) * __hist_stride);
         }
         else
             __subgroup_offset = __group_incoming;
@@ -407,27 +406,27 @@ struct __radix_sort_onesweep_slm_reorder_kernel
         const ::std::uint32_t __wg_size = __idx.get_local_range(0);
         const ::std::uint32_t __wg_count = __idx.get_group_range(0);
 
-        // max SLM is 256 * 4 * 64 + 256 * 2 * 64 + 257*2, 97KB, when  _DataPerWorkItem = 256, _BIN_COUNT = 256
+        // max SLM is 256 * 4 * 64 + 256 * 2 * 64 + 257*2, 97KB, when  __data_per_work_item = 256, __bin_count = 256
         // to support 512 processing size, we can use all SLM as reorder buffer with cost of more barrier
         // change __slm to reuse
 
-        const ::std::uint32_t __slm_bin_hist_this_thread = __local_tid * _BIN_COUNT * sizeof(_hist_t);
-        const ::std::uint32_t __slm_lookup_subgroup = __local_tid * sizeof(_hist_t) * _BIN_COUNT;
+        const ::std::uint32_t __slm_bin_hist_this_thread = __local_tid * __bin_count * sizeof(_HistT);
+        const ::std::uint32_t __slm_lookup_subgroup = __local_tid * sizeof(_HistT) * __bin_count;
 
-        simd<_hist_t, _BIN_COUNT> __bin_offset;
-        simd<_hist_t, _DataPerWorkItem> __ranks;
-        simd<_KeyT, _DataPerWorkItem> __keys;
-        simd<_bin_t, _DataPerWorkItem> __bins;
-        simd<_device_addr_t, _DATA_PER_STEP> __lane_id(0, 1);
+        simd<_HistT, __bin_count> __bin_offset;
+        simd<_HistT, __data_per_work_item> __ranks;
+        simd<_KeyT, __data_per_work_item> __keys;
+        simd<_BinT, __data_per_work_item> __bins;
+        simd<_DeviceAddrT, __data_per_step> __lane_id(0, 1);
 
-        const _device_addr_t __io_offset = _DataPerWorkItem * (__wg_id * __wg_size + __local_tid);
-        constexpr _KeyT __default_key = __utils::__sort_identity<_KeyT, _IsAscending>();
+        const _DeviceAddrT __io_offset = __data_per_work_item * (__wg_id * __wg_size + __local_tid);
+        constexpr _KeyT __default_key = __utils::__sort_identity<_KeyT, __is_ascending>();
 
-        _LoadKeys(__io_offset, __keys, __default_key);
+        __load_keys(__io_offset, __keys, __default_key);
 
-        __bins = __utils::__get_bucket<_MASK>(__utils::__order_preserving_cast<_IsAscending>(__keys), __stage * _RadixBits);
+        __bins = __utils::__get_bucket<__mask>(__utils::__order_preserving_cast<__is_ascending>(__keys), __stage * __radix_bits);
 
-        _ResetBinCounters(__slm_bin_hist_this_thread);
+        __reset_bin_counters(__slm_bin_hist_this_thread);
 
         fence<fence_mask::local_barrier>();
 
@@ -435,51 +434,51 @@ struct __radix_sort_onesweep_slm_reorder_kernel
 
         barrier();
 
-        simd<_hist_t, _BIN_COUNT> __subgroup_offset;
-        simd<_global_hist_t, _BIN_COUNT> __global_fix;
+        simd<_HistT, __bin_count> __subgroup_offset;
+        simd<_GlobalHistT, __bin_count> __global_fix;
 
-        _global_hist_t* __p_global_bin_start_buffer_allstages = reinterpret_cast<_global_hist_t*>(__p_global_buffer);
-        _global_hist_t* __p_global_bin_start_buffer =
-            __p_global_bin_start_buffer_allstages + _BIN_COUNT * _STAGES + _BIN_COUNT * __wg_count * __stage;
+        _GlobalHistT* __p_global_bin_start_buffer_allstages = reinterpret_cast<_GlobalHistT*>(__p_global_buffer);
+        _GlobalHistT* __p_global_bin_start_buffer =
+            __p_global_bin_start_buffer_allstages + __bin_count * __stage_count + __bin_count * __wg_count * __stage;
 
-        _global_hist_t* __p_global_bin_this_group = __p_global_bin_start_buffer + _BIN_COUNT * __wg_id;
-        _global_hist_t* __p_global_bin_prev_group = __p_global_bin_start_buffer + _BIN_COUNT * (__wg_id - 1);
-        __p_global_bin_prev_group = (0 == __wg_id) ? (__p_global_bin_start_buffer_allstages + _BIN_COUNT * __stage)
-                                               : (__p_global_bin_this_group - _BIN_COUNT);
+        _GlobalHistT* __p_global_bin_this_group = __p_global_bin_start_buffer + __bin_count * __wg_id;
+        _GlobalHistT* __p_global_bin_prev_group = __p_global_bin_start_buffer + __bin_count * (__wg_id - 1);
+        __p_global_bin_prev_group = (0 == __wg_id) ? (__p_global_bin_start_buffer_allstages + __bin_count * __stage)
+                                               : (__p_global_bin_this_group - __bin_count);
 
-        _UpdateGroupRank(__local_tid, __wg_id, __subgroup_offset, __global_fix, __p_global_bin_prev_group,
+        __update_group_rank(__local_tid, __wg_id, __subgroup_offset, __global_fix, __p_global_bin_prev_group,
                         __p_global_bin_this_group);
         barrier();
         {
-            __bins = __utils::__get_bucket<_MASK>(__utils::__order_preserving_cast<_IsAscending>(__keys), __stage * _RadixBits);
+            __bins = __utils::__get_bucket<__mask>(__utils::__order_preserving_cast<__is_ascending>(__keys), __stage * __radix_bits);
 
-            _slm_lookup_t<_hist_t> __subgroup_lookup(__slm_lookup_subgroup);
-            simd<_hist_t, _DataPerWorkItem> __wg_offset =
-                __ranks + __subgroup_lookup.template lookup<_DataPerWorkItem>(__subgroup_offset, __bins);
+            _slm_lookup_t<_HistT> __subgroup_lookup(__slm_lookup_subgroup);
+            simd<_HistT, __data_per_work_item> __wg_offset =
+                __ranks + __subgroup_lookup.template __lookup<__data_per_work_item>(__subgroup_offset, __bins);
             barrier();
 
-            __utils::_VectorStore<_KeyT, 1, _DataPerWorkItem>(simd<::std::uint32_t, _DataPerWorkItem>(__wg_offset) * sizeof(_KeyT),
+            __utils::__vector_store<_KeyT, 1, __data_per_work_item>(simd<::std::uint32_t, __data_per_work_item>(__wg_offset) * sizeof(_KeyT),
                                                            __keys);
         }
         barrier();
-        _slm_lookup_t<_global_hist_t> __global_fix_lookup(_REORDER_SLM_SIZE);
+        _slm_lookup_t<_GlobalHistT> __global_fix_lookup(__reorder_slm_size);
         if (__local_tid == 0)
         {
-            __global_fix_lookup.template setup(__global_fix);
+            __global_fix_lookup.__setup(__global_fix);
         }
         barrier();
         {
-            __keys = __utils::_BlockLoadSlm<_KeyT, _DataPerWorkItem>(__local_tid * _DataPerWorkItem * sizeof(_KeyT));
+            __keys = __utils::__block_load_slm<_KeyT, __data_per_work_item>(__local_tid * __data_per_work_item * sizeof(_KeyT));
 
-            __bins = __utils::__get_bucket<_MASK>(__utils::__order_preserving_cast<_IsAscending>(__keys), __stage * _RadixBits);
+            __bins = __utils::__get_bucket<__mask>(__utils::__order_preserving_cast<__is_ascending>(__keys), __stage * __radix_bits);
 
-            simd<_hist_t, _DataPerWorkItem> __group_offset =
-                __utils::__create_simd<_hist_t, _DataPerWorkItem>(__local_tid * _DataPerWorkItem, 1);
+            simd<_HistT, __data_per_work_item> __group_offset =
+                __utils::__create_simd<_HistT, __data_per_work_item>(__local_tid * __data_per_work_item, 1);
 
-            simd<_device_addr_t, _DataPerWorkItem> __global_offset =
-                __group_offset + __global_fix_lookup.template lookup<_DataPerWorkItem>(__bins);
+            simd<_DeviceAddrT, __data_per_work_item> __global_offset =
+                __group_offset + __global_fix_lookup.template __lookup<__data_per_work_item>(__bins);
 
-            __utils::_VectorStore<_KeyT, 1, _DataPerWorkItem>(__output, __global_offset * sizeof(_KeyT), __keys,
+            __utils::__vector_store<_KeyT, 1, __data_per_work_item>(__output, __global_offset * sizeof(_KeyT), __keys,
                                                            __global_offset < __n);
         }
     }
@@ -503,14 +502,14 @@ class __esimd_radix_sort_onesweep_odd;
 template <typename... _Name>
 class __esimd_radix_sort_onesweep_copyback;
 
-template <typename _KeyT, ::std::uint32_t _RadixBits, ::std::uint32_t _STAGES, ::std::uint32_t _HW_TG_COUNT,
-          ::std::uint32_t _WorkGroupSize, bool _IsAscending, typename _KernelName>
+template <typename _KeyT, ::std::uint32_t __radix_bits, ::std::uint32_t __stage_count, ::std::uint32_t __hist_work_group_count,
+          ::std::uint32_t __hist_work_group_size, bool __is_ascending, typename _KernelName>
 struct __radix_sort_onesweep_histogram_submitter;
 
-template <typename _KeyT, ::std::uint32_t _RadixBits, ::std::uint32_t _STAGES, ::std::uint32_t _HW_TG_COUNT,
-          ::std::uint32_t _WorkGroupSize, bool _IsAscending, typename... _Name>
+template <typename _KeyT, ::std::uint32_t __radix_bits, ::std::uint32_t __stage_count, ::std::uint32_t __hist_work_group_count,
+          ::std::uint32_t __hist_work_group_size, bool __is_ascending, typename... _Name>
 struct __radix_sort_onesweep_histogram_submitter<
-    _KeyT, _RadixBits, _STAGES, _HW_TG_COUNT, _WorkGroupSize, _IsAscending,
+    _KeyT, __radix_bits, __stage_count, __hist_work_group_count, __hist_work_group_size, __is_ascending,
     oneapi::dpl::__par_backend_hetero::__internal::__optional_kernel_name<_Name...>>
 {
     template <typename _Range, typename _GlobalOffsetData>
@@ -518,7 +517,7 @@ struct __radix_sort_onesweep_histogram_submitter<
     operator()(sycl::queue& __q, _Range&& __rng, const _GlobalOffsetData& __global_offset_data, ::std::size_t __n,
                const sycl::event& __e) const
     {
-        sycl::nd_range<1> __nd_range(_HW_TG_COUNT * _WorkGroupSize, _WorkGroupSize);
+        sycl::nd_range<1> __nd_range(__hist_work_group_count * __hist_work_group_size, __hist_work_group_size);
         return __q.submit(
             [&](sycl::handler& __cgh)
             {
@@ -527,26 +526,26 @@ struct __radix_sort_onesweep_histogram_submitter<
                 auto __data = __rng.data();
                 __cgh.parallel_for<_Name...>(
                     __nd_range, [=](sycl::nd_item<1> __nd_item) [[intel::sycl_explicit_simd]] {
-                        __global_histogram<_KeyT, decltype(__data), _RadixBits, _STAGES, _HW_TG_COUNT, _WorkGroupSize,
-                                         _IsAscending>(__nd_item, __n, __data, __global_offset_data);
+                        __global_histogram<_KeyT, decltype(__data), __radix_bits, __stage_count, __hist_work_group_count, __hist_work_group_size,
+                                         __is_ascending>(__nd_item, __n, __data, __global_offset_data);
                     });
             });
     }
 };
 
-template <::std::uint32_t _STAGES, ::std::uint32_t _BINCOUNT, typename _KernelName>
+template <::std::uint32_t __stage_count, ::std::uint32_t __bin_count, typename _KernelName>
 struct __radix_sort_onesweep_scan_submitter;
 
-template <::std::uint32_t _STAGES, ::std::uint32_t _BINCOUNT, typename... _Name>
+template <::std::uint32_t __stage_count, ::std::uint32_t __bin_count, typename... _Name>
 struct __radix_sort_onesweep_scan_submitter<
-    _STAGES, _BINCOUNT, oneapi::dpl::__par_backend_hetero::__internal::__optional_kernel_name<_Name...>>
+    __stage_count, __bin_count, oneapi::dpl::__par_backend_hetero::__internal::__optional_kernel_name<_Name...>>
 {
     template <typename _GlobalOffsetData>
     sycl::event
     operator()(sycl::queue& __q, _GlobalOffsetData& __global_offset_data, ::std::size_t __n,
                const sycl::event& __e) const
     {
-        sycl::nd_range<1> __nd_range(_STAGES * _BINCOUNT, _BINCOUNT);
+        sycl::nd_range<1> __nd_range(__stage_count * __bin_count, __bin_count);
         return __q.submit(
             [&](sycl::handler& __cgh)
             {
@@ -565,22 +564,22 @@ struct __radix_sort_onesweep_scan_submitter<
     }
 };
 
-template <bool _IsAscending, ::std::uint8_t _RadixBits, ::std::uint16_t _DataPerWorkItem,
-          ::std::uint16_t _WorkGroupSize, typename _KeyT, typename _KernelName>
+template <bool __is_ascending, ::std::uint8_t __radix_bits, ::std::uint16_t __data_per_work_item,
+          ::std::uint16_t __work_group_size, typename _KeyT, typename _KernelName>
 struct __radix_sort_onesweep_submitter;
 
-template <bool _IsAscending, ::std::uint8_t _RadixBits, ::std::uint16_t _DataPerWorkItem,
-          ::std::uint16_t _WorkGroupSize, typename _KeyT, typename... _Name>
-struct __radix_sort_onesweep_submitter<_IsAscending, _RadixBits, _DataPerWorkItem, _WorkGroupSize, _KeyT,
+template <bool __is_ascending, ::std::uint8_t __radix_bits, ::std::uint16_t __data_per_work_item,
+          ::std::uint16_t __work_group_size, typename _KeyT, typename... _Name>
+struct __radix_sort_onesweep_submitter<__is_ascending, __radix_bits, __data_per_work_item, __work_group_size, _KeyT,
                                        oneapi::dpl::__par_backend_hetero::__internal::__optional_kernel_name<_Name...>>
 {
     template <typename _InRange, typename _OutRange, typename _TmpData>
     sycl::event
     operator()(sycl::queue& __q, _InRange& __rng, _OutRange& __out_rng, const _TmpData& __tmp_data,
-               ::std::uint32_t __sweep_tg_count, ::std::size_t __n, ::std::uint32_t __stage,
+               ::std::uint32_t __sweep_work_group_count, ::std::size_t __n, ::std::uint32_t __stage,
                const sycl::event& __e) const
     {
-        sycl::nd_range<1> __nd_range(__sweep_tg_count * _WorkGroupSize, _WorkGroupSize);
+        sycl::nd_range<1> __nd_range(__sweep_work_group_count * __work_group_size, __work_group_size);
         return __q.submit(
             [&](sycl::handler& __cgh)
             {
@@ -588,7 +587,7 @@ struct __radix_sort_onesweep_submitter<_IsAscending, _RadixBits, _DataPerWorkIte
                 auto __in_data = __rng.data();
                 auto __out_data = __out_rng.data();
                 __cgh.depends_on(__e);
-                __radix_sort_onesweep_slm_reorder_kernel<_IsAscending, _RadixBits, _DataPerWorkItem, _WorkGroupSize,
+                __radix_sort_onesweep_slm_reorder_kernel<__is_ascending, __radix_bits, __data_per_work_item, __work_group_size,
                                                        _KeyT, decltype(__in_data), decltype(__out_data)>
                     __sweep_kernel(__n, __stage, __in_data, __out_data, __tmp_data);
                 __cgh.parallel_for<_Name...>(__nd_range, __sweep_kernel);
@@ -626,8 +625,8 @@ struct __radix_sort_copyback_submitter<_KeyT,
     }
 };
 
-template <typename _KernelName, bool _IsAscending, ::std::uint8_t _RadixBits, ::std::uint16_t _DataPerWorkItem,
-          ::std::uint16_t _WorkGroupSize, typename _Range>
+template <typename _KernelName, bool __is_ascending, ::std::uint8_t __radix_bits, ::std::uint16_t __data_per_work_item,
+          ::std::uint16_t __work_group_size, typename _Range>
 sycl::event
 __onesweep(sycl::queue __q, _Range&& __rng, ::std::size_t __n)
 {
@@ -647,26 +646,26 @@ __onesweep(sycl::queue __q, _Range&& __rng, ::std::size_t __n)
     using _EsimdRadixSortCopyback = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
         __esimd_radix_sort_onesweep_copyback<_KernelName>>;
 
-    using _global_hist_t = ::std::uint32_t;
-    constexpr ::std::uint32_t _BINCOUNT = 1 << _RadixBits;
+    using _GlobalHistT = ::std::uint32_t;
+    constexpr ::std::uint32_t __bin_count = 1 << __radix_bits;
 
     // TODO: consider adding a more versatile API, e.g. passing special kernel_config parameters for histogram computation
-    constexpr ::std::uint32_t _HistWorkGroupCount = 64;
-    constexpr ::std::uint32_t _HistWorkGroupSize = 64;
+    constexpr ::std::uint32_t __hist_work_group_count = 64;
+    constexpr ::std::uint32_t __hist_work_group_size = 64;
 
-    const ::std::uint32_t __sweep_tg_count = oneapi::dpl::__internal::__dpl_ceiling_div(__n, _WorkGroupSize * _DataPerWorkItem);
-    constexpr ::std::uint32_t _NBITS = sizeof(_KeyT) * 8;
-    constexpr ::std::uint32_t _STAGES = oneapi::dpl::__internal::__dpl_ceiling_div(_NBITS, _RadixBits);
+    const ::std::uint32_t __sweep_work_group_count = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __work_group_size * __data_per_work_item);
+    constexpr ::std::uint32_t __bit_count = sizeof(_KeyT) * 8;
+    constexpr ::std::uint32_t __stage_count = oneapi::dpl::__internal::__dpl_ceiling_div(__bit_count, __radix_bits);
 
-    // Memory for _SYNC_BUFFER_SIZE is used by onesweep kernel implicitly
-    // TODO: pass a pointer to the the memory allocated with _SYNC_BUFFER_SIZE to onesweep kernel
-    const ::std::uint32_t _SYNC_BUFFER_SIZE = __sweep_tg_count * _BINCOUNT * _STAGES * sizeof(_global_hist_t); //bytes
-    constexpr ::std::uint32_t _GLOBAL_OFFSET_SIZE = _BINCOUNT * _STAGES * sizeof(_global_hist_t);
-    size_t __temp_buffer_size = _GLOBAL_OFFSET_SIZE + _SYNC_BUFFER_SIZE;
+    // Memory for __sync_buffer_size is used by onesweep kernel implicitly
+    // TODO: pass a pointer to the the memory allocated with __sync_buffer_size to onesweep kernel
+    const ::std::uint32_t __sync_buffer_size = __sweep_work_group_count * __bin_count * __stage_count * sizeof(_GlobalHistT); //bytes
+    constexpr ::std::uint32_t __global_offset_size = __bin_count * __stage_count * sizeof(_GlobalHistT);
+    ::std::size_t __temp_buffer_size = __global_offset_size + __sync_buffer_size;
 
-    const size_t __full_buffer_size_global_hist = __temp_buffer_size * sizeof(::std::uint8_t);
-    const size_t __full_buffer_size_output = __n * sizeof(_KeyT);
-    const size_t __full_buffer_size = __full_buffer_size_global_hist + __full_buffer_size_output;
+    const ::std::size_t __full_buffer_size_global_hist = __temp_buffer_size * sizeof(::std::uint8_t);
+    const ::std::size_t __full_buffer_size_output = __n * sizeof(_KeyT);
+    const ::std::size_t __full_buffer_size = __full_buffer_size_global_hist + __full_buffer_size_output;
 
     ::std::uint8_t* __p_temp_memory = sycl::malloc_device<::std::uint8_t>(__full_buffer_size, __q);
 
@@ -683,30 +682,30 @@ __onesweep(sycl::queue __q, _Range&& __rng, ::std::size_t __n)
     sycl::event __event_chain = __q.memset(__p_globl_hist_buffer, 0, __temp_buffer_size);
 
     __event_chain =
-        __radix_sort_onesweep_histogram_submitter<_KeyT, _RadixBits, _STAGES, _HistWorkGroupCount, _HistWorkGroupSize,
-                                                  _IsAscending, _EsimdRadixSortHistogram>()(__q, __rng, __p_global_offset,
+        __radix_sort_onesweep_histogram_submitter<_KeyT, __radix_bits, __stage_count, __hist_work_group_count, __hist_work_group_size,
+                                                  __is_ascending, _EsimdRadixSortHistogram>()(__q, __rng, __p_global_offset,
                                                                                             __n, __event_chain);
 
-    __event_chain = __radix_sort_onesweep_scan_submitter<_STAGES, _BINCOUNT, _EsimdRadixSortScan>()(__q, __p_global_offset,
+    __event_chain = __radix_sort_onesweep_scan_submitter<__stage_count, __bin_count, _EsimdRadixSortScan>()(__q, __p_global_offset,
                                                                                                 __n, __event_chain);
 
-    for (::std::uint32_t __stage = 0; __stage < _STAGES; __stage++)
+    for (::std::uint32_t __stage = 0; __stage < __stage_count; __stage++)
     {
         if ((__stage % 2) == 0)
         {
-            __event_chain = __radix_sort_onesweep_submitter<_IsAscending, _RadixBits, _DataPerWorkItem, _WorkGroupSize,
+            __event_chain = __radix_sort_onesweep_submitter<__is_ascending, __radix_bits, __data_per_work_item, __work_group_size,
                                                           _KeyT, _EsimdRadixSortSweepEven>()(
-                __q, __rng, __out_rng, __p_globl_hist_buffer, __sweep_tg_count, __n, __stage, __event_chain);
+                __q, __rng, __out_rng, __p_globl_hist_buffer, __sweep_work_group_count, __n, __stage, __event_chain);
         }
         else
         {
-            __event_chain = __radix_sort_onesweep_submitter<_IsAscending, _RadixBits, _DataPerWorkItem, _WorkGroupSize,
+            __event_chain = __radix_sort_onesweep_submitter<__is_ascending, __radix_bits, __data_per_work_item, __work_group_size,
                                                           _KeyT, _EsimdRadixSortSweepOdd>()(
-                __q, __out_rng, __rng, __p_globl_hist_buffer, __sweep_tg_count, __n, __stage, __event_chain);
+                __q, __out_rng, __rng, __p_globl_hist_buffer, __sweep_work_group_count, __n, __stage, __event_chain);
         }
     }
 
-    if constexpr (_STAGES % 2 != 0)
+    if constexpr (__stage_count % 2 != 0)
     {
         __event_chain =
             __radix_sort_copyback_submitter<_KeyT, _EsimdRadixSortCopyback>()(__q, __out_rng, __rng, __n, __event_chain);

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort_utils.h
@@ -23,7 +23,7 @@
 
 namespace oneapi::dpl::experimental::kt::esimd::__impl
 {
-constexpr int _DATA_PER_STEP = 16;
+constexpr int __data_per_step = 16;
 
 namespace __dpl_esimd_ns = sycl::ext::intel::esimd;
 namespace __dpl_esimd_ens = sycl::ext::intel::experimental::esimd;
@@ -285,7 +285,7 @@ __order_preserving_cast(__dpl_esimd_ns::simd<_Float, _N> __src)
 template <typename _T, int _VSize, int _LANES, __dpl_esimd_ens::cache_hint _H1 = __dpl_esimd_ens::cache_hint::none,
           __dpl_esimd_ens::cache_hint _H3 = __dpl_esimd_ens::cache_hint::none>
 inline std::enable_if_t<(_VSize <= 4), __dpl_esimd_ns::simd<_T, _VSize * _LANES>>
-_VectorLoad(const _T* __src, const __dpl_esimd_ns::simd<::std::uint32_t, _LANES> __offset, __dpl_esimd_ns::simd_mask<_LANES> __mask = 1)
+__vector_load(const _T* __src, const __dpl_esimd_ns::simd<::std::uint32_t, _LANES> __offset, __dpl_esimd_ns::simd_mask<_LANES> __mask = 1)
 {
     return __dpl_esimd_ens::lsc_gather<_T, _VSize, __dpl_esimd_ens::lsc_data_size::default_size, _H1, _H3, _LANES>(
         __src, __offset, __mask);
@@ -294,12 +294,12 @@ _VectorLoad(const _T* __src, const __dpl_esimd_ns::simd<::std::uint32_t, _LANES>
 template <typename _T, int _VSize, int _LANES, __dpl_esimd_ens::cache_hint _H1 = __dpl_esimd_ens::cache_hint::none,
           __dpl_esimd_ens::cache_hint _H3 = __dpl_esimd_ens::cache_hint::none>
 inline std::enable_if_t<(_VSize > 4), __dpl_esimd_ns::simd<_T, _VSize * _LANES>>
-_VectorLoad(const _T* __src, const __dpl_esimd_ns::simd<::std::uint32_t, _LANES> __offset, __dpl_esimd_ns::simd_mask<_LANES> __mask = 1)
+__vector_load(const _T* __src, const __dpl_esimd_ns::simd<::std::uint32_t, _LANES> __offset, __dpl_esimd_ns::simd_mask<_LANES> __mask = 1)
 {
     __dpl_esimd_ns::simd<_T, _VSize * _LANES> __res;
-    __res.template select<4 * _LANES, 1>(0) = _VectorLoad<_T, 4, _LANES, _H1, _H3>(__src, __offset, __mask);
+    __res.template select<4 * _LANES, 1>(0) = __vector_load<_T, 4, _LANES, _H1, _H3>(__src, __offset, __mask);
     __res.template select<(_VSize - 4) * _LANES, 1>(4 * _LANES) =
-        _VectorLoad<_T, _VSize - 4, _LANES, _H1, _H3>(__src, __offset + 4 * sizeof(_T), __mask);
+        __vector_load<_T, _VSize - 4, _LANES, _H1, _H3>(__src, __offset + 4 * sizeof(_T), __mask);
     return __res;
 }
 
@@ -307,34 +307,34 @@ template <typename _T, int _VSize, int _LANES, int LaneStride = _VSize,
           __dpl_esimd_ens::cache_hint _H1 = __dpl_esimd_ens::cache_hint::none,
           __dpl_esimd_ens::cache_hint _H3 = __dpl_esimd_ens::cache_hint::none>
 inline __dpl_esimd_ns::simd<_T, _VSize * _LANES>
-_VectorLoad(const _T* __src, ::std::uint32_t __offset, __dpl_esimd_ns::simd_mask<_LANES> __mask = 1)
+__vector_load(const _T* __src, ::std::uint32_t __offset, __dpl_esimd_ns::simd_mask<_LANES> __mask = 1)
 {
-    return _VectorLoad<_T, _VSize, _LANES, _H1, _H3>(__src, {__offset, LaneStride * sizeof(_T)}, __mask);
+    return __vector_load<_T, _VSize, _LANES, _H1, _H3>(__src, {__offset, LaneStride * sizeof(_T)}, __mask);
 }
 
 template <typename _T, int _VSize, int _LANES>
 inline std::enable_if_t<(_VSize <= 4), __dpl_esimd_ns::simd<_T, _VSize * _LANES>>
-_VectorLoad(const __dpl_esimd_ns::simd<::std::uint32_t, _LANES> __offset, __dpl_esimd_ns::simd_mask<_LANES> __mask = 1)
+__vector_load(const __dpl_esimd_ns::simd<::std::uint32_t, _LANES> __offset, __dpl_esimd_ns::simd_mask<_LANES> __mask = 1)
 {
     return __dpl_esimd_ens::lsc_slm_gather<_T, _VSize, __dpl_esimd_ens::lsc_data_size::default_size, _LANES>(__offset, __mask);
 }
 
 template <typename _T, int _VSize, int _LANES>
 inline std::enable_if_t<(_VSize > 4), __dpl_esimd_ns::simd<_T, _VSize * _LANES>>
-_VectorLoad(const __dpl_esimd_ns::simd<::std::uint32_t, _LANES> __offset, __dpl_esimd_ns::simd_mask<_LANES> __mask = 1)
+__vector_load(const __dpl_esimd_ns::simd<::std::uint32_t, _LANES> __offset, __dpl_esimd_ns::simd_mask<_LANES> __mask = 1)
 {
     __dpl_esimd_ns::simd<_T, _VSize * _LANES> __res;
-    __res.template select<4 * _LANES, 1>(0) = _VectorLoad<_T, 4, _LANES>(__offset, __mask);
+    __res.template select<4 * _LANES, 1>(0) = __vector_load<_T, 4, _LANES>(__offset, __mask);
     __res.template select<(_VSize - 4) * _LANES, 1>(4 * _LANES) =
-        _VectorLoad<_T, _VSize - 4, _LANES>(__offset + 4 * sizeof(_T), __mask);
+        __vector_load<_T, _VSize - 4, _LANES>(__offset + 4 * sizeof(_T), __mask);
     return __res;
 }
 
 template <typename _T, int _VSize, int _LANES, int LaneStride = _VSize>
 inline __dpl_esimd_ns::simd<_T, _VSize * _LANES>
-_VectorLoad(::std::uint32_t __offset, __dpl_esimd_ns::simd_mask<_LANES> __mask = 1)
+__vector_load(::std::uint32_t __offset, __dpl_esimd_ns::simd_mask<_LANES> __mask = 1)
 {
-    return _VectorLoad<_T, _VSize, _LANES>({__offset, LaneStride * sizeof(_T)}, __mask);
+    return __vector_load<_T, _VSize, _LANES>({__offset, LaneStride * sizeof(_T)}, __mask);
 }
 
 template <typename TWhatEver>
@@ -353,7 +353,7 @@ inline constexpr bool is_sycl_accessor_v = __is_sycl_accessor<_Tp...>::value;
 template <typename _T, int _VSize, int _LANES, __dpl_esimd_ens::cache_hint _H1 = __dpl_esimd_ens::cache_hint::none,
           __dpl_esimd_ens::cache_hint _H3 = __dpl_esimd_ens::cache_hint::none>
 inline std::enable_if_t<(_VSize <= 4 && _LANES <= 32), void>
-_VectorStore(_T* __dest, __dpl_esimd_ns::simd<::std::uint32_t, _LANES> __offset, __dpl_esimd_ns::simd<_T, _VSize * _LANES> __data,
+__vector_store(_T* __dest, __dpl_esimd_ns::simd<::std::uint32_t, _LANES> __offset, __dpl_esimd_ns::simd<_T, _VSize * _LANES> __data,
             __dpl_esimd_ns::simd_mask<_LANES> __mask = 1)
 {
     __dpl_esimd_ens::lsc_scatter<_T, _VSize, __dpl_esimd_ens::lsc_data_size::default_size, _H1, _H3, _LANES>(__dest, __offset,
@@ -364,7 +364,7 @@ template <typename _T, int _VSize, int _LANES, typename _AccessorTy,
           __dpl_esimd_ens::cache_hint _H1 = __dpl_esimd_ens::cache_hint::none,
           __dpl_esimd_ens::cache_hint _H3 = __dpl_esimd_ens::cache_hint::none>
 inline std::enable_if_t<(is_sycl_accessor_v<_AccessorTy> && _VSize <= 4 && _LANES <= 32), void>
-_VectorStore(_AccessorTy __acc, __dpl_esimd_ns::simd<::std::uint32_t, _LANES> __offset, __dpl_esimd_ns::simd<_T, _VSize * _LANES> __data,
+__vector_store(_AccessorTy __acc, __dpl_esimd_ns::simd<::std::uint32_t, _LANES> __offset, __dpl_esimd_ns::simd<_T, _VSize * _LANES> __data,
             __dpl_esimd_ns::simd_mask<_LANES> __mask = 1)
 {
     __dpl_esimd_ens::lsc_scatter<_T, _VSize, __dpl_esimd_ens::lsc_data_size::default_size, _H1, _H3, _LANES>(__acc, __offset,
@@ -374,12 +374,12 @@ _VectorStore(_AccessorTy __acc, __dpl_esimd_ns::simd<::std::uint32_t, _LANES> __
 template <typename _T, int _VSize, int _LANES, __dpl_esimd_ens::cache_hint _H1 = __dpl_esimd_ens::cache_hint::none,
           __dpl_esimd_ens::cache_hint _H3 = __dpl_esimd_ens::cache_hint::none>
 inline std::enable_if_t<(_LANES > 32), void>
-_VectorStore(_T* __dest, __dpl_esimd_ns::simd<::std::uint32_t, _LANES> __offset, __dpl_esimd_ns::simd<_T, _VSize * _LANES> __data,
+__vector_store(_T* __dest, __dpl_esimd_ns::simd<::std::uint32_t, _LANES> __offset, __dpl_esimd_ns::simd<_T, _VSize * _LANES> __data,
             __dpl_esimd_ns::simd_mask<_LANES> __mask = 1)
 {
-    _VectorStore<_T, _VSize, 32>(__dest, __offset.template select<32, 1>(0), __data.template select<_VSize * 32, 1>(0),
+    __vector_store<_T, _VSize, 32>(__dest, __offset.template select<32, 1>(0), __data.template select<_VSize * 32, 1>(0),
                               __mask.template select<32, 1>(0));
-    _VectorStore<_T, _VSize, _LANES - 32>(__dest, __offset.template select<_LANES - 32, 1>(32),
+    __vector_store<_T, _VSize, _LANES - 32>(__dest, __offset.template select<_LANES - 32, 1>(32),
                                       __data.template select<_VSize*(_LANES - 32), 1>(32),
                                       __mask.template select<_LANES - 32, 1>(32));
 }
@@ -388,12 +388,12 @@ template <typename _T, int _VSize, int _LANES, typename _AccessorTy,
           __dpl_esimd_ens::cache_hint _H1 = __dpl_esimd_ens::cache_hint::none,
           __dpl_esimd_ens::cache_hint _H3 = __dpl_esimd_ens::cache_hint::none>
 inline std::enable_if_t<(is_sycl_accessor_v<_AccessorTy> && _LANES > 32), void>
-_VectorStore(_AccessorTy __acc, __dpl_esimd_ns::simd<::std::uint32_t, _LANES> __offset, __dpl_esimd_ns::simd<_T, _VSize * _LANES> __data,
+__vector_store(_AccessorTy __acc, __dpl_esimd_ns::simd<::std::uint32_t, _LANES> __offset, __dpl_esimd_ns::simd<_T, _VSize * _LANES> __data,
             __dpl_esimd_ns::simd_mask<_LANES> __mask = 1)
 {
-    _VectorStore<_T, _VSize, 32>(__acc, __offset.template select<32, 1>(0), __data.template select<_VSize * 32, 1>(0),
+    __vector_store<_T, _VSize, 32>(__acc, __offset.template select<32, 1>(0), __data.template select<_VSize * 32, 1>(0),
                               __mask.template select<32, 1>(0));
-    _VectorStore<_T, _VSize, _LANES - 32>(__acc, __offset.template select<_LANES - 32, 1>(32),
+    __vector_store<_T, _VSize, _LANES - 32>(__acc, __offset.template select<_LANES - 32, 1>(32),
                                       __data.template select<_VSize*(_LANES - 32), 1>(32),
                                       __mask.template select<_LANES - 32, 1>(32));
 }
@@ -401,11 +401,11 @@ _VectorStore(_AccessorTy __acc, __dpl_esimd_ns::simd<::std::uint32_t, _LANES> __
 template <typename _T, int _VSize, int _LANES, __dpl_esimd_ens::cache_hint _H1 = __dpl_esimd_ens::cache_hint::none,
           __dpl_esimd_ens::cache_hint _H3 = __dpl_esimd_ens::cache_hint::none>
 inline std::enable_if_t<(_VSize > 4 && _LANES <= 32), void>
-_VectorStore(_T* __dest, __dpl_esimd_ns::simd<::std::uint32_t, _LANES> __offset, __dpl_esimd_ns::simd<_T, _VSize * _LANES> __data,
+__vector_store(_T* __dest, __dpl_esimd_ns::simd<::std::uint32_t, _LANES> __offset, __dpl_esimd_ns::simd<_T, _VSize * _LANES> __data,
             __dpl_esimd_ns::simd_mask<_LANES> __mask = 1)
 {
-    _VectorStore<_T, 4, _LANES>(__dest, __offset, __data.template select<4 * _LANES, 1>(0), __mask);
-    _VectorStore<_T, _VSize - 4, _LANES>(__dest, __offset + 4 * sizeof(_T),
+    __vector_store<_T, 4, _LANES>(__dest, __offset, __data.template select<4 * _LANES, 1>(0), __mask);
+    __vector_store<_T, _VSize - 4, _LANES>(__dest, __offset + 4 * sizeof(_T),
                                      __data.template select<(_VSize - 4) * _LANES, 1>(4 * _LANES), __mask);
 }
 
@@ -413,11 +413,11 @@ template <typename _T, int _VSize, int _LANES, typename _AccessorTy,
           __dpl_esimd_ens::cache_hint _H1 = __dpl_esimd_ens::cache_hint::none,
           __dpl_esimd_ens::cache_hint _H3 = __dpl_esimd_ens::cache_hint::none>
 inline std::enable_if_t<(is_sycl_accessor_v<_AccessorTy> && _VSize > 4 && _LANES <= 32), void>
-_VectorStore(_AccessorTy __acc, __dpl_esimd_ns::simd<::std::uint32_t, _LANES> __offset, __dpl_esimd_ns::simd<_T, _VSize * _LANES> __data,
+__vector_store(_AccessorTy __acc, __dpl_esimd_ns::simd<::std::uint32_t, _LANES> __offset, __dpl_esimd_ns::simd<_T, _VSize * _LANES> __data,
             __dpl_esimd_ns::simd_mask<_LANES> __mask = 1)
 {
-    _VectorStore<_T, 4, _LANES, _AccessorTy>(__acc, __offset, __data.template select<4 * _LANES, 1>(0), __mask);
-    _VectorStore<_T, _VSize - 4, _LANES, _AccessorTy>(__acc, __offset + 4 * sizeof(_T),
+    __vector_store<_T, 4, _LANES, _AccessorTy>(__acc, __offset, __data.template select<4 * _LANES, 1>(0), __mask);
+    __vector_store<_T, _VSize - 4, _LANES, _AccessorTy>(__acc, __offset + 4 * sizeof(_T),
                                                  __data.template select<(_VSize - 4) * _LANES, 1>(4 * _LANES), __mask);
 }
 
@@ -425,27 +425,27 @@ template <typename _T, int _VSize, int _LANES, int LaneStride = _VSize,
           __dpl_esimd_ens::cache_hint _H1 = __dpl_esimd_ens::cache_hint::none,
           __dpl_esimd_ens::cache_hint _H3 = __dpl_esimd_ens::cache_hint::none>
 inline void
-_VectorStore(_T* __dest, ::std::uint32_t __offset, __dpl_esimd_ns::simd<_T, _VSize * _LANES> __data,
+__vector_store(_T* __dest, ::std::uint32_t __offset, __dpl_esimd_ns::simd<_T, _VSize * _LANES> __data,
             __dpl_esimd_ns::simd_mask<_LANES> __mask = 1)
 {
     // optimization needed here, hard for compiler to optimize the __offset vector calculation
-    _VectorStore<_T, _VSize, _LANES, _H1, _H3>(__dest, {__offset, LaneStride * sizeof(_T)}, __data, __mask);
+    __vector_store<_T, _VSize, _LANES, _H1, _H3>(__dest, {__offset, LaneStride * sizeof(_T)}, __data, __mask);
 }
 
 template <typename _T, int _VSize, int _LANES, typename _AccessorTy, int LaneStride = _VSize,
           __dpl_esimd_ens::cache_hint _H1 = __dpl_esimd_ens::cache_hint::none,
           __dpl_esimd_ens::cache_hint _H3 = __dpl_esimd_ens::cache_hint::none>
 inline std::enable_if_t<(is_sycl_accessor_v<_AccessorTy>), void>
-_VectorStore(_AccessorTy __acc, ::std::uint32_t __offset, __dpl_esimd_ns::simd<_T, _VSize * _LANES> __data,
+__vector_store(_AccessorTy __acc, ::std::uint32_t __offset, __dpl_esimd_ns::simd<_T, _VSize * _LANES> __data,
             __dpl_esimd_ns::simd_mask<_LANES> __mask = 1)
 {
     // optimization needed here, hard for compiler to optimize the __offset vector calculation
-    _VectorStore<_T, _VSize, _LANES, _H1, _H3>(__acc, {__offset, LaneStride * sizeof(_T)}, __data, __mask);
+    __vector_store<_T, _VSize, _LANES, _H1, _H3>(__acc, {__offset, LaneStride * sizeof(_T)}, __data, __mask);
 }
 
 template <typename _T, int _VSize, int _LANES>
 inline std::enable_if_t<(_VSize <= 4 && _LANES <= 32), void>
-_VectorStore(__dpl_esimd_ns::simd<::std::uint32_t, _LANES> __offset, __dpl_esimd_ns::simd<_T, _VSize * _LANES> __data,
+__vector_store(__dpl_esimd_ns::simd<::std::uint32_t, _LANES> __offset, __dpl_esimd_ns::simd<_T, _VSize * _LANES> __data,
             __dpl_esimd_ns::simd_mask<_LANES> __mask = 1)
 {
     __dpl_esimd_ens::lsc_slm_scatter<_T, _VSize>(__offset, __data, __mask);
@@ -453,31 +453,31 @@ _VectorStore(__dpl_esimd_ns::simd<::std::uint32_t, _LANES> __offset, __dpl_esimd
 
 template <typename _T, int _VSize, int _LANES>
 inline std::enable_if_t<(_LANES > 32), void>
-_VectorStore(__dpl_esimd_ns::simd<::std::uint32_t, _LANES> __offset, __dpl_esimd_ns::simd<_T, _VSize * _LANES> __data,
+__vector_store(__dpl_esimd_ns::simd<::std::uint32_t, _LANES> __offset, __dpl_esimd_ns::simd<_T, _VSize * _LANES> __data,
             __dpl_esimd_ns::simd_mask<_LANES> __mask = 1)
 {
-    _VectorStore<_T, _VSize, 32>(__offset.template select<32, 1>(0), __data.template select<_VSize * 32, 1>(0),
+    __vector_store<_T, _VSize, 32>(__offset.template select<32, 1>(0), __data.template select<_VSize * 32, 1>(0),
                               __mask.template select<32, 1>(0));
-    _VectorStore<_T, _VSize, _LANES - 32>(__offset.template select<_LANES - 32, 1>(32),
+    __vector_store<_T, _VSize, _LANES - 32>(__offset.template select<_LANES - 32, 1>(32),
                                       __data.template select<_VSize*(_LANES - 32), 1>(32),
                                       __mask.template select<_LANES - 32, 1>(32));
 }
 
 template <typename _T, int _VSize, int _LANES>
 inline std::enable_if_t<(_VSize > 4 && _LANES <= 32), void>
-_VectorStore(__dpl_esimd_ns::simd<::std::uint32_t, _LANES> __offset, __dpl_esimd_ns::simd<_T, _VSize * _LANES> __data,
+__vector_store(__dpl_esimd_ns::simd<::std::uint32_t, _LANES> __offset, __dpl_esimd_ns::simd<_T, _VSize * _LANES> __data,
             __dpl_esimd_ns::simd_mask<_LANES> __mask = 1)
 {
-    _VectorStore<_T, 4, _LANES>(__offset, __data.template select<4 * _LANES, 1>(0), __mask);
-    _VectorStore<_T, _VSize - 4, _LANES>(__offset + 4 * sizeof(_T), __data.template select<(_VSize - 4) * _LANES, 1>(4 * _LANES),
+    __vector_store<_T, 4, _LANES>(__offset, __data.template select<4 * _LANES, 1>(0), __mask);
+    __vector_store<_T, _VSize - 4, _LANES>(__offset + 4 * sizeof(_T), __data.template select<(_VSize - 4) * _LANES, 1>(4 * _LANES),
                                      __mask);
 }
 
 template <typename _T, int _VSize, int _LANES, int LaneStride = _VSize>
 inline void
-_VectorStore(::std::uint32_t __offset, __dpl_esimd_ns::simd<_T, _VSize * _LANES> __data, __dpl_esimd_ns::simd_mask<_LANES> __mask = 1)
+__vector_store(::std::uint32_t __offset, __dpl_esimd_ns::simd<_T, _VSize * _LANES> __data, __dpl_esimd_ns::simd_mask<_LANES> __mask = 1)
 {
-    return _VectorStore<_T, _VSize, _LANES>({__offset, LaneStride * sizeof(_T)}, __data, __mask);
+    return __vector_store<_T, _VSize, _LANES>({__offset, LaneStride * sizeof(_T)}, __data, __mask);
 }
 
 template <int _NElts>
@@ -518,61 +518,61 @@ __lsc_op_block_size()
 }
 
 template <typename _T>
-using lsc_op_aligned_t = ::std::conditional_t<sizeof(_T) <= sizeof(::std::uint32_t), ::std::uint32_t, ::std::uint64_t>;
+using _LscOpAlignedT = ::std::conditional_t<sizeof(_T) <= sizeof(::std::uint32_t), ::std::uint32_t, ::std::uint64_t>;
 
-template <typename _T, int _N, typename OpAlignedT = lsc_op_aligned_t<_T>,
-          int _NElts = __lsc_op_block_size<_T, _N, OpAlignedT>(),
+template <typename _T, int _N, typename _OpAlignedT = _LscOpAlignedT<_T>,
+          int _NElts = __lsc_op_block_size<_T, _N, _OpAlignedT>(),
           ::std::enable_if_t<_NElts == __lsc_slm_block_size_rounding<_NElts>(), int> = 0>
 inline __dpl_esimd_ns::simd<_T, _N>
-_BlockLoadSlm(::std::uint32_t slm_offset)
+__block_load_slm(::std::uint32_t __slm_offset)
 {
     __dpl_esimd_ns::simd<_T, _N> __res;
-    __res.template bit_cast_view<OpAlignedT>() = __dpl_esimd_ens::lsc_slm_block_load<OpAlignedT, _NElts>(slm_offset);
+    __res.template bit_cast_view<_OpAlignedT>() = __dpl_esimd_ens::lsc_slm_block_load<_OpAlignedT, _NElts>(__slm_offset);
     return __res;
 }
 
-template <typename _T, int _N, typename OpAlignedT = lsc_op_aligned_t<_T>,
-          int _NElts = __lsc_op_block_size<_T, _N, OpAlignedT>(),
+template <typename _T, int _N, typename _OpAlignedT = _LscOpAlignedT<_T>,
+          int _NElts = __lsc_op_block_size<_T, _N, _OpAlignedT>(),
           ::std::enable_if_t<_NElts != __lsc_slm_block_size_rounding<_NElts>(), int> = 0>
 inline __dpl_esimd_ns::simd<_T, _N>
-_BlockLoadSlm(::std::uint32_t slm_offset)
+__block_load_slm(::std::uint32_t __slm_offset)
 {
-    constexpr int BLOCK_SIZE_ROUNDED = __lsc_slm_block_size_rounding<_NElts>();
+    constexpr int __block_size_rounded = __lsc_slm_block_size_rounding<_NElts>();
 
     __dpl_esimd_ns::simd<_T, _N> __res;
-    constexpr int BLOCK_SIZE = __lsc_op_block_size<OpAlignedT, BLOCK_SIZE_ROUNDED, _T>();
-    __res.template select<BLOCK_SIZE, 1>(0) = _BlockLoadSlm<_T, BLOCK_SIZE>(slm_offset);
-    __res.template select<_N - BLOCK_SIZE, 1>(BLOCK_SIZE) =
-        _BlockLoadSlm<_T, _N - BLOCK_SIZE>(slm_offset + BLOCK_SIZE * sizeof(_T));
+    constexpr int __block_size = __lsc_op_block_size<_OpAlignedT, __block_size_rounded, _T>();
+    __res.template select<__block_size, 1>(0) = __block_load_slm<_T, __block_size>(__slm_offset);
+    __res.template select<_N - __block_size, 1>(__block_size) =
+        __block_load_slm<_T, _N - __block_size>(__slm_offset + __block_size * sizeof(_T));
     return __res;
 }
 
-template <typename _T, int _N, typename OpAlignedT = lsc_op_aligned_t<_T>,
-          int _NElts = __lsc_op_block_size<_T, _N, OpAlignedT>(),
+template <typename _T, int _N, typename _OpAlignedT = _LscOpAlignedT<_T>,
+          int _NElts = __lsc_op_block_size<_T, _N, _OpAlignedT>(),
           ::std::enable_if_t<_NElts == __lsc_slm_block_size_rounding<_NElts>(), int> = 0>
 void
-_BlockStoreSlm(::std::uint32_t slm_offset, __dpl_esimd_ns::simd<_T, _N> __data)
+__block_store_slm(::std::uint32_t __slm_offset, __dpl_esimd_ns::simd<_T, _N> __data)
 {
-    __dpl_esimd_ens::lsc_slm_block_store<OpAlignedT, _NElts>(slm_offset, __data.template bit_cast_view<::std::uint32_t>());
+    __dpl_esimd_ens::lsc_slm_block_store<_OpAlignedT, _NElts>(__slm_offset, __data.template bit_cast_view<::std::uint32_t>());
 }
 
-template <typename _T, int _N, typename OpAlignedT = lsc_op_aligned_t<_T>,
-          int _NElts = __lsc_op_block_size<_T, _N, OpAlignedT>(),
+template <typename _T, int _N, typename _OpAlignedT = _LscOpAlignedT<_T>,
+          int _NElts = __lsc_op_block_size<_T, _N, _OpAlignedT>(),
           ::std::enable_if_t<_NElts != __lsc_slm_block_size_rounding<_NElts>(), int> = 0>
 void
-_BlockStoreSlm(::std::uint32_t slm_offset, __dpl_esimd_ns::simd<_T, _N> __data)
+__block_store_slm(::std::uint32_t __slm_offset, __dpl_esimd_ns::simd<_T, _N> __data)
 {
-    constexpr int BLOCK_SIZE_ROUNDED = __lsc_slm_block_size_rounding<_NElts>();
+    constexpr int __block_size_rounded = __lsc_slm_block_size_rounding<_NElts>();
 
-    constexpr int BLOCK_SIZE = __lsc_op_block_size<OpAlignedT, BLOCK_SIZE_ROUNDED, _T>();
-    _BlockStoreSlm<_T, BLOCK_SIZE>(slm_offset, __data.template select<BLOCK_SIZE, 1>(0));
-    _BlockStoreSlm<_T, _N - BLOCK_SIZE>(slm_offset + BLOCK_SIZE * sizeof(_T),
-                                     __data.template select<_N - BLOCK_SIZE, 1>(BLOCK_SIZE));
+    constexpr int __block_size = __lsc_op_block_size<_OpAlignedT, __block_size_rounded, _T>();
+    __block_store_slm<_T, __block_size>(__slm_offset, __data.template select<__block_size, 1>(0));
+    __block_store_slm<_T, _N - __block_size>(__slm_offset + __block_size * sizeof(_T),
+                                     __data.template select<_N - __block_size, 1>(__block_size));
 }
 
 template <typename _T, int _NElts, ::std::enable_if_t<sizeof(_T) == sizeof(::std::uint8_t), int> = 0>
 constexpr int
-lsc_block_store_size_rounding()
+__lsc_block_store_size_rounding()
 {
     // https://github.com/intel/llvm/blob/3dbc2c00c26e599e8a10d44e3168a45d3c496eeb/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp#L2067
     // Allowed _NElts values for 8 bit data are 4, 8, 12, 16, 32, 64, 128, 256, 512.
@@ -608,7 +608,7 @@ lsc_block_store_size_rounding()
 
 template <typename _T, int _NElts, ::std::enable_if_t<sizeof(_T) == sizeof(::std::uint16_t), int> = 0>
 constexpr int
-lsc_block_store_size_rounding()
+__lsc_block_store_size_rounding()
 {
     // https://github.com/intel/llvm/blob/3dbc2c00c26e599e8a10d44e3168a45d3c496eeb/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp#L2067
     // Allowed _NElts values for 16 bit data are 2, 4, 8, 16, 32, 64, 128, 256.
@@ -644,7 +644,7 @@ lsc_block_store_size_rounding()
 
 template <typename _T, int _NElts, ::std::enable_if_t<sizeof(_T) == sizeof(::std::uint32_t), int> = 0>
 constexpr int
-lsc_block_store_size_rounding()
+__lsc_block_store_size_rounding()
 {
     // https://github.com/intel/llvm/blob/3dbc2c00c26e599e8a10d44e3168a45d3c496eeb/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp#L2067
     // Allowed _NElts values for 32 bit data are 1, 2, 3, 4, 8, 16, 32, 64, 128.
@@ -680,7 +680,7 @@ lsc_block_store_size_rounding()
 
 template <typename _T, int _NElts, ::std::enable_if_t<sizeof(_T) == sizeof(::std::uint64_t), int> = 0>
 constexpr int
-lsc_block_store_size_rounding()
+__lsc_block_store_size_rounding()
 {
     // https://github.com/intel/llvm/blob/3dbc2c00c26e599e8a10d44e3168a45d3c496eeb/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp#L2067
     // Allowed _NElts values for 64 bit data are 1, 2, 3, 4, 8, 16, 32, 64.
@@ -713,9 +713,9 @@ lsc_block_store_size_rounding()
 
 template <typename _T, int _N, __dpl_esimd_ens::cache_hint _H1 = __dpl_esimd_ens::cache_hint::none,
           __dpl_esimd_ens::cache_hint _H3 = __dpl_esimd_ens::cache_hint::none,
-          ::std::enable_if_t<_N == lsc_block_store_size_rounding<_T, _N>(), int> = 0>
+          ::std::enable_if_t<_N == __lsc_block_store_size_rounding<_T, _N>(), int> = 0>
 inline void
-_BlockStore(_T* __dst, __dpl_esimd_ns::simd<_T, _N> __data)
+__block_store(_T* __dst, __dpl_esimd_ns::simd<_T, _N> __data)
 {
     // https://github.com/intel/llvm/blob/3dbc2c00c26e599e8a10d44e3168a45d3c496eeb/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp#L2067
     // Allowed _NElts values for  8 bit data are          4, 8, 12, 16, 32, 64, 128, 256, 512.
@@ -728,17 +728,17 @@ _BlockStore(_T* __dst, __dpl_esimd_ns::simd<_T, _N> __data)
 
 template <typename _T, int _N, __dpl_esimd_ens::cache_hint _H1 = __dpl_esimd_ens::cache_hint::none,
           __dpl_esimd_ens::cache_hint _H3 = __dpl_esimd_ens::cache_hint::none,
-          ::std::enable_if_t<_N != lsc_block_store_size_rounding<_T, _N>(), int> = 0>
+          ::std::enable_if_t<_N != __lsc_block_store_size_rounding<_T, _N>(), int> = 0>
 inline void
-_BlockStore(_T* __dst, __dpl_esimd_ns::simd<_T, _N> __data)
+__block_store(_T* __dst, __dpl_esimd_ns::simd<_T, _N> __data)
 {
-    constexpr ::std::uint32_t BLOCK_SIZE = 64 * sizeof(::std::uint32_t) / sizeof(_T);
+    constexpr ::std::uint32_t __block_size = 64 * sizeof(::std::uint32_t) / sizeof(_T);
 
-    constexpr int BLOCK_SIZE_ROUNDED = lsc_block_store_size_rounding<_T, _N>();
-    static_assert(BLOCK_SIZE == BLOCK_SIZE_ROUNDED);
+    constexpr int __block_size_rounded = __lsc_block_store_size_rounding<_T, _N>();
+    static_assert(__block_size == __block_size_rounded);
 
-    _BlockStore<_T, BLOCK_SIZE>(__dst, __data.template select<BLOCK_SIZE, 1>(0));
-    _BlockStore<_T, _N - BLOCK_SIZE>(__dst + BLOCK_SIZE, __data.template select<_N - BLOCK_SIZE, 1>(BLOCK_SIZE));
+    __block_store<_T, __block_size>(__dst, __data.template select<__block_size, 1>(0));
+    __block_store<_T, _N - __block_size>(__dst + __block_size, __data.template select<_N - __block_size, 1>(__block_size));
 }
 
 template <typename _T, int _N>

--- a/include/oneapi/dpl/experimental/kt/kernel_param.h
+++ b/include/oneapi/dpl/experimental/kt/kernel_param.h
@@ -17,12 +17,12 @@
 namespace oneapi::dpl::experimental::kt
 {
 
-template <std::uint16_t _DataPerWorkItem, std::uint16_t _WorkGroupSize,
+template <std::uint16_t __data_per_work_item, std::uint16_t __work_group_size,
           typename _KernelName = oneapi::dpl::execution::DefaultKernelName>
 struct kernel_param
 {
-    static constexpr std::uint16_t data_per_workitem = _DataPerWorkItem;
-    static constexpr std::uint16_t workgroup_size = _WorkGroupSize;
+    static constexpr std::uint16_t data_per_workitem = __data_per_work_item;
+    static constexpr std::uint16_t workgroup_size = __work_group_size;
     using kernel_name = _KernelName;
 };
 


### PR DESCRIPTION
oneDPL code uses snake_case for variables (even for constexpr ones), function names; PascalCase for types. 
The names are preserved for ESIMD function wrappers to be aligned with ESIMD.