### PR TITLE
oneDPL code cleanup and simplification - types

### DIFF
--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -70,7 +70,7 @@ struct custom_brick
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename StrictWeakOrdering>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<typename ::std::decay<Policy>::type, OutputIterator>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<::std::decay_t<Policy>, OutputIterator>
 lower_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, InputIterator2 value_start,
                  InputIterator2 value_end, OutputIterator result, StrictWeakOrdering comp)
 {
@@ -82,7 +82,7 @@ lower_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, Inpu
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename StrictWeakOrdering>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<typename ::std::decay<Policy>::type, OutputIterator>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<::std::decay_t<Policy>, OutputIterator>
 upper_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, InputIterator2 value_start,
                  InputIterator2 value_end, OutputIterator result, StrictWeakOrdering comp)
 {
@@ -94,7 +94,7 @@ upper_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, Inpu
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename StrictWeakOrdering>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<typename ::std::decay<Policy>::type, OutputIterator>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<::std::decay_t<Policy>, OutputIterator>
 binary_search_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, InputIterator2 value_start,
                    InputIterator2 value_end, OutputIterator result, StrictWeakOrdering comp)
 {
@@ -107,7 +107,7 @@ binary_search_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, In
 #if _ONEDPL_BACKEND_SYCL
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename StrictWeakOrdering>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<typename ::std::decay<Policy>::type, OutputIterator>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<::std::decay_t<Policy>, OutputIterator>
 lower_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, InputIterator2 value_start,
                  InputIterator2 value_end, OutputIterator result, StrictWeakOrdering comp)
 {
@@ -137,7 +137,7 @@ lower_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, Inpu
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename StrictWeakOrdering>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<typename ::std::decay<Policy>::type, OutputIterator>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<::std::decay_t<Policy>, OutputIterator>
 upper_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, InputIterator2 value_start,
                  InputIterator2 value_end, OutputIterator result, StrictWeakOrdering comp)
 {
@@ -167,7 +167,7 @@ upper_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, Inpu
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename StrictWeakOrdering>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<typename ::std::decay<Policy>::type, OutputIterator>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<::std::decay_t<Policy>, OutputIterator>
 binary_search_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, InputIterator2 value_start,
                    InputIterator2 value_end, OutputIterator result, StrictWeakOrdering comp)
 {

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -70,7 +70,7 @@ struct custom_brick
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename StrictWeakOrdering>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<::std::decay_t<Policy>, OutputIterator>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<Policy, OutputIterator>
 lower_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, InputIterator2 value_start,
                  InputIterator2 value_end, OutputIterator result, StrictWeakOrdering comp)
 {
@@ -82,7 +82,7 @@ lower_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, Inpu
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename StrictWeakOrdering>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<::std::decay_t<Policy>, OutputIterator>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<Policy, OutputIterator>
 upper_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, InputIterator2 value_start,
                  InputIterator2 value_end, OutputIterator result, StrictWeakOrdering comp)
 {
@@ -94,7 +94,7 @@ upper_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, Inpu
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename StrictWeakOrdering>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<::std::decay_t<Policy>, OutputIterator>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<Policy, OutputIterator>
 binary_search_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, InputIterator2 value_start,
                    InputIterator2 value_end, OutputIterator result, StrictWeakOrdering comp)
 {
@@ -107,7 +107,7 @@ binary_search_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, In
 #if _ONEDPL_BACKEND_SYCL
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename StrictWeakOrdering>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<::std::decay_t<Policy>, OutputIterator>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<Policy, OutputIterator>
 lower_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, InputIterator2 value_start,
                  InputIterator2 value_end, OutputIterator result, StrictWeakOrdering comp)
 {
@@ -137,7 +137,7 @@ lower_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, Inpu
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename StrictWeakOrdering>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<::std::decay_t<Policy>, OutputIterator>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<Policy, OutputIterator>
 upper_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, InputIterator2 value_start,
                  InputIterator2 value_end, OutputIterator result, StrictWeakOrdering comp)
 {
@@ -167,7 +167,7 @@ upper_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, Inpu
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename StrictWeakOrdering>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<::std::decay_t<Policy>, OutputIterator>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<Policy, OutputIterator>
 binary_search_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, InputIterator2 value_start,
                    InputIterator2 value_end, OutputIterator result, StrictWeakOrdering comp)
 {

--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -39,7 +39,7 @@ class ExclusiveScan2;
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator, typename T,
           typename BinaryPredicate, typename Operator>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<typename ::std::decay<Policy>::type, OutputIterator>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<::std::decay_t<Policy>, OutputIterator>
 pattern_exclusive_scan_by_segment(Policy&& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                                   OutputIterator result, T init, BinaryPredicate binary_pred, Operator binary_op)
 {
@@ -57,7 +57,7 @@ pattern_exclusive_scan_by_segment(Policy&& policy, InputIterator1 first1, InputI
     typedef typename ::std::iterator_traits<OutputIterator>::value_type OutputType;
     typedef typename ::std::iterator_traits<InputIterator2>::value_type ValueType;
     typedef unsigned int FlagType;
-    typedef typename ::std::decay<Policy>::type policy_type;
+    typedef ::std::decay_t<Policy> policy_type;
 
     InputIterator2 last2 = first2 + n;
 
@@ -94,7 +94,7 @@ pattern_exclusive_scan_by_segment(Policy&& policy, InputIterator1 first1, InputI
 #if _ONEDPL_BACKEND_SYCL
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator, typename T,
           typename BinaryPredicate, typename Operator>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<typename ::std::decay<Policy>::type, OutputIterator>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<::std::decay_t<Policy>, OutputIterator>
 exclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                                OutputIterator result, T init, BinaryPredicate binary_pred, Operator binary_op,
                                ::std::true_type /* has_known_identity*/)
@@ -105,7 +105,7 @@ exclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIter
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator, typename T,
           typename BinaryPredicate, typename Operator>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<typename ::std::decay<Policy>::type, OutputIterator>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<::std::decay_t<Policy>, OutputIterator>
 exclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                                OutputIterator result, T init, BinaryPredicate binary_pred, Operator binary_op,
                                ::std::false_type /* has_known_identity*/)
@@ -115,7 +115,7 @@ exclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIter
     typedef typename ::std::iterator_traits<OutputIterator>::value_type OutputType;
     typedef typename ::std::iterator_traits<InputIterator2>::value_type ValueType;
     typedef unsigned int FlagType;
-    typedef typename ::std::decay<Policy>::type policy_type;
+    typedef ::std::decay_t<Policy> policy_type;
 
     InputIterator2 last2 = first2 + n;
 

--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -39,7 +39,7 @@ class ExclusiveScan2;
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator, typename T,
           typename BinaryPredicate, typename Operator>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<::std::decay_t<Policy>, OutputIterator>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<Policy, OutputIterator>
 pattern_exclusive_scan_by_segment(Policy&& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                                   OutputIterator result, T init, BinaryPredicate binary_pred, Operator binary_op)
 {
@@ -94,7 +94,7 @@ pattern_exclusive_scan_by_segment(Policy&& policy, InputIterator1 first1, InputI
 #if _ONEDPL_BACKEND_SYCL
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator, typename T,
           typename BinaryPredicate, typename Operator>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<::std::decay_t<Policy>, OutputIterator>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<Policy, OutputIterator>
 exclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                                OutputIterator result, T init, BinaryPredicate binary_pred, Operator binary_op,
                                ::std::true_type /* has_known_identity*/)
@@ -105,7 +105,7 @@ exclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIter
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator, typename T,
           typename BinaryPredicate, typename Operator>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<::std::decay_t<Policy>, OutputIterator>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<Policy, OutputIterator>
 exclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                                OutputIterator result, T init, BinaryPredicate binary_pred, Operator binary_op,
                                ::std::false_type /* has_known_identity*/)
@@ -164,7 +164,7 @@ exclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIter
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator, typename T,
           typename BinaryPredicate, typename Operator>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<::std::decay_t<Policy>, OutputIterator>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<Policy, OutputIterator>
 pattern_exclusive_scan_by_segment(Policy&& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                                   OutputIterator result, T init, BinaryPredicate binary_pred, Operator binary_op)
 {

--- a/include/oneapi/dpl/internal/function.h
+++ b/include/oneapi/dpl/internal/function.h
@@ -41,7 +41,7 @@ using oneapi::dpl::__par_backend_hetero::__internal::__buffer;
 // algorithm from either a SYCL iterator or a USM pointer.
 template <sycl::access::mode Mode, typename Policy, typename Iterator>
 auto
-get_access(Policy, Iterator i, ::std::enable_if_t<is_hetero_iterator<Iterator>::value, void>* = nullptr)
+get_access(Policy, Iterator i, ::std::enable_if_t<is_hetero_iterator<Iterator>::value>* = nullptr)
     -> decltype(i.get_buffer().template get_access<Mode>())
 {
     return i.get_buffer().template get_access<Mode>();
@@ -49,7 +49,7 @@ get_access(Policy, Iterator i, ::std::enable_if_t<is_hetero_iterator<Iterator>::
 
 template <sycl::access::mode Mode, typename Policy, typename Iterator>
 Iterator
-get_access(Policy, Iterator i, ::std::enable_if_t<!is_hetero_iterator<Iterator>::value, void>* = nullptr)
+get_access(Policy, Iterator i, ::std::enable_if_t<!is_hetero_iterator<Iterator>::value>* = nullptr)
 {
     return i;
 }
@@ -77,7 +77,7 @@ struct is_discard_iterator : ::std::false_type
 };
 
 template <typename Iter> // for discard iterators
-struct is_discard_iterator<Iter, ::std::enable_if_t<Iter::is_discard::value, void>> : ::std::true_type
+struct is_discard_iterator<Iter, ::std::enable_if_t<Iter::is_discard::value>> : ::std::true_type
 {
 };
 

--- a/include/oneapi/dpl/internal/function.h
+++ b/include/oneapi/dpl/internal/function.h
@@ -41,7 +41,7 @@ using oneapi::dpl::__par_backend_hetero::__internal::__buffer;
 // algorithm from either a SYCL iterator or a USM pointer.
 template <sycl::access::mode Mode, typename Policy, typename Iterator>
 auto
-get_access(Policy, Iterator i, typename ::std::enable_if<is_hetero_iterator<Iterator>::value, void>::type* = nullptr)
+get_access(Policy, Iterator i, ::std::enable_if_t<is_hetero_iterator<Iterator>::value, void>* = nullptr)
     -> decltype(i.get_buffer().template get_access<Mode>())
 {
     return i.get_buffer().template get_access<Mode>();
@@ -49,7 +49,7 @@ get_access(Policy, Iterator i, typename ::std::enable_if<is_hetero_iterator<Iter
 
 template <sycl::access::mode Mode, typename Policy, typename Iterator>
 Iterator
-get_access(Policy, Iterator i, typename ::std::enable_if<!is_hetero_iterator<Iterator>::value, void>::type* = nullptr)
+get_access(Policy, Iterator i, ::std::enable_if_t<!is_hetero_iterator<Iterator>::value, void>* = nullptr)
 {
     return i;
 }
@@ -77,7 +77,7 @@ struct is_discard_iterator : ::std::false_type
 };
 
 template <typename Iter> // for discard iterators
-struct is_discard_iterator<Iter, typename ::std::enable_if<Iter::is_discard::value, void>::type> : ::std::true_type
+struct is_discard_iterator<Iter, ::std::enable_if_t<Iter::is_discard::value, void>> : ::std::true_type
 {
 };
 

--- a/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
@@ -38,7 +38,7 @@ class InclusiveScan1;
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename BinaryPredicate, typename BinaryOperator>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<::std::decay_t<Policy>, OutputIterator>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<Policy, OutputIterator>
 pattern_inclusive_scan_by_segment(Policy&& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                                   OutputIterator result, BinaryPredicate binary_pred, BinaryOperator binary_op)
 {
@@ -75,7 +75,7 @@ pattern_inclusive_scan_by_segment(Policy&& policy, InputIterator1 first1, InputI
 #if _ONEDPL_BACKEND_SYCL
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename BinaryPredicate, typename BinaryOperator>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<::std::decay_t<Policy>, OutputIterator>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<Policy, OutputIterator>
 inclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                                OutputIterator result, BinaryPredicate binary_pred, BinaryOperator binary_op,
                                ::std::true_type /* has_known_identity */)
@@ -88,7 +88,7 @@ inclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIter
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename BinaryPredicate, typename BinaryOperator>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<::std::decay_t<Policy>, OutputIterator>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<Policy, OutputIterator>
 inclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                                OutputIterator result, BinaryPredicate binary_pred, BinaryOperator binary_op,
                                ::std::false_type /* has_known_identity */)
@@ -127,7 +127,7 @@ inclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIter
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename BinaryPredicate, typename BinaryOperator>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<::std::decay_t<Policy>, OutputIterator>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<Policy, OutputIterator>
 pattern_inclusive_scan_by_segment(Policy&& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                                   OutputIterator result, BinaryPredicate binary_pred, BinaryOperator binary_op)
 {

--- a/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
@@ -38,7 +38,7 @@ class InclusiveScan1;
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename BinaryPredicate, typename BinaryOperator>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<typename ::std::decay<Policy>::type, OutputIterator>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<::std::decay_t<Policy>, OutputIterator>
 pattern_inclusive_scan_by_segment(Policy&& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                                   OutputIterator result, BinaryPredicate binary_pred, BinaryOperator binary_op)
 {
@@ -55,7 +55,7 @@ pattern_inclusive_scan_by_segment(Policy&& policy, InputIterator1 first1, InputI
 
     typedef unsigned int FlagType;
     typedef typename ::std::iterator_traits<InputIterator2>::value_type ValueType;
-    typedef typename ::std::decay<Policy>::type policy_type;
+    typedef ::std::decay_t<Policy> policy_type;
 
     oneapi::dpl::__par_backend::__buffer<policy_type, FlagType> _mask(n);
     auto mask = _mask.get();
@@ -75,7 +75,7 @@ pattern_inclusive_scan_by_segment(Policy&& policy, InputIterator1 first1, InputI
 #if _ONEDPL_BACKEND_SYCL
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename BinaryPredicate, typename BinaryOperator>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<typename ::std::decay<Policy>::type, OutputIterator>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<::std::decay_t<Policy>, OutputIterator>
 inclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                                OutputIterator result, BinaryPredicate binary_pred, BinaryOperator binary_op,
                                ::std::true_type /* has_known_identity */)
@@ -88,7 +88,7 @@ inclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIter
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename BinaryPredicate, typename BinaryOperator>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<typename ::std::decay<Policy>::type, OutputIterator>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<::std::decay_t<Policy>, OutputIterator>
 inclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                                OutputIterator result, BinaryPredicate binary_pred, BinaryOperator binary_op,
                                ::std::false_type /* has_known_identity */)
@@ -96,7 +96,7 @@ inclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIter
 
     typedef unsigned int FlagType;
     typedef typename ::std::iterator_traits<InputIterator2>::value_type ValueType;
-    typedef typename ::std::decay<Policy>::type policy_type;
+    typedef ::std::decay_t<Policy> policy_type;
 
     const auto n = ::std::distance(first1, last1);
 
@@ -127,7 +127,7 @@ inclusive_scan_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIter
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename BinaryPredicate, typename BinaryOperator>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<typename ::std::decay<Policy>::type, OutputIterator>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<::std::decay_t<Policy>, OutputIterator>
 pattern_inclusive_scan_by_segment(Policy&& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                                   OutputIterator result, BinaryPredicate binary_pred, BinaryOperator binary_op)
 {

--- a/include/oneapi/dpl/internal/random_impl/bernoulli_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/bernoulli_distribution.h
@@ -141,7 +141,7 @@ class bernoulli_distribution
 
     // Implementation for generate function
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         return generate_vec<_Ndistr, _Engine>(__engine, __params);
@@ -149,7 +149,7 @@ class bernoulli_distribution
 
     // Specialization of the scalar generation
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr == 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr == 0), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         oneapi::dpl::uniform_real_distribution<double> __distr;
@@ -158,7 +158,7 @@ class bernoulli_distribution
 
     // Specialization of the vector generation with size = [1; 2; 3]
     template <int __N, class _Engine>
-    typename ::std::enable_if<(__N <= 3), result_type>::type
+    ::std::enable_if_t<(__N <= 3), result_type>
     generate_vec(_Engine& __engine, const param_type& __params)
     {
         return generate_n_elems<_Engine>(__engine, __params, __N);
@@ -166,7 +166,7 @@ class bernoulli_distribution
 
     // Specialization of the vector generation with size = [4; 8; 16]
     template <int __N, class _Engine>
-    typename ::std::enable_if<(__N > 3), result_type>::type
+    ::std::enable_if_t<(__N > 3), result_type>
     generate_vec(_Engine& __engine, const param_type& __params)
     {
         oneapi::dpl::uniform_real_distribution<sycl::vec<double, __N>> __distr;
@@ -192,7 +192,7 @@ class bernoulli_distribution
 
     // Implementation for result_portion function
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     result_portion_internal(_Engine& __engine, const param_type& __params, unsigned int __N)
     {
         result_type __part_vec;

--- a/include/oneapi/dpl/internal/random_impl/cauchy_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/cauchy_distribution.h
@@ -155,7 +155,7 @@ class cauchy_distribution
 
     // Implementation for generate function
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         return generate_vec<_Ndistr, _Engine>(__engine, __params);
@@ -163,7 +163,7 @@ class cauchy_distribution
 
     // Specialization of the scalar generation
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr == 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr == 0), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         oneapi::dpl::uniform_real_distribution<scalar_type> __u;
@@ -172,7 +172,7 @@ class cauchy_distribution
 
     // Specialization of the vector generation with size = [1; 2; 3]
     template <int __N, class _Engine>
-    typename ::std::enable_if<(__N <= 3), result_type>::type
+    ::std::enable_if_t<(__N <= 3), result_type>
     generate_vec(_Engine& __engine, const param_type& __params)
     {
         return generate_n_elems<_Engine>(__engine, __params, __N);
@@ -180,7 +180,7 @@ class cauchy_distribution
 
     // Specialization of the vector generation with size = [4; 8; 16]
     template <int __N, class _Engine>
-    typename ::std::enable_if<(__N > 3), result_type>::type
+    ::std::enable_if_t<(__N > 3), result_type>
     generate_vec(_Engine& __engine, const param_type& __params)
     {
         oneapi::dpl::uniform_real_distribution<sycl::vec<scalar_type, __N>> __distr;
@@ -202,7 +202,7 @@ class cauchy_distribution
 
     // Implementation for result_portion function
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     result_portion_internal(_Engine& __engine, const param_type& __params, unsigned int __N)
     {
         result_type __part_vec;

--- a/include/oneapi/dpl/internal/random_impl/discard_block_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/discard_block_engine.h
@@ -139,7 +139,7 @@ class discard_block_engine
 
     // Function for state adjustment
     template <int _N>
-    typename ::std::enable_if<(_N == 0), scalar_type>::type
+    ::std::enable_if_t<(_N == 0), scalar_type>
     generate_internal_scalar()
     {
         if (n_ >= used_block)
@@ -152,7 +152,7 @@ class discard_block_engine
     };
 
     template <int N>
-    typename ::std::enable_if<(N > 0), scalar_type>::type
+    ::std::enable_if_t<(N > 0), scalar_type>
     generate_internal_scalar()
     {
         if (n_ >= used_block)
@@ -166,14 +166,14 @@ class discard_block_engine
 
     // Generate implementation
     template <int _N>
-    typename ::std::enable_if<(_N == 0), result_type>::type
+    ::std::enable_if_t<(_N == 0), result_type>
     generate_internal()
     {
         return generate_internal_scalar<internal::type_traits_t<result_type>::num_elems>();
     }
 
     template <int _N>
-    typename ::std::enable_if<(_N > 0), result_type>::type
+    ::std::enable_if_t<(_N > 0), result_type>
     generate_internal()
     {
         result_type __res;
@@ -193,7 +193,7 @@ class discard_block_engine
     }
 
     template <int _N>
-    typename ::std::enable_if<(_N > 0), result_type>::type
+    ::std::enable_if_t<(_N > 0), result_type>
     generate_internal(unsigned int __random_nums)
     {
         if (__random_nums >= _N)

--- a/include/oneapi/dpl/internal/random_impl/exponential_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/exponential_distribution.h
@@ -141,7 +141,7 @@ class exponential_distribution
 
     // Implementation for generate function
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         return generate_vec<_Ndistr, _Engine>(__engine, __params);
@@ -149,7 +149,7 @@ class exponential_distribution
 
     // Specialization of the scalar generation
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr == 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr == 0), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         result_type __res;
@@ -160,7 +160,7 @@ class exponential_distribution
 
     // Specialization of the vector generation  with size = [1; 2; 3]
     template <int __N, class _Engine>
-    typename ::std::enable_if<(__N <= 3), result_type>::type
+    ::std::enable_if_t<(__N <= 3), result_type>
     generate_vec(_Engine& __engine, const param_type& __params)
     {
         return generate_n_elems<_Engine>(__engine, __params, __N);
@@ -168,7 +168,7 @@ class exponential_distribution
 
     // Specialization of the vector generation with size = [4; 8; 16]
     template <int __N, class _Engine>
-    typename ::std::enable_if<(__N > 3), result_type>::type
+    ::std::enable_if_t<(__N > 3), result_type>
     generate_vec(_Engine& __engine, const param_type& __params)
     {
         oneapi::dpl::uniform_real_distribution<result_type> __u;
@@ -194,7 +194,7 @@ class exponential_distribution
 
     // Implementation for result_portion function
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     result_portion_internal(_Engine& __engine, const param_type& __params, unsigned int __N)
     {
         result_type __part_vec;

--- a/include/oneapi/dpl/internal/random_impl/extreme_value_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/extreme_value_distribution.h
@@ -170,7 +170,7 @@ class extreme_value_distribution
 
     // Implementation for generate function
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         return generate_vec<_Ndistr, _Engine>(__engine, __params);
@@ -178,7 +178,7 @@ class extreme_value_distribution
 
     // Specialization of the scalar generation
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr == 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr == 0), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         oneapi::dpl::exponential_distribution<scalar_type> __distr;
@@ -189,7 +189,7 @@ class extreme_value_distribution
 
     // Specialization of the vector generation with size = [1; 2; 3]
     template <int __N, class _Engine>
-    typename ::std::enable_if<(__N <= 3), result_type>::type
+    ::std::enable_if_t<(__N <= 3), result_type>
     generate_vec(_Engine& __engine, const param_type& __params)
     {
         return generate_n_elems<_Engine>(__engine, __params, __N);
@@ -197,7 +197,7 @@ class extreme_value_distribution
 
     // Specialization of the vector generation with size = [4; 8; 16]
     template <int __N, class _Engine>
-    typename ::std::enable_if<(__N > 3), result_type>::type
+    ::std::enable_if_t<(__N > 3), result_type>
     generate_vec(_Engine& __engine, const param_type& __params)
     {
         oneapi::dpl::exponential_distribution<result_type> __distr;
@@ -226,7 +226,7 @@ class extreme_value_distribution
 
     // Implementation for result_portion function
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     result_portion_internal(_Engine& __engine, const param_type& __params, unsigned int __N)
     {
         result_type __part_vec;

--- a/include/oneapi/dpl/internal/random_impl/geometric_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/geometric_distribution.h
@@ -141,7 +141,7 @@ class geometric_distribution
 
     // Implementation for generate function
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         return generate_vec<_Ndistr, _Engine>(__engine, __params);
@@ -149,7 +149,7 @@ class geometric_distribution
 
     // Specialization of the scalar generation
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr == 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr == 0), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         oneapi::dpl::uniform_real_distribution<double> __u;
@@ -158,7 +158,7 @@ class geometric_distribution
 
     // Specialization of the vector generation with size = [1; 2; 3]
     template <int __N, class _Engine>
-    typename ::std::enable_if<(__N <= 3), result_type>::type
+    ::std::enable_if_t<(__N <= 3), result_type>
     generate_vec(_Engine& __engine, const param_type& __params)
     {
         return generate_n_elems<_Engine>(__engine, __params, __N);
@@ -166,7 +166,7 @@ class geometric_distribution
 
     // Specialization of the vector generation with size = [4; 8; 16]
     template <int __N, class _Engine>
-    typename ::std::enable_if<(__N > 3), result_type>::type
+    ::std::enable_if_t<(__N > 3), result_type>
     generate_vec(_Engine& __engine, const param_type& __params)
     {
         oneapi::dpl::uniform_real_distribution<sycl::vec<double, __N>> __distr;
@@ -191,7 +191,7 @@ class geometric_distribution
 
     // Implementation for result_portion function
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     result_portion_internal(_Engine& __engine, const param_type& __params, unsigned int __N)
     {
         result_type __part_vec;

--- a/include/oneapi/dpl/internal/random_impl/linear_congruential_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/linear_congruential_engine.h
@@ -114,7 +114,7 @@ class linear_congruential_engine
 
     // Initialization function
     template <int _N = 0>
-    typename ::std::enable_if<(_N == 0)>::type
+    ::std::enable_if_t<(_N == 0)>
     init(scalar_type __seed)
     {
         if ((increment % modulus == 0) && (__seed % modulus == 0))
@@ -129,7 +129,7 @@ class linear_congruential_engine
     }
 
     template <int _N = 0>
-    typename ::std::enable_if<(_N > 0)>::type
+    ::std::enable_if_t<(_N > 0)>
     init(scalar_type __seed)
     {
         if ((increment % modulus == 0) && (__seed % modulus == 0))
@@ -177,7 +177,7 @@ class linear_congruential_engine
     // _FLAG - is flag that used for optimizations
     // if _FLAG == true in this case we can used optimized versions of skip_seq
     template <int _N = 0, bool _FLAG = false>
-    typename ::std::enable_if<(_N == 0) && (_FLAG == false)>::type
+    ::std::enable_if_t<(_N == 0) && (_FLAG == false)>
     skip_seq(unsigned long long __num_to_skip)
     {
         for (; __num_to_skip > 0; --__num_to_skip)
@@ -185,7 +185,7 @@ class linear_congruential_engine
     }
 
     template <int _N = 0, bool _FLAG = false>
-    typename ::std::enable_if<(_N == 1) && (_FLAG == false)>::type
+    ::std::enable_if_t<(_N == 1) && (_FLAG == false)>
     skip_seq(unsigned long long __num_to_skip)
     {
         for (; __num_to_skip > 0; --__num_to_skip)
@@ -193,7 +193,7 @@ class linear_congruential_engine
     }
 
     template <int _N = 0, bool _FLAG = false>
-    typename ::std::enable_if<(_N > 1) && (_FLAG == false)>::type
+    ::std::enable_if_t<(_N > 1) && (_FLAG == false)>
     skip_seq(unsigned long long __num_to_skip)
     {
         for (; __num_to_skip > 0; --__num_to_skip)
@@ -207,7 +207,7 @@ class linear_congruential_engine
     }
 
     template <int _N = 0, bool _FLAG = false>
-    typename ::std::enable_if<(_N == 0) && (_FLAG == true)>::type
+    ::std::enable_if_t<(_N == 0) && (_FLAG == true)>
     skip_seq(unsigned long long __num_to_skip)
     {
         ::std::uint64_t __mod = modulus;
@@ -216,7 +216,7 @@ class linear_congruential_engine
     }
 
     template <int _N = 0, bool _FLAG = false>
-    typename ::std::enable_if<(_N == 1) && (_FLAG == true)>::type
+    ::std::enable_if_t<(_N == 1) && (_FLAG == true)>
     skip_seq(unsigned long long __num_to_skip)
     {
         ::std::uint64_t __mod = modulus;
@@ -225,7 +225,7 @@ class linear_congruential_engine
     }
 
     template <int _N = 0, bool _FLAG = false>
-    typename ::std::enable_if<(_N > 1) && (_FLAG == true)>::type
+    ::std::enable_if_t<(_N > 1) && (_FLAG == true)>
     skip_seq(unsigned long long __num_to_skip)
     {
         ::std::uint64_t __mod = modulus;
@@ -235,7 +235,7 @@ class linear_congruential_engine
 
     // result_portion implementation
     template <int _N>
-    typename ::std::enable_if<(_N > 0), result_type>::type
+    ::std::enable_if_t<(_N > 0), result_type>
     result_portion_internal(unsigned int __random_nums)
     {
         result_type __part_vec;

--- a/include/oneapi/dpl/internal/random_impl/lognormal_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/lognormal_distribution.h
@@ -147,8 +147,8 @@ class lognormal_distribution
     // Size of type
     static constexpr int size_of_type_ = internal::type_traits_t<result_type>::num_elems;
 
-    using normal_distr = oneapi::dpl::normal_distribution<
-        typename ::std::conditional<(size_of_type_ <= 3), scalar_type, result_type>::type>;
+    using normal_distr =
+        oneapi::dpl::normal_distribution<::std::conditional_t<(size_of_type_ <= 3), scalar_type, result_type>>;
     using normal_distr_param_type = typename normal_distr::param_type;
 
     // Static asserts

--- a/include/oneapi/dpl/internal/random_impl/lognormal_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/lognormal_distribution.h
@@ -160,7 +160,7 @@ class lognormal_distribution
 
     // Implementation for generate function
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         return generate_vec<_Ndistr, _Engine>(__engine, __params);
@@ -168,7 +168,7 @@ class lognormal_distribution
 
     // Specialization of the scalar generation
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr == 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr == 0), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         return sycl::exp(nd_(__engine, normal_distr_param_type(__params.m(), __params.s())));
@@ -176,7 +176,7 @@ class lognormal_distribution
 
     // Specialization of the vector generation with size = [1; 2; 3]
     template <int __N, class _Engine>
-    typename ::std::enable_if<(__N <= 3), result_type>::type
+    ::std::enable_if_t<(__N <= 3), result_type>
     generate_vec(_Engine& __engine, const param_type& __params)
     {
         result_type __res;
@@ -187,7 +187,7 @@ class lognormal_distribution
 
     // Specialization of the vector generation with size = [4; 8; 16]
     template <int __N, class _Engine>
-    typename ::std::enable_if<(__N > 3), result_type>::type
+    ::std::enable_if_t<(__N > 3), result_type>
     generate_vec(_Engine& __engine, const param_type& __params)
     {
         return sycl::exp(nd_(__engine, normal_distr_param_type(__params.m(), __params.s())));
@@ -195,7 +195,7 @@ class lognormal_distribution
 
     // Implementation for the N vector's elements generation with size = [4; 8; 16]
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr > 3), result_type>::type
+    ::std::enable_if_t<(_Ndistr > 3), result_type>
     generate_n_elems(_Engine& __engine, const param_type& __params, unsigned int __N)
     {
         result_type __res = nd_(__engine, normal_distr_param_type(__params.m(), __params.s()), __N);
@@ -206,7 +206,7 @@ class lognormal_distribution
 
     // Implementation for the N vector's elements generation with size = [1; 2; 3]
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr <= 3), result_type>::type
+    ::std::enable_if_t<(_Ndistr <= 3), result_type>
     generate_n_elems(_Engine& __engine, const param_type& __params, unsigned int __N)
     {
         result_type __res;
@@ -217,7 +217,7 @@ class lognormal_distribution
 
     // Implementation for result_portion function
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     result_portion_internal(_Engine& __engine, const param_type& __params, unsigned int __N)
     {
         result_type __part_vec;

--- a/include/oneapi/dpl/internal/random_impl/normal_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/normal_distribution.h
@@ -166,7 +166,7 @@ class normal_distribution
 
     // Type of real distribution
     using uniform_result_type =
-        typename ::std::conditional<size_of_type_ % 2, sycl::vec<scalar_type, size_of_type_ + 1>, result_type>::type;
+        ::std::conditional_t<size_of_type_ % 2, sycl::vec<scalar_type, size_of_type_ + 1>, result_type>;
 
     // Distribution parameters
     scalar_type mean_;

--- a/include/oneapi/dpl/internal/random_impl/normal_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/normal_distribution.h
@@ -215,7 +215,7 @@ class normal_distribution
 
     // Implementation for generate function
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     generate(_Engine& __engine, const param_type __params)
     {
         return generate_vec<_Ndistr, _Engine>(__engine, __params);
@@ -223,7 +223,7 @@ class normal_distribution
 
     // Specialization of the scalar generation
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr == 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr == 0), result_type>
     generate(_Engine& __engine, const param_type __params)
     {
         result_type __res;
@@ -257,7 +257,7 @@ class normal_distribution
 
     // Specialization of the vector generation with size = [1; 2; 3]
     template <int __N, class _Engine>
-    typename ::std::enable_if<(__N <= 3), result_type>::type
+    ::std::enable_if_t<(__N <= 3), result_type>
     generate_vec(_Engine& __engine, const param_type __params)
     {
         return generate_n_elems<_Engine>(__engine, __params, __N);
@@ -265,7 +265,7 @@ class normal_distribution
 
     // Specialization of the vector generation with size = [4; 8; 16]
     template <int __N, class _Engine>
-    typename ::std::enable_if<(__N > 3), result_type>::type
+    ::std::enable_if_t<(__N > 3), result_type>
     generate_vec(_Engine& __engine, const param_type __params)
     {
         uniform_result_type __u;
@@ -404,7 +404,7 @@ class normal_distribution
 
     // Implementation for result_portion function
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     result_portion_internal(_Engine& __engine, const param_type __params, unsigned int __N)
     {
         result_type __part_vec;

--- a/include/oneapi/dpl/internal/random_impl/subtract_with_carry_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/subtract_with_carry_engine.h
@@ -136,14 +136,14 @@ class subtract_with_carry_engine
 
     // Generate implementation
     template <int _N>
-    typename ::std::enable_if<(_N == 0), result_type>::type
+    ::std::enable_if_t<(_N == 0), result_type>
     generate_internal()
     {
         return generate_internal_scalar();
     }
 
     template <int _N>
-    typename ::std::enable_if<(_N > 0), result_type>::type
+    ::std::enable_if_t<(_N > 0), result_type>
     generate_internal()
     {
         result_type __res;
@@ -156,7 +156,7 @@ class subtract_with_carry_engine
 
     // result_portion implementation
     template <int _N>
-    typename ::std::enable_if<(_N > 0), result_type>::type
+    ::std::enable_if_t<(_N > 0), result_type>
     result_portion_internal(unsigned int __random_nums)
     {
         result_type __part_vec;

--- a/include/oneapi/dpl/internal/random_impl/uniform_int_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/uniform_int_distribution.h
@@ -151,7 +151,7 @@ class uniform_int_distribution
     static constexpr int size_of_type_ = internal::type_traits_t<result_type>::num_elems;
 
     // Type of real distribution
-    using RealType = typename ::std::conditional<size_of_type_ == 0, double, sycl::vec<double, size_of_type_>>::type;
+    using RealType = ::std::conditional_t<size_of_type_ == 0, double, sycl::vec<double, size_of_type_>>;
 
     // Static asserts
     static_assert(::std::is_integral<scalar_type>::value,

--- a/include/oneapi/dpl/internal/random_impl/uniform_int_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/uniform_int_distribution.h
@@ -166,7 +166,7 @@ class uniform_int_distribution
 
     // Implementation for generate function
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         RealType __res = uniform_real_distribution_(
@@ -181,7 +181,7 @@ class uniform_int_distribution
     }
 
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr == 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr == 0), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         RealType __res = uniform_real_distribution_(
@@ -193,7 +193,7 @@ class uniform_int_distribution
 
     // Implementation for result_portion function
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     result_portion_internal(_Engine& __engine, const param_type& __params, unsigned int __N)
     {
         result_type __part_vec;

--- a/include/oneapi/dpl/internal/random_impl/uniform_real_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/uniform_real_distribution.h
@@ -158,7 +158,7 @@ class uniform_real_distribution
 
     // Implementation for generate function
     template <int _Ndistr, int _Nengine, class _Engine>
-    typename ::std::enable_if<((_Ndistr == _Nengine) & (_Ndistr != 0)), result_type>::type
+    ::std::enable_if_t<((_Ndistr == _Nengine) & (_Ndistr != 0)), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         auto __engine_output = __engine();
@@ -174,7 +174,7 @@ class uniform_real_distribution
     }
 
     template <int _Ndistr, int _Nengine, class _Engine>
-    typename ::std::enable_if<((_Ndistr == _Nengine) & (_Ndistr == 0)), result_type>::type
+    ::std::enable_if_t<((_Ndistr == _Nengine) & (_Ndistr == 0)), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         auto __engine_output = __engine();
@@ -187,7 +187,7 @@ class uniform_real_distribution
     }
 
     template <int _Ndistr, int _Nengine, class _Engine>
-    typename ::std::enable_if<((_Ndistr < _Nengine) & (_Ndistr != 0)), result_type>::type
+    ::std::enable_if_t<((_Ndistr < _Nengine) & (_Ndistr != 0)), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         auto __engine_output = __engine(_Ndistr);
@@ -204,7 +204,7 @@ class uniform_real_distribution
     }
 
     template <int _Ndistr, int _Nengine, class _Engine>
-    typename ::std::enable_if<((_Ndistr < _Nengine) & (_Ndistr == 0)), result_type>::type
+    ::std::enable_if_t<((_Ndistr < _Nengine) & (_Ndistr == 0)), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         scalar_type __res = static_cast<scalar_type>(__engine(1)[0]);
@@ -215,7 +215,7 @@ class uniform_real_distribution
     }
 
     template <int _Ndistr, int _Nengine, class _Engine>
-    typename ::std::enable_if<((_Ndistr > _Nengine) & (_Nengine != 0)), result_type>::type
+    ::std::enable_if_t<((_Ndistr > _Nengine) & (_Nengine != 0)), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         sycl::vec<scalar_type, _Ndistr> __res;
@@ -250,7 +250,7 @@ class uniform_real_distribution
     }
 
     template <int _Ndistr, int _Nengine, class _Engine>
-    typename ::std::enable_if<((_Ndistr > _Nengine) & (_Nengine == 0)), result_type>::type
+    ::std::enable_if_t<((_Ndistr > _Nengine) & (_Nengine == 0)), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         sycl::vec<scalar_type, _Ndistr> __res;
@@ -267,7 +267,7 @@ class uniform_real_distribution
 
     // Implementation for result_portion function
     template <int _Ndistr, int _Nengine, class _Engine>
-    typename ::std::enable_if<((_Ndistr <= _Nengine) & (_Ndistr != 0)), result_type>::type
+    ::std::enable_if_t<((_Ndistr <= _Nengine) & (_Ndistr != 0)), result_type>
     generate_n_elems(_Engine& __engine, const param_type& __params, unsigned int __N)
     {
         auto __engine_output = __engine(__N);
@@ -284,7 +284,7 @@ class uniform_real_distribution
     }
 
     template <int _Ndistr, int _Nengine, class _Engine>
-    typename ::std::enable_if<((_Ndistr > _Nengine) & (_Nengine != 0)), result_type>::type
+    ::std::enable_if_t<((_Ndistr > _Nengine) & (_Nengine != 0)), result_type>
     generate_n_elems(_Engine& __engine, const param_type& __params, unsigned int __N)
     {
         result_type __res;
@@ -338,7 +338,7 @@ class uniform_real_distribution
     }
 
     template <int _Ndistr, int _Nengine, class _Engine>
-    typename ::std::enable_if<((_Ndistr > _Nengine) & (_Nengine == 0)), result_type>::type
+    ::std::enable_if_t<((_Ndistr > _Nengine) & (_Nengine == 0)), result_type>
     generate_n_elems(_Engine& __engine, const param_type& __params, unsigned int __N)
     {
         result_type __res;
@@ -355,7 +355,7 @@ class uniform_real_distribution
 
     // Implementation for result_portion function
     template <int _Ndistr, int _Nengine, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     result_portion_internal(_Engine& __engine, const param_type __params, unsigned int __N)
     {
         result_type __part_vec;

--- a/include/oneapi/dpl/internal/random_impl/weibull_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/weibull_distribution.h
@@ -155,7 +155,7 @@ class weibull_distribution
 
     // Implementation for generate function
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         return generate_vec<_Ndistr, _Engine>(__engine, __params);
@@ -163,7 +163,7 @@ class weibull_distribution
 
     // Specialization of the scalar generation
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr == 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr == 0), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
         oneapi::dpl::uniform_real_distribution<scalar_type> __u;
@@ -172,7 +172,7 @@ class weibull_distribution
 
     // Specialization of the vector generation with size = [1; 2; 3]
     template <int __N, class _Engine>
-    typename ::std::enable_if<(__N <= 3), result_type>::type
+    ::std::enable_if_t<(__N <= 3), result_type>
     generate_vec(_Engine& __engine, const param_type& __params)
     {
         return generate_n_elems<_Engine>(__engine, __params, __N);
@@ -180,7 +180,7 @@ class weibull_distribution
 
     // Specialization of the vector generation with size = [4; 8; 16]
     template <int __N, class _Engine>
-    typename ::std::enable_if<(__N > 3), result_type>::type
+    ::std::enable_if_t<(__N > 3), result_type>
     generate_vec(_Engine& __engine, const param_type& __params)
     {
         oneapi::dpl::uniform_real_distribution<sycl::vec<scalar_type, __N>> __distr;
@@ -203,7 +203,7 @@ class weibull_distribution
 
     // Implementation for result_portion function
     template <int _Ndistr, class _Engine>
-    typename ::std::enable_if<(_Ndistr != 0), result_type>::type
+    ::std::enable_if_t<(_Ndistr != 0), result_type>
     result_portion_internal(_Engine& __engine, const param_type& __params, unsigned int __N)
     {
         result_type __part_vec;

--- a/include/oneapi/dpl/internal/reduce_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/reduce_by_segment_impl.h
@@ -80,7 +80,7 @@ class Reduce4;
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator1,
           typename OutputIterator2, typename BinaryPred, typename BinaryOperator>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<::std::decay_t<Policy>,
+oneapi::dpl::__internal::__enable_if_host_execution_policy<Policy,
                                                            ::std::pair<OutputIterator1, OutputIterator2>>
 reduce_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                        OutputIterator1 result1, OutputIterator2 result2, BinaryPred binary_pred,

--- a/include/oneapi/dpl/internal/reduce_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/reduce_by_segment_impl.h
@@ -80,8 +80,7 @@ class Reduce4;
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator1,
           typename OutputIterator2, typename BinaryPred, typename BinaryOperator>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<Policy,
-                                                           ::std::pair<OutputIterator1, OutputIterator2>>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<Policy, ::std::pair<OutputIterator1, OutputIterator2>>
 reduce_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                        OutputIterator1 result1, OutputIterator2 result2, BinaryPred binary_pred,
                        BinaryOperator binary_op)

--- a/include/oneapi/dpl/internal/reduce_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/reduce_by_segment_impl.h
@@ -581,9 +581,9 @@ __sycl_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2&& 
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator1,
           typename OutputIterator2, typename BinaryPred, typename BinaryOperator>
-typename ::std::enable_if<
+::std::enable_if_t<
     oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value,
-    ::std::pair<OutputIterator1, OutputIterator2>>::type
+    ::std::pair<OutputIterator1, OutputIterator2>>
 reduce_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                        OutputIterator1 result1, OutputIterator2 result2, BinaryPred binary_pred,
                        BinaryOperator binary_op)

--- a/include/oneapi/dpl/internal/reduce_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/reduce_by_segment_impl.h
@@ -581,9 +581,7 @@ __sycl_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2&& 
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator1,
           typename OutputIterator2, typename BinaryPred, typename BinaryOperator>
-::std::enable_if_t<
-    oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value,
-    ::std::pair<OutputIterator1, OutputIterator2>>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<Policy, ::std::pair<OutputIterator1, OutputIterator2>>
 reduce_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                        OutputIterator1 result1, OutputIterator2 result2, BinaryPred binary_pred,
                        BinaryOperator binary_op)

--- a/include/oneapi/dpl/internal/reduce_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/reduce_by_segment_impl.h
@@ -80,7 +80,7 @@ class Reduce4;
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator1,
           typename OutputIterator2, typename BinaryPred, typename BinaryOperator>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<typename ::std::decay<Policy>::type,
+oneapi::dpl::__internal::__enable_if_host_execution_policy<::std::decay_t<Policy>,
                                                            ::std::pair<OutputIterator1, OutputIterator2>>
 reduce_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                        OutputIterator1 result1, OutputIterator2 result2, BinaryPred binary_pred,
@@ -110,7 +110,7 @@ reduce_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIterator1 la
     typedef uint64_t FlagType;
     typedef typename ::std::iterator_traits<InputIterator2>::value_type ValueType;
     typedef uint64_t CountType;
-    typedef typename ::std::decay<Policy>::type policy_type;
+    typedef ::std::decay_t<Policy> policy_type;
 
     // buffer that is used to store a flag indicating if the associated key is not equal to
     // the next key, and thus its associated sum should be part of the final result
@@ -582,7 +582,7 @@ __sycl_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2&& 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator1,
           typename OutputIterator2, typename BinaryPred, typename BinaryOperator>
 typename ::std::enable_if<
-    oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<Policy>::type>::value,
+    oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value,
     ::std::pair<OutputIterator1, OutputIterator2>>::type
 reduce_by_segment_impl(Policy&& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                        OutputIterator1 result1, OutputIterator2 result2, BinaryPred binary_pred,

--- a/include/oneapi/dpl/internal/scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/scan_by_segment_impl.h
@@ -369,7 +369,7 @@ struct __sycl_scan_by_segment_impl
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator, typename T,
           typename BinaryPredicate, typename Operator, typename Inclusive>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<typename ::std::decay<Policy>::type, OutputIterator>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<::std::decay_t<Policy>, OutputIterator>
 __scan_by_segment_impl_common(Policy&& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                               OutputIterator result, T init, BinaryPredicate binary_pred, Operator binary_op, Inclusive)
 {

--- a/include/oneapi/dpl/internal/scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/scan_by_segment_impl.h
@@ -369,7 +369,7 @@ struct __sycl_scan_by_segment_impl
 
 template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator, typename T,
           typename BinaryPredicate, typename Operator, typename Inclusive>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<::std::decay_t<Policy>, OutputIterator>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<Policy, OutputIterator>
 __scan_by_segment_impl_common(Policy&& policy, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
                               OutputIterator result, T init, BinaryPredicate binary_pred, Operator binary_op, Inclusive)
 {

--- a/include/oneapi/dpl/pstl/algorithm_fwd.h
+++ b/include/oneapi/dpl/pstl/algorithm_fwd.h
@@ -823,7 +823,7 @@ oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_sort_by_key(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __keys_first,
                       _RandomAccessIterator1 __keys_last, _RandomAccessIterator2 __values_first, _Compare __comp,
                       _IsVector /*vector=*/, /*is_parallel=*/::std::false_type) noexcept;
-                      
+
 template <typename _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2,
           typename _Compare, typename _IsVector>
 oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>

--- a/include/oneapi/dpl/pstl/algorithm_fwd.h
+++ b/include/oneapi/dpl/pstl/algorithm_fwd.h
@@ -71,14 +71,14 @@ __pattern_walk1(_ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _Functio
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Function, class _IsVector>
 oneapi::dpl::__internal::__enable_if_host_execution_policy_conditional<
-    _ExecutionPolicy, __is_random_access_iterator<_RandomAccessIterator>::value, void>
+    _ExecutionPolicy, __is_random_access_iterator<_RandomAccessIterator>::value>
 __pattern_walk1(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Function __f,
                 _IsVector __is_vector,
                 /*parallel=*/::std::true_type);
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Function, class _IsVector>
 oneapi::dpl::__internal::__enable_if_host_execution_policy_conditional<
-    _ExecutionPolicy, !__is_random_access_iterator<_RandomAccessIterator>::value, void>
+    _ExecutionPolicy, !__is_random_access_iterator<_RandomAccessIterator>::value>
 __pattern_walk1(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Function __f,
                 _IsVector __is_vector,
                 /*parallel=*/::std::true_type);

--- a/include/oneapi/dpl/pstl/algorithm_fwd.h
+++ b/include/oneapi/dpl/pstl/algorithm_fwd.h
@@ -65,7 +65,7 @@ void __brick_walk1(_RandomAccessIterator, _RandomAccessIterator, _Function,
                    /*vector=*/::std::true_type) noexcept;
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Function, class _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_walk1(_ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _Function, _IsVector,
                 /*parallel=*/::std::false_type) noexcept;
 
@@ -84,12 +84,12 @@ __pattern_walk1(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _Rando
                 /*parallel=*/::std::true_type);
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Brick>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_walk_brick(_ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _Brick,
                      /*parallel=*/::std::false_type) noexcept;
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Brick>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_walk_brick(_ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _Brick,
                      /*parallel=*/::std::true_type);
 
@@ -606,12 +606,12 @@ void __brick_reverse(_RandomAccessIterator, _RandomAccessIterator, _RandomAccess
                      /*is_vector=*/::std::true_type) noexcept;
 
 template <class _ExecutionPolicy, class _BidirectionalIterator, class _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_reverse(_ExecutionPolicy&&, _BidirectionalIterator, _BidirectionalIterator, _IsVector,
                   /*is_parallel=*/::std::false_type) noexcept;
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_reverse(_ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _IsVector,
                   /*is_parallel=*/::std::true_type);
 
@@ -788,12 +788,12 @@ __pattern_partition_copy(_ExecutionPolicy&&, _RandomAccessIterator, _RandomAcces
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _IsVector,
           class _IsMoveConstructible>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_sort(_ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _Compare, _IsVector /*is_vector*/,
                /*is_parallel=*/::std::false_type, _IsMoveConstructible) noexcept;
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_sort(_ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _Compare, _IsVector /*is_vector*/,
                /*is_parallel=*/::std::true_type,
                /*is_move_constructible=*/::std::true_type);
@@ -803,13 +803,13 @@ __pattern_sort(_ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator,
 //------------------------------------------------------------------------
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_stable_sort(_ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _Compare,
                       _IsVector /*is_vector*/,
                       /*is_parallel=*/::std::false_type) noexcept;
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_stable_sort(_ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _Compare,
                       _IsVector /*is_vector*/,
                       /*is_parallel=*/::std::true_type);
@@ -819,14 +819,14 @@ __pattern_stable_sort(_ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIt
 //------------------------------------------------------------------------
 template <typename _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2,
           typename _Compare, typename _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_sort_by_key(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __keys_first,
                       _RandomAccessIterator1 __keys_last, _RandomAccessIterator2 __values_first, _Compare __comp,
                       _IsVector /*vector=*/, /*is_parallel=*/::std::false_type) noexcept;
                       
 template <typename _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2,
           typename _Compare, typename _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_sort_by_key(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __keys_first,
                       _RandomAccessIterator1 __keys_last, _RandomAccessIterator2 __values_first, _Compare __comp,
                       _IsVector /*vector=*/, /*is_parallel=*/::std::true_type);
@@ -836,13 +836,13 @@ __pattern_sort_by_key(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __keys_f
 //------------------------------------------------------------------------
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_partial_sort(_ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _RandomAccessIterator,
                        _Compare, _IsVector,
                        /*is_parallel=*/::std::false_type) noexcept;
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_partial_sort(_ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _RandomAccessIterator,
                        _Compare, _IsVector,
                        /*is_parallel=*/::std::true_type);
@@ -893,13 +893,13 @@ __pattern_adjacent_find(_ExecutionPolicy&&, _RandomAccessIterator, _RandomAccess
 // nth_element
 //------------------------------------------------------------------------
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_nth_element(_ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _RandomAccessIterator, _Compare,
                       _IsVector,
                       /*is_parallel=*/::std::false_type) noexcept;
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_nth_element(_ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _RandomAccessIterator, _Compare,
                       _IsVector,
                       /*is_parallel=*/::std::true_type);
@@ -911,7 +911,7 @@ template <typename _Tp, typename _ExecutionPolicy, typename = void>
 struct __brick_fill;
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Tp, class _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_fill(_ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, const _Tp&,
                /*is_parallel=*/::std::false_type, _IsVector) noexcept;
 
@@ -946,7 +946,7 @@ void __brick_generate(_ForwardIterator, _ForwardIterator, _Generator,
                       /* is_vector = */ ::std::false_type) noexcept;
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Generator, class _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_generate(_ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _Generator,
                    /*is_parallel=*/::std::false_type, _IsVector) noexcept;
 
@@ -1034,13 +1034,13 @@ void __brick_inplace_merge(_RandomAccessIterator, _RandomAccessIterator, _Random
                            /* __is_vector = */ ::std::true_type) noexcept;
 
 template <class _ExecutionPolicy, class _BidirectionalIterator, class _Compare, class _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_inplace_merge(_ExecutionPolicy&&, _BidirectionalIterator, _BidirectionalIterator, _BidirectionalIterator,
                         _Compare, _IsVector,
                         /* is_parallel = */ ::std::false_type) noexcept;
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_inplace_merge(_ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _RandomAccessIterator,
                         _Compare, _IsVector,
                         /*is_parallel=*/::std::true_type);

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -145,7 +145,7 @@ __pattern_walk1(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator _
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Function, class _IsVector>
 oneapi::dpl::__internal::__enable_if_host_execution_policy_conditional<
-    _ExecutionPolicy, __is_random_access_iterator<_RandomAccessIterator>::value, void>
+    _ExecutionPolicy, __is_random_access_iterator<_RandomAccessIterator>::value>
 __pattern_walk1(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Function __f,
                 _IsVector __is_vector,
                 /*parallel=*/::std::true_type)
@@ -160,7 +160,7 @@ __pattern_walk1(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _Rando
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Function, class _IsVector>
 oneapi::dpl::__internal::__enable_if_host_execution_policy_conditional<
-    _ExecutionPolicy, !__is_random_access_iterator<_ForwardIterator>::value, void>
+    _ExecutionPolicy, !__is_random_access_iterator<_ForwardIterator>::value>
 __pattern_walk1(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Function __f, _IsVector,
                 /*parallel=*/::std::true_type)
 {

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -135,7 +135,7 @@ __brick_walk1(_DifferenceType __n, _Function __f, ::std::true_type) noexcept
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Function, class _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_walk1(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, _Function __f,
                 _IsVector __is_vector,
                 /*parallel=*/::std::false_type) noexcept
@@ -172,7 +172,7 @@ __pattern_walk1(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIte
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Brick>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_walk_brick(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Brick __brick,
                      /*parallel=*/::std::false_type) noexcept
 {
@@ -181,7 +181,7 @@ __pattern_walk_brick(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Forwa
 }
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Brick>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_walk_brick(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last,
                      _Brick __brick,
                      /*parallel=*/::std::true_type)
@@ -1019,7 +1019,7 @@ __pattern_search_n(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _Ra
 
 template <typename _ExecutionPolicy>
 struct __brick_copy_n<_ExecutionPolicy,
-                      oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>>
+                      oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>>
 {
     template <typename _RandomAccessIterator1, typename _Size, typename _RandomAccessIterator2>
     _RandomAccessIterator2
@@ -1045,7 +1045,7 @@ struct __brick_copy_n<_ExecutionPolicy,
 
 template <typename _ExecutionPolicy>
 struct __brick_copy<_ExecutionPolicy,
-                    oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>>
+                    oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>>
 {
 
     template <typename _RandomAccessIterator1, typename _RandomAccessIterator2>
@@ -1079,7 +1079,7 @@ struct __brick_copy<_ExecutionPolicy,
 
 template <typename _ExecutionPolicy>
 struct __brick_move<_ExecutionPolicy,
-                    oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>>
+                    oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>>
 {
 
     template <typename _RandomAccessIterator1, typename _RandomAccessIterator2>
@@ -1105,7 +1105,7 @@ struct __brick_move_destroy;
 
 template <typename _ExecutionPolicy>
 struct __brick_move_destroy<_ExecutionPolicy,
-                            oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>>
+                            oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>>
 {
     template <typename _RandomAccessIterator1, typename _RandomAccessIterator2>
     _RandomAccessIterator2
@@ -1664,7 +1664,7 @@ __brick_reverse(_RandomAccessIterator __first, _RandomAccessIterator __last, _Ra
 }
 
 template <class _ExecutionPolicy, class _BidirectionalIterator, class _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_reverse(_ExecutionPolicy&&, _BidirectionalIterator __first, _BidirectionalIterator __last,
                   _IsVector _is_vector,
                   /*is_parallel=*/::std::false_type) noexcept
@@ -1673,7 +1673,7 @@ __pattern_reverse(_ExecutionPolicy&&, _BidirectionalIterator __first, _Bidirecti
 }
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_reverse(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last,
                   _IsVector __is_vector, /*is_parallel=*/::std::true_type)
 {
@@ -2323,7 +2323,7 @@ __pattern_partition_copy(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __fir
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _IsVector,
           class _IsMoveConstructible>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_sort(_ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
                _IsVector /*is_vector*/, /*is_parallel=*/::std::false_type, _IsMoveConstructible) noexcept
 {
@@ -2331,7 +2331,7 @@ __pattern_sort(_ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessI
 }
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
                _IsVector /*is_vector*/, /*is_parallel=*/::std::true_type, /*is_move_constructible=*/::std::true_type)
 {
@@ -2348,7 +2348,7 @@ __pattern_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _Random
 //------------------------------------------------------------------------
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_stable_sort(_ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
                       _IsVector /*is_vector*/, /*is_parallel=*/::std::false_type) noexcept
 {
@@ -2356,7 +2356,7 @@ __pattern_stable_sort(_ExecutionPolicy&&, _RandomAccessIterator __first, _Random
 }
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_stable_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last,
                       _Compare __comp, _IsVector /*is_vector*/, /*is_parallel=*/::std::true_type)
 {
@@ -2374,7 +2374,7 @@ __pattern_stable_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, 
 
 template <typename _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2,
           typename _Compare, typename _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_sort_by_key(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __keys_first,
                       _RandomAccessIterator1 __keys_last, _RandomAccessIterator2 __values_first, _Compare __comp,
                       _IsVector /*vector=*/, /*is_parallel=*/::std::false_type) noexcept
@@ -2389,7 +2389,7 @@ __pattern_sort_by_key(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __keys_f
 
 template <typename _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2,
           typename _Compare, typename _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_sort_by_key(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __keys_first,
                       _RandomAccessIterator1 __keys_last, _RandomAccessIterator2 __values_first, _Compare __comp,
                       _IsVector /*vector=*/, /*is_parallel=*/::std::true_type)
@@ -2415,7 +2415,7 @@ __pattern_sort_by_key(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __keys_f
 //------------------------------------------------------------------------
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_partial_sort(_ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __middle,
                        _RandomAccessIterator __last, _Compare __comp, _IsVector,
                        /*is_parallel=*/::std::false_type) noexcept
@@ -2424,7 +2424,7 @@ __pattern_partial_sort(_ExecutionPolicy&&, _RandomAccessIterator __first, _Rando
 }
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_partial_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __middle,
                        _RandomAccessIterator __last, _Compare __comp, _IsVector, /*is_parallel=*/::std::true_type)
 {
@@ -2608,7 +2608,7 @@ __pattern_adjacent_find(_ExecutionPolicy&& __exec, _RandomAccessIterator __first
 //------------------------------------------------------------------------
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_nth_element(_ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __nth,
                       _RandomAccessIterator __last, _Compare __comp, _IsVector,
                       /*is_parallel=*/::std::false_type) noexcept
@@ -2617,7 +2617,7 @@ __pattern_nth_element(_ExecutionPolicy&&, _RandomAccessIterator __first, _Random
 }
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_nth_element(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __nth,
                       _RandomAccessIterator __last, _Compare __comp, _IsVector __is_vector,
                       /*is_parallel=*/::std::true_type)
@@ -2665,7 +2665,7 @@ __pattern_nth_element(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, 
 //------------------------------------------------------------------------
 template <typename _Tp, typename _ExecutionPolicy>
 struct __brick_fill<_Tp, _ExecutionPolicy,
-                    oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>>
+                    oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>>
 {
     const _Tp& __value;
 
@@ -2687,7 +2687,7 @@ struct __brick_fill<_Tp, _ExecutionPolicy,
 };
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Tp, class _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_fill(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value,
                /*is_parallel=*/::std::false_type, _IsVector __is_vector) noexcept
 {
@@ -2712,7 +2712,7 @@ __pattern_fill(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _Random
 
 template <typename _Tp, typename _ExecutionPolicy>
 struct __brick_fill_n<_Tp, _ExecutionPolicy,
-                      oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>>
+                      oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>>
 {
     const _Tp& __value;
 
@@ -2770,7 +2770,7 @@ __brick_generate(_ForwardIterator __first, _ForwardIterator __last, _Generator _
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Generator, class _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_generate(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator __last, _Generator __g,
                    /*is_parallel=*/::std::false_type, _IsVector __is_vector) noexcept
 {
@@ -2950,7 +2950,7 @@ __brick_inplace_merge(_RandomAccessIterator __first, _RandomAccessIterator __mid
 }
 
 template <class _ExecutionPolicy, class _BidirectionalIterator, class _Compare, class _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_inplace_merge(_ExecutionPolicy&&, _BidirectionalIterator __first, _BidirectionalIterator __middle,
                         _BidirectionalIterator __last, _Compare __comp, _IsVector __is_vector,
                         /* is_parallel = */ ::std::false_type) noexcept
@@ -2959,7 +2959,7 @@ __pattern_inplace_merge(_ExecutionPolicy&&, _BidirectionalIterator __first, _Bid
 }
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_inplace_merge(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __middle,
                         _RandomAccessIterator __last, _Compare __comp, _IsVector __is_vector,
                         /*is_parallel=*/::std::true_type)

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1018,8 +1018,7 @@ __pattern_search_n(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _Ra
 // Sometimes a little duplication for sake of regularity is better than the alternative.
 
 template <typename _ExecutionPolicy>
-struct __brick_copy_n<_ExecutionPolicy,
-                      oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>>
+struct __brick_copy_n<_ExecutionPolicy, oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>>
 {
     template <typename _RandomAccessIterator1, typename _Size, typename _RandomAccessIterator2>
     _RandomAccessIterator2
@@ -1044,8 +1043,7 @@ struct __brick_copy_n<_ExecutionPolicy,
 //------------------------------------------------------------------------
 
 template <typename _ExecutionPolicy>
-struct __brick_copy<_ExecutionPolicy,
-                    oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>>
+struct __brick_copy<_ExecutionPolicy, oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>>
 {
 
     template <typename _RandomAccessIterator1, typename _RandomAccessIterator2>
@@ -1078,8 +1076,7 @@ struct __brick_copy<_ExecutionPolicy,
 //------------------------------------------------------------------------
 
 template <typename _ExecutionPolicy>
-struct __brick_move<_ExecutionPolicy,
-                    oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>>
+struct __brick_move<_ExecutionPolicy, oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>>
 {
 
     template <typename _RandomAccessIterator1, typename _RandomAccessIterator2>
@@ -2664,8 +2661,7 @@ __pattern_nth_element(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, 
 // fill, fill_n
 //------------------------------------------------------------------------
 template <typename _Tp, typename _ExecutionPolicy>
-struct __brick_fill<_Tp, _ExecutionPolicy,
-                    oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>>
+struct __brick_fill<_Tp, _ExecutionPolicy, oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>>
 {
     const _Tp& __value;
 

--- a/include/oneapi/dpl/pstl/execution_defs.h
+++ b/include/oneapi/dpl/pstl/execution_defs.h
@@ -176,7 +176,7 @@ struct __is_host_execution_policy<oneapi::dpl::execution::unsequenced_policy> : 
 {
 };
 
-template <class _ExecPolicy, class _T>
+template <class _ExecPolicy, class _T = void>
 using __enable_if_execution_policy = ::std::enable_if_t<
     oneapi::dpl::execution::is_execution_policy<::std::decay_t<_ExecPolicy>>::value, _T>;
 

--- a/include/oneapi/dpl/pstl/execution_defs.h
+++ b/include/oneapi/dpl/pstl/execution_defs.h
@@ -177,17 +177,17 @@ struct __is_host_execution_policy<oneapi::dpl::execution::unsequenced_policy> : 
 };
 
 template <class _ExecPolicy, class _T>
-using __enable_if_execution_policy = typename ::std::enable_if<
-    oneapi::dpl::execution::is_execution_policy<::std::decay_t<_ExecPolicy>>::value, _T>::type;
+using __enable_if_execution_policy = ::std::enable_if_t<
+    oneapi::dpl::execution::is_execution_policy<::std::decay_t<_ExecPolicy>>::value, _T>;
 
 template <class _ExecPolicy, class _T>
-using __enable_if_host_execution_policy = typename ::std::enable_if<
-    oneapi::dpl::__internal::__is_host_execution_policy<::std::decay_t<_ExecPolicy>>::value, _T>::type;
+using __enable_if_host_execution_policy = ::std::enable_if_t<
+    oneapi::dpl::__internal::__is_host_execution_policy<::std::decay_t<_ExecPolicy>>::value, _T>;
 
 template <class _ExecPolicy, const bool __condition, class _T>
-using __enable_if_host_execution_policy_conditional = typename ::std::enable_if<
+using __enable_if_host_execution_policy_conditional = ::std::enable_if_t<
     oneapi::dpl::__internal::__is_host_execution_policy<::std::decay_t<_ExecPolicy>>::value && __condition,
-    _T>::type;
+    _T>;
 
 template <typename _ExecPolicy, typename _T>
 struct __ref_or_copy_impl

--- a/include/oneapi/dpl/pstl/execution_defs.h
+++ b/include/oneapi/dpl/pstl/execution_defs.h
@@ -184,7 +184,7 @@ template <class _ExecPolicy, class _T = void>
 using __enable_if_host_execution_policy = ::std::enable_if_t<
     oneapi::dpl::__internal::__is_host_execution_policy<::std::decay_t<_ExecPolicy>>::value, _T>;
 
-template <class _ExecPolicy, const bool __condition, class _T>
+template <class _ExecPolicy, const bool __condition, class _T = void>
 using __enable_if_host_execution_policy_conditional = ::std::enable_if_t<
     oneapi::dpl::__internal::__is_host_execution_policy<::std::decay_t<_ExecPolicy>>::value && __condition,
     _T>;

--- a/include/oneapi/dpl/pstl/execution_defs.h
+++ b/include/oneapi/dpl/pstl/execution_defs.h
@@ -177,17 +177,16 @@ struct __is_host_execution_policy<oneapi::dpl::execution::unsequenced_policy> : 
 };
 
 template <class _ExecPolicy, class _T = void>
-using __enable_if_execution_policy = ::std::enable_if_t<
-    oneapi::dpl::execution::is_execution_policy<::std::decay_t<_ExecPolicy>>::value, _T>;
+using __enable_if_execution_policy =
+    ::std::enable_if_t<oneapi::dpl::execution::is_execution_policy<::std::decay_t<_ExecPolicy>>::value, _T>;
 
 template <class _ExecPolicy, class _T = void>
-using __enable_if_host_execution_policy = ::std::enable_if_t<
-    oneapi::dpl::__internal::__is_host_execution_policy<::std::decay_t<_ExecPolicy>>::value, _T>;
+using __enable_if_host_execution_policy =
+    ::std::enable_if_t<oneapi::dpl::__internal::__is_host_execution_policy<::std::decay_t<_ExecPolicy>>::value, _T>;
 
 template <class _ExecPolicy, const bool __condition, class _T = void>
 using __enable_if_host_execution_policy_conditional = ::std::enable_if_t<
-    oneapi::dpl::__internal::__is_host_execution_policy<::std::decay_t<_ExecPolicy>>::value && __condition,
-    _T>;
+    oneapi::dpl::__internal::__is_host_execution_policy<::std::decay_t<_ExecPolicy>>::value && __condition, _T>;
 
 template <typename _ExecPolicy, typename _T>
 struct __ref_or_copy_impl
@@ -196,8 +195,7 @@ struct __ref_or_copy_impl
 };
 
 template <typename _ExecPolicy, typename _T>
-using __ref_or_copy =
-    typename oneapi::dpl::__internal::__ref_or_copy_impl<::std::decay_t<_ExecPolicy>, _T>::type;
+using __ref_or_copy = typename oneapi::dpl::__internal::__ref_or_copy_impl<::std::decay_t<_ExecPolicy>, _T>::type;
 
 // utilities for Range API
 template <typename _R>

--- a/include/oneapi/dpl/pstl/execution_defs.h
+++ b/include/oneapi/dpl/pstl/execution_defs.h
@@ -180,7 +180,7 @@ template <class _ExecPolicy, class _T = void>
 using __enable_if_execution_policy = ::std::enable_if_t<
     oneapi::dpl::execution::is_execution_policy<::std::decay_t<_ExecPolicy>>::value, _T>;
 
-template <class _ExecPolicy, class _T>
+template <class _ExecPolicy, class _T = void>
 using __enable_if_host_execution_policy = ::std::enable_if_t<
     oneapi::dpl::__internal::__is_host_execution_policy<::std::decay_t<_ExecPolicy>>::value, _T>;
 

--- a/include/oneapi/dpl/pstl/execution_defs.h
+++ b/include/oneapi/dpl/pstl/execution_defs.h
@@ -209,7 +209,7 @@ auto
 __check_size(...) -> decltype(::std::declval<_R&>().get_count());
 
 template <typename _R>
-using __difference_t = typename ::std::make_signed<decltype(__check_size<_R>(0))>::type;
+using __difference_t = ::std::make_signed_t<decltype(__check_size<_R>(0))>;
 
 } // namespace __internal
 

--- a/include/oneapi/dpl/pstl/execution_defs.h
+++ b/include/oneapi/dpl/pstl/execution_defs.h
@@ -178,15 +178,15 @@ struct __is_host_execution_policy<oneapi::dpl::execution::unsequenced_policy> : 
 
 template <class _ExecPolicy, class _T>
 using __enable_if_execution_policy = typename ::std::enable_if<
-    oneapi::dpl::execution::is_execution_policy<typename ::std::decay<_ExecPolicy>::type>::value, _T>::type;
+    oneapi::dpl::execution::is_execution_policy<::std::decay_t<_ExecPolicy>>::value, _T>::type;
 
 template <class _ExecPolicy, class _T>
 using __enable_if_host_execution_policy = typename ::std::enable_if<
-    oneapi::dpl::__internal::__is_host_execution_policy<typename ::std::decay<_ExecPolicy>::type>::value, _T>::type;
+    oneapi::dpl::__internal::__is_host_execution_policy<::std::decay_t<_ExecPolicy>>::value, _T>::type;
 
 template <class _ExecPolicy, const bool __condition, class _T>
 using __enable_if_host_execution_policy_conditional = typename ::std::enable_if<
-    oneapi::dpl::__internal::__is_host_execution_policy<typename ::std::decay<_ExecPolicy>::type>::value && __condition,
+    oneapi::dpl::__internal::__is_host_execution_policy<::std::decay_t<_ExecPolicy>>::value && __condition,
     _T>::type;
 
 template <typename _ExecPolicy, typename _T>
@@ -197,7 +197,7 @@ struct __ref_or_copy_impl
 
 template <typename _ExecPolicy, typename _T>
 using __ref_or_copy =
-    typename oneapi::dpl::__internal::__ref_or_copy_impl<typename ::std::decay<_ExecPolicy>::type, _T>::type;
+    typename oneapi::dpl::__internal::__ref_or_copy_impl<::std::decay_t<_ExecPolicy>, _T>::type;
 
 // utilities for Range API
 template <typename _R>

--- a/include/oneapi/dpl/pstl/execution_impl.h
+++ b/include/oneapi/dpl/pstl/execution_impl.h
@@ -97,19 +97,19 @@ struct __policy_traits<oneapi::dpl::execution::parallel_unsequenced_policy>
 
 template <typename _ExecutionPolicy>
 using __collector_t =
-    typename __internal::__policy_traits<typename ::std::decay<_ExecutionPolicy>::type>::__collector_type;
+    typename __internal::__policy_traits<::std::decay_t<_ExecutionPolicy>>::__collector_type;
 
 template <typename _ExecutionPolicy>
 using __allow_vector =
-    typename __internal::__policy_traits<typename ::std::decay<_ExecutionPolicy>::type>::__allow_vector;
+    typename __internal::__policy_traits<::std::decay_t<_ExecutionPolicy>>::__allow_vector;
 
 template <typename _ExecutionPolicy>
 using __allow_unsequenced =
-    typename __internal::__policy_traits<typename ::std::decay<_ExecutionPolicy>::type>::__allow_unsequenced;
+    typename __internal::__policy_traits<::std::decay_t<_ExecutionPolicy>>::__allow_unsequenced;
 
 template <typename _ExecutionPolicy>
 using __allow_parallel =
-    typename __internal::__policy_traits<typename ::std::decay<_ExecutionPolicy>::type>::__allow_parallel;
+    typename __internal::__policy_traits<::std::decay_t<_ExecutionPolicy>>::__allow_parallel;
 
 template <typename _ExecutionPolicy, typename... _IteratorTypes>
 auto

--- a/include/oneapi/dpl/pstl/execution_impl.h
+++ b/include/oneapi/dpl/pstl/execution_impl.h
@@ -96,20 +96,16 @@ struct __policy_traits<oneapi::dpl::execution::parallel_unsequenced_policy>
 };
 
 template <typename _ExecutionPolicy>
-using __collector_t =
-    typename __internal::__policy_traits<::std::decay_t<_ExecutionPolicy>>::__collector_type;
+using __collector_t = typename __internal::__policy_traits<::std::decay_t<_ExecutionPolicy>>::__collector_type;
 
 template <typename _ExecutionPolicy>
-using __allow_vector =
-    typename __internal::__policy_traits<::std::decay_t<_ExecutionPolicy>>::__allow_vector;
+using __allow_vector = typename __internal::__policy_traits<::std::decay_t<_ExecutionPolicy>>::__allow_vector;
 
 template <typename _ExecutionPolicy>
-using __allow_unsequenced =
-    typename __internal::__policy_traits<::std::decay_t<_ExecutionPolicy>>::__allow_unsequenced;
+using __allow_unsequenced = typename __internal::__policy_traits<::std::decay_t<_ExecutionPolicy>>::__allow_unsequenced;
 
 template <typename _ExecutionPolicy>
-using __allow_parallel =
-    typename __internal::__policy_traits<::std::decay_t<_ExecutionPolicy>>::__allow_parallel;
+using __allow_parallel = typename __internal::__policy_traits<::std::decay_t<_ExecutionPolicy>>::__allow_parallel;
 
 template <typename _ExecutionPolicy, typename... _IteratorTypes>
 auto

--- a/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
@@ -38,14 +38,14 @@ namespace __internal
 
 // Generalization of ::std::advance to work with an argitraty integral type
 template <typename _Ip, typename _Diff>
-typename ::std::enable_if<::std::is_integral<_Ip>::value>::type
+::std::enable_if_t<::std::is_integral<_Ip>::value>
 __advance(_Ip& __val, _Diff __diff)
 {
     __val += __diff;
 }
 
 template <typename _Ip, typename _Diff>
-typename ::std::enable_if<!::std::is_integral<_Ip>::value>::type
+::std::enable_if_t<!::std::is_integral<_Ip>::value>
 __advance(_Ip& __val, _Diff __diff)
 {
     ::std::advance(__val, __diff);
@@ -56,14 +56,14 @@ template <typename _Ip, typename = void>
 struct __difference;
 
 template <typename _Ip>
-struct __difference<_Ip, typename ::std::enable_if<::std::is_integral<_Ip>::value>::type>
+struct __difference<_Ip, ::std::enable_if_t<::std::is_integral<_Ip>::value>>
 {
     // Define the type similar to C++20's incrementable_traits
     using __type = typename ::std::make_signed<decltype(::std::declval<_Ip>() - ::std::declval<_Ip>())>::type;
 };
 
 template <typename _Ip>
-struct __difference<_Ip, typename ::std::enable_if<!::std::is_integral<_Ip>::value>::type>
+struct __difference<_Ip, ::std::enable_if_t<!::std::is_integral<_Ip>::value>>
 {
     using __type = typename oneapi::dpl::__internal::__iterator_traits<_Ip>::difference_type;
 };
@@ -205,21 +205,21 @@ struct __is_random_access_or_integral : ::std::false_type
 };
 
 template <typename _Ip>
-struct __is_random_access_or_integral<_Ip, typename ::std::enable_if<::std::is_integral<_Ip>::value>::type>
+struct __is_random_access_or_integral<_Ip, ::std::enable_if_t<::std::is_integral<_Ip>::value>>
     : ::std::true_type
 {
 };
 
 template <typename _Ip>
 struct __is_random_access_or_integral<
-    _Ip, typename ::std::enable_if<oneapi::dpl::__internal::__is_random_access_iterator<_Ip>::value>::type>
+    _Ip, ::std::enable_if_t<oneapi::dpl::__internal::__is_random_access_iterator<_Ip>::value>>
     : ::std::true_type
 {
 };
 
 // Sequenced version of for_loop for RAI and integral types
 template <typename _ExecutionPolicy, typename _Ip, typename _Function, typename _Sp, typename... _Rest>
-typename ::std::enable_if<__is_random_access_or_integral<_Ip>::value>::type
+::std::enable_if_t<__is_random_access_or_integral<_Ip>::value>
 __pattern_for_loop(_ExecutionPolicy&& __exec, _Ip __first, _Ip __last, _Function __f, _Sp __stride,
                    /*vector=*/::std::false_type, /*parallel=*/::std::false_type, _Rest&&... __rest) noexcept
 {
@@ -230,9 +230,9 @@ __pattern_for_loop(_ExecutionPolicy&& __exec, _Ip __first, _Ip __last, _Function
 }
 
 template <typename _Ip, typename _Function, typename _Sp, typename _Pack, typename _IndexType>
-typename ::std::enable_if<::std::is_same<typename oneapi::dpl::__internal::__iterator_traits<_Ip>::iterator_category,
-                                         ::std::bidirectional_iterator_tag>::value,
-                          _IndexType>::type
+::std::enable_if_t<::std::is_same<typename oneapi::dpl::__internal::__iterator_traits<_Ip>::iterator_category,
+                                  ::std::bidirectional_iterator_tag>::value,
+                   _IndexType>
 __execute_loop_strided(_Ip __first, _Ip __last, _Function __f, _Sp __stride, _Pack& __pack, _IndexType) noexcept
 {
     _IndexType __ordinal_position = 0;
@@ -267,12 +267,12 @@ __execute_loop_strided(_Ip __first, _Ip __last, _Function __f, _Sp __stride, _Pa
 }
 
 template <typename _Ip, typename _Function, typename _Sp, typename _Pack, typename _IndexType>
-typename ::std::enable_if<
+::std::enable_if_t<
     ::std::is_same<typename oneapi::dpl::__internal::__iterator_traits<_Ip>::iterator_category,
                    ::std::forward_iterator_tag>::value ||
         ::std::is_same<typename oneapi::dpl::__internal::__iterator_traits<_Ip>::iterator_category,
                        ::std::input_iterator_tag>::value,
-    _IndexType>::type
+    _IndexType>
 __execute_loop_strided(_Ip __first, _Ip __last, _Function __f, _Sp __stride, _Pack& __pack, _IndexType) noexcept
 {
     _IndexType __ordinal_position = 0;
@@ -293,7 +293,7 @@ __execute_loop_strided(_Ip __first, _Ip __last, _Function __f, _Sp __stride, _Pa
 
 // Sequenced version of for_loop for non-RAI and non-integral types
 template <typename _ExecutionPolicy, typename _Ip, typename _Function, typename... _Rest>
-typename ::std::enable_if<!__is_random_access_or_integral<_Ip>::value>::type
+::std::enable_if_t<!__is_random_access_or_integral<_Ip>::value>
 __pattern_for_loop(_ExecutionPolicy&&, _Ip __first, _Ip __last, _Function __f, __single_stride_type,
                    /*vector=*/::std::false_type, /*parallel=*/::std::false_type, _Rest&&... __rest) noexcept
 {
@@ -311,7 +311,7 @@ __pattern_for_loop(_ExecutionPolicy&&, _Ip __first, _Ip __last, _Function __f, _
 }
 
 template <typename _ExecutionPolicy, typename _Ip, typename _Function, typename _Sp, typename... _Rest>
-typename ::std::enable_if<!__is_random_access_or_integral<_Ip>::value>::type
+::std::enable_if_t<!__is_random_access_or_integral<_Ip>::value>
 __pattern_for_loop(_ExecutionPolicy&&, _Ip __first, _Ip __last, _Function __f, _Sp __stride,
                    /*vector=*/::std::false_type, /*parallel=*/::std::false_type, _Rest&&... __rest) noexcept
 {
@@ -475,7 +475,7 @@ template <typename _Ip, typename = void>
 struct __use_par_vec_helper;
 
 template <typename _Ip>
-struct __use_par_vec_helper<_Ip, typename ::std::enable_if<::std::is_integral<_Ip>::value>::type>
+struct __use_par_vec_helper<_Ip, ::std::enable_if_t<::std::is_integral<_Ip>::value>>
 {
     template <typename _ExecutionPolicy>
     static constexpr auto
@@ -493,7 +493,7 @@ struct __use_par_vec_helper<_Ip, typename ::std::enable_if<::std::is_integral<_I
 };
 
 template <typename _Ip>
-struct __use_par_vec_helper<_Ip, typename ::std::enable_if<!::std::is_integral<_Ip>::value>::type>
+struct __use_par_vec_helper<_Ip, ::std::enable_if_t<!::std::is_integral<_Ip>::value>>
 {
     template <typename _ExecutionPolicy>
     static constexpr auto

--- a/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
@@ -102,7 +102,7 @@ class __reduction_pack
 {
     // No matter how the Ts objects are provided(lvalue or rvalue) we need to store copies of them,
     // to avoid modification of the original ones.
-    ::std::tuple<typename ::std::remove_cv<::std::remove_reference_t<_Ts>>::type...> __objects_;
+    ::std::tuple<::std::remove_cv_t<::std::remove_reference_t<_Ts>>...> __objects_;
 
     template <typename _Fp, typename _Ip, typename _Position, ::std::size_t... _Is>
     void

--- a/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
@@ -102,7 +102,7 @@ class __reduction_pack
 {
     // No matter how the Ts objects are provided(lvalue or rvalue) we need to store copies of them,
     // to avoid modification of the original ones.
-    ::std::tuple<typename ::std::remove_cv<typename ::std::remove_reference<_Ts>::type>::type...> __objects_;
+    ::std::tuple<typename ::std::remove_cv<::std::remove_reference_t<_Ts>>::type...> __objects_;
 
     template <typename _Fp, typename _Ip, typename _Position, ::std::size_t... _Is>
     void

--- a/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
@@ -205,15 +205,13 @@ struct __is_random_access_or_integral : ::std::false_type
 };
 
 template <typename _Ip>
-struct __is_random_access_or_integral<_Ip, ::std::enable_if_t<::std::is_integral<_Ip>::value>>
-    : ::std::true_type
+struct __is_random_access_or_integral<_Ip, ::std::enable_if_t<::std::is_integral<_Ip>::value>> : ::std::true_type
 {
 };
 
 template <typename _Ip>
 struct __is_random_access_or_integral<
-    _Ip, ::std::enable_if_t<oneapi::dpl::__internal::__is_random_access_iterator<_Ip>::value>>
-    : ::std::true_type
+    _Ip, ::std::enable_if_t<oneapi::dpl::__internal::__is_random_access_iterator<_Ip>::value>> : ::std::true_type
 {
 };
 
@@ -267,12 +265,11 @@ __execute_loop_strided(_Ip __first, _Ip __last, _Function __f, _Sp __stride, _Pa
 }
 
 template <typename _Ip, typename _Function, typename _Sp, typename _Pack, typename _IndexType>
-::std::enable_if_t<
-    ::std::is_same<typename oneapi::dpl::__internal::__iterator_traits<_Ip>::iterator_category,
-                   ::std::forward_iterator_tag>::value ||
-        ::std::is_same<typename oneapi::dpl::__internal::__iterator_traits<_Ip>::iterator_category,
-                       ::std::input_iterator_tag>::value,
-    _IndexType>
+::std::enable_if_t<::std::is_same<typename oneapi::dpl::__internal::__iterator_traits<_Ip>::iterator_category,
+                                  ::std::forward_iterator_tag>::value ||
+                       ::std::is_same<typename oneapi::dpl::__internal::__iterator_traits<_Ip>::iterator_category,
+                                      ::std::input_iterator_tag>::value,
+                   _IndexType>
 __execute_loop_strided(_Ip __first, _Ip __last, _Function __f, _Sp __stride, _Pack& __pack, _IndexType) noexcept
 {
     _IndexType __ordinal_position = 0;

--- a/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
@@ -59,7 +59,7 @@ template <typename _Ip>
 struct __difference<_Ip, ::std::enable_if_t<::std::is_integral<_Ip>::value>>
 {
     // Define the type similar to C++20's incrementable_traits
-    using __type = typename ::std::make_signed<decltype(::std::declval<_Ip>() - ::std::declval<_Ip>())>::type;
+    using __type = ::std::make_signed_t<decltype(::std::declval<_Ip>() - ::std::declval<_Ip>())>;
 };
 
 template <typename _Ip>

--- a/include/oneapi/dpl/pstl/experimental/internal/induction_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/induction_impl.h
@@ -33,8 +33,8 @@ namespace __internal
 // construction the induction object
 template <typename _Tp>
 using __induction_value_type = typename ::std::conditional<
-    ::std::is_lvalue_reference<_Tp>::value && !::std::is_const<typename ::std::remove_reference<_Tp>::type>::value, _Tp,
-    typename ::std::remove_cv<typename ::std::remove_reference<_Tp>::type>::type>::type;
+    ::std::is_lvalue_reference<_Tp>::value && !::std::is_const<::std::remove_reference_t<_Tp>>::value, _Tp,
+    typename ::std::remove_cv<::std::remove_reference_t<_Tp>>::type>::type;
 
 // Definition of induction_object structure to represent "induction" object.
 
@@ -58,7 +58,7 @@ class __induction_object
     }
 
     template <typename _Index>
-    typename ::std::remove_reference<__value_type>::type
+    ::std::remove_reference_t<__value_type>
     __get_induction_or_reduction_value(_Index __p)
     {
         return __var_ + __p * __stride_;
@@ -96,7 +96,7 @@ class __induction_object<_Tp, void>
     }
 
     template <typename _Index>
-    typename ::std::remove_reference<__value_type>::type
+    ::std::remove_reference_t<__value_type>
     __get_induction_or_reduction_value(_Index __p)
     {
         return __var_ + __p;

--- a/include/oneapi/dpl/pstl/experimental/internal/induction_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/induction_impl.h
@@ -32,9 +32,9 @@ namespace __internal
 // We're not interested in T&& here as the rvalue-ness is stripped from T before
 // construction the induction object
 template <typename _Tp>
-using __induction_value_type = typename ::std::conditional<
+using __induction_value_type = ::std::conditional_t<
     ::std::is_lvalue_reference<_Tp>::value && !::std::is_const<::std::remove_reference_t<_Tp>>::value, _Tp,
-    ::std::remove_cv_t<::std::remove_reference_t<_Tp>>>::type;
+    ::std::remove_cv_t<::std::remove_reference_t<_Tp>>>;
 
 // Definition of induction_object structure to represent "induction" object.
 

--- a/include/oneapi/dpl/pstl/experimental/internal/induction_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/induction_impl.h
@@ -34,7 +34,7 @@ namespace __internal
 template <typename _Tp>
 using __induction_value_type = typename ::std::conditional<
     ::std::is_lvalue_reference<_Tp>::value && !::std::is_const<::std::remove_reference_t<_Tp>>::value, _Tp,
-    ::std::remove_cv_t<typename ::std::remove_reference<_Tp>::type>>::type;
+    ::std::remove_cv_t<::std::remove_reference_t<_Tp>>>::type;
 
 // Definition of induction_object structure to represent "induction" object.
 

--- a/include/oneapi/dpl/pstl/experimental/internal/induction_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/induction_impl.h
@@ -34,7 +34,7 @@ namespace __internal
 template <typename _Tp>
 using __induction_value_type = typename ::std::conditional<
     ::std::is_lvalue_reference<_Tp>::value && !::std::is_const<::std::remove_reference_t<_Tp>>::value, _Tp,
-    typename ::std::remove_cv<::std::remove_reference_t<_Tp>>::type>::type;
+    ::std::remove_cv_t<typename ::std::remove_reference<_Tp>::type>>::type;
 
 // Definition of induction_object structure to represent "induction" object.
 

--- a/include/oneapi/dpl/pstl/experimental/internal/induction_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/induction_impl.h
@@ -32,9 +32,9 @@ namespace __internal
 // We're not interested in T&& here as the rvalue-ness is stripped from T before
 // construction the induction object
 template <typename _Tp>
-using __induction_value_type = ::std::conditional_t<
-    ::std::is_lvalue_reference<_Tp>::value && !::std::is_const<::std::remove_reference_t<_Tp>>::value, _Tp,
-    ::std::remove_cv_t<::std::remove_reference_t<_Tp>>>;
+using __induction_value_type = ::std::conditional_t<::std::is_lvalue_reference<_Tp>::value &&
+                                                        !::std::is_const<::std::remove_reference_t<_Tp>>::value,
+                                                    _Tp, ::std::remove_cv_t<::std::remove_reference_t<_Tp>>>;
 
 // Definition of induction_object structure to represent "induction" object.
 

--- a/include/oneapi/dpl/pstl/glue_algorithm_defs.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_defs.h
@@ -47,7 +47,7 @@ none_of(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __
 // [alg.foreach]
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Function>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 for_each(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Function __f);
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Function>
@@ -176,12 +176,12 @@ transform(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator
 // [alg.replace]
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate, class _Tp>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 replace_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred,
            const _Tp& __new_value);
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 replace(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __old_value,
         const _Tp& __new_value);
 
@@ -198,7 +198,7 @@ replace_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardItera
 // [alg.fill]
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 fill(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value);
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Tp>
@@ -207,7 +207,7 @@ fill_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __count, const
 
 // [alg.generate]
 template <class _ExecutionPolicy, class _ForwardIterator, class _Generator>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 generate(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Generator __g);
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Generator>
@@ -256,7 +256,7 @@ unique_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterat
 // [alg.reverse]
 
 template <class _ExecutionPolicy, class _BidirectionalIterator>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 reverse(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __last);
 
 template <class _ExecutionPolicy, class _BidirectionalIterator, class _ForwardIterator>
@@ -300,33 +300,33 @@ partition_copy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIter
 // [alg.sort]
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp);
 
 template <class _ExecutionPolicy, class _RandomAccessIterator>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last);
 
 // [stable.sort]
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 stable_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp);
 
 template <class _ExecutionPolicy, class _RandomAccessIterator>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 stable_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last);
 
 // oneapi::dpl::sort_by_key
 
 template <typename _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2,
           typename _Compare>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 sort_by_key(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __keys_first, _RandomAccessIterator1 __keys_last,
             _RandomAccessIterator2 __values_first, _Compare __comp);
 
 template <typename _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 sort_by_key(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __keys_first, _RandomAccessIterator1 __keys_last,
             _RandomAccessIterator2 __values_first);
 
@@ -387,12 +387,12 @@ move(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __l
 // definitions
 
 template <class _ExecutionPolicy, class _RandomAccessIterator>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 partial_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __middle,
              _RandomAccessIterator __last);
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 partial_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __middle,
              _RandomAccessIterator __last, _Compare __comp);
 
@@ -435,12 +435,12 @@ is_sorted_until(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIte
 // [alg.nth.element]
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 nth_element(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __nth,
             _RandomAccessIterator __last, _Compare __comp);
 
 template <class _ExecutionPolicy, class _RandomAccessIterator>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 nth_element(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __nth,
             _RandomAccessIterator __last);
 
@@ -457,12 +457,12 @@ merge(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 _
       _ForwardIterator2 __last2, _ForwardIterator __d_first);
 
 template <class _ExecutionPolicy, class _BidirectionalIterator, class _Compare>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 inplace_merge(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __middle,
               _BidirectionalIterator __last, _Compare __comp);
 
 template <class _ExecutionPolicy, class _BidirectionalIterator>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 inplace_merge(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __middle,
               _BidirectionalIterator __last);
 

--- a/include/oneapi/dpl/pstl/glue_algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_impl.h
@@ -393,9 +393,9 @@ replace_copy_if(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIt
         ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
         oneapi::dpl::__internal::__replace_copy_functor<
             oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _Tp>,
-            typename ::std::conditional<
+            ::std::conditional_t<
                 oneapi::dpl::__internal::__is_const_callable_object<_UnaryPredicate>::value, _UnaryPredicate,
-                oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, _UnaryPredicate>>::type>(__new_value, __pred),
+                oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, _UnaryPredicate>>>(__new_value, __pred),
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(
             __exec),
         oneapi::dpl::__internal::__is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(

--- a/include/oneapi/dpl/pstl/glue_algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_impl.h
@@ -283,7 +283,7 @@ template <class _ExecutionPolicy, class _ForwardIterator1, class _Size, class _F
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
 copy_n(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _Size __n, _ForwardIterator2 __result)
 {
-    using _DecayedExecutionPolicy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _DecayedExecutionPolicy = ::std::decay_t<_ExecutionPolicy>;
 
     return oneapi::dpl::__internal::__pattern_walk2_brick_n(
         ::std::forward<_ExecutionPolicy>(__exec), __first, __n, __result,
@@ -806,7 +806,7 @@ template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterato
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
 move(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __d_first)
 {
-    using _DecayedExecutionPolicy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _DecayedExecutionPolicy = ::std::decay_t<_ExecutionPolicy>;
 
     return oneapi::dpl::__internal::__pattern_walk2_brick(
         ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __d_first,

--- a/include/oneapi/dpl/pstl/glue_algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_impl.h
@@ -393,9 +393,10 @@ replace_copy_if(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIt
         ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
         oneapi::dpl::__internal::__replace_copy_functor<
             oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _Tp>,
-            ::std::conditional_t<
-                oneapi::dpl::__internal::__is_const_callable_object<_UnaryPredicate>::value, _UnaryPredicate,
-                oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, _UnaryPredicate>>>(__new_value, __pred),
+            ::std::conditional_t<oneapi::dpl::__internal::__is_const_callable_object<_UnaryPredicate>::value,
+                                 _UnaryPredicate,
+                                 oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, _UnaryPredicate>>>(
+            __new_value, __pred),
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(
             __exec),
         oneapi::dpl::__internal::__is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(

--- a/include/oneapi/dpl/pstl/glue_algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_impl.h
@@ -72,7 +72,7 @@ none_of(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __
 // [alg.foreach]
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Function>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 for_each(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Function __f)
 {
     oneapi::dpl::__internal::__pattern_walk1(
@@ -359,7 +359,7 @@ transform(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterato
 // [alg.replace]
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate, class _Tp>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 replace_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred,
            const _Tp& __new_value)
 {
@@ -373,7 +373,7 @@ replace_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 replace(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __old_value,
         const _Tp& __new_value)
 {
@@ -417,7 +417,7 @@ replace_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardItera
 // [alg.fill]
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 fill(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value)
 {
     oneapi::dpl::__internal::__pattern_fill(
@@ -441,7 +441,7 @@ fill_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __count, const
 
 // [alg.generate]
 template <class _ExecutionPolicy, class _ForwardIterator, class _Generator>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 generate(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Generator __g)
 {
     oneapi::dpl::__internal::__pattern_generate(
@@ -551,7 +551,7 @@ unique_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterat
 // [alg.reverse]
 
 template <class _ExecutionPolicy, class _BidirectionalIterator>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 reverse(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __last)
 {
     oneapi::dpl::__internal::__pattern_reverse(
@@ -649,7 +649,7 @@ partition_copy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIter
 // [alg.sort]
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp)
 {
     typedef typename ::std::iterator_traits<_RandomAccessIterator>::value_type _InputType;
@@ -661,7 +661,7 @@ sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIter
 }
 
 template <class _ExecutionPolicy, class _RandomAccessIterator>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last)
 {
     oneapi::dpl::sort(::std::forward<_ExecutionPolicy>(__exec), __first, __last,
@@ -671,7 +671,7 @@ sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIter
 // [stable.sort]
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 stable_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp)
 {
     oneapi::dpl::__internal::__pattern_stable_sort(
@@ -681,7 +681,7 @@ stable_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAcc
 }
 
 template <class _ExecutionPolicy, class _RandomAccessIterator>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 stable_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last)
 {
     oneapi::dpl::stable_sort(::std::forward<_ExecutionPolicy>(__exec), __first, __last,
@@ -692,7 +692,7 @@ stable_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAcc
 
 template <typename _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2,
           typename _Compare>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 sort_by_key(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __keys_first, _RandomAccessIterator1 __keys_last,
             _RandomAccessIterator2 __values_first, _Compare __comp)
 {
@@ -705,7 +705,7 @@ sort_by_key(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __keys_first, _Ran
 }
 
 template <typename _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 sort_by_key(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __keys_first, _RandomAccessIterator1 __keys_last,
             _RandomAccessIterator2 __values_first)
 {
@@ -818,7 +818,7 @@ move(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __l
 // [partial.sort]
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 partial_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __middle,
              _RandomAccessIterator __last, _Compare __comp)
 {
@@ -829,7 +829,7 @@ partial_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAc
 }
 
 template <class _ExecutionPolicy, class _RandomAccessIterator>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 partial_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __middle,
              _RandomAccessIterator __last)
 {
@@ -928,7 +928,7 @@ merge(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 _
 }
 
 template <class _ExecutionPolicy, class _BidirectionalIterator, class _Compare>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 inplace_merge(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __middle,
               _BidirectionalIterator __last, _Compare __comp)
 {
@@ -939,7 +939,7 @@ inplace_merge(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _Bidire
 }
 
 template <class _ExecutionPolicy, class _BidirectionalIterator>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 inplace_merge(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __middle,
               _BidirectionalIterator __last)
 {
@@ -1167,7 +1167,7 @@ minmax_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIter
 // [alg.nth.element]
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 nth_element(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __nth,
             _RandomAccessIterator __last, _Compare __comp)
 {
@@ -1178,7 +1178,7 @@ nth_element(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAcc
 }
 
 template <class _ExecutionPolicy, class _RandomAccessIterator>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 nth_element(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __nth,
             _RandomAccessIterator __last)
 {

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_defs.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_defs.h
@@ -49,7 +49,7 @@ none_of(_ExecutionPolicy&& __exec, _Range&& __rng, _Predicate __pred);
 // [alg.foreach]
 
 template <typename _ExecutionPolicy, typename _Range, typename _Function>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 for_each(_ExecutionPolicy&& __exec, _Range&& __rng, _Function __f);
 
 // [alg.find]
@@ -133,7 +133,7 @@ search_n(_ExecutionPolicy&& __exec, _Range&& __rng, _Size __count, const _Tp& __
 // [alg.copy]
 
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 copy(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __result);
 
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Predicate>
@@ -151,11 +151,11 @@ swap_ranges(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2);
 // [alg.transform]
 
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _UnaryOperation>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 transform(_ExecutionPolicy&& __exec, _Range1&& __rng, _Range2&& __result, _UnaryOperation __op);
 
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _BinaryOperation>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 transform(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _Range3&& __result, _BinaryOperation __op);
 
 // [alg.remove]
@@ -201,7 +201,7 @@ unique_copy(_ExecutionPolicy&& __exec, _Range1&& __rng, _Range2&& __result);
 // [alg.reverse]
 
 template <typename _ExecutionPolicy, typename _Range>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 reverse(_ExecutionPolicy&& __exec, _Range&& __rng);
 
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2>
@@ -218,11 +218,11 @@ rotate_copy(_ExecutionPolicy&& __exec, _Range1&& __rng, oneapi::dpl::__internal:
 // [alg.replace]
 
 template <typename _ExecutionPolicy, typename _Range, typename _UnaryPredicate, typename _Tp>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 replace_if(_ExecutionPolicy&& __exec, _Range&& __rng, _UnaryPredicate __pred, const _Tp& __new_value);
 
 template <typename _ExecutionPolicy, typename _Range, typename _Tp>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 replace(_ExecutionPolicy&& __exec, _Range&& __rng, const _Tp& __old_value, const _Tp& __new_value);
 
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _UnaryPredicate, typename _Tp>
@@ -240,21 +240,21 @@ replace_copy(_ExecutionPolicy&& __exec, _Range1&& __rng, _Range2&& __result, con
 // [alg.sort]
 
 template <typename _ExecutionPolicy, typename _Range, typename _Compare, typename _Proj = oneapi::dpl::identity>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp, _Proj __proj = {});
 
 template <typename _ExecutionPolicy, typename _Range>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 sort(_ExecutionPolicy&& __exec, _Range&& __rng);
 
 // [stable.sort]
 
 template <typename _ExecutionPolicy, typename _Range, typename _Compare>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 stable_sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp);
 
 template <typename _ExecutionPolicy, typename _Range>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 stable_sort(_ExecutionPolicy&& __exec, _Range&& __rng);
 
 // [is.sorted]
@@ -288,7 +288,7 @@ equal(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2);
 // [alg.move]
 
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 move(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2);
 
 // [alg.merge]

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -67,7 +67,7 @@ none_of(_ExecutionPolicy&& __exec, _Range&& __rng, _Predicate __pred)
 // [alg.foreach]
 
 template <typename _ExecutionPolicy, typename _Range, typename _Function>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 for_each(_ExecutionPolicy&& __exec, _Range&& __rng, _Function __f)
 {
     oneapi::dpl::__internal::__ranges::__pattern_walk_n(::std::forward<_ExecutionPolicy>(__exec), __f,
@@ -227,7 +227,7 @@ search_n(_ExecutionPolicy&& __exec, _Range&& __rng, _Size __count, const _Tp& __
 // [alg.copy]
 
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 copy(_ExecutionPolicy&& __exec, _Range1&& __rng, _Range2&& __result)
 {
     oneapi::dpl::__internal::__ranges::__pattern_walk_n(
@@ -266,7 +266,7 @@ swap_ranges(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2)
 // [alg.transform]
 
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _UnaryOperation>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 transform(_ExecutionPolicy&& __exec, _Range1&& __rng, _Range2&& __result, _UnaryOperation __op)
 {
     oneapi::dpl::__internal::__ranges::__pattern_walk_n(
@@ -275,7 +275,7 @@ transform(_ExecutionPolicy&& __exec, _Range1&& __rng, _Range2&& __result, _Unary
 }
 
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _BinaryOperation>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 transform(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _Range3&& __result, _BinaryOperation __op)
 {
     oneapi::dpl::__internal::__ranges::__pattern_walk_n(
@@ -366,7 +366,7 @@ unique_copy(_ExecutionPolicy&& __exec, _Range1&& __rng, _Range2&& __result)
 // [alg.reverse]
 
 template <typename _ExecutionPolicy, typename _Range>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 reverse(_ExecutionPolicy&& __exec, _Range&& __rng)
 {
     auto __v = views::all(::std::forward<_Range>(__rng));
@@ -403,7 +403,7 @@ rotate_copy(_ExecutionPolicy&& __exec, _Range1&& __rng, oneapi::dpl::__internal:
 // [alg.replace]
 
 template <typename _ExecutionPolicy, typename _Range, typename _UnaryPredicate, typename _Tp>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 replace_if(_ExecutionPolicy&& __exec, _Range&& __rng, _UnaryPredicate __pred, const _Tp& __new_value)
 {
     oneapi::dpl::__internal::__ranges::__pattern_walk_n(
@@ -415,7 +415,7 @@ replace_if(_ExecutionPolicy&& __exec, _Range&& __rng, _UnaryPredicate __pred, co
 }
 
 template <typename _ExecutionPolicy, typename _Range, typename _Tp>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 replace(_ExecutionPolicy&& __exec, _Range&& __rng, const _Tp& __old_value, const _Tp& __new_value)
 {
     replace_if(
@@ -459,7 +459,7 @@ replace_copy(_ExecutionPolicy&& __exec, _Range1&& __rng, _Range2&& __result, con
 // [alg.sort]
 
 template <typename _ExecutionPolicy, typename _Range, typename _Compare, typename _Proj>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp, _Proj __proj)
 {
     oneapi::dpl::__internal::__ranges::__pattern_sort(::std::forward<_ExecutionPolicy>(__exec),
@@ -467,7 +467,7 @@ sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp, _Proj __proj)
 }
 
 template <typename _ExecutionPolicy, typename _Range>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 sort(_ExecutionPolicy&& __exec, _Range&& __rng)
 {
     sort(::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range>(__rng),
@@ -477,14 +477,14 @@ sort(_ExecutionPolicy&& __exec, _Range&& __rng)
 // [stable.sort]
 
 template <typename _ExecutionPolicy, typename _Range, typename _Compare>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 stable_sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp)
 {
     sort(::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range>(__rng), __comp);
 }
 
 template <typename _ExecutionPolicy, typename _Range>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 stable_sort(_ExecutionPolicy&& __exec, _Range&& __rng)
 {
     sort(::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range>(__rng),
@@ -554,7 +554,7 @@ equal(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2)
 // [alg.move]
 
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 move(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2)
 {
     using _DecayedExecutionPolicy = ::std::decay_t<_ExecutionPolicy>;

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -436,9 +436,10 @@ replace_copy_if(_ExecutionPolicy&& __exec, _Range1&& __rng, _Range2&& __result, 
         ::std::forward<_ExecutionPolicy>(__exec),
         oneapi::dpl::__internal::__replace_copy_functor<
             oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _Tp>,
-            ::std::conditional_t<
-                oneapi::dpl::__internal::__is_const_callable_object<_UnaryPredicate>::value, _UnaryPredicate,
-                oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, _UnaryPredicate>>>(__new_value, __pred),
+            ::std::conditional_t<oneapi::dpl::__internal::__is_const_callable_object<_UnaryPredicate>::value,
+                                 _UnaryPredicate,
+                                 oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, _UnaryPredicate>>>(
+            __new_value, __pred),
         __src, views::all_write(::std::forward<_Range2>(__result)));
     return __src.size();
 }

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -436,9 +436,9 @@ replace_copy_if(_ExecutionPolicy&& __exec, _Range1&& __rng, _Range2&& __result, 
         ::std::forward<_ExecutionPolicy>(__exec),
         oneapi::dpl::__internal::__replace_copy_functor<
             oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _Tp>,
-            typename ::std::conditional<
+            ::std::conditional_t<
                 oneapi::dpl::__internal::__is_const_callable_object<_UnaryPredicate>::value, _UnaryPredicate,
-                oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, _UnaryPredicate>>::type>(__new_value, __pred),
+                oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, _UnaryPredicate>>>(__new_value, __pred),
         __src, views::all_write(::std::forward<_Range2>(__result)));
     return __src.size();
 }

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -557,7 +557,7 @@ template <typename _ExecutionPolicy, typename _Range1, typename _Range2>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
 move(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2)
 {
-    using _DecayedExecutionPolicy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _DecayedExecutionPolicy = ::std::decay_t<_ExecutionPolicy>;
 
     oneapi::dpl::__internal::__ranges::__pattern_walk_n(
         ::std::forward<_ExecutionPolicy>(__exec), oneapi::dpl::__internal::__brick_move<_DecayedExecutionPolicy>{},

--- a/include/oneapi/dpl/pstl/glue_memory_defs.h
+++ b/include/oneapi/dpl/pstl/glue_memory_defs.h
@@ -46,7 +46,7 @@ uninitialized_move_n(_ExecutionPolicy&& __exec, _InputIterator __first, _Size __
 // [uninitialized.fill]
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 uninitialized_fill(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value);
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Tp>
@@ -56,7 +56,7 @@ uninitialized_fill_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size 
 // [specialized.destroy]
 
 template <class _ExecutionPolicy, class _ForwardIterator>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 destroy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last);
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Size>
@@ -66,7 +66,7 @@ destroy_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n);
 // [uninitialized.construct.default]
 
 template <class _ExecutionPolicy, class _ForwardIterator>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 uninitialized_default_construct(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last);
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Size>
@@ -76,7 +76,7 @@ uninitialized_default_construct_n(_ExecutionPolicy&& __exec, _ForwardIterator __
 // [uninitialized.construct.value]
 
 template <class _ExecutionPolicy, class _ForwardIterator>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 uninitialized_value_construct(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last);
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Size>

--- a/include/oneapi/dpl/pstl/glue_memory_impl.h
+++ b/include/oneapi/dpl/pstl/glue_memory_impl.h
@@ -41,7 +41,7 @@ uninitialized_copy(_ExecutionPolicy&& __exec, _InputIterator __first, _InputIter
 {
     typedef typename ::std::iterator_traits<_InputIterator>::value_type _ValueType1;
     typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType2;
-    typedef typename ::std::decay<_ExecutionPolicy>::type _DecayedExecutionPolicy;
+    typedef ::std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     const auto __is_parallel =
         oneapi::dpl::__internal::__is_parallelization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(
@@ -71,7 +71,7 @@ uninitialized_copy_n(_ExecutionPolicy&& __exec, _InputIterator __first, _Size __
 {
     typedef typename ::std::iterator_traits<_InputIterator>::value_type _ValueType1;
     typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType2;
-    typedef typename ::std::decay<_ExecutionPolicy>::type _DecayedExecutionPolicy;
+    typedef ::std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     const auto __is_parallel =
         oneapi::dpl::__internal::__is_parallelization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(
@@ -103,7 +103,7 @@ uninitialized_move(_ExecutionPolicy&& __exec, _InputIterator __first, _InputIter
 {
     typedef typename ::std::iterator_traits<_InputIterator>::value_type _ValueType1;
     typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType2;
-    typedef typename ::std::decay<_ExecutionPolicy>::type _DecayedExecutionPolicy;
+    typedef ::std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     const auto __is_parallel =
         oneapi::dpl::__internal::__is_parallelization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(
@@ -133,7 +133,7 @@ uninitialized_move_n(_ExecutionPolicy&& __exec, _InputIterator __first, _Size __
 {
     typedef typename ::std::iterator_traits<_InputIterator>::value_type _ValueType1;
     typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType2;
-    typedef typename ::std::decay<_ExecutionPolicy>::type _DecayedExecutionPolicy;
+    typedef ::std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     const auto __is_parallel =
         oneapi::dpl::__internal::__is_parallelization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(
@@ -164,7 +164,7 @@ oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
 uninitialized_fill(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value)
 {
     typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType;
-    typedef typename ::std::decay<_ExecutionPolicy>::type _DecayedExecutionPolicy;
+    typedef ::std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     const auto __is_parallel =
         oneapi::dpl::__internal::__is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
@@ -192,7 +192,7 @@ oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _Forward
 uninitialized_fill_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n, const _Tp& __value)
 {
     typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType;
-    typedef typename ::std::decay<_ExecutionPolicy>::type _DecayedExecutionPolicy;
+    typedef ::std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     const auto __is_parallel =
         oneapi::dpl::__internal::__is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
@@ -268,7 +268,7 @@ oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
 uninitialized_default_construct(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last)
 {
     typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType;
-    typedef typename ::std::decay<_ExecutionPolicy>::type _DecayedExecutionPolicy;
+    typedef ::std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     const auto __is_parallel =
         oneapi::dpl::__internal::__is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
@@ -289,7 +289,7 @@ oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _Forward
 uninitialized_default_construct_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n)
 {
     typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType;
-    typedef typename ::std::decay<_ExecutionPolicy>::type _DecayedExecutionPolicy;
+    typedef ::std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     const auto __is_parallel =
         oneapi::dpl::__internal::__is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
@@ -316,7 +316,7 @@ oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
 uninitialized_value_construct(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last)
 {
     typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType;
-    typedef typename ::std::decay<_ExecutionPolicy>::type _DecayedExecutionPolicy;
+    typedef ::std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     const auto __is_parallel =
         oneapi::dpl::__internal::__is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
@@ -344,7 +344,7 @@ oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _Forward
 uninitialized_value_construct_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n)
 {
     typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType;
-    typedef typename ::std::decay<_ExecutionPolicy>::type _DecayedExecutionPolicy;
+    typedef ::std::decay_t<_ExecutionPolicy> _DecayedExecutionPolicy;
 
     const auto __is_parallel =
         oneapi::dpl::__internal::__is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);

--- a/include/oneapi/dpl/pstl/glue_memory_impl.h
+++ b/include/oneapi/dpl/pstl/glue_memory_impl.h
@@ -160,7 +160,7 @@ uninitialized_move_n(_ExecutionPolicy&& __exec, _InputIterator __first, _Size __
 // [uninitialized.fill]
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 uninitialized_fill(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value)
 {
     typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType;
@@ -218,7 +218,7 @@ uninitialized_fill_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size 
 // [specialized.destroy]
 
 template <class _ExecutionPolicy, class _ForwardIterator>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 destroy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last)
 {
     typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType;
@@ -264,7 +264,7 @@ destroy_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n)
 // [uninitialized.construct.default]
 
 template <class _ExecutionPolicy, class _ForwardIterator>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 uninitialized_default_construct(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last)
 {
     typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType;
@@ -312,7 +312,7 @@ uninitialized_default_construct_n(_ExecutionPolicy&& __exec, _ForwardIterator __
 // [uninitialized.construct.value]
 
 template <class _ExecutionPolicy, class _ForwardIterator>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 uninitialized_value_construct(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last)
 {
     typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType;

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -306,8 +306,7 @@ __pattern_generate(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Forward
 //------------------------------------------------------------------------
 
 template <typename _ExecutionPolicy>
-struct __brick_copy_n<_ExecutionPolicy,
-                      oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy>>
+struct __brick_copy_n<_ExecutionPolicy, oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy>>
 {
     template <typename _SourceT, typename _TargetT>
     void
@@ -318,8 +317,7 @@ struct __brick_copy_n<_ExecutionPolicy,
 };
 
 template <typename _ExecutionPolicy>
-struct __brick_copy<_ExecutionPolicy,
-                    oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy>>
+struct __brick_copy<_ExecutionPolicy, oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy>>
 {
     template <typename _SourceT, typename _TargetT>
     oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy>
@@ -330,8 +328,7 @@ struct __brick_copy<_ExecutionPolicy,
 };
 
 template <typename _ExecutionPolicy>
-struct __brick_move<_ExecutionPolicy,
-                    oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy>>
+struct __brick_move<_ExecutionPolicy, oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy>>
 {
     template <typename _SourceT, typename _TargetT>
     oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy>

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -40,7 +40,7 @@ namespace __internal
 //------------------------------------------------------------------------
 
 template <typename _ExecutionPolicy, typename _ForwardIterator, typename _Function>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy>
 __pattern_walk1(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Function __f,
                 /*vector=*/::std::true_type, /*parallel=*/::std::true_type)
 {
@@ -176,7 +176,7 @@ struct __walk_brick_wrapper
 };
 
 template <typename _ExecutionPolicy, typename _ForwardIterator, typename _Function>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy>
 __pattern_walk_brick(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Function __f,
                      /*parallel=*/::std::true_type)
 {
@@ -307,7 +307,7 @@ __pattern_generate(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Forward
 
 template <typename _ExecutionPolicy>
 struct __brick_copy_n<_ExecutionPolicy,
-                      oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, void>>
+                      oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy>>
 {
     template <typename _SourceT, typename _TargetT>
     void
@@ -319,10 +319,10 @@ struct __brick_copy_n<_ExecutionPolicy,
 
 template <typename _ExecutionPolicy>
 struct __brick_copy<_ExecutionPolicy,
-                    oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, void>>
+                    oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy>>
 {
     template <typename _SourceT, typename _TargetT>
-    oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, void>
+    oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy>
     operator()(_SourceT&& __source, _TargetT&& __target) const
     {
         __target = ::std::forward<_SourceT>(__source);
@@ -331,10 +331,10 @@ struct __brick_copy<_ExecutionPolicy,
 
 template <typename _ExecutionPolicy>
 struct __brick_move<_ExecutionPolicy,
-                    oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, void>>
+                    oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy>>
 {
     template <typename _SourceT, typename _TargetT>
-    oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, void>
+    oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy>
     operator()(_SourceT&& __source, _TargetT&& __target) const
     {
         __target = ::std::move(__source);
@@ -343,11 +343,11 @@ struct __brick_move<_ExecutionPolicy,
 
 template <typename _SourceT, typename _ExecutionPolicy>
 struct __brick_fill<_SourceT, _ExecutionPolicy,
-                    oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, void>>
+                    oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy>>
 {
     _SourceT __value;
     template <typename _TargetT>
-    oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, void>
+    oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy>
     operator()(_TargetT& __target) const
     {
         __target = __value;
@@ -356,11 +356,11 @@ struct __brick_fill<_SourceT, _ExecutionPolicy,
 
 template <typename _SourceT, typename _ExecutionPolicy>
 struct __brick_fill_n<_SourceT, _ExecutionPolicy,
-                      oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, void>>
+                      oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy>>
 {
     _SourceT __value;
     template <typename _TargetT>
-    oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, void>
+    oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy>
     operator()(_TargetT& __target) const
     {
         __target = __value;
@@ -1132,7 +1132,7 @@ __pattern_merge(_ExecutionPolicy&& __exec, _Iterator1 __first1, _Iterator1 __las
 // inplace_merge
 //------------------------------------------------------------------------
 template <typename _ExecutionPolicy, typename _Iterator, typename _Compare>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy>
 __pattern_inplace_merge(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __middle, _Iterator __last,
                         _Compare __comp, /*vector=*/::std::true_type, /*parallel=*/::std::true_type)
 {
@@ -1180,7 +1180,7 @@ __stable_sort_with_projection(_ExecutionPolicy&& __exec, _Iterator __first, _Ite
 }
 
 template <typename _ExecutionPolicy, typename _Iterator, typename _Compare>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy>
 __pattern_sort(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, _Compare __comp,
                /*vector=*/::std::true_type, /*parallel=*/::std::true_type, /*is_move_constructible=*/::std::true_type)
 {
@@ -1192,7 +1192,7 @@ __pattern_sort(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, _
 // stable_sort
 //------------------------------------------------------------------------
 template <typename _ExecutionPolicy, typename _Iterator, typename _Compare>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy>
 __pattern_stable_sort(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, _Compare __comp,
                       /*vector=*/::std::true_type, /*parallel=*/::std::true_type)
 {
@@ -1201,7 +1201,7 @@ __pattern_stable_sort(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __
 }
 
 template <typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2, typename _Compare>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy>
 __pattern_sort_by_key(_ExecutionPolicy&& __exec, _Iterator1 __keys_first, _Iterator1 __keys_last,
                       _Iterator2 __values_first, _Compare __comp, /*vector=*/::std::true_type,
                       /*parallel=*/::std::true_type)
@@ -1351,7 +1351,7 @@ __pattern_includes(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _Forwa
 // partial_sort
 //------------------------------------------------------------------------
 template <typename _ExecutionPolicy, typename _Iterator, typename _Compare>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy>
 __pattern_partial_sort(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __mid, _Iterator __last, _Compare __comp,
                        /*vector=*/::std::true_type, /*parallel=*/::std::true_type)
 {
@@ -1460,7 +1460,7 @@ __pattern_partial_sort_copy(_ExecutionPolicy&& __exec, _InIterator __first, _InI
 //------------------------------------------------------------------------
 
 template <typename _ExecutionPolicy, typename _Iterator, typename _Compare>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy>
 __pattern_nth_element(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __nth, _Iterator __last, _Compare __comp,
                       /*vector*/ ::std::true_type, /*parallel*/ ::std::true_type) noexcept
 {
@@ -1478,7 +1478,7 @@ __pattern_nth_element(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __
 // reverse
 //------------------------------------------------------------------------
 template <typename _ExecutionPolicy, typename _Iterator>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy>
 __pattern_reverse(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, /*vector=*/::std::true_type,
                   /*parallel=*/::std::true_type)
 {

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1046,7 +1046,7 @@ struct __is_heap_check
     operator()(const _Idx __idx, const _Accessor& __acc) const
     {
         // Make sure that we have a signed integer here to avoid getting negative value when __idx == 0
-        using _SignedIdx = typename ::std::make_signed<_Idx>::type;
+        using _SignedIdx = ::std::make_signed_t<_Idx>;
         return __comp_(__acc[(static_cast<_SignedIdx>(__idx) - 1) / 2], __acc[__idx]);
     }
 };

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -380,8 +380,7 @@ __pattern_min_element(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __
         return __last;
 
     using _IteratorValueType = typename ::std::iterator_traits<_Iterator>::value_type;
-    using _IndexValueType =
-        typename ::std::make_unsigned<typename ::std::iterator_traits<_Iterator>::difference_type>::type;
+    using _IndexValueType = ::std::make_unsigned_t<typename ::std::iterator_traits<_Iterator>::difference_type>;
     using _ReduceValueType = tuple<_IndexValueType, _IteratorValueType>;
 
     // This operator doesn't track the lowest found index in case of equal min. or max. values. Thus, this operator is
@@ -437,8 +436,7 @@ __pattern_minmax_element(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator
         return ::std::make_pair(__first, __first);
 
     using _IteratorValueType = typename ::std::iterator_traits<_Iterator>::value_type;
-    using _IndexValueType =
-        typename ::std::make_unsigned<typename ::std::iterator_traits<_Iterator>::difference_type>::type;
+    using _IndexValueType = ::std::make_unsigned_t<typename ::std::iterator_traits<_Iterator>::difference_type>;
     using _ReduceValueType = ::std::tuple<_IndexValueType, _IndexValueType, _IteratorValueType, _IteratorValueType>;
 
     // This operator doesn't track the lowest found index in case of equal min. values and the highest found index in

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -285,8 +285,8 @@ __pattern_adjacent_find(_ExecutionPolicy&& __exec, _Range&& __rng, _BinaryPredic
     using _Predicate =
         oneapi::dpl::unseq_backend::single_match_pred<_ExecutionPolicy, adjacent_find_fn<_BinaryPredicate>>;
     using _TagType =
-        typename ::std::conditional<__is__or_semantic(), oneapi::dpl::__par_backend_hetero::__parallel_or_tag,
-                                    oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_Range>>::type;
+        ::std::conditional_t<__is__or_semantic(), oneapi::dpl::__par_backend_hetero::__parallel_or_tag,
+                             oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_Range>>;
 
     auto __rng1 = __rng | oneapi::dpl::experimental::ranges::views::take(__rng.size() - 1);
     auto __rng2 = __rng | oneapi::dpl::experimental::ranges::views::drop(1);

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -284,9 +284,8 @@ __pattern_adjacent_find(_ExecutionPolicy&& __exec, _Range&& __rng, _BinaryPredic
 
     using _Predicate =
         oneapi::dpl::unseq_backend::single_match_pred<_ExecutionPolicy, adjacent_find_fn<_BinaryPredicate>>;
-    using _TagType =
-        ::std::conditional_t<__is__or_semantic(), oneapi::dpl::__par_backend_hetero::__parallel_or_tag,
-                             oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_Range>>;
+    using _TagType = ::std::conditional_t<__is__or_semantic(), oneapi::dpl::__par_backend_hetero::__parallel_or_tag,
+                                          oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_Range>>;
 
     auto __rng1 = __rng | oneapi::dpl::experimental::ranges::views::take(__rng.size() - 1);
     auto __rng2 = __rng | oneapi::dpl::experimental::ranges::views::drop(1);

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -40,7 +40,7 @@ namespace __ranges
 //------------------------------------------------------------------------
 
 template <typename _ExecutionPolicy, typename _Function, typename... _Ranges>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy>
 __pattern_walk_n(_ExecutionPolicy&& __exec, _Function __f, _Ranges&&... __rngs)
 {
     auto __n = oneapi::dpl::__ranges::__get_first_range_size(__rngs...);
@@ -523,7 +523,7 @@ __pattern_merge(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _
 //------------------------------------------------------------------------
 
 template <typename _ExecutionPolicy, typename _Range, typename _Compare, typename _Proj>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy, void>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<_ExecutionPolicy>
 __pattern_sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp, _Proj __proj)
 {
     if (__rng.size() >= 2)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -284,7 +284,7 @@ using __enable_if_device_execution_policy =
                            oneapi::dpl::__internal::__is_convertible_to_event<_Events...>,
                        _T>;
 
-template <typename _ExecPolicy, typename _T>
+template <typename _ExecPolicy, typename _T = void>
 using __enable_if_hetero_execution_policy =
     ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<_ExecPolicy>>::value, _T>;
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -288,7 +288,7 @@ template <typename _ExecPolicy, typename _T = void>
 using __enable_if_hetero_execution_policy =
     ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<_ExecPolicy>>::value, _T>;
 
-template <typename _ExecPolicy, typename _T>
+template <typename _ExecPolicy, typename _T = void>
 using __enable_if_fpga_execution_policy =
     ::std::enable_if_t<oneapi::dpl::__internal::__is_fpga_execution_policy<::std::decay_t<_ExecPolicy>>::value, _T>;
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1045,9 +1045,8 @@ struct __early_exit_find_or
         for (_IterSize __i = 0; __i < __n_iter; ++__i)
         {
             //in case of find-semantic __shifted_idx must be the same type as the atomic for a correct comparison
-            using _ShiftedIdxType =
-                typename ::std::conditional<_OrTagType::value, decltype(__init_index + __i * __shift),
-                                            decltype(__found_local.load())>::type;
+            using _ShiftedIdxType = ::std::conditional_t<_OrTagType::value, decltype(__init_index + __i * __shift),
+                                                         decltype(__found_local.load())>;
 
             _IterSize __current_iter = __i;
             if constexpr (_BackwardTagType::value)
@@ -1080,9 +1079,9 @@ struct __early_exit_find_or
 template <typename _ExecutionPolicy, typename _Brick, typename _BrickTag, typename... _Ranges>
 oneapi::dpl::__internal::__enable_if_device_execution_policy<
     _ExecutionPolicy,
-    typename ::std::conditional<::std::is_same<_BrickTag, __parallel_or_tag>::value, bool,
-                                oneapi::dpl::__internal::__difference_t<
-                                    typename oneapi::dpl::__ranges::__get_first_range_type<_Ranges...>::type>>::type>
+    ::std::conditional_t<::std::is_same<_BrickTag, __parallel_or_tag>::value, bool,
+                         oneapi::dpl::__internal::__difference_t<
+                             typename oneapi::dpl::__ranges::__get_first_range_type<_Ranges...>::type>>>
 __parallel_find_or(_ExecutionPolicy&& __exec, _Brick __f, _BrickTag __brick_tag, _Ranges&&... __rngs)
 {
     using _Policy = ::std::decay_t<_ExecutionPolicy>;
@@ -1238,9 +1237,8 @@ __parallel_find(_ExecutionPolicy&& __exec, _Iterator1 __first, _Iterator1 __last
     auto __s_keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator2>();
     auto __s_buf = __s_keep(__s_first, __s_last);
 
-    using _TagType =
-        typename ::std::conditional<_IsFirst::value, __parallel_find_forward_tag<decltype(__buf.all_view())>,
-                                    __parallel_find_backward_tag<decltype(__buf.all_view())>>::type;
+    using _TagType = ::std::conditional_t<_IsFirst::value, __parallel_find_forward_tag<decltype(__buf.all_view())>,
+                                          __parallel_find_backward_tag<decltype(__buf.all_view())>>;
     return __first + oneapi::dpl::__par_backend_hetero::__parallel_find_or(
                          __par_backend_hetero::make_wrapped_policy<__find_policy_wrapper>(
                              ::std::forward<_ExecutionPolicy>(__exec)),
@@ -1257,9 +1255,8 @@ __parallel_find(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, 
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
     auto __buf = __keep(__first, __last);
 
-    using _TagType =
-        typename ::std::conditional<_IsFirst::value, __parallel_find_forward_tag<decltype(__buf.all_view())>,
-                                    __parallel_find_backward_tag<decltype(__buf.all_view())>>::type;
+    using _TagType = ::std::conditional_t<_IsFirst::value, __parallel_find_forward_tag<decltype(__buf.all_view())>,
+                                          __parallel_find_backward_tag<decltype(__buf.all_view())>>;
     return __first + oneapi::dpl::__par_backend_hetero::__parallel_find_or(
                          __par_backend_hetero::make_wrapped_policy<__find_policy_wrapper>(
                              ::std::forward<_ExecutionPolicy>(__exec)),

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -380,7 +380,7 @@ struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name
                 sycl::range<1>(__n_groups * __size_per_wg),
                 __global_scan_caller<_GlobalScan, ::std::decay_t<_Range2>,
                                      ::std::decay_t<_Range1>, decltype(__wg_sums_acc), decltype(__n)>(
-                                         __global_scan, __rng2, __rng1, __wg_sums_acc, __n, __size_per_wg));
+                    __global_scan, __rng2, __rng1, __wg_sums_acc, __n, __size_per_wg));
         });
 
         return __future(__final_event, sycl::buffer(__wg_sums, sycl::id<1>(__n_groups - 1), sycl::range<1>(1)));

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -249,7 +249,7 @@ template <typename _ExecutionPolicy, typename _Fp, typename _Index,
 auto
 __parallel_for(_ExecutionPolicy&& __exec, _Fp __brick, _Index __count, _Ranges&&... __rngs)
 {
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using _CustomName = typename _Policy::kernel_name;
     using _ForKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<_CustomName>;
 
@@ -378,9 +378,9 @@ struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name
             auto __wg_sums_acc = __wg_sums.template get_access<access_mode::read>(__cgh);
             __cgh.parallel_for<_PropagateScanName...>(
                 sycl::range<1>(__n_groups * __size_per_wg),
-                __global_scan_caller<_GlobalScan, typename ::std::decay<_Range2>::type,
-                                     typename ::std::decay<_Range1>::type, decltype(__wg_sums_acc), decltype(__n)>(
-                    __global_scan, __rng2, __rng1, __wg_sums_acc, __n, __size_per_wg));
+                    __global_scan_caller<_GlobalScan, ::std::decay_t<_Range2>, ::std::decay_t<_Range1>,
+                                         decltype(__wg_sums_acc), decltype(__n)>(__global_scan, __rng2, __rng1,
+                                                                                 __wg_sums_acc, __n, __size_per_wg));
         });
 
         return __future(__final_event, sycl::buffer(__wg_sums, sycl::id<1>(__n_groups - 1), sycl::range<1>(1)));
@@ -747,7 +747,7 @@ __parallel_transform_scan_base(_ExecutionPolicy&& __exec, _Range1&& __in_rng, _R
                                _BinaryOperation __binary_op, _InitType __init, _LocalScan __local_scan,
                                _GroupScan __group_scan, _GlobalScan __global_scan)
 {
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using _CustomName = typename _Policy::kernel_name;
 
     using _PropagateKernel =
@@ -1085,7 +1085,7 @@ oneapi::dpl::__internal::__enable_if_device_execution_policy<
                                     typename oneapi::dpl::__ranges::__get_first_range_type<_Ranges...>::type>>::type>
 __parallel_find_or(_ExecutionPolicy&& __exec, _Brick __f, _BrickTag __brick_tag, _Ranges&&... __rngs)
 {
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using _CustomName = typename _Policy::kernel_name;
     using _AtomicType = typename _BrickTag::_AtomicType;
     using _FindOrKernel =
@@ -1502,7 +1502,7 @@ template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typenam
 auto
 __parallel_merge(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _Range3&& __rng3, _Compare __comp)
 {
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using _CustomName = typename _Policy::kernel_name;
 
     const auto __n = __rng1.size() + __rng2.size();
@@ -1564,7 +1564,7 @@ struct __parallel_sort_submitter<_IdType, __internal::__optional_kernel_name<_Le
     auto
     operator()(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp) const
     {
-        using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+        using _Policy = ::std::decay_t<_ExecutionPolicy>;
         using _Tp = oneapi::dpl::__internal::__value_t<_Range>;
         using _Size = oneapi::dpl::__internal::__difference_t<_Range>;
 
@@ -1658,7 +1658,7 @@ template <typename _ExecutionPolicy, typename _Range, typename _Compare,
 auto
 __parallel_sort_impl(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp)
 {
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using _CustomName = typename _Policy::kernel_name;
 
     const auto __n = __rng.size();
@@ -1700,7 +1700,7 @@ struct __parallel_partial_sort_submitter<__internal::__optional_kernel_name<_Glo
     auto
     operator()(_ExecutionPolicy&& __exec, _Range&& __rng, _Merge __merge, _Compare __comp) const
     {
-        using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+        using _Policy = ::std::decay_t<_ExecutionPolicy>;
         using _Tp = oneapi::dpl::__internal::__value_t<_Range>;
         using _Size = oneapi::dpl::__internal::__difference_t<_Range>;
 
@@ -1767,7 +1767,7 @@ template <typename _ExecutionPolicy, typename _Range, typename _Merge, typename 
 auto
 __parallel_partial_sort_impl(_ExecutionPolicy&& __exec, _Range&& __rng, _Merge __merge, _Compare __comp)
 {
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using _CustomName = typename _Policy::kernel_name;
     using _GlobalSortKernel =
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<__sort_global_kernel<_CustomName>>;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -372,19 +372,16 @@ struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name
         }
 
         // 3. Final scan for whole range
-        auto __final_event = __exec.queue().submit(
-            [&](sycl::handler& __cgh)
-            {
-                __cgh.depends_on(__submit_event);
-                oneapi::dpl::__ranges::__require_access(__cgh, __rng1,
-                                                        __rng2); //get an access to data under SYCL buffer
-                auto __wg_sums_acc = __wg_sums.template get_access<access_mode::read>(__cgh);
-                __cgh.parallel_for<_PropagateScanName...>(
-                    sycl::range<1>(__n_groups * __size_per_wg),
-                    __global_scan_caller<_GlobalScan, ::std::decay_t<_Range2>, ::std::decay_t<_Range1>,
-                                         decltype(__wg_sums_acc), decltype(__n)>(__global_scan, __rng2, __rng1,
-                                                                                 __wg_sums_acc, __n, __size_per_wg));
-            });
+        auto __final_event = __exec.queue().submit([&](sycl::handler& __cgh) {
+            __cgh.depends_on(__submit_event);
+            oneapi::dpl::__ranges::__require_access(__cgh, __rng1, __rng2); //get an access to data under SYCL buffer
+            auto __wg_sums_acc = __wg_sums.template get_access<access_mode::read>(__cgh);
+            __cgh.parallel_for<_PropagateScanName...>(
+                sycl::range<1>(__n_groups * __size_per_wg),
+                __global_scan_caller<_GlobalScan, ::std::decay_t<_Range2>,
+                                     ::std::decay_t<_Range1>, decltype(__wg_sums_acc), decltype(__n)>(
+                                         __global_scan, __rng2, __rng1, __wg_sums_acc, __n, __size_per_wg));
+        });
 
         return __future(__final_event, sycl::buffer(__wg_sums, sycl::id<1>(__n_groups - 1), sycl::range<1>(1)));
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -378,9 +378,9 @@ struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name
             auto __wg_sums_acc = __wg_sums.template get_access<access_mode::read>(__cgh);
             __cgh.parallel_for<_PropagateScanName...>(
                 sycl::range<1>(__n_groups * __size_per_wg),
-                __global_scan_caller<_GlobalScan, ::std::decay_t<_Range2>,
-                                     ::std::decay_t<_Range1>, decltype(__wg_sums_acc), decltype(__n)>(
-                    __global_scan, __rng2, __rng1, __wg_sums_acc, __n, __size_per_wg));
+                __global_scan_caller<_GlobalScan, ::std::decay_t<_Range2>, ::std::decay_t<_Range1>,
+                                     decltype(__wg_sums_acc), decltype(__n)>(__global_scan, __rng2, __rng1,
+                                                                             __wg_sums_acc, __n, __size_per_wg));
         });
 
         return __future(__final_event, sycl::buffer(__wg_sums, sycl::id<1>(__n_groups - 1), sycl::range<1>(1)));

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
@@ -181,9 +181,9 @@ __parallel_scan_copy(_ExecutionPolicy&& __exec, _InRng&& __in_rng, _OutRng&& __o
 template <typename _ExecutionPolicy, typename _Brick, typename _BrickTag, typename... _Ranges>
 oneapi::dpl::__internal::__enable_if_fpga_execution_policy<
     _ExecutionPolicy,
-    typename ::std::conditional<::std::is_same<_BrickTag, __parallel_or_tag>::value, bool,
-                                oneapi::dpl::__internal::__difference_t<
-                                    typename oneapi::dpl::__ranges::__get_first_range_type<_Ranges...>::type>>::type>
+    ::std::conditional_t<::std::is_same<_BrickTag, __parallel_or_tag>::value, bool,
+                         oneapi::dpl::__internal::__difference_t<
+                             typename oneapi::dpl::__ranges::__get_first_range_type<_Ranges...>::type>>>
 __parallel_find_or(_ExecutionPolicy&& __exec, _Brick __f, _BrickTag __brick_tag, _Ranges&&... __rngs)
 {
     using _Policy = ::std::decay_t<_ExecutionPolicy>;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
@@ -250,7 +250,7 @@ __parallel_find(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, 
 template <typename _ExecutionPolicy>
 auto
 __device_policy(_ExecutionPolicy&& __exec)
-    -> decltype(oneapi::dpl::execution::make_device_policy<::std::decay_t<_ExecutionPolicy>::kernel_name>(
+    -> decltype(oneapi::dpl::execution::make_device_policy<typename ::std::decay_t<_ExecutionPolicy>::kernel_name>(
         __exec.queue()))
 {
     using _Policy = ::std::decay_t<_ExecutionPolicy>;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
@@ -81,7 +81,7 @@ template <typename _ExecutionPolicy, typename _Fp, typename _Index, typename... 
 auto
 __parallel_for(_ExecutionPolicy&& __exec, _Fp __brick, _Index __count, _Ranges&&... __rngs)
 {
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using __parallel_for_name = __internal::__kernel_name_provider<typename _Policy::kernel_name>;
 
     return __parallel_for_fpga_submitter<__parallel_for_name>()(std::forward<_ExecutionPolicy>(__exec), __brick,
@@ -100,7 +100,7 @@ __parallel_transform_reduce(_ExecutionPolicy&& __exec, _ReduceOp __reduce_op, _T
                             _InitType __init, _Ranges&&... __rngs)
 {
     // workaround until we implement more performant version for patterns
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using __kernel_name = typename _Policy::kernel_name;
     auto __device_policy = oneapi::dpl::execution::make_device_policy<__kernel_name>(__exec.queue());
     return oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_Tp, _Commutative>(
@@ -119,7 +119,7 @@ __parallel_transform_scan(_ExecutionPolicy&& __exec, _Range1&& __in_rng, _Range2
                           _UnaryOperation __unary_op, _InitType __init, _BinaryOperation __binary_op, _Inclusive)
 {
     // workaround until we implement more performant version for patterns
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using __kernel_name = typename _Policy::kernel_name;
     auto __device_policy = oneapi::dpl::execution::make_device_policy<__kernel_name>(__exec.queue());
     return oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(
@@ -136,7 +136,7 @@ __parallel_transform_scan_base(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Ran
                                _GroupScan __group_scan, _GlobalScan __global_scan)
 {
     // workaround until we implement more performant version for patterns
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using __kernel_name = typename _Policy::kernel_name;
     auto __device_policy = oneapi::dpl::execution::make_device_policy<__kernel_name>(__exec.queue());
     return oneapi::dpl::__par_backend_hetero::__parallel_transform_scan_base(
@@ -150,7 +150,7 @@ auto
 __parallel_copy_if(_ExecutionPolicy&& __exec, _InRng&& __in_rng, _OutRng&& __out_rng, _Size __n, _Pred __pred)
 {
     // workaround until we implement more performant version for patterns
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using __kernel_name = typename _Policy::kernel_name;
     auto __device_policy = oneapi::dpl::execution::make_device_policy<__kernel_name>(__exec.queue());
     return oneapi::dpl::__par_backend_hetero::__parallel_copy_if(
@@ -167,7 +167,7 @@ __parallel_scan_copy(_ExecutionPolicy&& __exec, _InRng&& __in_rng, _OutRng&& __o
                      _CreateMaskOp __create_mask_op, _CopyByMaskOp __copy_by_mask_op)
 {
     // workaround until we implement more performant version for patterns
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using __kernel_name = typename _Policy::kernel_name;
     auto __device_policy = oneapi::dpl::execution::make_device_policy<__kernel_name>(__exec.queue());
     return oneapi::dpl::__par_backend_hetero::__parallel_scan_copy(
@@ -186,7 +186,7 @@ oneapi::dpl::__internal::__enable_if_fpga_execution_policy<
                                     typename oneapi::dpl::__ranges::__get_first_range_type<_Ranges...>::type>>::type>
 __parallel_find_or(_ExecutionPolicy&& __exec, _Brick __f, _BrickTag __brick_tag, _Ranges&&... __rngs)
 {
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using __kernel_name = typename _Policy::kernel_name;
     auto __device_policy = oneapi::dpl::execution::make_device_policy<__kernel_name>(__exec.queue());
     return oneapi::dpl::__par_backend_hetero::__parallel_find_or(__device_policy, __f, __brick_tag,
@@ -202,7 +202,7 @@ __parallel_or(_ExecutionPolicy&& __exec, _Iterator1 __first, _Iterator1 __last, 
               _Iterator2 __s_last, _Brick __f)
 {
     // workaround until we implement more performant version for patterns
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using __kernel_name = typename _Policy::kernel_name;
     auto __device_policy = oneapi::dpl::execution::make_device_policy<__kernel_name>(__exec.queue());
     return oneapi::dpl::__par_backend_hetero::__parallel_or(__device_policy, __first, __last, __s_first, __s_last, __f);
@@ -213,7 +213,7 @@ oneapi::dpl::__internal::__enable_if_fpga_execution_policy<_ExecutionPolicy, boo
 __parallel_or(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, _Brick __f)
 {
     // workaround until we implement more performant version for patterns
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using __kernel_name = typename _Policy::kernel_name;
     auto __device_policy = oneapi::dpl::execution::make_device_policy<__kernel_name>(__exec.queue());
     return oneapi::dpl::__par_backend_hetero::__parallel_or(__device_policy, __first, __last, __f);
@@ -229,7 +229,7 @@ __parallel_find(_ExecutionPolicy&& __exec, _Iterator1 __first, _Iterator1 __last
                 _Iterator2 __s_last, _Brick __f, _IsFirst __is_first)
 {
     // workaround until we implement more performant version for patterns
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using __kernel_name = typename _Policy::kernel_name;
     auto __device_policy = oneapi::dpl::execution::make_device_policy<__kernel_name>(__exec.queue());
     return oneapi::dpl::__par_backend_hetero::__parallel_find(__device_policy, __first, __last, __s_first, __s_last,
@@ -241,7 +241,7 @@ oneapi::dpl::__internal::__enable_if_fpga_execution_policy<_ExecutionPolicy, _It
 __parallel_find(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, _Brick __f, _IsFirst __is_first)
 {
     // workaround until we implement more performant version for patterns
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using __kernel_name = typename _Policy::kernel_name;
     auto __device_policy = oneapi::dpl::execution::make_device_policy<__kernel_name>(__exec.queue());
     return oneapi::dpl::__par_backend_hetero::__parallel_find(__device_policy, __first, __last, __f, __is_first);
@@ -250,10 +250,10 @@ __parallel_find(_ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last, 
 template <typename _ExecutionPolicy>
 auto
 __device_policy(_ExecutionPolicy&& __exec)
-    -> decltype(oneapi::dpl::execution::make_device_policy<typename ::std::decay<_ExecutionPolicy>::type::kernel_name>(
+    -> decltype(oneapi::dpl::execution::make_device_policy<::std::decay_t<_ExecutionPolicy>::kernel_name>(
         __exec.queue()))
 {
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using __kernel_name = typename _Policy::kernel_name;
     return oneapi::dpl::execution::make_device_policy<__kernel_name>(__exec.queue());
 }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -140,7 +140,7 @@ auto
 __parallel_transform_reduce_small_impl(_ExecutionPolicy&& __exec, const _Size __n, _ReduceOp __reduce_op,
                                        _TransformOp __transform_op, _InitType __init, _Ranges&&... __rngs)
 {
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using _CustomName = typename _Policy::kernel_name;
     using _ReduceKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
         __reduce_small_kernel<::std::integral_constant<::std::uint8_t, __iters_per_work_item>, _CustomName>>;
@@ -259,7 +259,7 @@ auto
 __parallel_transform_reduce_mid_impl(_ExecutionPolicy&& __exec, _Size __n, _ReduceOp __reduce_op,
                                      _TransformOp __transform_op, _InitType __init, _Ranges&&... __rngs)
 {
-    using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+    using _Policy = ::std::decay_t<_ExecutionPolicy>;
     using _CustomName = typename _Policy::kernel_name;
 
     // The same value for __iters_per_work_item_device_kernel is currently used. Include
@@ -297,7 +297,7 @@ struct __parallel_transform_reduce_impl
     submit(_ExecutionPolicy&& __exec, _Size __n, ::std::uint16_t __work_group_size, _ReduceOp __reduce_op,
            _TransformOp __transform_op, _InitType __init, _Ranges&&... __rngs)
     {
-        using _Policy = typename ::std::decay<_ExecutionPolicy>::type;
+        using _Policy = ::std::decay_t<_ExecutionPolicy>;
         using _CustomName = typename _Policy::kernel_name;
         using _NoOpFunctor = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;
         using _ReduceKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -150,7 +150,7 @@ using access_mode = sycl::access_mode;
 
 // substitution for C++17 convenience types
 template <typename _T>
-using __decay_t = typename ::std::decay<_T>::type;
+using __decay_t = ::std::decay_t<_T>;
 template <bool __flag, typename _T = void>
 using __enable_if_t = typename ::std::enable_if<__flag, _T>::type;
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -219,8 +219,8 @@ struct __optional_kernel_name;
 template <typename _CustomName>
 using __kernel_name_provider =
 #if __SYCL_UNNAMED_LAMBDA__
-    typename ::std::conditional<_HasDefaultName<_CustomName>::value, __optional_kernel_name<>,
-                                __optional_kernel_name<_CustomName>>::type;
+    ::std::conditional_t<_HasDefaultName<_CustomName>::value, __optional_kernel_name<>,
+                         __optional_kernel_name<_CustomName>>;
 #else
     __optional_kernel_name<_CustomName>;
 #endif

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -152,7 +152,7 @@ using access_mode = sycl::access_mode;
 template <typename _T>
 using __decay_t = ::std::decay_t<_T>;
 template <bool __flag, typename _T = void>
-using __enable_if_t = typename ::std::enable_if<__flag, _T>::type;
+using __enable_if_t = ::std::enable_if_t<__flag, _T>;
 
 // function to simplify zip_iterator creation
 template <typename... T>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -42,7 +42,7 @@ struct sycl_iterator
 
   public:
     using value_type = T;
-    using difference_type = ::std::make_signed<Size>::type;
+    using difference_type = ::std::make_signed_t<Size>;
     using pointer = T*;
     using reference = T&;
     using iterator_category = ::std::random_access_iterator_tag;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -32,8 +32,6 @@ namespace unseq_backend
 // helpers to encapsulate void and other types
 template <typename _Tp>
 using void_type = ::std::enable_if_t<::std::is_void<_Tp>::value, _Tp>;
-template <typename _Tp>
-using non_void_type = ::std::enable_if_t<!::std::is_void<_Tp>::value, _Tp>;
 
 #if _USE_GROUP_ALGOS && _ONEDPL_SYCL_INTEL_COMPILER
 //This optimization depends on Intel(R) oneAPI DPC++ Compiler implementation such as support of binary operators from std namespace.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -42,16 +42,15 @@ using __has_known_identity =
 #    if _ONEDPL_LIBSYCL_VERSION >= 50200
     typename ::std::disjunction<
         __dpl_sycl::__has_known_identity<_BinaryOp, _Tp>,
-        ::std::conjunction<
-            ::std::is_arithmetic<_Tp>,
-            ::std::disjunction<::std::is_same<::std::decay_t<_BinaryOp>, ::std::plus<_Tp>>,
-                               ::std::is_same<::std::decay_t<_BinaryOp>, ::std::plus<void>>,
-                               ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__plus<_Tp>>,
-                               ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__plus<void>>,
-                               ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__minimum<_Tp>>,
-                               ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__minimum<void>>,
-                               ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__maximum<_Tp>>,
-                               ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__maximum<void>>>>>;
+        ::std::conjunction<::std::is_arithmetic<_Tp>,
+                           ::std::disjunction<::std::is_same<::std::decay_t<_BinaryOp>, ::std::plus<_Tp>>,
+                                              ::std::is_same<::std::decay_t<_BinaryOp>, ::std::plus<void>>,
+                                              ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__plus<_Tp>>,
+                                              ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__plus<void>>,
+                                              ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__minimum<_Tp>>,
+                                              ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__minimum<void>>,
+                                              ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__maximum<_Tp>>,
+                                              ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__maximum<void>>>>>;
 #    else  //_ONEDPL_LIBSYCL_VERSION >= 50200
     typename ::std::conjunction<
         ::std::is_arithmetic<_Tp>,
@@ -469,9 +468,9 @@ struct __copy_by_mask
         {
             auto __out_idx = get<N>(__in_acc[__item_idx]) - 1;
 
-            using __tuple_type = typename __internal::__get_tuple_type<
-                ::std::decay_t<decltype(get<0>(__in_acc[__item_idx]))>,
-                ::std::decay_t<decltype(__out_acc[__out_idx])>>::__type;
+            using __tuple_type =
+                typename __internal::__get_tuple_type<::std::decay_t<decltype(get<0>(__in_acc[__item_idx]))>,
+                                                      ::std::decay_t<decltype(__out_acc[__out_idx])>>::__type;
 
             // calculation of position for copy
             if (__item_idx >= __size_per_wg)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -49,21 +49,21 @@ using __has_known_identity =
         __dpl_sycl::__has_known_identity<_BinaryOp, _Tp>,
         ::std::conjunction<
             ::std::is_arithmetic<_Tp>,
-            ::std::disjunction<::std::is_same<typename ::std::decay<_BinaryOp>::type, ::std::plus<_Tp>>,
-                               ::std::is_same<typename ::std::decay<_BinaryOp>::type, ::std::plus<void>>,
-                               ::std::is_same<typename ::std::decay<_BinaryOp>::type, __dpl_sycl::__plus<_Tp>>,
-                               ::std::is_same<typename ::std::decay<_BinaryOp>::type, __dpl_sycl::__plus<void>>,
-                               ::std::is_same<typename ::std::decay<_BinaryOp>::type, __dpl_sycl::__minimum<_Tp>>,
-                               ::std::is_same<typename ::std::decay<_BinaryOp>::type, __dpl_sycl::__minimum<void>>,
-                               ::std::is_same<typename ::std::decay<_BinaryOp>::type, __dpl_sycl::__maximum<_Tp>>,
-                               ::std::is_same<typename ::std::decay<_BinaryOp>::type, __dpl_sycl::__maximum<void>>>>>;
+            ::std::disjunction<::std::is_same<::std::decay_t<_BinaryOp>, ::std::plus<_Tp>>,
+                               ::std::is_same<::std::decay_t<_BinaryOp>, ::std::plus<void>>,
+                               ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__plus<_Tp>>,
+                               ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__plus<void>>,
+                               ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__minimum<_Tp>>,
+                               ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__minimum<void>>,
+                               ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__maximum<_Tp>>,
+                               ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__maximum<void>>>>>;
 #    else  //_ONEDPL_LIBSYCL_VERSION >= 50200
     typename ::std::conjunction<
         ::std::is_arithmetic<_Tp>,
-        ::std::disjunction<::std::is_same<typename ::std::decay<_BinaryOp>::type, ::std::plus<_Tp>>,
-                           ::std::is_same<typename ::std::decay<_BinaryOp>::type, ::std::plus<void>>,
-                           ::std::is_same<typename ::std::decay<_BinaryOp>::type, __dpl_sycl::__plus<_Tp>>,
-                           ::std::is_same<typename ::std::decay<_BinaryOp>::type, __dpl_sycl::__plus<void>>>>;
+        ::std::disjunction<::std::is_same<::std::decay_t<_BinaryOp>, ::std::plus<_Tp>>,
+                           ::std::is_same<::std::decay_t<_BinaryOp>, ::std::plus<void>>,
+                           ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__plus<_Tp>>,
+                           ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__plus<void>>>>;
 #    endif //_ONEDPL_LIBSYCL_VERSION >= 50200
 
 #else //_USE_GROUP_ALGOS && _ONEDPL_SYCL_INTEL_COMPILER
@@ -475,8 +475,8 @@ struct __copy_by_mask
             auto __out_idx = get<N>(__in_acc[__item_idx]) - 1;
 
             using __tuple_type = typename __internal::__get_tuple_type<
-                typename ::std::decay<decltype(get<0>(__in_acc[__item_idx]))>::type,
-                typename ::std::decay<decltype(__out_acc[__out_idx])>::type>::__type;
+                ::std::decay_t<decltype(get<0>(__in_acc[__item_idx]))>,
+                ::std::decay_t<decltype(__out_acc[__out_idx])>>::__type;
 
             // calculation of position for copy
             if (__item_idx >= __size_per_wg)
@@ -519,7 +519,7 @@ struct __partition_by_mask
         if (__item_idx < __n)
         {
             using ::std::get;
-            using __in_type = typename ::std::decay<decltype(get<0>(__in_acc[__item_idx]))>::type;
+            using __in_type = ::std::decay_t<decltype(get<0>(__in_acc[__item_idx]))>;
             auto __wg_sums_idx = __item_idx / __size_per_wg;
             bool __not_first_wg = __item_idx >= __size_per_wg;
             if (get<1>(__in_acc[__item_idx]) &&
@@ -527,7 +527,7 @@ struct __partition_by_mask
             {
                 auto __out_idx = get<1>(__in_acc[__item_idx]) - 1;
                 using __tuple_type = typename __internal::__get_tuple_type<
-                    __in_type, typename ::std::decay<decltype(get<0>(__out_acc[__out_idx]))>::type>::__type;
+                    __in_type, ::std::decay_t<decltype(get<0>(__out_acc[__out_idx]))>>::__type;
 
                 if (__not_first_wg)
                     __out_idx = __binary_op(__out_idx, __wg_sums_acc[__wg_sums_idx - 1]);
@@ -537,7 +537,7 @@ struct __partition_by_mask
             {
                 auto __out_idx = __item_idx - get<1>(__in_acc[__item_idx]);
                 using __tuple_type = typename __internal::__get_tuple_type<
-                    __in_type, typename ::std::decay<decltype(get<1>(__out_acc[__out_idx]))>::type>::__type;
+                    __in_type, ::std::decay_t<decltype(get<1>(__out_acc[__out_idx]))>>::__type;
 
                 if (__not_first_wg)
                     __out_idx -= __wg_sums_acc[__wg_sums_idx - 1];

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -31,9 +31,9 @@ namespace unseq_backend
 {
 // helpers to encapsulate void and other types
 template <typename _Tp>
-using void_type = typename ::std::enable_if<::std::is_void<_Tp>::value, _Tp>::type;
+using void_type = ::std::enable_if_t<::std::is_void<_Tp>::value, _Tp>;
 template <typename _Tp>
-using non_void_type = typename ::std::enable_if<!::std::is_void<_Tp>::value, _Tp>::type;
+using non_void_type = ::std::enable_if_t<!::std::is_void<_Tp>::value, _Tp>;
 
 #if _USE_GROUP_ALGOS && _ONEDPL_SYCL_INTEL_COMPILER
 //This optimization depends on Intel(R) oneAPI DPC++ Compiler implementation such as support of binary operators from std namespace.
@@ -568,8 +568,8 @@ struct __global_scan_functor
             // an initial value precedes the first group for the exclusive scan
             __item_idx += __shift;
             auto __bin_op_result = __binary_op(__wg_sums_acc[__wg_sums_idx], __out_acc[__item_idx]);
-            using __out_type = typename ::std::decay<decltype(__out_acc[__item_idx])>::type;
-            using __in_type = typename ::std::decay<decltype(__bin_op_result)>::type;
+            using __out_type = ::std::decay_t<decltype(__out_acc[__item_idx])>;
+            using __in_type = ::std::decay_t<decltype(__bin_op_result)>;
             __out_acc[__item_idx] =
                 static_cast<typename __internal::__get_tuple_type<__in_type, __out_type>::__type>(__bin_op_result);
         }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -29,9 +29,6 @@ namespace dpl
 {
 namespace unseq_backend
 {
-// helpers to encapsulate void and other types
-template <typename _Tp>
-using void_type = ::std::enable_if_t<::std::is_void<_Tp>::value, _Tp>;
 
 #if _USE_GROUP_ALGOS && _ONEDPL_SYCL_INTEL_COMPILER
 //This optimization depends on Intel(R) oneAPI DPC++ Compiler implementation such as support of binary operators from std namespace.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -53,7 +53,7 @@ template <typename _T, sycl::access::mode _AccMode = sycl::access::mode::read,
           sycl::access::placeholder _Placeholder = sycl::access::placeholder::true_t>
 class all_view
 {
-    using __return_t = typename ::std::conditional<_AccMode == sycl::access::mode::read, const _T, _T>::type;
+    using __return_t = ::std::conditional_t<_AccMode == sycl::access::mode::read, const _T, _T>;
     using __diff_type = typename ::std::iterator_traits<_T*>::difference_type;
     using __accessor_t = sycl::accessor<_T, 1, _AccMode, _Target, _Placeholder>;
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -202,8 +202,7 @@ struct is_temp_buff : ::std::false_type
 
 template <typename _Iter>
 struct is_temp_buff<_Iter, ::std::enable_if_t<!is_hetero_it<_Iter>::value && !::std::is_pointer<_Iter>::value &&
-                                                  !is_passed_directly_it<_Iter>::value,
-                                              void>> : ::std::true_type
+                                              !is_passed_directly_it<_Iter>::value>> : ::std::true_type
 {
 };
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -173,7 +173,7 @@ struct is_zip : ::std::false_type
 };
 
 template <typename Iter> // for iterators defined as direct pass
-struct is_zip<Iter, typename ::std::enable_if<Iter::is_zip::value, void>::type> : ::std::true_type
+struct is_zip<Iter, ::std::enable_if_t<Iter::is_zip::value, void>> : ::std::true_type
 {
 };
 
@@ -183,7 +183,7 @@ struct is_permutation : ::std::false_type
 };
 
 template <typename Iter> // for permutation_iterators
-struct is_permutation<Iter, typename ::std::enable_if<Iter::is_permutation::value, void>::type> : ::std::true_type
+struct is_permutation<Iter, ::std::enable_if_t<Iter::is_permutation::value, void>> : ::std::true_type
 {
 };
 
@@ -201,9 +201,9 @@ struct is_temp_buff : ::std::false_type
 };
 
 template <typename _Iter>
-struct is_temp_buff<_Iter, typename ::std::enable_if<!is_hetero_it<_Iter>::value && !::std::is_pointer<_Iter>::value &&
-                                                         !is_passed_directly_it<_Iter>::value,
-                                                     void>::type> : ::std::true_type
+struct is_temp_buff<_Iter, ::std::enable_if_t<!is_hetero_it<_Iter>::value && !::std::is_pointer<_Iter>::value &&
+                                                  !is_passed_directly_it<_Iter>::value,
+                                              void>> : ::std::true_type
 {
 };
 
@@ -428,7 +428,7 @@ struct __get_sycl_range
 
   private:
     template <typename _R, typename _Map, typename _Size,
-              typename ::std::enable_if<oneapi::dpl::__internal::__is_functor<_Map>, int>::type = 0>
+              ::std::enable_if_t<oneapi::dpl::__internal::__is_functor<_Map>, int> = 0>
     static auto
     __get_permutation_view(_R __r, _Map __m, _Size __s)
     {
@@ -437,7 +437,7 @@ struct __get_sycl_range
 
     template <
         typename _R, typename _Map, typename _Size,
-        typename ::std::enable_if<oneapi::dpl::__internal::__is_random_access_iterator<_Map>::value, int>::type = 0>
+        ::std::enable_if_t<oneapi::dpl::__internal::__is_random_access_iterator<_Map>::value, int> = 0>
     auto
     __get_permutation_view(_R __r, _Map __m, _Size __s)
     {
@@ -447,7 +447,7 @@ struct __get_sycl_range
 
   public:
     //specialization for permutation_iterator using sycl_iterator as source
-    template <typename _It, typename _Map, typename ::std::enable_if<is_hetero_it<_It>::value, int>::type = 0>
+    template <typename _It, typename _Map, ::std::enable_if_t<is_hetero_it<_It>::value, int> = 0>
     auto
     operator()(oneapi::dpl::permutation_iterator<_It, _Map> __first,
                oneapi::dpl::permutation_iterator<_It, _Map> __last)
@@ -466,7 +466,7 @@ struct __get_sycl_range
     // TODO Add specialization for general case, e.g., permutation_iterator using host
     // or another fancy iterator.
     //specialization for permutation_iterator using USM pointer as source
-    template <typename _It, typename _Map, typename ::std::enable_if<!is_hetero_it<_It>::value, int>::type = 0>
+    template <typename _It, typename _Map, ::std::enable_if_t<!is_hetero_it<_It>::value, int> = 0>
     auto
     operator()(oneapi::dpl::permutation_iterator<_It, _Map> __first,
                oneapi::dpl::permutation_iterator<_It, _Map> __last)
@@ -500,8 +500,7 @@ struct __get_sycl_range
 
     // for raw pointers and direct pass objects (for example, counting_iterator, iterator of USM-containers)
     template <typename _Iter>
-    typename ::std::enable_if<is_passed_directly_it<_Iter>::value,
-                              __range_holder<oneapi::dpl::__ranges::guard_view<_Iter>>>::type
+    ::std::enable_if_t<is_passed_directly_it<_Iter>::value, __range_holder<oneapi::dpl::__ranges::guard_view<_Iter>>>
     operator()(_Iter __first, _Iter __last)
     {
         assert(__first < __last);
@@ -513,8 +512,8 @@ struct __get_sycl_range
     template <typename _Iter>
     auto
     operator()(_Iter __first, _Iter __last) ->
-        typename ::std::enable_if<is_hetero_it<_Iter>::value,
-                                  __range_holder<oneapi::dpl::__ranges::all_view<val_t<_Iter>, AccMode>>>::type
+        ::std::enable_if_t<is_hetero_it<_Iter>::value,
+                                  __range_holder<oneapi::dpl::__ranges::all_view<val_t<_Iter>, AccMode>>>
     {
         assert(__first < __last);
         using value_type = val_t<_Iter>;
@@ -533,8 +532,8 @@ struct __get_sycl_range
     template <typename _Iter>
     auto
     operator()(_Iter __first, _Iter __last) ->
-        typename ::std::enable_if<is_temp_buff<_Iter>::value && !is_zip<_Iter>::value && !is_permutation<_Iter>::value,
-                                  __buffer_holder<val_t<_Iter>, AccMode>>::type
+        ::std::enable_if_t<is_temp_buff<_Iter>::value && !is_zip<_Iter>::value && !is_permutation<_Iter>::value,
+                           __buffer_holder<val_t<_Iter>, AccMode>>
     {
         static_assert(!oneapi::dpl::__internal::is_const_iterator<_Iter>::value || AccMode == sycl::access::mode::read,
                       "Should be non-const iterator for a modifying algorithm.");

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -173,7 +173,7 @@ struct is_zip : ::std::false_type
 };
 
 template <typename Iter> // for iterators defined as direct pass
-struct is_zip<Iter, ::std::enable_if_t<Iter::is_zip::value, void>> : ::std::true_type
+struct is_zip<Iter, ::std::enable_if_t<Iter::is_zip::value>> : ::std::true_type
 {
 };
 
@@ -183,7 +183,7 @@ struct is_permutation : ::std::false_type
 };
 
 template <typename Iter> // for permutation_iterators
-struct is_permutation<Iter, ::std::enable_if_t<Iter::is_permutation::value, void>> : ::std::true_type
+struct is_permutation<Iter, ::std::enable_if_t<Iter::is_permutation::value>> : ::std::true_type
 {
 };
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -434,9 +434,8 @@ struct __get_sycl_range
         return oneapi::dpl::__ranges::permutation_view_simple<_R, _Map>{__r, __m, __s};
     }
 
-    template <
-        typename _R, typename _Map, typename _Size,
-        ::std::enable_if_t<oneapi::dpl::__internal::__is_random_access_iterator<_Map>::value, int> = 0>
+    template <typename _R, typename _Map, typename _Size,
+              ::std::enable_if_t<oneapi::dpl::__internal::__is_random_access_iterator<_Map>::value, int> = 0>
     auto
     __get_permutation_view(_R __r, _Map __m, _Size __s)
     {
@@ -510,9 +509,9 @@ struct __get_sycl_range
     //specialization for hetero iterator
     template <typename _Iter>
     auto
-    operator()(_Iter __first, _Iter __last) ->
-        ::std::enable_if_t<is_hetero_it<_Iter>::value,
-                                  __range_holder<oneapi::dpl::__ranges::all_view<val_t<_Iter>, AccMode>>>
+    operator()(_Iter __first, _Iter __last)
+        -> ::std::enable_if_t<is_hetero_it<_Iter>::value,
+                              __range_holder<oneapi::dpl::__ranges::all_view<val_t<_Iter>, AccMode>>>
     {
         assert(__first < __last);
         using value_type = val_t<_Iter>;
@@ -530,9 +529,9 @@ struct __get_sycl_range
     //specialization for a host iterator
     template <typename _Iter>
     auto
-    operator()(_Iter __first, _Iter __last) ->
-        ::std::enable_if_t<is_temp_buff<_Iter>::value && !is_zip<_Iter>::value && !is_permutation<_Iter>::value,
-                           __buffer_holder<val_t<_Iter>, AccMode>>
+    operator()(_Iter __first, _Iter __last)
+        -> ::std::enable_if_t<is_temp_buff<_Iter>::value && !is_zip<_Iter>::value && !is_permutation<_Iter>::value,
+                              __buffer_holder<val_t<_Iter>, AccMode>>
     {
         static_assert(!oneapi::dpl::__internal::is_const_iterator<_Iter>::value || AccMode == sycl::access::mode::read,
                       "Should be non-const iterator for a modifying algorithm.");

--- a/include/oneapi/dpl/pstl/iterator_defs.h
+++ b/include/oneapi/dpl/pstl/iterator_defs.h
@@ -67,8 +67,8 @@ struct __is_random_access_iterator_impl<_IteratorType,
 /* iterator */
 template <typename _IteratorType, typename... _OtherIteratorTypes>
 struct __is_random_access_iterator
-    : ::std::conditional<__is_random_access_iterator_impl<_IteratorType>::value,
-                         __is_random_access_iterator<_OtherIteratorTypes...>, ::std::false_type>::type
+    : ::std::conditional_t<__is_random_access_iterator_impl<_IteratorType>::value,
+                           __is_random_access_iterator<_OtherIteratorTypes...>, ::std::false_type>
 {
 };
 

--- a/include/oneapi/dpl/pstl/iterator_defs.h
+++ b/include/oneapi/dpl/pstl/iterator_defs.h
@@ -94,14 +94,12 @@ struct is_passed_directly : ::std::false_type
 };
 
 template <typename Iter> // for iterators defined as direct pass
-struct is_passed_directly<Iter, ::std::enable_if_t<Iter::is_passed_directly::value>>
-    : ::std::true_type
+struct is_passed_directly<Iter, ::std::enable_if_t<Iter::is_passed_directly::value>> : ::std::true_type
 {
 };
 
 template <typename Iter> // for pointers to objects on device
-struct is_passed_directly<Iter, ::std::enable_if_t<::std::is_pointer<Iter>::value>>
-    : ::std::true_type
+struct is_passed_directly<Iter, ::std::enable_if_t<::std::is_pointer<Iter>::value>> : ::std::true_type
 {
 };
 

--- a/include/oneapi/dpl/pstl/iterator_defs.h
+++ b/include/oneapi/dpl/pstl/iterator_defs.h
@@ -84,7 +84,7 @@ struct is_hetero_iterator : ::std::false_type
 };
 
 template <typename Iter> // for heterogeneous iterators
-struct is_hetero_iterator<Iter, typename ::std::enable_if<Iter::is_hetero::value, void>::type> : ::std::true_type
+struct is_hetero_iterator<Iter, ::std::enable_if_t<Iter::is_hetero::value, void>> : ::std::true_type
 {
 };
 // struct for checking if iterator should be passed directly to device or not
@@ -94,13 +94,13 @@ struct is_passed_directly : ::std::false_type
 };
 
 template <typename Iter> // for iterators defined as direct pass
-struct is_passed_directly<Iter, typename ::std::enable_if<Iter::is_passed_directly::value, void>::type>
+struct is_passed_directly<Iter, ::std::enable_if_t<Iter::is_passed_directly::value, void>>
     : ::std::true_type
 {
 };
 
 template <typename Iter> // for pointers to objects on device
-struct is_passed_directly<Iter, typename ::std::enable_if<::std::is_pointer<Iter>::value, void>::type>
+struct is_passed_directly<Iter, ::std::enable_if_t<::std::is_pointer<Iter>::value, void>>
     : ::std::true_type
 {
 };

--- a/include/oneapi/dpl/pstl/iterator_defs.h
+++ b/include/oneapi/dpl/pstl/iterator_defs.h
@@ -84,7 +84,7 @@ struct is_hetero_iterator : ::std::false_type
 };
 
 template <typename Iter> // for heterogeneous iterators
-struct is_hetero_iterator<Iter, ::std::enable_if_t<Iter::is_hetero::value, void>> : ::std::true_type
+struct is_hetero_iterator<Iter, ::std::enable_if_t<Iter::is_hetero::value>> : ::std::true_type
 {
 };
 // struct for checking if iterator should be passed directly to device or not
@@ -94,13 +94,13 @@ struct is_passed_directly : ::std::false_type
 };
 
 template <typename Iter> // for iterators defined as direct pass
-struct is_passed_directly<Iter, ::std::enable_if_t<Iter::is_passed_directly::value, void>>
+struct is_passed_directly<Iter, ::std::enable_if_t<Iter::is_passed_directly::value>>
     : ::std::true_type
 {
 };
 
 template <typename Iter> // for pointers to objects on device
-struct is_passed_directly<Iter, ::std::enable_if_t<::std::is_pointer<Iter>::value, void>>
+struct is_passed_directly<Iter, ::std::enable_if_t<::std::is_pointer<Iter>::value>>
     : ::std::true_type
 {
 };

--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -570,10 +570,10 @@ template <typename SourceIterator, typename _Permutation>
 class permutation_iterator
 {
   public:
-    typedef typename std::conditional<
+    typedef std::conditional_t<
         !__internal::__is_functor<_Permutation>, _Permutation,
         transform_iterator<counting_iterator<typename ::std::iterator_traits<SourceIterator>::difference_type>,
-                           _Permutation>>::type IndexMap;
+                           _Permutation>> IndexMap;
     typedef typename ::std::iterator_traits<SourceIterator>::difference_type difference_type;
     typedef typename ::std::iterator_traits<SourceIterator>::value_type value_type;
     typedef typename ::std::iterator_traits<SourceIterator>::pointer pointer;

--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -573,7 +573,8 @@ class permutation_iterator
     typedef std::conditional_t<
         !__internal::__is_functor<_Permutation>, _Permutation,
         transform_iterator<counting_iterator<typename ::std::iterator_traits<SourceIterator>::difference_type>,
-                           _Permutation>> IndexMap;
+                           _Permutation>>
+        IndexMap;
     typedef typename ::std::iterator_traits<SourceIterator>::difference_type difference_type;
     typedef typename ::std::iterator_traits<SourceIterator>::value_type value_type;
     typedef typename ::std::iterator_traits<SourceIterator>::pointer pointer;

--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -83,7 +83,7 @@ class zip_forward_iterator
     typedef typename ::std::tuple<_Types...> __it_types;
 
   public:
-    typedef typename ::std::make_signed<::std::size_t>::type difference_type;
+    typedef ::std::make_signed_t<::std::size_t> difference_type;
     typedef ::std::tuple<typename ::std::iterator_traits<_Types>::value_type...> value_type;
     typedef ::std::tuple<typename ::std::iterator_traits<_Types>::reference...> reference;
     typedef ::std::tuple<typename ::std::iterator_traits<_Types>::pointer...> pointer;
@@ -153,7 +153,7 @@ class counting_iterator
     static_assert(::std::is_integral<_Ip>::value, "Cannot instantiate counting_iterator with a non-integer type");
 
   public:
-    typedef typename ::std::make_signed<_Ip>::type difference_type;
+    typedef ::std::make_signed_t<_Ip> difference_type;
     typedef _Ip value_type;
     typedef const _Ip* pointer;
     // There is no storage behind the iterator, so we return a value instead of reference.
@@ -269,7 +269,7 @@ class zip_iterator
     typedef oneapi::dpl::__internal::tuple<_Types...> __it_types;
 
   public:
-    typedef typename ::std::make_signed<::std::size_t>::type difference_type;
+    typedef ::std::make_signed_t<::std::size_t> difference_type;
     typedef oneapi::dpl::__internal::tuple<typename ::std::iterator_traits<_Types>::value_type...> value_type;
     typedef oneapi::dpl::__internal::tuple<typename ::std::iterator_traits<_Types>::reference...> reference;
     typedef ::std::tuple<typename ::std::iterator_traits<_Types>::pointer...> pointer;

--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -421,7 +421,7 @@ class transform_iterator
   public:
     typedef typename ::std::iterator_traits<_Iter>::difference_type difference_type;
     typedef decltype(__my_unary_func_(::std::declval<typename ::std::iterator_traits<_Iter>::reference>())) reference;
-    typedef typename ::std::remove_reference<reference>::type value_type;
+    typedef ::std::remove_reference_t<reference> value_type;
     typedef typename ::std::iterator_traits<_Iter>::pointer pointer;
     typedef typename ::std::iterator_traits<_Iter>::iterator_category iterator_category;
 

--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -584,19 +584,19 @@ class permutation_iterator
 
     permutation_iterator() = default;
 
-    template <typename _T = _Permutation, typename ::std::enable_if<!__internal::__is_functor<_T>, int>::type = 0>
+    template <typename _T = _Permutation, ::std::enable_if_t<!__internal::__is_functor<_T>, int> = 0>
     permutation_iterator(SourceIterator input1, _Permutation input2) : my_source_it(input1), my_index(input2)
     {
     }
 
-    template <typename _T = _Permutation, typename ::std::enable_if<__internal::__is_functor<_T>, int>::type = 0>
+    template <typename _T = _Permutation, ::std::enable_if_t<__internal::__is_functor<_T>, int> = 0>
     permutation_iterator(SourceIterator input1, _Permutation __f, difference_type __idx = 0)
         : my_source_it(input1), my_index(counting_iterator<difference_type>(__idx), __f)
     {
     }
 
   private:
-    template <typename _T = _Permutation, typename ::std::enable_if<__internal::__is_functor<_T>, int>::type = 0>
+    template <typename _T = _Permutation, ::std::enable_if_t<__internal::__is_functor<_T>, int> = 0>
     permutation_iterator(SourceIterator input1, IndexMap input2) : my_source_it(input1), my_index(input2)
     {
     }

--- a/include/oneapi/dpl/pstl/memory_impl.h
+++ b/include/oneapi/dpl/pstl/memory_impl.h
@@ -118,7 +118,7 @@ struct __op_uninitialized_copy<_ExecutionPolicy>
     void
     operator()(_SourceT&& __source, _TargetT& __target) const
     {
-        using _TargetValueType = typename ::std::decay<_TargetT>::type;
+        using _TargetValueType = ::std::decay_t<_TargetT>;
 
         ::new (::std::addressof(__target)) _TargetValueType(::std::forward<_SourceT>(__source));
     }
@@ -135,7 +135,7 @@ struct __op_uninitialized_move<_ExecutionPolicy>
     void
     operator()(_SourceT&& __source, _TargetT& __target) const
     {
-        using _TargetValueType = typename ::std::decay<_TargetT>::type;
+        using _TargetValueType = ::std::decay_t<_TargetT>;
 
         ::new (::std::addressof(__target)) _TargetValueType(::std::move(__source));
     }
@@ -154,7 +154,7 @@ struct __op_uninitialized_fill<_SourceT, _ExecutionPolicy>
     void
     operator()(_TargetT& __target) const
     {
-        using _TargetValueType = typename ::std::decay<_TargetT>::type;
+        using _TargetValueType = ::std::decay_t<_TargetT>;
 
         ::new (::std::addressof(__target)) _TargetValueType(__source);
     }
@@ -171,7 +171,7 @@ struct __op_destroy<_ExecutionPolicy>
     void
     operator()(_TargetT& __target) const
     {
-        using _TargetValueType = typename ::std::decay<_TargetT>::type;
+        using _TargetValueType = ::std::decay_t<_TargetT>;
         __target.~_TargetValueType();
     }
 };
@@ -187,7 +187,7 @@ struct __op_uninitialized_default_construct<_ExecutionPolicy>
     void
     operator()(_TargetT& __target) const
     {
-        using _TargetValueType = typename ::std::decay<_TargetT>::type;
+        using _TargetValueType = ::std::decay_t<_TargetT>;
 
         ::new (::std::addressof(__target)) _TargetValueType;
     }
@@ -204,7 +204,7 @@ struct __op_uninitialized_value_construct<_ExecutionPolicy>
     void
     operator()(_TargetT& __target) const
     {
-        using _TargetValueType = typename ::std::decay<_TargetT>::type;
+        using _TargetValueType = ::std::decay_t<_TargetT>;
 
         ::new (::std::addressof(__target)) _TargetValueType();
     }

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -200,7 +200,7 @@ using is_arithmetic_udop = ::std::integral_constant<bool, ::std::is_arithmetic_v
 // [violation] - default ctor of T shall set the identity value for binary_op.
 template <class _RandomAccessIterator, class _OutputIterator, class _UnaryOperation, class _Tp, class _BinaryOperation,
           class _Inclusive>
-typename ::std::enable_if<!is_arithmetic_udop<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>::type
+::std::enable_if_t<!is_arithmetic_udop<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>
 __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __last, _OutputIterator __result,
                        _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op, _Inclusive,
                        /*is_vector=*/::std::true_type) noexcept
@@ -217,7 +217,7 @@ __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __la
 
 template <class _RandomAccessIterator, class _OutputIterator, class _UnaryOperation, class _Tp, class _BinaryOperation,
           class _Inclusive>
-typename ::std::enable_if<is_arithmetic_udop<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>::type
+::std::enable_if_t<is_arithmetic_udop<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>
 __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __last, _OutputIterator __result,
                        _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op, _Inclusive,
                        /*is_vector=*/::std::true_type) noexcept

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -732,7 +732,7 @@ class __merge_func
 {
     typedef typename ::std::iterator_traits<_RandomAccessIterator1>::difference_type _DifferenceType1;
     typedef typename ::std::iterator_traits<_RandomAccessIterator2>::difference_type _DifferenceType2;
-    typedef typename ::std::common_type<_DifferenceType1, _DifferenceType2>::type _SizeType;
+    typedef typename ::std::common_type_t<_DifferenceType1, _DifferenceType2> _SizeType;
     typedef typename ::std::iterator_traits<_RandomAccessIterator1>::value_type _ValueType;
 
     _RandomAccessIterator1 _M_x_beg;
@@ -1112,7 +1112,7 @@ class __stable_sort_func
   public:
     typedef typename ::std::iterator_traits<_RandomAccessIterator1>::difference_type _DifferenceType1;
     typedef typename ::std::iterator_traits<_RandomAccessIterator2>::difference_type _DifferenceType2;
-    typedef typename ::std::common_type<_DifferenceType1, _DifferenceType2>::type _SizeType;
+    typedef typename ::std::common_type_t<_DifferenceType1, _DifferenceType2> _SizeType;
 
   private:
     _RandomAccessIterator1 _M_xs, _M_xe, _M_x_beg;
@@ -1234,7 +1234,7 @@ operator()(__task* __self)
 {
     typedef typename ::std::iterator_traits<_RandomAccessIterator1>::difference_type _DifferenceType1;
     typedef typename ::std::iterator_traits<_RandomAccessIterator2>::difference_type _DifferenceType2;
-    typedef typename ::std::common_type<_DifferenceType1, _DifferenceType2>::type _SizeType;
+    typedef typename ::std::common_type_t<_DifferenceType1, _DifferenceType2> _SizeType;
     const _SizeType __n = (_M_xe - _M_xs) + (_M_ye - _M_ys);
     const _SizeType __merge_cut_off = _ONEDPL_MERGE_CUT_OFF;
     if (__n <= __merge_cut_off)
@@ -1275,7 +1275,7 @@ __parallel_merge(_ExecutionPolicy&&, _RandomAccessIterator1 __xs, _RandomAccessI
 {
     typedef typename ::std::iterator_traits<_RandomAccessIterator1>::difference_type _DifferenceType1;
     typedef typename ::std::iterator_traits<_RandomAccessIterator2>::difference_type _DifferenceType2;
-    typedef typename ::std::common_type<_DifferenceType1, _DifferenceType2>::type _SizeType;
+    typedef typename ::std::common_type_t<_DifferenceType1, _DifferenceType2> _SizeType;
     const _SizeType __n = (__xe - __xs) + (__ye - __ys);
     const _SizeType __merge_cut_off = _ONEDPL_MERGE_CUT_OFF;
     if (__n <= __merge_cut_off)

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -447,14 +447,14 @@ class __task : public tbb::task
     __task*
     make_continuation(_Fn&& __f)
     {
-        return new (allocate_continuation()) __func_task<typename ::std::decay<_Fn>::type>(::std::forward<_Fn>(__f));
+        return new (allocate_continuation()) __func_task<::std::decay_t<_Fn>>(::std::forward<_Fn>(__f));
     }
 
     template <typename _Fn>
     __task*
     make_child_of(__task* parent, _Fn&& __f)
     {
-        return new (parent->allocate_child()) __func_task<typename ::std::decay<_Fn>::type>(::std::forward<_Fn>(__f));
+        return new (parent->allocate_child()) __func_task<::std::decay_t<_Fn>>(::std::forward<_Fn>(__f));
     }
 
     template <typename _Fn>
@@ -462,7 +462,7 @@ class __task : public tbb::task
     make_additional_child_of(tbb::task* parent, _Fn&& __f)
     {
         return new (tbb::task::allocate_additional_child_of(*parent))
-            __func_task<typename ::std::decay<_Fn>::type>(::std::forward<_Fn>(__f));
+            __func_task<::std::decay_t<_Fn>>(::std::forward<_Fn>(__f));
     }
 
     inline void
@@ -547,8 +547,7 @@ class __task : public tbb::detail::d1::task
     {
         assert(_M_execute_data != nullptr);
         tbb::detail::d1::small_object_allocator __alloc{};
-        auto __t = __alloc.new_object<__func_task<typename ::std::decay<_Fn>::type>>(*_M_execute_data,
-                                                                                     ::std::forward<_Fn>(__f));
+        auto __t = __alloc.new_object<__func_task<::std::decay_t<_Fn>>>(*_M_execute_data, ::std::forward<_Fn>(__f));
         __t->_M_allocator = __alloc;
         return __t;
     }

--- a/include/oneapi/dpl/pstl/parallel_impl.h
+++ b/include/oneapi/dpl/pstl/parallel_impl.h
@@ -40,7 +40,7 @@ __parallel_find(_ExecutionPolicy&& __exec, _Index __first, _Index __last, _Brick
     const _DifferenceType __n = __last - __first;
     _DifferenceType __initial_dist = _IsFirst::value ? __n : -1;
 
-    constexpr auto __comp = typename ::std::conditional<_IsFirst::value, __pstl_less, __pstl_greater>::type{};
+    constexpr auto __comp = ::std::conditional_t<_IsFirst::value, __pstl_less, __pstl_greater>{};
 
     ::std::atomic<_DifferenceType> __extremum(__initial_dist);
     // TODO: find out what is better here: parallel_for or parallel_reduce

--- a/include/oneapi/dpl/pstl/tuple_impl.h
+++ b/include/oneapi/dpl/pstl/tuple_impl.h
@@ -91,7 +91,7 @@ struct __lvref_or_val
 template <typename _Tp>
 struct __lvref_or_val<_Tp, false>
 {
-    using __type = typename ::std::remove_reference<_Tp>::type;
+    using __type = ::std::remove_reference_t<_Tp>;
 };
 
 template <typename T>

--- a/include/oneapi/dpl/pstl/tuple_impl.h
+++ b/include/oneapi/dpl/pstl/tuple_impl.h
@@ -328,21 +328,21 @@ struct tuple<T1, T...>
     tuple() = default;
     tuple(const tuple& other) = default;
     tuple(tuple&& other) = default;
-    template <typename _U1, typename... _U, typename = typename ::std::enable_if<(sizeof...(_U) == sizeof...(T))>::type>
+    template <typename _U1, typename... _U, typename = ::std::enable_if_t<(sizeof...(_U) == sizeof...(T))>>
     tuple(const tuple<_U1, _U...>& other) : holder(other.template get<0>()), next(other.next)
     {
     }
 
-    template <typename _U1, typename... _U, typename = typename ::std::enable_if<(sizeof...(_U) == sizeof...(T))>::type>
+    template <typename _U1, typename... _U, typename = ::std::enable_if_t<(sizeof...(_U) == sizeof...(T))>>
     tuple(tuple<_U1, _U...>&& other) : holder(std::move(other).template get<0>()), next(std::move(other.next))
     {
     }
 
     template <typename _U1, typename... _U,
-              typename = typename ::std::enable_if<
+              typename = ::std::enable_if_t<
                   (sizeof...(_U) == sizeof...(T) &&
                    oneapi::dpl::__internal::__conjunction<::std::is_constructible<T1, _U1&&>,
-                                                          ::std::is_constructible<T, _U&&>...>::value)>::type>
+                                                          ::std::is_constructible<T, _U&&>...>::value)>>
     tuple(_U1&& _value, _U&&... _next) : holder(::std::forward<_U1>(_value)), next(::std::forward<_U>(_next)...)
     {
     }

--- a/include/oneapi/dpl/pstl/tuple_impl.h
+++ b/include/oneapi/dpl/pstl/tuple_impl.h
@@ -163,7 +163,7 @@ template <>
 struct get_impl<0>
 {
     template <typename... T>
-    using ret_type = typename ::std::tuple_element<0, oneapi::dpl::__internal::tuple<T...>>::type;
+    using ret_type = ::std::tuple_element_t<0, oneapi::dpl::__internal::tuple<T...>>;
 
     template <typename... T>
     constexpr ret_type<T...>&
@@ -645,27 +645,27 @@ using __decay_with_tuple_specialization_t = typename __decay_with_tuple_speciali
 namespace std
 {
 template <size_t _Idx, typename... _Tp>
-constexpr typename ::std::tuple_element<_Idx, oneapi::dpl::__internal::tuple<_Tp...>>::type&
+constexpr ::std::tuple_element_t<_Idx, oneapi::dpl::__internal::tuple<_Tp...>>&
 get(oneapi::dpl::__internal::tuple<_Tp...>& __a)
 {
     return __a.template get<_Idx>();
 }
 
 template <size_t _Idx, typename... _Tp>
-constexpr typename ::std::tuple_element<_Idx, oneapi::dpl::__internal::tuple<_Tp...>>::type const&
+constexpr ::std::tuple_element_t<_Idx, oneapi::dpl::__internal::tuple<_Tp...>> const&
 get(const oneapi::dpl::__internal::tuple<_Tp...>& __a)
 {
     return __a.template get<_Idx>();
 }
 template <size_t _Idx, typename... _Tp>
-constexpr typename ::std::tuple_element<_Idx, oneapi::dpl::__internal::tuple<_Tp...>>::type&&
+constexpr ::std::tuple_element_t<_Idx, oneapi::dpl::__internal::tuple<_Tp...>>&&
 get(oneapi::dpl::__internal::tuple<_Tp...>&& __a)
 {
     return ::std::move(__a).template get<_Idx>();
 }
 
 template <size_t _Idx, typename... _Tp>
-constexpr typename ::std::tuple_element<_Idx, oneapi::dpl::__internal::tuple<_Tp...>>::type const&&
+constexpr ::std::tuple_element_t<_Idx, oneapi::dpl::__internal::tuple<_Tp...>> const&&
 get(const oneapi::dpl::__internal::tuple<_Tp...>&& __a)
 {
     return ::std::move(__a).template get<_Idx>();

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -477,7 +477,7 @@ using is_arithmetic_plus = ::std::integral_constant<bool, ::std::is_arithmetic_v
                                                                ::std::is_same_v<_BinaryOperation, ::std::plus<void>>)>;
 
 template <typename _DifferenceType, typename _Tp, typename _BinaryOperation, typename _UnaryOperation>
-typename ::std::enable_if<is_arithmetic_plus<_Tp, _BinaryOperation>::value, _Tp>::type
+::std::enable_if_t<is_arithmetic_plus<_Tp, _BinaryOperation>::value, _Tp>
 __simd_transform_reduce(_DifferenceType __n, _Tp __init, _BinaryOperation, _UnaryOperation __f) noexcept
 {
     _ONEDPL_PRAGMA_SIMD_REDUCTION(+ : __init)
@@ -487,7 +487,7 @@ __simd_transform_reduce(_DifferenceType __n, _Tp __init, _BinaryOperation, _Unar
 }
 
 template <typename _Size, typename _Tp, typename _BinaryOperation, typename _UnaryOperation>
-typename ::std::enable_if<!is_arithmetic_plus<_Tp, _BinaryOperation>::value, _Tp>::type
+::std::enable_if_t<!is_arithmetic_plus<_Tp, _BinaryOperation>::value, _Tp>
 __simd_transform_reduce(_Size __n, _Tp __init, _BinaryOperation __binary_op, _UnaryOperation __f) noexcept
 {
     const _Size __block_size = __lane_size / sizeof(_Tp);
@@ -544,7 +544,7 @@ __simd_transform_reduce(_Size __n, _Tp __init, _BinaryOperation __binary_op, _Un
 // Exclusive scan for "+" and arithmetic types
 template <class _InputIterator, class _Size, class _OutputIterator, class _UnaryOperation, class _Tp,
           class _BinaryOperation>
-typename ::std::enable_if<is_arithmetic_plus<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>::type
+::std::enable_if_t<is_arithmetic_plus<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>
 __simd_scan(_InputIterator __first, _Size __n, _OutputIterator __result, _UnaryOperation __unary_op, _Tp __init,
             _BinaryOperation, /*Inclusive*/ ::std::false_type)
 {
@@ -582,7 +582,7 @@ struct _Combiner
 // Exclusive scan for other binary operations and types
 template <class _InputIterator, class _Size, class _OutputIterator, class _UnaryOperation, class _Tp,
           class _BinaryOperation>
-typename ::std::enable_if<!is_arithmetic_plus<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>::type
+::std::enable_if_t<!is_arithmetic_plus<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>
 __simd_scan(_InputIterator __first, _Size __n, _OutputIterator __result, _UnaryOperation __unary_op, _Tp __init,
             _BinaryOperation __binary_op, /*Inclusive*/ ::std::false_type)
 {
@@ -605,7 +605,7 @@ __simd_scan(_InputIterator __first, _Size __n, _OutputIterator __result, _UnaryO
 // Inclusive scan for "+" and arithmetic types
 template <class _InputIterator, class _Size, class _OutputIterator, class _UnaryOperation, class _Tp,
           class _BinaryOperation>
-typename ::std::enable_if<is_arithmetic_plus<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>::type
+::std::enable_if_t<is_arithmetic_plus<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>
 __simd_scan(_InputIterator __first, _Size __n, _OutputIterator __result, _UnaryOperation __unary_op, _Tp __init,
             _BinaryOperation, /*Inclusive*/ ::std::true_type)
 {
@@ -622,7 +622,7 @@ __simd_scan(_InputIterator __first, _Size __n, _OutputIterator __result, _UnaryO
 // Inclusive scan for other binary operations and types
 template <class _InputIterator, class _Size, class _OutputIterator, class _UnaryOperation, class _Tp,
           class _BinaryOperation>
-typename ::std::enable_if<!is_arithmetic_plus<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>::type
+::std::enable_if_t<!is_arithmetic_plus<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>
 __simd_scan(_InputIterator __first, _Size __n, _OutputIterator __result, _UnaryOperation __unary_op, _Tp __init,
             _BinaryOperation __binary_op, ::std::true_type)
 {

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -527,18 +527,18 @@ using __is_const_callable_object =
 struct __next_to_last
 {
     template <typename _Iterator>
-    typename ::std::enable_if<::std::is_base_of<::std::random_access_iterator_tag,
-                                                typename ::std::iterator_traits<_Iterator>::iterator_category>::value,
-                              _Iterator>::type
+    ::std::enable_if_t<::std::is_base_of<::std::random_access_iterator_tag,
+                                         typename ::std::iterator_traits<_Iterator>::iterator_category>::value,
+                       _Iterator>
     operator()(_Iterator __it, _Iterator __last, typename ::std::iterator_traits<_Iterator>::difference_type __n)
     {
         return __n > __last - __it ? __last : __it + __n;
     }
 
     template <typename _Iterator>
-    typename ::std::enable_if<!::std::is_base_of<::std::random_access_iterator_tag,
-                                                 typename ::std::iterator_traits<_Iterator>::iterator_category>::value,
-                              _Iterator>::type
+    ::std::enable_if_t<!::std::is_base_of<::std::random_access_iterator_tag,
+                                          typename ::std::iterator_traits<_Iterator>::iterator_category>::value,
+                       _Iterator>
     operator()(_Iterator __it, _Iterator __last, typename ::std::iterator_traits<_Iterator>::difference_type __n)
     {
         for (; --__n >= 0 && __it != __last; ++__it)

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -399,7 +399,7 @@ __pstl_right_bound(_Buffer& __a, _Index __first, _Index __last, const _Value& __
 template <typename _IntType, typename _Acc>
 struct _ReverseCounter
 {
-    typedef typename ::std::make_signed<_IntType>::type difference_type;
+    typedef ::std::make_signed_t<_IntType> difference_type;
 
     _IntType __my_cn;
 

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -50,7 +50,7 @@ namespace __internal
 
 template <typename Iterator>
 using is_const_iterator =
-    typename ::std::is_const<typename ::std::remove_pointer<typename ::std::iterator_traits<Iterator>::pointer>::type>;
+    typename ::std::is_const<::std::remove_pointer_t<typename ::std::iterator_traits<Iterator>::pointer>>;
 
 template <typename _Fp>
 auto

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -449,7 +449,7 @@ struct _ReverseCounter
 
     class __private_class;
 
-    operator typename ::std::conditional<decltype(__check_braces<_Acc>(0))::value, sycl::id<1>, __private_class>::type()
+    operator ::std::conditional_t<decltype(__check_braces<_Acc>(0))::value, sycl::id<1>, __private_class>()
     {
         return sycl::id<1>(__my_cn);
     }
@@ -561,7 +561,7 @@ struct __conjunction<_B1> : _B1
 };
 
 template <typename _B1, typename... _Bs>
-struct __conjunction<_B1, _Bs...> : ::std::conditional<!bool(_B1::value), _B1, __conjunction<_Bs...>>::type
+struct __conjunction<_B1, _Bs...> : ::std::conditional_t<!bool(_B1::value), _B1, __conjunction<_Bs...>>
 {
 };
 

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -116,7 +116,7 @@ struct pipeline_base_range
 
 // use ::std::conditional to understand what class to inherit from
 template <typename Range>
-struct pipeline_base_range<Range, ::std::enable_if_t<is_pipeline_object<Range>::value, void>>
+struct pipeline_base_range<Range, ::std::enable_if_t<is_pipeline_object<Range>::value>>
 {
     Range rng;
 

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -95,7 +95,7 @@ struct pipeline_base
 };
 
 template <typename Range>
-struct pipeline_base<Range, typename ::std::enable_if<is_pipeline_object<Range>::value>::type>
+struct pipeline_base<Range, ::std::enable_if_t<is_pipeline_object<Range>::value>>
 {
     using type = typename pipeline_base<::std::decay_t<decltype(::std::declval<Range>().base())>>::type;
 };
@@ -116,7 +116,7 @@ struct pipeline_base_range
 
 // use ::std::conditional to understand what class to inherit from
 template <typename Range>
-struct pipeline_base_range<Range, typename ::std::enable_if<is_pipeline_object<Range>::value, void>::type>
+struct pipeline_base_range<Range, ::std::enable_if_t<is_pipeline_object<Range>::value, void>>
 {
     Range rng;
 
@@ -456,7 +456,7 @@ struct permutation_view_simple;
 
 //permutation view: specialization for an index map functor
 template <typename _R, typename _M>
-struct permutation_view_simple<_R, _M, typename ::std::enable_if<oneapi::dpl::__internal::__is_functor<_M>>::type>
+struct permutation_view_simple<_R, _M, ::std::enable_if_t<oneapi::dpl::__internal::__is_functor<_M>>>
 {
     using value_type = typename ::std::decay_t<_R>::value_type;
     using _Size = oneapi::dpl::__internal::__difference_t<_R>;
@@ -495,7 +495,7 @@ struct permutation_view_simple<_R, _M, typename ::std::enable_if<oneapi::dpl::__
 
 //permutation view: specialization for a map view (a viewable range concept)
 template <typename _R, typename _M>
-struct permutation_view_simple<_R, _M, typename ::std::enable_if<is_map_view<_M>::value>::type>
+struct permutation_view_simple<_R, _M, ::std::enable_if_t<is_map_view<_M>::value>>
 {
     using value_type = typename ::std::decay_t<_R>::value_type;
 

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -97,7 +97,7 @@ struct pipeline_base
 template <typename Range>
 struct pipeline_base<Range, typename ::std::enable_if<is_pipeline_object<Range>::value>::type>
 {
-    using type = typename pipeline_base<typename ::std::decay<decltype(::std::declval<Range>().base())>::type>::type;
+    using type = typename pipeline_base<::std::decay_t<decltype(::std::declval<Range>().base())>>::type;
 };
 
 //pipeline_base_range

--- a/test/parallel_api/algorithm/alg.merge/inplace_merge.pass.cpp
+++ b/test/parallel_api/algorithm/alg.merge/inplace_merge.pass.cpp
@@ -28,7 +28,7 @@ struct test_one_policy
     // inplace_merge works with bidirectional iterators at least
     template <typename Policy, typename BiDirIt1, typename Size, typename Generator1, typename Generator2,
               typename Compare>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt1>::value, void>
+    ::std::enable_if_t<is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt1>::value>
     operator()(Policy&& exec, BiDirIt1 first1, BiDirIt1 last1, BiDirIt1 first2, BiDirIt1 last2, Size n, Size m,
                Generator1 generator1, Generator2 generator2, Compare comp)
     {
@@ -39,7 +39,7 @@ struct test_one_policy
     }
 
     template <typename Policy, typename BiDirIt1, typename Size, typename Generator1, typename Generator2>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt1>::value, void>
+    ::std::enable_if_t<is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt1>::value>
     operator()(Policy&& exec, BiDirIt1 first1, BiDirIt1 last1, BiDirIt1 first2, BiDirIt1 last2, Size n, Size m,
                Generator1 generator1, Generator2 generator2)
     {
@@ -64,14 +64,14 @@ struct test_one_policy
     }
 
     template <typename Policy, typename BiDirIt1, typename Size, typename Generator1, typename Generator2>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt1>::value, void>
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt1>::value>
     operator()(Policy&& /* exec */, BiDirIt1 /* first1 */, BiDirIt1 /* last1 */, BiDirIt1 /* first2 */, BiDirIt1 /* last2 */, Size /* n */, Size /* m */,
                Generator1 /* generator1 */, Generator2 /* generator2 */)
     {
     }
     template <typename Policy, typename BiDirIt1, typename Size, typename Generator1, typename Generator2,
               typename Compare>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt1>::value, void>
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt1>::value>
     operator()(Policy&& /* exec */, BiDirIt1 /* first1 */, BiDirIt1 /* last1 */, BiDirIt1 /* first2 */, BiDirIt1 /* last2 */, Size /* n */, Size /* m */,
                Generator1 /* generator1 */, Generator2 /* generator2 */, Compare /* comp */)
     {

--- a/test/parallel_api/algorithm/alg.merge/inplace_merge.pass.cpp
+++ b/test/parallel_api/algorithm/alg.merge/inplace_merge.pass.cpp
@@ -28,7 +28,7 @@ struct test_one_policy
     // inplace_merge works with bidirectional iterators at least
     template <typename Policy, typename BiDirIt1, typename Size, typename Generator1, typename Generator2,
               typename Compare>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt1>::value, void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt1>::value, void>
     operator()(Policy&& exec, BiDirIt1 first1, BiDirIt1 last1, BiDirIt1 first2, BiDirIt1 last2, Size n, Size m,
                Generator1 generator1, Generator2 generator2, Compare comp)
     {
@@ -39,7 +39,7 @@ struct test_one_policy
     }
 
     template <typename Policy, typename BiDirIt1, typename Size, typename Generator1, typename Generator2>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt1>::value, void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt1>::value, void>
     operator()(Policy&& exec, BiDirIt1 first1, BiDirIt1 last1, BiDirIt1 first2, BiDirIt1 last2, Size n, Size m,
                Generator1 generator1, Generator2 generator2)
     {
@@ -64,14 +64,14 @@ struct test_one_policy
     }
 
     template <typename Policy, typename BiDirIt1, typename Size, typename Generator1, typename Generator2>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt1>::value, void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt1>::value, void>
     operator()(Policy&& /* exec */, BiDirIt1 /* first1 */, BiDirIt1 /* last1 */, BiDirIt1 /* first2 */, BiDirIt1 /* last2 */, Size /* n */, Size /* m */,
                Generator1 /* generator1 */, Generator2 /* generator2 */)
     {
     }
     template <typename Policy, typename BiDirIt1, typename Size, typename Generator1, typename Generator2,
               typename Compare>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt1>::value, void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt1>::value, void>
     operator()(Policy&& /* exec */, BiDirIt1 /* first1 */, BiDirIt1 /* last1 */, BiDirIt1 /* first2 */, BiDirIt1 /* last2 */, Size /* n */, Size /* m */,
                Generator1 /* generator1 */, Generator2 /* generator2 */, Compare /* comp */)
     {

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition.pass.cpp
@@ -54,15 +54,15 @@ struct DataType
 };
 
 template <typename Iterator>
-typename ::std::enable_if<::std::is_trivial<typename ::std::iterator_traits<Iterator>::value_type>::value, bool>::type
+::std::enable_if_t<::std::is_trivial<typename ::std::iterator_traits<Iterator>::value_type>::value, bool>
 is_equal(Iterator first, Iterator last, Iterator d_first)
 {
     return ::std::equal(first, last, d_first);
 }
 
 template <typename Iterator>
-typename ::std::enable_if<!::std::is_trivial<typename ::std::iterator_traits<Iterator>::value_type>::value, bool>::type
-is_equal(Iterator /* first */, Iterator /* last */, Iterator /* d_first */)
+::std::enable_if_t<!::std::is_trivial<typename ::std::iterator_traits<Iterator>::value_type>::value, bool>
+    is_equal(Iterator /* first */, Iterator /* last */, Iterator /* d_first */)
 {
     return true;
 }
@@ -71,7 +71,7 @@ template<typename T>
 struct test_partition
 {
     template <typename Policy, typename BiDirIt, typename Size, typename UnaryOp, typename Generator>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt>::value, void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt>::value, void>
     operator()(Policy&& exec, BiDirIt first, BiDirIt last, BiDirIt /* exp_first */, BiDirIt /* exp_last */, Size /* n */,
                UnaryOp unary_op, Generator generator)
     {
@@ -82,7 +82,7 @@ struct test_partition
     }
 
     template <typename Policy, typename BiDirIt, typename Size, typename UnaryOp, typename Generator>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt>::value, void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt>::value, void>
     operator()(Policy&& /* exec */, BiDirIt /* first */, BiDirIt /* last */, BiDirIt /* exp_first */, BiDirIt /* exp_last */, Size /* n */,
                UnaryOp /* unary_op */, Generator /* generator */)
     {

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition.pass.cpp
@@ -62,7 +62,7 @@ is_equal(Iterator first, Iterator last, Iterator d_first)
 
 template <typename Iterator>
 ::std::enable_if_t<!::std::is_trivial<typename ::std::iterator_traits<Iterator>::value_type>::value, bool>
-    is_equal(Iterator /* first */, Iterator /* last */, Iterator /* d_first */)
+is_equal(Iterator /* first */, Iterator /* last */, Iterator /* d_first */)
 {
     return true;
 }

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition.pass.cpp
@@ -71,7 +71,7 @@ template<typename T>
 struct test_partition
 {
     template <typename Policy, typename BiDirIt, typename Size, typename UnaryOp, typename Generator>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt>::value, void>
+    ::std::enable_if_t<is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt>::value>
     operator()(Policy&& exec, BiDirIt first, BiDirIt last, BiDirIt /* exp_first */, BiDirIt /* exp_last */, Size /* n */,
                UnaryOp unary_op, Generator generator)
     {
@@ -82,7 +82,7 @@ struct test_partition
     }
 
     template <typename Policy, typename BiDirIt, typename Size, typename UnaryOp, typename Generator>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt>::value, void>
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt>::value>
     operator()(Policy&& /* exec */, BiDirIt /* first */, BiDirIt /* last */, BiDirIt /* exp_first */, BiDirIt /* exp_last */, Size /* n */,
                UnaryOp /* unary_op */, Generator /* generator */)
     {

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/stable_partition.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/stable_partition.pass.cpp
@@ -71,7 +71,7 @@ template <typename T>
 struct test_stable_partition
 {
     template <typename Policy, typename BiDirIt, typename Size, typename UnaryOp, typename Generator>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt>::value, void>
+    ::std::enable_if_t<is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt>::value>
     operator()(Policy&& exec, BiDirIt first, BiDirIt last, BiDirIt exp_first, BiDirIt exp_last, Size /* n */,
                UnaryOp unary_op, Generator generator)
     {
@@ -86,7 +86,7 @@ struct test_stable_partition
     }
 
     template <typename Policy, typename BiDirIt, typename Size, typename UnaryOp, typename Generator>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt>::value, void>
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt>::value>
     operator()(Policy&& /* exec */, BiDirIt /* first */, BiDirIt /* last */, BiDirIt /* exp_first */, BiDirIt /* exp_last */, Size /* n */,
                UnaryOp /* unary_op */, Generator /* generator */)
     {

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/stable_partition.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/stable_partition.pass.cpp
@@ -62,7 +62,7 @@ is_equal(Iterator first, Iterator last, Iterator d_first)
 
 template <typename Iterator>
 ::std::enable_if_t<!::std::is_trivial<typename ::std::iterator_traits<Iterator>::value_type>::value, bool>
-    is_equal(Iterator /* first */, Iterator /* last */, Iterator /* d_first */)
+is_equal(Iterator /* first */, Iterator /* last */, Iterator /* d_first */)
 {
     return true;
 }

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/stable_partition.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/stable_partition.pass.cpp
@@ -54,15 +54,15 @@ struct DataType
 };
 
 template <typename Iterator>
-typename ::std::enable_if<::std::is_trivial<typename ::std::iterator_traits<Iterator>::value_type>::value, bool>::type
+::std::enable_if_t<::std::is_trivial<typename ::std::iterator_traits<Iterator>::value_type>::value, bool>
 is_equal(Iterator first, Iterator last, Iterator d_first)
 {
     return ::std::equal(first, last, d_first);
 }
 
 template <typename Iterator>
-typename ::std::enable_if<!::std::is_trivial<typename ::std::iterator_traits<Iterator>::value_type>::value, bool>::type
-is_equal(Iterator /* first */, Iterator /* last */, Iterator /* d_first */)
+::std::enable_if_t<!::std::is_trivial<typename ::std::iterator_traits<Iterator>::value_type>::value, bool>
+    is_equal(Iterator /* first */, Iterator /* last */, Iterator /* d_first */)
 {
     return true;
 }
@@ -71,7 +71,7 @@ template <typename T>
 struct test_stable_partition
 {
     template <typename Policy, typename BiDirIt, typename Size, typename UnaryOp, typename Generator>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt>::value, void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt>::value, void>
     operator()(Policy&& exec, BiDirIt first, BiDirIt last, BiDirIt exp_first, BiDirIt exp_last, Size /* n */,
                UnaryOp unary_op, Generator generator)
     {
@@ -86,7 +86,7 @@ struct test_stable_partition
     }
 
     template <typename Policy, typename BiDirIt, typename Size, typename UnaryOp, typename Generator>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt>::value, void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt>::value, void>
     operator()(Policy&& /* exec */, BiDirIt /* first */, BiDirIt /* last */, BiDirIt /* exp_first */, BiDirIt /* exp_last */, Size /* n */,
                UnaryOp /* unary_op */, Generator /* generator */)
     {

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse.pass.cpp
@@ -29,14 +29,14 @@ struct test_one_policy
 {
 #if _PSTL_ICC_18_VC141_TEST_SIMD_LAMBDA_RELEASE_BROKEN // dummy specialization by policy type, in case of broken configuration
     template <typename Iterator1, typename Iterator2>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value, void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value, void>
     operator()(oneapi::dpl::execution::unsequenced_policy, Iterator1 data_b, Iterator1 data_e, Iterator2 actual_b,
                Iterator2 actual_e)
     {
     }
 
     template <typename Iterator1, typename Iterator2>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value, void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value, void>
     operator()(oneapi::dpl::execution::parallel_unsequenced_policy, Iterator1 data_b, Iterator1 data_e, Iterator2 actual_b,
                Iterator2 actual_e)
     {
@@ -44,7 +44,7 @@ struct test_one_policy
 #endif
 
     template <typename ExecutionPolicy, typename Iterator1, typename Iterator2>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::bidirectional_iterator_tag, Iterator1>::value>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::bidirectional_iterator_tag, Iterator1>::value>
     operator()(ExecutionPolicy&& exec, Iterator1 data_b, Iterator1 data_e, Iterator2 actual_b, Iterator2 actual_e)
     {
         using namespace std;
@@ -59,7 +59,7 @@ struct test_one_policy
     }
 
     template <typename ExecutionPolicy, typename Iterator1, typename Iterator2>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, Iterator1>::value>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, Iterator1>::value>
     operator()(ExecutionPolicy&& /* exec */, Iterator1 /* data_b */, Iterator1 /* data_e */, Iterator2 /* actual_b */, Iterator2 /* actual_e */)
     {
     }

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse.pass.cpp
@@ -29,14 +29,14 @@ struct test_one_policy
 {
 #if _PSTL_ICC_18_VC141_TEST_SIMD_LAMBDA_RELEASE_BROKEN // dummy specialization by policy type, in case of broken configuration
     template <typename Iterator1, typename Iterator2>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value, void>
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value>
     operator()(oneapi::dpl::execution::unsequenced_policy, Iterator1 data_b, Iterator1 data_e, Iterator2 actual_b,
                Iterator2 actual_e)
     {
     }
 
     template <typename Iterator1, typename Iterator2>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value, void>
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value>
     operator()(oneapi::dpl::execution::parallel_unsequenced_policy, Iterator1 data_b, Iterator1 data_e, Iterator2 actual_b,
                Iterator2 actual_e)
     {

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse_copy.pass.cpp
@@ -55,7 +55,7 @@ template<typename T1, typename T2>
 struct test_one_policy
 {
     template <typename ExecutionPolicy, typename Iterator1, typename Iterator2>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::bidirectional_iterator_tag, Iterator1>::value>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::bidirectional_iterator_tag, Iterator1>::value>
     operator()(ExecutionPolicy&& exec, Iterator1 data_b, Iterator1 data_e, Iterator2 actual_b, Iterator2 actual_e)
     {
         using namespace std;
@@ -72,7 +72,7 @@ struct test_one_policy
     }
 
     template <typename ExecutionPolicy, typename Iterator1, typename Iterator2>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, Iterator1>::value>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, Iterator1>::value>
     operator()(ExecutionPolicy&& /* exec */, Iterator1 /* data_b */, Iterator1 /* data_e */, Iterator2 /* actual_b */, Iterator2 /* actual_e*/)
     {
     }

--- a/test/parallel_api/algorithm/alg.modifying.operations/replace.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/replace.pass.cpp
@@ -84,7 +84,7 @@ struct test_replace
     }
 
     template <typename T, typename Iterator1>
-    typename ::std::enable_if<::std::is_same<T, copy_int>::value, bool>::type_t
+    ::std::enable_if_t<::std::is_same<T, copy_int>::value, bool>
     check(Iterator1 b, Iterator1 e)
     {
         return ::std::all_of(b, e, [](const copy_int& elem) { return elem.copied_times == 0; });

--- a/test/parallel_api/algorithm/alg.modifying.operations/rotate.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/rotate.pass.cpp
@@ -101,11 +101,11 @@ struct test_one_policy
     }
 
     template <typename ExecutionPolicy, typename Iterator, typename Size>
-    typename ::std::enable_if<
+    ::std::enable_if_t<
         is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
         !::std::is_same<ExecutionPolicy, oneapi::dpl::execution::sequenced_policy>::value &&
         ::std::is_same<typename ::std::iterator_traits<Iterator>::value_type, wrapper<float32_t>>::value,
-        bool>::type
+        bool>
     check_move(ExecutionPolicy&& /* exec */, Iterator b, Iterator e, Size shift)
     {
         bool result = all_of(b, e, [](wrapper<float32_t>& a) {
@@ -117,11 +117,11 @@ struct test_one_policy
     }
 
     template <typename ExecutionPolicy, typename Iterator, typename Size>
-    typename ::std::enable_if<
+    ::std::enable_if_t<
         !(is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
         !::std::is_same<ExecutionPolicy, oneapi::dpl::execution::sequenced_policy>::value &&
         ::std::is_same<typename ::std::iterator_traits<Iterator>::value_type, wrapper<float32_t>>::value),
-        bool>::type
+        bool>
     check_move(ExecutionPolicy&& /* exec */, Iterator /* b */, Iterator /* e */, Size /* shift */)
     {
         return true;

--- a/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
@@ -169,7 +169,7 @@ struct shift_right_algo
     }
 
     template <typename It, typename ItExp>
-    ::std::enable_if_t<TestUtils::is_base_of_iterator_category<::std::bidirectional_iterator_tag, It>::value, void>
+    ::std::enable_if_t<TestUtils::is_base_of_iterator_category<::std::bidirectional_iterator_tag, It>::value>
     check(It res, It first, typename ::std::iterator_traits<It>::difference_type m, ItExp first_exp,
         typename ::std::iterator_traits<It>::difference_type n)
     {
@@ -189,7 +189,7 @@ struct shift_right_algo
     }
     //skip the check for non-bidirectional iterator (forward iterator, etc)
     template <typename It, typename ItExp>
-    ::std::enable_if_t<!TestUtils::is_base_of_iterator_category<::std::bidirectional_iterator_tag, It>::value, void>
+    ::std::enable_if_t<!TestUtils::is_base_of_iterator_category<::std::bidirectional_iterator_tag, It>::value>
     check(It res, It first, typename ::std::iterator_traits<It>::difference_type m, ItExp first_exp,
         typename ::std::iterator_traits<It>::difference_type n)
     {

--- a/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
@@ -155,27 +155,21 @@ struct shift_left_algo
 struct shift_right_algo
 {
     template <typename Policy, typename It>
-    typename ::std::enable_if<TestUtils::is_base_of_iterator_category<::std::bidirectional_iterator_tag,
-                            It>::value,
-                            It>::type
+    ::std::enable_if_t<TestUtils::is_base_of_iterator_category<::std::bidirectional_iterator_tag, It>::value, It>
     operator()(Policy&& exec, It first, It last, typename ::std::iterator_traits<It>::difference_type n)
     {
         return std::shift_right(::std::forward<Policy>(exec), first, last, n);
     }
     //skip the test for non-bidirectional iterator (forward iterator, etc)
     template <typename Policy, typename It>
-    typename ::std::enable_if<!TestUtils::is_base_of_iterator_category<::std::bidirectional_iterator_tag,
-                            It>::value,
-                            It>::type
+    ::std::enable_if_t<!TestUtils::is_base_of_iterator_category<::std::bidirectional_iterator_tag, It>::value, It>
     operator()(Policy&& exec, It first, It last, typename ::std::iterator_traits<It>::difference_type n)
     {
         return first;
     }
 
     template <typename It, typename ItExp>
-    typename ::std::enable_if<TestUtils::is_base_of_iterator_category<::std::bidirectional_iterator_tag,
-                            It>::value,
-                            void>::type
+    ::std::enable_if_t<TestUtils::is_base_of_iterator_category<::std::bidirectional_iterator_tag, It>::value, void>
     check(It res, It first, typename ::std::iterator_traits<It>::difference_type m, ItExp first_exp,
         typename ::std::iterator_traits<It>::difference_type n)
     {
@@ -195,9 +189,7 @@ struct shift_right_algo
     }
     //skip the check for non-bidirectional iterator (forward iterator, etc)
     template <typename It, typename ItExp>
-    typename ::std::enable_if<!TestUtils::is_base_of_iterator_category<::std::bidirectional_iterator_tag,
-                            It>::value,
-                            void>::type
+    ::std::enable_if_t<!TestUtils::is_base_of_iterator_category<::std::bidirectional_iterator_tag, It>::value, void>
     check(It res, It first, typename ::std::iterator_traits<It>::difference_type m, ItExp first_exp,
         typename ::std::iterator_traits<It>::difference_type n)
     {

--- a/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
@@ -49,7 +49,7 @@ struct test_shift
 #if __SYCL_PSTL_OFFLOAD__
                      || std::is_same<std::decay_t<Policy>, std::execution::parallel_unsequenced_policy>::value
 #endif
-                     , void>
+                     >
     operator()(Policy&& exec, It first, typename ::std::iterator_traits<It>::difference_type m,
         It first_exp, typename ::std::iterator_traits<It>::difference_type n, Algo algo)
     {

--- a/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
@@ -87,7 +87,7 @@ struct test_shift
 #endif
 
     template <typename Policy, typename It, typename Algo>
-    oneapi::dpl::__internal::__enable_if_hetero_execution_policy<Policy, void>
+    oneapi::dpl::__internal::__enable_if_hetero_execution_policy<Policy>
     operator()(Policy&& exec, It first, typename ::std::iterator_traits<It>::difference_type m,
         It first_exp, typename ::std::iterator_traits<It>::difference_type n, Algo algo)
     {

--- a/test/parallel_api/algorithm/alg.nonmodifying/nth_element.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/nth_element.pass.cpp
@@ -77,7 +77,7 @@ struct test_without_compare
     // nth_element works only with random access iterators
     template <typename Policy, typename Iterator1, typename Size, typename Generator1, typename Generator2>
     ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value &&
-                       can_use_default_less_operator<Type>::value, void>
+                       can_use_default_less_operator<Type>::value>
     operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator1 first2, Iterator1 last2, Size n, Size m,
                Generator1 generator1, Generator2 generator2)
     {
@@ -100,7 +100,7 @@ struct test_without_compare
 
     template <typename Policy, typename Iterator1, typename Size, typename Generator1, typename Generator2>
     ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value ||
-                       !can_use_default_less_operator<Type>::value, void>
+                       !can_use_default_less_operator<Type>::value>
     operator()(Policy&& /* exec */, Iterator1 /* first1 */, Iterator1 /* last1 */, Iterator1 /* first2 */, Iterator1 /* last2 */, Size /* n */, Size /* m */,
                Generator1 /* generator1 */, Generator2 /* generator2 */)
     {

--- a/test/parallel_api/algorithm/alg.nonmodifying/nth_element.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/nth_element.pass.cpp
@@ -76,8 +76,9 @@ struct test_without_compare
 {
     // nth_element works only with random access iterators
     template <typename Policy, typename Iterator1, typename Size, typename Generator1, typename Generator2>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value &&
-                              can_use_default_less_operator<Type>::value, void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value &&
+                           can_use_default_less_operator<Type>::value,
+                       void>
     operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator1 first2, Iterator1 last2, Size n, Size m,
                Generator1 generator1, Generator2 generator2)
     {
@@ -99,8 +100,9 @@ struct test_without_compare
     }
 
     template <typename Policy, typename Iterator1, typename Size, typename Generator1, typename Generator2>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value ||
-                              !can_use_default_less_operator<Type>::value, void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value ||
+                           !can_use_default_less_operator<Type>::value,
+                       void>
     operator()(Policy&& /* exec */, Iterator1 /* first1 */, Iterator1 /* last1 */, Iterator1 /* first2 */, Iterator1 /* last2 */, Size /* n */, Size /* m */,
                Generator1 /* generator1 */, Generator2 /* generator2 */)
     {
@@ -113,7 +115,7 @@ struct test_with_compare
     // nth_element works only with random access iterators
     template <typename Policy, typename Iterator1, typename Size, typename Generator1, typename Generator2,
               typename Compare>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value, void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value, void>
     operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator1 first2, Iterator1 last2, Size n, Size m,
                Generator1 generator1, Generator2 generator2, Compare comp)
     {
@@ -136,7 +138,7 @@ struct test_with_compare
 
     template <typename Policy, typename Iterator1, typename Size, typename Generator1, typename Generator2,
               typename Compare>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value, void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value, void>
     operator()(Policy&& /* exec */, Iterator1 /* first1 */, Iterator1 /* last1 */, Iterator1 /* first2 */, Iterator1 /* last2 */, Size /* n */, Size /* m */,
                Generator1 /* generator1 */, Generator2 /* generator2 */, Compare /* comp */)
     {

--- a/test/parallel_api/algorithm/alg.nonmodifying/nth_element.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/nth_element.pass.cpp
@@ -115,7 +115,7 @@ struct test_with_compare
     // nth_element works only with random access iterators
     template <typename Policy, typename Iterator1, typename Size, typename Generator1, typename Generator2,
               typename Compare>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value, void>
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value>
     operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator1 first2, Iterator1 last2, Size n, Size m,
                Generator1 generator1, Generator2 generator2, Compare comp)
     {
@@ -138,7 +138,7 @@ struct test_with_compare
 
     template <typename Policy, typename Iterator1, typename Size, typename Generator1, typename Generator2,
               typename Compare>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value, void>
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value>
     operator()(Policy&& /* exec */, Iterator1 /* first1 */, Iterator1 /* last1 */, Iterator1 /* first2 */, Iterator1 /* last2 */, Size /* n */, Size /* m */,
                Generator1 /* generator1 */, Generator2 /* generator2 */, Compare /* comp */)
     {

--- a/test/parallel_api/algorithm/alg.nonmodifying/nth_element.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/nth_element.pass.cpp
@@ -77,8 +77,7 @@ struct test_without_compare
     // nth_element works only with random access iterators
     template <typename Policy, typename Iterator1, typename Size, typename Generator1, typename Generator2>
     ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value &&
-                           can_use_default_less_operator<Type>::value,
-                       void>
+                       can_use_default_less_operator<Type>::value, void>
     operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator1 first2, Iterator1 last2, Size n, Size m,
                Generator1 generator1, Generator2 generator2)
     {
@@ -101,8 +100,7 @@ struct test_without_compare
 
     template <typename Policy, typename Iterator1, typename Size, typename Generator1, typename Generator2>
     ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value ||
-                           !can_use_default_less_operator<Type>::value,
-                       void>
+                       !can_use_default_less_operator<Type>::value, void>
     operator()(Policy&& /* exec */, Iterator1 /* first1 */, Iterator1 /* last1 */, Iterator1 /* first2 */, Iterator1 /* last2 */, Size /* n */, Size /* m */,
                Generator1 /* generator1 */, Generator2 /* generator2 */)
     {

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
@@ -56,7 +56,7 @@ DEFINE_TEST(test_binary_search)
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     typename ::std::enable_if<
-        oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<Policy>::type>::value &&
+        oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
         void>::type
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
@@ -95,7 +95,7 @@ DEFINE_TEST(test_binary_search)
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     typename ::std::enable_if<
 #if TEST_DPCPP_BACKEND_PRESENT
-        !oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<Policy>::type>::value &&
+        !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
         void>::type

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
@@ -56,8 +56,7 @@ DEFINE_TEST(test_binary_search)
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
-                           is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-                       void>
+                       is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {
@@ -96,8 +95,7 @@ DEFINE_TEST(test_binary_search)
 #if TEST_DPCPP_BACKEND_PRESENT
         !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif
-            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-        void>
+            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
@@ -117,7 +117,7 @@ DEFINE_TEST(test_binary_search)
 
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value, void>
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
@@ -55,10 +55,9 @@ DEFINE_TEST(test_binary_search)
 #if TEST_DPCPP_BACKEND_PRESENT
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    typename ::std::enable_if<
-        oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
-            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-        void>::type
+    ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
+                           is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
+                       void>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {
@@ -93,12 +92,12 @@ DEFINE_TEST(test_binary_search)
 
     // specialization for host execution policies
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    typename ::std::enable_if<
+    ::std::enable_if_t<
 #if TEST_DPCPP_BACKEND_PRESENT
         !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-        void>::type
+        void>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {
@@ -118,8 +117,7 @@ DEFINE_TEST(test_binary_search)
 
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-                              void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value, void>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
@@ -51,7 +51,7 @@ DEFINE_TEST(test_lower_bound)
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
-                           is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
+                       is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
@@ -51,7 +51,7 @@ DEFINE_TEST(test_lower_bound)
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     typename ::std::enable_if<
-        oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<Policy>::type>::value &&
+        oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
         void>::type
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
@@ -90,7 +90,7 @@ DEFINE_TEST(test_lower_bound)
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     typename ::std::enable_if<
 #if TEST_DPCPP_BACKEND_PRESENT
-        !oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<Policy>::type>::value &&
+        !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
         void>::type

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
@@ -51,8 +51,7 @@ DEFINE_TEST(test_lower_bound)
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
-                           is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-                       void>
+                           is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {
@@ -91,8 +90,7 @@ DEFINE_TEST(test_lower_bound)
 #if TEST_DPCPP_BACKEND_PRESENT
         !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif
-            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-        void>
+            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
@@ -111,7 +111,7 @@ DEFINE_TEST(test_lower_bound)
 
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value, void>
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
@@ -50,10 +50,9 @@ DEFINE_TEST(test_lower_bound)
 #if TEST_DPCPP_BACKEND_PRESENT
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    typename ::std::enable_if<
-        oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
-            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-        void>::type
+    ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
+                           is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
+                       void>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {
@@ -88,12 +87,12 @@ DEFINE_TEST(test_lower_bound)
 
     // specialization for host execution policies
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    typename ::std::enable_if<
+    ::std::enable_if_t<
 #if TEST_DPCPP_BACKEND_PRESENT
         !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-        void>::type
+        void>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {
@@ -112,8 +111,7 @@ DEFINE_TEST(test_lower_bound)
 
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-                              void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value, void>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
@@ -58,7 +58,7 @@ DEFINE_TEST(test_upper_bound)
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     typename ::std::enable_if<
-        oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<Policy>::type>::value &&
+        oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
         void>::type
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
@@ -97,7 +97,7 @@ DEFINE_TEST(test_upper_bound)
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     typename ::std::enable_if<
 #if TEST_DPCPP_BACKEND_PRESENT
-        !oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<Policy>::type>::value &&
+        !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
         void>::type

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
@@ -58,7 +58,7 @@ DEFINE_TEST(test_upper_bound)
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
-                           is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
+                       is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
@@ -118,7 +118,7 @@ DEFINE_TEST(test_upper_bound)
 
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value, void>
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
@@ -57,10 +57,9 @@ DEFINE_TEST(test_upper_bound)
 #if TEST_DPCPP_BACKEND_PRESENT
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    typename ::std::enable_if<
-        oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
-            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-        void>::type
+    ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
+                           is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
+                       void>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {
@@ -95,12 +94,12 @@ DEFINE_TEST(test_upper_bound)
 
     // specialization for host execution policies
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    typename ::std::enable_if<
+    ::std::enable_if_t<
 #if TEST_DPCPP_BACKEND_PRESENT
         !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-        void>::type
+        void>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {
@@ -119,8 +118,7 @@ DEFINE_TEST(test_upper_bound)
 
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-                              void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value, void>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
@@ -58,8 +58,7 @@ DEFINE_TEST(test_upper_bound)
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
-                           is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-                       void>
+                           is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {
@@ -98,8 +97,7 @@ DEFINE_TEST(test_upper_bound)
 #if TEST_DPCPP_BACKEND_PRESENT
         !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif
-            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-        void>
+            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {

--- a/test/parallel_api/algorithm/alg.sorting/alg.heap.operations/is_heap.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.heap.operations/is_heap.pass.cpp
@@ -48,7 +48,7 @@ template <typename T>
 struct test_is_heap
 {
     template <typename Policy, typename Iterator>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value>
     operator()(Policy&& exec, Iterator first, Iterator last)
     {
         using namespace std;
@@ -59,7 +59,7 @@ struct test_is_heap
 
     // is_heap works only with random access iterators
     template <typename Policy, typename Iterator>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value>
     operator()(Policy&& /* exec */, Iterator /* first */, Iterator /* last */)
     {
     }
@@ -69,7 +69,7 @@ template <typename T>
 struct test_is_heap_predicate
 {
     template <typename Policy, typename Iterator, typename Predicate>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value>
     operator()(Policy&& exec, Iterator first, Iterator last, Predicate pred)
     {
         using namespace std;
@@ -80,7 +80,7 @@ struct test_is_heap_predicate
 
     // is_heap works only with random access iterators
     template <typename Policy, typename Iterator, typename Predicate>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value>
     operator()(Policy&& /* exec */, Iterator /* first */, Iterator /* last */, Predicate /* pred */)
     {
     }
@@ -90,7 +90,7 @@ template <typename T>
 struct test_is_heap_until
 {
     template <typename Policy, typename Iterator>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value>
     operator()(Policy&& exec, Iterator first, Iterator last)
     {
         using namespace std;
@@ -101,7 +101,7 @@ struct test_is_heap_until
 
     // is_heap, is_heap_until works only with random access iterators
     template <typename Policy, typename Iterator>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value>
     operator()(Policy&& /* exec */, Iterator /* first */, Iterator /* last */)
     {
     }
@@ -111,7 +111,7 @@ template <typename T>
 struct test_is_heap_until_predicate
 {
     template <typename Policy, typename Iterator, typename Predicate>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value>
     operator()(Policy&& exec, Iterator first, Iterator last, Predicate pred)
     {
         using namespace std;
@@ -122,7 +122,7 @@ struct test_is_heap_until_predicate
 
     // is_heap, is_heap_until works only with random access iterators
     template <typename Policy, typename Iterator, typename Predicate>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value>
     operator()(Policy&& /* exec */, Iterator /* first */, Iterator /* last */, Predicate /* pred */)
     {
     }

--- a/test/parallel_api/algorithm/alg.sorting/alg.heap.operations/is_heap.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.heap.operations/is_heap.pass.cpp
@@ -48,7 +48,7 @@ template <typename T>
 struct test_is_heap
 {
     template <typename Policy, typename Iterator>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>
     operator()(Policy&& exec, Iterator first, Iterator last)
     {
         using namespace std;
@@ -59,7 +59,7 @@ struct test_is_heap
 
     // is_heap works only with random access iterators
     template <typename Policy, typename Iterator>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>
     operator()(Policy&& /* exec */, Iterator /* first */, Iterator /* last */)
     {
     }
@@ -69,7 +69,7 @@ template <typename T>
 struct test_is_heap_predicate
 {
     template <typename Policy, typename Iterator, typename Predicate>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>
     operator()(Policy&& exec, Iterator first, Iterator last, Predicate pred)
     {
         using namespace std;
@@ -80,7 +80,7 @@ struct test_is_heap_predicate
 
     // is_heap works only with random access iterators
     template <typename Policy, typename Iterator, typename Predicate>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>
     operator()(Policy&& /* exec */, Iterator /* first */, Iterator /* last */, Predicate /* pred */)
     {
     }
@@ -90,7 +90,7 @@ template <typename T>
 struct test_is_heap_until
 {
     template <typename Policy, typename Iterator>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>
     operator()(Policy&& exec, Iterator first, Iterator last)
     {
         using namespace std;
@@ -101,7 +101,7 @@ struct test_is_heap_until
 
     // is_heap, is_heap_until works only with random access iterators
     template <typename Policy, typename Iterator>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>
     operator()(Policy&& /* exec */, Iterator /* first */, Iterator /* last */)
     {
     }
@@ -111,7 +111,7 @@ template <typename T>
 struct test_is_heap_until_predicate
 {
     template <typename Policy, typename Iterator, typename Predicate>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>
     operator()(Policy&& exec, Iterator first, Iterator last, Predicate pred)
     {
         using namespace std;
@@ -122,7 +122,7 @@ struct test_is_heap_until_predicate
 
     // is_heap, is_heap_until works only with random access iterators
     template <typename Policy, typename Iterator, typename Predicate>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>
     operator()(Policy&& /* exec */, Iterator /* first */, Iterator /* last */, Predicate /* pred */)
     {
     }

--- a/test/parallel_api/algorithm/alg.sorting/alg.set.operations/includes.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.set.operations/includes.pass.cpp
@@ -50,8 +50,7 @@ template <typename T>
 struct test_without_compare
 {
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    typename ::std::enable_if<!TestUtils::isReverse<InputIterator1>::value &&
-                              can_use_default_less_operator<T>::value, void>::type
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value && can_use_default_less_operator<T>::value, void>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2)
     {
         auto expect_res = ::std::includes(first1, last1, first2, last2);
@@ -61,8 +60,7 @@ struct test_without_compare
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    typename ::std::enable_if<TestUtils::isReverse<InputIterator1>::value ||
-                              !can_use_default_less_operator<T>::value, void>::type
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value || !can_use_default_less_operator<T>::value, void>
     operator()(Policy&& /* exec */, InputIterator1 /* first1 */, InputIterator1 /* last1 */, InputIterator2 /* first2 */, InputIterator2 /* last2 */)
     {
     }
@@ -72,7 +70,7 @@ template <typename T>
 struct test_with_compare
 {
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    typename ::std::enable_if<!TestUtils::isReverse<InputIterator1>::value, void>::type
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value, void>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2,
                Compare comp)
     {
@@ -84,7 +82,7 @@ struct test_with_compare
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    typename ::std::enable_if<TestUtils::isReverse<InputIterator1>::value, void>::type
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value, void>
     operator()(Policy&& /* exec */, InputIterator1 /* first1 */, InputIterator1 /* last1 */, InputIterator2 /* first2 */, InputIterator2 /* last2 */,
                Compare /* comp */)
     {

--- a/test/parallel_api/algorithm/alg.sorting/alg.set.operations/includes.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.set.operations/includes.pass.cpp
@@ -50,7 +50,7 @@ template <typename T>
 struct test_without_compare
 {
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value && can_use_default_less_operator<T>::value, void>
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value && can_use_default_less_operator<T>::value>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2)
     {
         auto expect_res = ::std::includes(first1, last1, first2, last2);
@@ -60,7 +60,7 @@ struct test_without_compare
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value || !can_use_default_less_operator<T>::value, void>
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value || !can_use_default_less_operator<T>::value>
     operator()(Policy&& /* exec */, InputIterator1 /* first1 */, InputIterator1 /* last1 */, InputIterator2 /* first2 */, InputIterator2 /* last2 */)
     {
     }
@@ -70,7 +70,7 @@ template <typename T>
 struct test_with_compare
 {
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value, void>
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2,
                Compare comp)
     {
@@ -82,7 +82,7 @@ struct test_with_compare
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value, void>
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value>
     operator()(Policy&& /* exec */, InputIterator1 /* first1 */, InputIterator1 /* last1 */, InputIterator2 /* first2 */, InputIterator2 /* last2 */,
                Compare /* comp */)
     {

--- a/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_common.h
+++ b/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_common.h
@@ -85,7 +85,7 @@ template <typename Type>
 struct test_set_union
 {
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value, void>
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2,
                Compare comp)
     {
@@ -101,7 +101,7 @@ struct test_set_union
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value, void>
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2)
     {
         auto sequences = init(first1, last1, first2, last2);
@@ -115,13 +115,13 @@ struct test_set_union
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value, void>
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value>
     operator()(Policy&&, InputIterator1, InputIterator1, InputIterator2, InputIterator2)
     {
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value, void>
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value>
     operator()(Policy&&, InputIterator1, InputIterator1, InputIterator2, InputIterator2, Compare)
     {
     }
@@ -131,7 +131,7 @@ template <typename Type>
 struct test_set_intersection
 {
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value, void>
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2,
                Compare comp)
     {
@@ -146,7 +146,7 @@ struct test_set_intersection
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value, void>
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2)
     {
         auto sequences = init(first1, last1, first2, last2);
@@ -160,13 +160,13 @@ struct test_set_intersection
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value, void>
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value>
     operator()(Policy&&, InputIterator1, InputIterator1, InputIterator2, InputIterator2)
     {
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value, void>
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value>
     operator()(Policy&&, InputIterator1, InputIterator1, InputIterator2, InputIterator2, Compare)
     {
     }
@@ -176,7 +176,7 @@ template <typename Type>
 struct test_set_difference
 {
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value, void>
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2,
                Compare comp)
     {
@@ -191,7 +191,7 @@ struct test_set_difference
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value, void>
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2)
     {
         auto sequences = init(first1, last1, first2, last2);
@@ -207,13 +207,13 @@ struct test_set_difference
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value, void>
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value>
     operator()(Policy&&, InputIterator1, InputIterator1, InputIterator2, InputIterator2)
     {
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value, void>
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value>
     operator()(Policy&&, InputIterator1, InputIterator1, InputIterator2, InputIterator2, Compare)
     {
     }
@@ -223,7 +223,7 @@ template <typename Type>
 struct test_set_symmetric_difference
 {
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value, void>
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2,
                Compare comp)
     {
@@ -239,7 +239,7 @@ struct test_set_symmetric_difference
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value, void>
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2)
     {
         auto sequences = init(first1, last1, first2, last2);
@@ -255,13 +255,13 @@ struct test_set_symmetric_difference
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value, void>
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value>
     operator()(Policy&&, InputIterator1, InputIterator1, InputIterator2, InputIterator2)
     {
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value, void>
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value>
     operator()(Policy&&, InputIterator1, InputIterator1, InputIterator2, InputIterator2, Compare)
     {
     }

--- a/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_common.h
+++ b/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_common.h
@@ -85,7 +85,7 @@ template <typename Type>
 struct test_set_union
 {
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    typename ::std::enable_if<!TestUtils::isReverse<InputIterator1>::value, void>::type
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value, void>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2,
                Compare comp)
     {
@@ -101,7 +101,7 @@ struct test_set_union
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    typename ::std::enable_if<!TestUtils::isReverse<InputIterator1>::value, void>::type
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value, void>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2)
     {
         auto sequences = init(first1, last1, first2, last2);
@@ -115,13 +115,13 @@ struct test_set_union
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    typename ::std::enable_if<TestUtils::isReverse<InputIterator1>::value, void>::type
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value, void>
     operator()(Policy&&, InputIterator1, InputIterator1, InputIterator2, InputIterator2)
     {
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    typename ::std::enable_if<TestUtils::isReverse<InputIterator1>::value, void>::type
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value, void>
     operator()(Policy&&, InputIterator1, InputIterator1, InputIterator2, InputIterator2, Compare)
     {
     }
@@ -131,7 +131,7 @@ template <typename Type>
 struct test_set_intersection
 {
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    typename ::std::enable_if<!TestUtils::isReverse<InputIterator1>::value, void>::type
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value, void>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2,
                Compare comp)
     {
@@ -146,7 +146,7 @@ struct test_set_intersection
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    typename ::std::enable_if<!TestUtils::isReverse<InputIterator1>::value, void>::type
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value, void>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2)
     {
         auto sequences = init(first1, last1, first2, last2);
@@ -160,13 +160,13 @@ struct test_set_intersection
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    typename ::std::enable_if<TestUtils::isReverse<InputIterator1>::value, void>::type
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value, void>
     operator()(Policy&&, InputIterator1, InputIterator1, InputIterator2, InputIterator2)
     {
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    typename ::std::enable_if<TestUtils::isReverse<InputIterator1>::value, void>::type
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value, void>
     operator()(Policy&&, InputIterator1, InputIterator1, InputIterator2, InputIterator2, Compare)
     {
     }
@@ -176,7 +176,7 @@ template <typename Type>
 struct test_set_difference
 {
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    typename ::std::enable_if<!TestUtils::isReverse<InputIterator1>::value, void>::type
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value, void>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2,
                Compare comp)
     {
@@ -191,7 +191,7 @@ struct test_set_difference
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    typename ::std::enable_if<!TestUtils::isReverse<InputIterator1>::value, void>::type
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value, void>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2)
     {
         auto sequences = init(first1, last1, first2, last2);
@@ -207,13 +207,13 @@ struct test_set_difference
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    typename ::std::enable_if<TestUtils::isReverse<InputIterator1>::value, void>::type
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value, void>
     operator()(Policy&&, InputIterator1, InputIterator1, InputIterator2, InputIterator2)
     {
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    typename ::std::enable_if<TestUtils::isReverse<InputIterator1>::value, void>::type
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value, void>
     operator()(Policy&&, InputIterator1, InputIterator1, InputIterator2, InputIterator2, Compare)
     {
     }
@@ -223,7 +223,7 @@ template <typename Type>
 struct test_set_symmetric_difference
 {
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    typename ::std::enable_if<!TestUtils::isReverse<InputIterator1>::value, void>::type
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value, void>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2,
                Compare comp)
     {
@@ -239,7 +239,7 @@ struct test_set_symmetric_difference
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    typename ::std::enable_if<!TestUtils::isReverse<InputIterator1>::value, void>::type
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value, void>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2)
     {
         auto sequences = init(first1, last1, first2, last2);
@@ -255,13 +255,13 @@ struct test_set_symmetric_difference
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    typename ::std::enable_if<TestUtils::isReverse<InputIterator1>::value, void>::type
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value, void>
     operator()(Policy&&, InputIterator1, InputIterator1, InputIterator2, InputIterator2)
     {
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    typename ::std::enable_if<TestUtils::isReverse<InputIterator1>::value, void>::type
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value, void>
     operator()(Policy&&, InputIterator1, InputIterator1, InputIterator2, InputIterator2, Compare)
     {
     }

--- a/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
@@ -58,7 +58,7 @@ template <typename Type>
 struct test_brick_partial_sort
 {
     template <typename Policy, typename InputIterator, typename Compare>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value, void>
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value>
     operator()(Policy&& exec, InputIterator first, InputIterator last, InputIterator exp_first, InputIterator exp_last,
                InputIterator tmp_first, InputIterator tmp_last, Compare compare)
     {
@@ -101,7 +101,7 @@ struct test_brick_partial_sort
     }
 
     template <typename Policy, typename InputIterator, typename Compare>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value, void>
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value>
     operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, InputIterator /* exp_first */,
                InputIterator /* exp_last */, InputIterator /* tmp_first */, InputIterator /* tmp_last */, Compare /* compare */)
     {

--- a/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
@@ -109,8 +109,7 @@ struct test_brick_partial_sort
 
     template <typename Policy, typename InputIterator>
     ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value &&
-                           can_use_default_less_operator<Type>::value,
-                       void>
+                           can_use_default_less_operator<Type>::value, void>
     operator()(Policy&& exec, InputIterator first, InputIterator last, InputIterator exp_first, InputIterator exp_last,
                InputIterator tmp_first, InputIterator tmp_last)
     {
@@ -131,8 +130,7 @@ struct test_brick_partial_sort
 
     template <typename Policy, typename InputIterator>
     ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value ||
-                           !can_use_default_less_operator<Type>::value,
-                       void>
+                           !can_use_default_less_operator<Type>::value, void>
     operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, InputIterator /* exp_first */,
                InputIterator /* exp_last */, InputIterator /* tmp_first */, InputIterator /* tmp_last */)
     {

--- a/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
@@ -58,8 +58,7 @@ template <typename Type>
 struct test_brick_partial_sort
 {
     template <typename Policy, typename InputIterator, typename Compare>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value,
-                            void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value, void>
     operator()(Policy&& exec, InputIterator first, InputIterator last, InputIterator exp_first, InputIterator exp_last,
                InputIterator tmp_first, InputIterator tmp_last, Compare compare)
     {
@@ -102,16 +101,16 @@ struct test_brick_partial_sort
     }
 
     template <typename Policy, typename InputIterator, typename Compare>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value,
-                            void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value, void>
     operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, InputIterator /* exp_first */,
                InputIterator /* exp_last */, InputIterator /* tmp_first */, InputIterator /* tmp_last */, Compare /* compare */)
     {
     }
 
     template <typename Policy, typename InputIterator>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value &&
-                              can_use_default_less_operator<Type>::value, void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value &&
+                           can_use_default_less_operator<Type>::value,
+                       void>
     operator()(Policy&& exec, InputIterator first, InputIterator last, InputIterator exp_first, InputIterator exp_last,
                InputIterator tmp_first, InputIterator tmp_last)
     {
@@ -131,8 +130,9 @@ struct test_brick_partial_sort
     }
 
     template <typename Policy, typename InputIterator>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value ||
-                              !can_use_default_less_operator<Type>::value, void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value ||
+                           !can_use_default_less_operator<Type>::value,
+                       void>
     operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, InputIterator /* exp_first */,
                InputIterator /* exp_last */, InputIterator /* tmp_first */, InputIterator /* tmp_last */)
     {

--- a/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
@@ -109,7 +109,7 @@ struct test_brick_partial_sort
 
     template <typename Policy, typename InputIterator>
     ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value &&
-                           can_use_default_less_operator<Type>::value, void>
+                           can_use_default_less_operator<Type>::value>
     operator()(Policy&& exec, InputIterator first, InputIterator last, InputIterator exp_first, InputIterator exp_last,
                InputIterator tmp_first, InputIterator tmp_last)
     {
@@ -130,7 +130,7 @@ struct test_brick_partial_sort
 
     template <typename Policy, typename InputIterator>
     ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value ||
-                           !can_use_default_less_operator<Type>::value, void>
+                           !can_use_default_less_operator<Type>::value>
     operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, InputIterator /* exp_first */,
                InputIterator /* exp_last */, InputIterator /* tmp_first */, InputIterator /* tmp_last */)
     {

--- a/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
@@ -271,7 +271,7 @@ std::enable_if_t<oneapi::dpl::__internal::__is_host_execution_policy<std::decay_
 #if __SYCL_PSTL_OFFLOAD__
                  || std::is_same<std::decay_t<Policy>, std::execution::parallel_unsequenced_policy>::value
 #endif
-                 , void>
+                 >
 run_test(Policy&& exec, OutputIterator tmp_first, OutputIterator tmp_last, OutputIterator2 expected_first,
          OutputIterator2 expected_last, InputIterator first, InputIterator /*last*/, Size n, Compare ...compare)
 {
@@ -314,8 +314,7 @@ struct test_sort_op
               typename... Compare>
     ::std::enable_if_t<
         TestUtils::is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value &&
-            (TestUtils::can_use_default_less_operator<T>::value || sizeof...(Compare) > 0),
-        void>
+            (TestUtils::can_use_default_less_operator<T>::value || sizeof...(Compare) > 0)>
     operator()(Policy&& exec, OutputIterator tmp_first, OutputIterator tmp_last, OutputIterator2 expected_first,
                OutputIterator2 expected_last, InputIterator first, InputIterator last, Size n, Compare ...compare)
     {
@@ -327,8 +326,7 @@ struct test_sort_op
               typename... Compare>
     ::std::enable_if_t<
         !TestUtils::is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value ||
-            !(TestUtils::can_use_default_less_operator<T>::value || sizeof...(Compare) > 0),
-        void>
+            !(TestUtils::can_use_default_less_operator<T>::value || sizeof...(Compare) > 0)>
     operator()(Policy&& /* exec */, OutputIterator /* tmp_first */, OutputIterator /* tmp_last */,
                OutputIterator2 /* expected_first */, OutputIterator2 /* expected_last */, InputIterator /* first */,
                InputIterator /* last */, Size /* n */, Compare .../*compare*/)

--- a/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
@@ -293,7 +293,7 @@ run_test(Policy&& exec, OutputIterator tmp_first, OutputIterator tmp_last, Outpu
 #if _PSTL_SYCL_TEST_USM
 template <typename Policy, typename InputIterator, typename OutputIterator, typename OutputIterator2, typename Size,
           typename... Compare>
-oneapi::dpl::__internal::__enable_if_hetero_execution_policy<Policy, void>
+oneapi::dpl::__internal::__enable_if_hetero_execution_policy<Policy>
 run_test(Policy&& exec, OutputIterator tmp_first, OutputIterator tmp_last, OutputIterator2 expected_first,
             OutputIterator2 expected_last, InputIterator first, InputIterator last, Size n, Compare ...compare)
 {

--- a/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
@@ -311,10 +311,11 @@ template <typename T>
 struct test_sort_op
 {
     template <typename Policy, typename InputIterator, typename OutputIterator, typename OutputIterator2, typename Size,
-              typename ...Compare>
-    typename ::std::enable_if<TestUtils::is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value
-                          && (TestUtils::can_use_default_less_operator<T>::value || sizeof...(Compare) > 0),
-                              void>::type
+              typename... Compare>
+    ::std::enable_if_t<
+        TestUtils::is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value &&
+            (TestUtils::can_use_default_less_operator<T>::value || sizeof...(Compare) > 0),
+        void>
     operator()(Policy&& exec, OutputIterator tmp_first, OutputIterator tmp_last, OutputIterator2 expected_first,
                OutputIterator2 expected_last, InputIterator first, InputIterator last, Size n, Compare ...compare)
     {
@@ -323,10 +324,11 @@ struct test_sort_op
     }
 
     template <typename Policy, typename InputIterator, typename OutputIterator, typename OutputIterator2, typename Size,
-              typename ...Compare>
-    typename ::std::enable_if<!TestUtils::is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value
-                          || !(TestUtils::can_use_default_less_operator<T>::value || sizeof...(Compare) > 0),
-                              void>::type
+              typename... Compare>
+    ::std::enable_if_t<
+        !TestUtils::is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value ||
+            !(TestUtils::can_use_default_less_operator<T>::value || sizeof...(Compare) > 0),
+        void>
     operator()(Policy&& /* exec */, OutputIterator /* tmp_first */, OutputIterator /* tmp_last */,
                OutputIterator2 /* expected_first */, OutputIterator2 /* expected_last */, InputIterator /* first */,
                InputIterator /* last */, Size /* n */, Compare .../*compare*/)

--- a/test/parallel_api/experimental/for_loop.pass.cpp
+++ b/test/parallel_api/experimental/for_loop.pass.cpp
@@ -108,7 +108,7 @@ test_body_for_loop_strided(Policy&& exec, Iterator first, Iterator last, Iterato
 
     ::std::experimental::for_loop_strided(exec, first, last, loop_stride, [&flip](Iterator iter) { flip(*iter); });
 
-    typename ::std::make_signed<Size>::type idx = 0;
+    ::std::make_signed_t<Size> idx = 0;
     for (auto iter = expected_first; iter != expected_last; ::std::advance(iter, single_stride), ++idx)
     {
         if (idx % loop_stride != 0)
@@ -238,7 +238,7 @@ test_body_for_loop_strided_neg(Policy&& exec, Iterator first, Iterator /* last *
 {
     assert(loop_stride < 0);
 
-    using Ssize = typename ::std::make_signed<Size>::type;
+    using Ssize = ::std::make_signed_t<Size>;
 
     // Test negative stride value with non-forward iterators on range (first - 1, first)
     auto new_first = first;

--- a/test/parallel_api/experimental/for_loop.pass.cpp
+++ b/test/parallel_api/experimental/for_loop.pass.cpp
@@ -230,9 +230,9 @@ struct test_for_loop_impl
 };
 
 template <typename Policy, typename Iterator, typename Size, typename S>
-typename ::std::enable_if<
+::std::enable_if_t<
     !::std::is_same<typename ::std::iterator_traits<Iterator>::iterator_category, ::std::forward_iterator_tag>::value,
-    void>::type
+    void>
 test_body_for_loop_strided_neg(Policy&& exec, Iterator first, Iterator /* last */, Iterator expected_first,
                                Iterator /* expected_last */, Size n, S loop_stride)
 {
@@ -256,9 +256,9 @@ test_body_for_loop_strided_neg(Policy&& exec, Iterator first, Iterator /* last *
 }
 
 template <typename Policy, typename Iterator, typename Size, typename S>
-typename ::std::enable_if<
+::std::enable_if_t<
     ::std::is_same<typename ::std::iterator_traits<Iterator>::iterator_category, ::std::forward_iterator_tag>::value,
-    void>::type
+    void>
 test_body_for_loop_strided_neg(Policy&& /* exec */, Iterator /* first */, Iterator /* last */, Iterator /* expected_first */,
                                Iterator /* expected_last */, Size /* n */, S /* loop_stride */)
 {

--- a/test/parallel_api/experimental/for_loop.pass.cpp
+++ b/test/parallel_api/experimental/for_loop.pass.cpp
@@ -231,8 +231,7 @@ struct test_for_loop_impl
 
 template <typename Policy, typename Iterator, typename Size, typename S>
 ::std::enable_if_t<
-    !::std::is_same<typename ::std::iterator_traits<Iterator>::iterator_category, ::std::forward_iterator_tag>::value,
-    void>
+    !::std::is_same<typename ::std::iterator_traits<Iterator>::iterator_category, ::std::forward_iterator_tag>::value>
 test_body_for_loop_strided_neg(Policy&& exec, Iterator first, Iterator /* last */, Iterator expected_first,
                                Iterator /* expected_last */, Size n, S loop_stride)
 {
@@ -257,8 +256,7 @@ test_body_for_loop_strided_neg(Policy&& exec, Iterator first, Iterator /* last *
 
 template <typename Policy, typename Iterator, typename Size, typename S>
 ::std::enable_if_t<
-    ::std::is_same<typename ::std::iterator_traits<Iterator>::iterator_category, ::std::forward_iterator_tag>::value,
-    void>
+    ::std::is_same<typename ::std::iterator_traits<Iterator>::iterator_category, ::std::forward_iterator_tag>::value>
 test_body_for_loop_strided_neg(Policy&& /* exec */, Iterator /* first */, Iterator /* last */, Iterator /* expected_first */,
                                Iterator /* expected_last */, Size /* n */, S /* loop_stride */)
 {

--- a/test/parallel_api/experimental/for_loop_induction.pass.cpp
+++ b/test/parallel_api/experimental/for_loop_induction.pass.cpp
@@ -80,7 +80,7 @@ test_body_induction_strided(Policy&& exec, Iterator first, Iterator last, Iterat
         const T ind_init = n % 97;
         T lval_ind = ind_init;
 
-        using Ssize = typename ::std::make_signed<Size>::type;
+        using Ssize = ::std::make_signed_t<Size>;
 
         ::std::experimental::for_loop_n_strided(::std::forward<Policy>(exec), Ssize(0), Ssize(n), loop_stride,
                                               ::std::experimental::induction(lval_ind),

--- a/test/parallel_api/experimental/for_loop_reduction.pass.cpp
+++ b/test/parallel_api/experimental/for_loop_reduction.pass.cpp
@@ -127,7 +127,7 @@ struct test_body_predefined
 struct test_body_predefined_bits
 {
     template <typename Policy, typename Iterator, typename Size>
-    ::std::enable_if_t<!::std::is_floating_point<typename ::std::iterator_traits<Iterator>::value_type>::value, void>
+    ::std::enable_if_t<!::std::is_floating_point<typename ::std::iterator_traits<Iterator>::value_type>::value>
     operator()(Policy&& exec, Iterator first, Iterator last, Iterator /*expected_first*/, Iterator /*expected_last*/,
                Size /* n */)
     {
@@ -161,7 +161,7 @@ struct test_body_predefined_bits
     }
 
     template <typename Policy, typename Iterator, typename Size>
-    ::std::enable_if_t<::std::is_floating_point<typename ::std::iterator_traits<Iterator>::value_type>::value, void>
+    ::std::enable_if_t<::std::is_floating_point<typename ::std::iterator_traits<Iterator>::value_type>::value>
     operator()(Policy&& /* exec */, Iterator /* first */, Iterator /* last */, Iterator /*expected_first*/, Iterator /*expected_last*/,
                Size /* n */)
     {

--- a/test/parallel_api/experimental/for_loop_reduction.pass.cpp
+++ b/test/parallel_api/experimental/for_loop_reduction.pass.cpp
@@ -127,8 +127,7 @@ struct test_body_predefined
 struct test_body_predefined_bits
 {
     template <typename Policy, typename Iterator, typename Size>
-    typename ::std::enable_if<!::std::is_floating_point<typename ::std::iterator_traits<Iterator>::value_type>::value,
-                            void>::type
+    ::std::enable_if_t<!::std::is_floating_point<typename ::std::iterator_traits<Iterator>::value_type>::value, void>
     operator()(Policy&& exec, Iterator first, Iterator last, Iterator /*expected_first*/, Iterator /*expected_last*/,
                Size /* n */)
     {
@@ -162,8 +161,7 @@ struct test_body_predefined_bits
     }
 
     template <typename Policy, typename Iterator, typename Size>
-    typename ::std::enable_if<::std::is_floating_point<typename ::std::iterator_traits<Iterator>::value_type>::value,
-                            void>::type
+    ::std::enable_if_t<::std::is_floating_point<typename ::std::iterator_traits<Iterator>::value_type>::value, void>
     operator()(Policy&& /* exec */, Iterator /* first */, Iterator /* last */, Iterator /*expected_first*/, Iterator /*expected_last*/,
                Size /* n */)
     {

--- a/test/parallel_api/numeric/numeric.ops/adjacent_difference.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/adjacent_difference.pass.cpp
@@ -62,7 +62,7 @@ compare(const wrapper<T>& a, const wrapper<T>& b)
 }
 
 template <typename Iterator1, typename Iterator2, typename T, typename Function>
-typename ::std::enable_if<!::std::is_floating_point<T>::value, bool>::type
+::std::enable_if_t<!::std::is_floating_point<T>::value, bool>
 compute_and_check(Iterator1 first, Iterator1 last, Iterator2 d_first, T, Function f)
 {
     using T2 = typename ::std::iterator_traits<Iterator2>::value_type;
@@ -89,7 +89,7 @@ compute_and_check(Iterator1 first, Iterator1 last, Iterator2 d_first, T, Functio
 // we don't want to check equality here
 // because we can't be sure it will be strictly equal for floating point types
 template <typename Iterator1, typename Iterator2, typename T, typename Function>
-typename ::std::enable_if<::std::is_floating_point<T>::value, bool>::type
+::std::enable_if_t<::std::is_floating_point<T>::value, bool>
 compute_and_check(Iterator1 /* first */, Iterator1 /* last */, Iterator2 /* d_first */, T, Function)
 {
     return true;

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
@@ -114,8 +114,7 @@ DEFINE_TEST_2(test_exclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
-                           is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-                       void>
+                           is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 val_res_first, Iterator3 val_res_last, Size n)
     {
@@ -187,8 +186,7 @@ DEFINE_TEST_2(test_exclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
 #if TEST_DPCPP_BACKEND_PRESENT
         !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif // TEST_DPCPP_BACKEND_PRESENT
-            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-        void>
+            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 val_res_first, Iterator3 val_res_last, Size n)
     {

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
@@ -225,7 +225,7 @@ DEFINE_TEST_2(test_exclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
 
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value, void>
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 val_res_first, Iterator3 val_res_last, Size n)
     {

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
@@ -114,7 +114,7 @@ DEFINE_TEST_2(test_exclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
-                           is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
+                       is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 val_res_first, Iterator3 val_res_last, Size n)
     {

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
@@ -113,10 +113,9 @@ DEFINE_TEST_2(test_exclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
 #if TEST_DPCPP_BACKEND_PRESENT
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    typename ::std::enable_if<
-        oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
-            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-        void>::type
+    ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
+                           is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
+                       void>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 val_res_first, Iterator3 val_res_last, Size n)
     {
@@ -184,12 +183,12 @@ DEFINE_TEST_2(test_exclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
 
     // specialization for host execution policies
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    typename ::std::enable_if<
+    ::std::enable_if_t<
 #if TEST_DPCPP_BACKEND_PRESENT
         !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif // TEST_DPCPP_BACKEND_PRESENT
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-        void>::type
+        void>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 val_res_first, Iterator3 val_res_last, Size n)
     {
@@ -226,8 +225,7 @@ DEFINE_TEST_2(test_exclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
 
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-                              void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value, void>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 val_res_first, Iterator3 val_res_last, Size n)
     {

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
@@ -114,7 +114,7 @@ DEFINE_TEST_2(test_exclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     typename ::std::enable_if<
-        oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<Policy>::type>::value &&
+        oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
         void>::type
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
@@ -186,7 +186,7 @@ DEFINE_TEST_2(test_exclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     typename ::std::enable_if<
 #if TEST_DPCPP_BACKEND_PRESENT
-        !oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<Policy>::type>::value &&
+        !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif // TEST_DPCPP_BACKEND_PRESENT
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
         void>::type

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -111,8 +111,7 @@ DEFINE_TEST_2(test_inclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
-                           is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-                       void>
+                           is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 val_res_first, Iterator3 val_res_last, Size n)
     {
@@ -166,8 +165,7 @@ DEFINE_TEST_2(test_inclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
 #if TEST_DPCPP_BACKEND_PRESENT
         !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif
-            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-        void>
+            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 val_res_first, Iterator3 val_res_last, Size n)
     {

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -110,10 +110,9 @@ DEFINE_TEST_2(test_inclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
 #if TEST_DPCPP_BACKEND_PRESENT
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    typename ::std::enable_if<
-        oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
-            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-        void>::type
+    ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
+                           is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
+                       void>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 val_res_first, Iterator3 val_res_last, Size n)
     {
@@ -163,12 +162,12 @@ DEFINE_TEST_2(test_inclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
 
     // specialization for host execution policies
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    typename ::std::enable_if<
+    ::std::enable_if_t<
 #if TEST_DPCPP_BACKEND_PRESENT
         !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-        void>::type
+        void>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 val_res_first, Iterator3 val_res_last, Size n)
     {
@@ -194,8 +193,7 @@ DEFINE_TEST_2(test_inclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
 
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
-                              void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value, void>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 val_res_first, Iterator3 val_res_last, Size n)
     {

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -111,7 +111,7 @@ DEFINE_TEST_2(test_inclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     typename ::std::enable_if<
-        oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<Policy>::type>::value &&
+        oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
         void>::type
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
@@ -165,7 +165,7 @@ DEFINE_TEST_2(test_inclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     typename ::std::enable_if<
 #if TEST_DPCPP_BACKEND_PRESENT
-        !oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<Policy>::type>::value &&
+        !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value,
         void>::type

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -193,7 +193,7 @@ DEFINE_TEST_2(test_inclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
 
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value, void>
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 val_res_first, Iterator3 val_res_last, Size n)
     {

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -111,7 +111,7 @@ DEFINE_TEST_2(test_inclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
-                           is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
+                       is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 val_res_first, Iterator3 val_res_last, Size n)
     {

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -129,8 +129,7 @@ DEFINE_TEST_2(test_reduce_by_segment, BinaryPredicate, BinaryOperation)
               typename Size>
     ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
                            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value &&
-                           is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator4>::value,
-                       void>
+                           is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator4>::value>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 key_res_first, Iterator3 key_res_last, Iterator4 val_res_first, Iterator4 val_res_last, Size n)
     {
@@ -196,8 +195,7 @@ DEFINE_TEST_2(test_reduce_by_segment, BinaryPredicate, BinaryOperation)
         !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value &&
-            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator4>::value,
-        void>
+            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator4>::value>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 key_res_first, Iterator3 key_res_last, Iterator4 val_res_first, Iterator4 val_res_last, Size n)
     {
@@ -232,8 +230,7 @@ DEFINE_TEST_2(test_reduce_by_segment, BinaryPredicate, BinaryOperation)
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4,
               typename Size>
     ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value ||
-                           !is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator4>::value,
-                       void>
+                           !is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator4>::value>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 key_res_first, Iterator3 key_res_last, Iterator4 val_res_first, Iterator4 val_res_last, Size n)
     {

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -128,8 +128,8 @@ DEFINE_TEST_2(test_reduce_by_segment, BinaryPredicate, BinaryOperation)
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4,
               typename Size>
     ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
-                           is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value &&
-                           is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator4>::value>
+                       is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value &&
+                       is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator4>::value>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 key_res_first, Iterator3 key_res_last, Iterator4 val_res_first, Iterator4 val_res_last, Size n)
     {

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -127,11 +127,10 @@ DEFINE_TEST_2(test_reduce_by_segment, BinaryPredicate, BinaryOperation)
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4,
               typename Size>
-    typename ::std::enable_if<
-        oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
-            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value &&
-            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator4>::value,
-        void>::type
+    ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
+                           is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value &&
+                           is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator4>::value,
+                       void>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 key_res_first, Iterator3 key_res_last, Iterator4 val_res_first, Iterator4 val_res_last, Size n)
     {
@@ -192,13 +191,13 @@ DEFINE_TEST_2(test_reduce_by_segment, BinaryPredicate, BinaryOperation)
     // specialization for host execution policies
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4,
               typename Size>
-    typename ::std::enable_if<
+    ::std::enable_if_t<
 #if TEST_DPCPP_BACKEND_PRESENT
-        !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
+            !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value &&
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator4>::value,
-        void>::type
+        void>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 key_res_first, Iterator3 key_res_last, Iterator4 val_res_first, Iterator4 val_res_last, Size n)
     {
@@ -232,9 +231,9 @@ DEFINE_TEST_2(test_reduce_by_segment, BinaryPredicate, BinaryOperation)
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4,
               typename Size>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value ||
-                                  !is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator4>::value,
-                              void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value ||
+                           !is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator4>::value,
+                       void>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 key_res_first, Iterator3 key_res_last, Iterator4 val_res_first, Iterator4 val_res_last, Size n)
     {

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -193,7 +193,7 @@ DEFINE_TEST_2(test_reduce_by_segment, BinaryPredicate, BinaryOperation)
               typename Size>
     ::std::enable_if_t<
 #if TEST_DPCPP_BACKEND_PRESENT
-            !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
+        !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value &&
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator4>::value,

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -128,7 +128,7 @@ DEFINE_TEST_2(test_reduce_by_segment, BinaryPredicate, BinaryOperation)
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4,
               typename Size>
     typename ::std::enable_if<
-        oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<Policy>::type>::value &&
+        oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value &&
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator4>::value,
         void>::type
@@ -194,7 +194,7 @@ DEFINE_TEST_2(test_reduce_by_segment, BinaryPredicate, BinaryOperation)
               typename Size>
     typename ::std::enable_if<
 #if TEST_DPCPP_BACKEND_PRESENT
-        !oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<Policy>::type>::value &&
+        !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value &&
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator4>::value,

--- a/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
@@ -124,7 +124,7 @@ struct test_inclusive_scan_with_binary_op
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T,
               typename BinaryOp>
-    ::std::enable_if_t<!TestUtils::isReverse<Iterator1>::value, void>
+    ::std::enable_if_t<!TestUtils::isReverse<Iterator1>::value>
     operator()(Policy&& exec, Iterator1 in_first, Iterator1 in_last, Iterator2 out_first, Iterator2 out_last,
                Iterator3 expected_first, Iterator3 /* expected_last */, Size n, T init, BinaryOp binary_op, T trash)
     {
@@ -140,7 +140,7 @@ struct test_inclusive_scan_with_binary_op
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T,
               typename BinaryOp>
-    ::std::enable_if_t<!TestUtils::isReverse<Iterator1>::value, void>
+    ::std::enable_if_t<!TestUtils::isReverse<Iterator1>::value>
     operator()(Policy&& exec, Iterator1 in_first, Iterator1 in_last, Iterator2 out_first, Iterator2 out_last,
                Iterator3 expected_first, Iterator3 /* expected_last */, Size n, BinaryOp binary_op, T trash)
     {
@@ -156,7 +156,7 @@ struct test_inclusive_scan_with_binary_op
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T,
               typename BinaryOp>
-    ::std::enable_if_t<TestUtils::isReverse<Iterator1>::value, void>
+    ::std::enable_if_t<TestUtils::isReverse<Iterator1>::value>
     operator()(Policy&& /* exec */, Iterator1 /* in_first */, Iterator1 /* in_last */, Iterator2 /* out_first */, Iterator2 /* out_last */,
                Iterator3 /* expected_first */, Iterator3 /* expected_last */, Size /* n */, BinaryOp /* binary_op */, T /* trash */)
     {
@@ -164,7 +164,7 @@ struct test_inclusive_scan_with_binary_op
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T,
               typename BinaryOp>
-    ::std::enable_if_t<TestUtils::isReverse<Iterator1>::value, void>
+    ::std::enable_if_t<TestUtils::isReverse<Iterator1>::value>
     operator()(Policy&& /* exec */, Iterator1 /* in_first */, Iterator1 /* in_last */, Iterator2 /* out_first */, Iterator2 /* out_last */,
                Iterator3 /* expected_first */, Iterator3 /* expected_last */, Size /* n */, T /* init */, BinaryOp /* binary_op */, T /* trash */)
     {
@@ -176,7 +176,7 @@ struct test_exclusive_scan_with_binary_op
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T,
               typename BinaryOp>
-    ::std::enable_if_t<!TestUtils::isReverse<Iterator1>::value, void>
+    ::std::enable_if_t<!TestUtils::isReverse<Iterator1>::value>
     operator()(Policy&& exec, Iterator1 in_first, Iterator1 in_last, Iterator2 out_first, Iterator2 out_last,
                Iterator3 expected_first, Iterator3 /* expected_last */, Size n, T init, BinaryOp binary_op, T trash)
     {
@@ -193,7 +193,7 @@ struct test_exclusive_scan_with_binary_op
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T,
               typename BinaryOp>
-    ::std::enable_if_t<TestUtils::isReverse<Iterator1>::value, void>
+    ::std::enable_if_t<TestUtils::isReverse<Iterator1>::value>
     operator()(Policy&& /* exec */, Iterator1 /* in_first */, Iterator1 /* in_last */, Iterator2 /* out_first */, Iterator2 /* out_last */,
                Iterator3 /* expected_first */, Iterator3 /* expected_last */, Size /* n */, T /* init */, BinaryOp /* binary_op */, T /* trash */)
     {

--- a/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
@@ -124,7 +124,7 @@ struct test_inclusive_scan_with_binary_op
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T,
               typename BinaryOp>
-    typename ::std::enable_if<!TestUtils::isReverse<Iterator1>::value, void>::type
+    ::std::enable_if_t<!TestUtils::isReverse<Iterator1>::value, void>
     operator()(Policy&& exec, Iterator1 in_first, Iterator1 in_last, Iterator2 out_first, Iterator2 out_last,
                Iterator3 expected_first, Iterator3 /* expected_last */, Size n, T init, BinaryOp binary_op, T trash)
     {
@@ -140,7 +140,7 @@ struct test_inclusive_scan_with_binary_op
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T,
               typename BinaryOp>
-    typename ::std::enable_if<!TestUtils::isReverse<Iterator1>::value, void>::type
+    ::std::enable_if_t<!TestUtils::isReverse<Iterator1>::value, void>
     operator()(Policy&& exec, Iterator1 in_first, Iterator1 in_last, Iterator2 out_first, Iterator2 out_last,
                Iterator3 expected_first, Iterator3 /* expected_last */, Size n, BinaryOp binary_op, T trash)
     {
@@ -156,7 +156,7 @@ struct test_inclusive_scan_with_binary_op
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T,
               typename BinaryOp>
-    typename ::std::enable_if<TestUtils::isReverse<Iterator1>::value, void>::type
+    ::std::enable_if_t<TestUtils::isReverse<Iterator1>::value, void>
     operator()(Policy&& /* exec */, Iterator1 /* in_first */, Iterator1 /* in_last */, Iterator2 /* out_first */, Iterator2 /* out_last */,
                Iterator3 /* expected_first */, Iterator3 /* expected_last */, Size /* n */, BinaryOp /* binary_op */, T /* trash */)
     {
@@ -164,7 +164,7 @@ struct test_inclusive_scan_with_binary_op
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T,
               typename BinaryOp>
-    typename ::std::enable_if<TestUtils::isReverse<Iterator1>::value, void>::type
+    ::std::enable_if_t<TestUtils::isReverse<Iterator1>::value, void>
     operator()(Policy&& /* exec */, Iterator1 /* in_first */, Iterator1 /* in_last */, Iterator2 /* out_first */, Iterator2 /* out_last */,
                Iterator3 /* expected_first */, Iterator3 /* expected_last */, Size /* n */, T /* init */, BinaryOp /* binary_op */, T /* trash */)
     {
@@ -176,7 +176,7 @@ struct test_exclusive_scan_with_binary_op
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T,
               typename BinaryOp>
-    typename ::std::enable_if<!TestUtils::isReverse<Iterator1>::value, void>::type
+    ::std::enable_if_t<!TestUtils::isReverse<Iterator1>::value, void>
     operator()(Policy&& exec, Iterator1 in_first, Iterator1 in_last, Iterator2 out_first, Iterator2 out_last,
                Iterator3 expected_first, Iterator3 /* expected_last */, Size n, T init, BinaryOp binary_op, T trash)
     {
@@ -193,7 +193,7 @@ struct test_exclusive_scan_with_binary_op
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T,
               typename BinaryOp>
-    typename ::std::enable_if<TestUtils::isReverse<Iterator1>::value, void>::type
+    ::std::enable_if_t<TestUtils::isReverse<Iterator1>::value, void>
     operator()(Policy&& /* exec */, Iterator1 /* in_first */, Iterator1 /* in_last */, Iterator2 /* out_first */, Iterator2 /* out_last */,
                Iterator3 /* expected_first */, Iterator3 /* expected_last */, Size /* n */, T /* init */, BinaryOp /* binary_op */, T /* trash */)
     {

--- a/test/parallel_api/numeric/numeric.ops/scan_2.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan_2.pass.cpp
@@ -218,7 +218,7 @@ DEFINE_TEST_1(test_scan_non_inplace, TestingAlgoritm)
 
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value, void>
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value>
     operator()(Policy&& exec,
                Iterator1 keys_first, Iterator1 keys_last,
                Iterator2 vals_first, Iterator2 vals_last,
@@ -289,7 +289,7 @@ DEFINE_TEST_1(test_scan_inplace, TestingAlgoritm)
 
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Size>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value, void>
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Size n)
     {
     }

--- a/test/parallel_api/numeric/numeric.ops/scan_2.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan_2.pass.cpp
@@ -145,10 +145,10 @@ DEFINE_TEST_1(test_scan_non_inplace, TestingAlgoritm)
 
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
-    typename ::std::enable_if<
+    ::std::enable_if_t<
         oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value,
-        void>::type
+        void>
     operator()(Policy&& exec,
                Iterator1 keys_first, Iterator1 keys_last,
                Iterator2 vals_first, Iterator2 vals_last,
@@ -193,10 +193,10 @@ DEFINE_TEST_1(test_scan_non_inplace, TestingAlgoritm)
 
     // specialization for host execution policies
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
-    typename ::std::enable_if<
+    ::std::enable_if_t<
         !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value,
-        void>::type
+        void>
     operator()(Policy&& exec,
                Iterator1 keys_first, Iterator1 keys_last,
                Iterator2 vals_first, Iterator2 vals_last,
@@ -218,7 +218,7 @@ DEFINE_TEST_1(test_scan_non_inplace, TestingAlgoritm)
 
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value, void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value, void>
     operator()(Policy&& exec,
                Iterator1 keys_first, Iterator1 keys_last,
                Iterator2 vals_first, Iterator2 vals_last,
@@ -233,10 +233,10 @@ DEFINE_TEST_1(test_scan_inplace, TestingAlgoritm)
 
     // specialization for host execution policies
     template <typename Policy, typename Iterator1, typename Size>
-    typename ::std::enable_if<
+    ::std::enable_if_t<
         !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value,
-        void>::type
+        void>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Size n)
     {
         using KeyT = typename ::std::iterator_traits<Iterator1>::value_type;
@@ -257,10 +257,10 @@ DEFINE_TEST_1(test_scan_inplace, TestingAlgoritm)
 
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Size>
-    typename ::std::enable_if<
+    ::std::enable_if_t<
         oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value,
-        void>::type
+        void>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last,
                Size n)
     {
@@ -289,7 +289,7 @@ DEFINE_TEST_1(test_scan_inplace, TestingAlgoritm)
 
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Size>
-    typename ::std::enable_if<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value, void>::type
+    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value, void>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Size n)
     {
     }

--- a/test/parallel_api/numeric/numeric.ops/scan_2.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan_2.pass.cpp
@@ -146,7 +146,7 @@ DEFINE_TEST_1(test_scan_non_inplace, TestingAlgoritm)
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     typename ::std::enable_if<
-        oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<Policy>::type>::value &&
+        oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value,
         void>::type
     operator()(Policy&& exec,
@@ -194,7 +194,7 @@ DEFINE_TEST_1(test_scan_non_inplace, TestingAlgoritm)
     // specialization for host execution policies
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     typename ::std::enable_if<
-        !oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<Policy>::type>::value &&
+        !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value,
         void>::type
     operator()(Policy&& exec,
@@ -234,7 +234,7 @@ DEFINE_TEST_1(test_scan_inplace, TestingAlgoritm)
     // specialization for host execution policies
     template <typename Policy, typename Iterator1, typename Size>
     typename ::std::enable_if<
-        !oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<Policy>::type>::value &&
+        !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value,
         void>::type
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Size n)
@@ -258,7 +258,7 @@ DEFINE_TEST_1(test_scan_inplace, TestingAlgoritm)
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Size>
     typename ::std::enable_if<
-        oneapi::dpl::__internal::__is_hetero_execution_policy<typename ::std::decay<Policy>::type>::value &&
+        oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
             is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value,
         void>::type
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last,

--- a/test/parallel_api/numeric/numeric.ops/scan_2.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan_2.pass.cpp
@@ -147,8 +147,7 @@ DEFINE_TEST_1(test_scan_non_inplace, TestingAlgoritm)
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     ::std::enable_if_t<
         oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
-            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value,
-        void>
+            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value>
     operator()(Policy&& exec,
                Iterator1 keys_first, Iterator1 keys_last,
                Iterator2 vals_first, Iterator2 vals_last,
@@ -195,8 +194,7 @@ DEFINE_TEST_1(test_scan_non_inplace, TestingAlgoritm)
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     ::std::enable_if_t<
         !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
-            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value,
-        void>
+            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value>
     operator()(Policy&& exec,
                Iterator1 keys_first, Iterator1 keys_last,
                Iterator2 vals_first, Iterator2 vals_last,
@@ -235,8 +233,7 @@ DEFINE_TEST_1(test_scan_inplace, TestingAlgoritm)
     template <typename Policy, typename Iterator1, typename Size>
     ::std::enable_if_t<
         !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
-            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value,
-        void>
+            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Size n)
     {
         using KeyT = typename ::std::iterator_traits<Iterator1>::value_type;
@@ -259,8 +256,7 @@ DEFINE_TEST_1(test_scan_inplace, TestingAlgoritm)
     template <typename Policy, typename Iterator1, typename Size>
     ::std::enable_if_t<
         oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
-            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value,
-        void>
+            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last,
                Size n)
     {

--- a/test/parallel_api/numeric/numeric.ops/transform_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/transform_scan.pass.cpp
@@ -45,7 +45,7 @@ struct test_transform_exclusive_scan
 {
     template <typename Policy, typename InputIterator, typename OutputIterator, typename Size, typename UnaryOp,
               typename T, typename BinaryOp>
-    typename ::std::enable_if<!TestUtils::isReverse<InputIterator>::value, void>::type
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator>::value, void>
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
                OutputIterator out_last, OutputIterator expected_first, OutputIterator /* expected_last */, Size n,
                UnaryOp unary_op, T init, BinaryOp binary_op, T trash)
@@ -61,7 +61,7 @@ struct test_transform_exclusive_scan
 
     template <typename Policy, typename InputIterator, typename OutputIterator, typename Size, typename UnaryOp,
               typename T, typename BinaryOp>
-    typename ::std::enable_if<TestUtils::isReverse<InputIterator>::value, void>::type
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator>::value, void>
     operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, OutputIterator /* out_first */,
                OutputIterator /* out_last */, OutputIterator /* expected_first */, OutputIterator /* expected_last */, Size /* n */,
                UnaryOp /* unary_op */, T /* init */, BinaryOp /* binary_op */, T /* trash */)
@@ -74,7 +74,7 @@ struct test_transform_inclusive_scan_init
 {
     template <typename Policy, typename InputIterator, typename OutputIterator, typename Size, typename UnaryOp,
               typename T, typename BinaryOp>
-    typename ::std::enable_if<!TestUtils::isReverse<InputIterator>::value, void>::type
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator>::value, void>
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
                OutputIterator out_last, OutputIterator expected_first, OutputIterator /* expected_last */, Size n,
                UnaryOp unary_op, T init, BinaryOp binary_op, T trash)
@@ -90,7 +90,7 @@ struct test_transform_inclusive_scan_init
 
     template <typename Policy, typename InputIterator, typename OutputIterator, typename Size, typename UnaryOp,
               typename T, typename BinaryOp>
-    typename ::std::enable_if<TestUtils::isReverse<InputIterator>::value, void>::type
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator>::value, void>
     operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, OutputIterator /* out_first */,
                OutputIterator /* out_last */, OutputIterator /* expected_first */, OutputIterator /* expected_last */, Size /* n */,
                UnaryOp /* unary_op */, T /* init */, BinaryOp /* binary_op */, T /* trash */)
@@ -103,7 +103,7 @@ struct test_transform_inclusive_scan
 {
     template <typename Policy, typename InputIterator, typename OutputIterator, typename Size, typename UnaryOp,
               typename T, typename BinaryOp>
-    typename ::std::enable_if<!TestUtils::isReverse<InputIterator>::value, void>::type
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator>::value, void>
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
                OutputIterator out_last, OutputIterator expected_first, OutputIterator /* expected_last */, Size n,
                UnaryOp unary_op, T /* init */, BinaryOp binary_op, T trash)
@@ -122,7 +122,7 @@ struct test_transform_inclusive_scan
 
     template <typename Policy, typename InputIterator, typename OutputIterator, typename Size, typename UnaryOp,
               typename T, typename BinaryOp>
-    typename ::std::enable_if<TestUtils::isReverse<InputIterator>::value, void>::type
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator>::value, void>
     operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, OutputIterator /* out_first */,
                OutputIterator /* out_last */, OutputIterator /* expected_first */, OutputIterator /* expected_last */, Size /* n */,
                UnaryOp /* unary_op */, T /* init */, BinaryOp /* binary_op */, T /* trash */)

--- a/test/parallel_api/numeric/numeric.ops/transform_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/transform_scan.pass.cpp
@@ -45,7 +45,7 @@ struct test_transform_exclusive_scan
 {
     template <typename Policy, typename InputIterator, typename OutputIterator, typename Size, typename UnaryOp,
               typename T, typename BinaryOp>
-    ::std::enable_if_t<!TestUtils::isReverse<InputIterator>::value, void>
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator>::value>
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
                OutputIterator out_last, OutputIterator expected_first, OutputIterator /* expected_last */, Size n,
                UnaryOp unary_op, T init, BinaryOp binary_op, T trash)
@@ -61,7 +61,7 @@ struct test_transform_exclusive_scan
 
     template <typename Policy, typename InputIterator, typename OutputIterator, typename Size, typename UnaryOp,
               typename T, typename BinaryOp>
-    ::std::enable_if_t<TestUtils::isReverse<InputIterator>::value, void>
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator>::value>
     operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, OutputIterator /* out_first */,
                OutputIterator /* out_last */, OutputIterator /* expected_first */, OutputIterator /* expected_last */, Size /* n */,
                UnaryOp /* unary_op */, T /* init */, BinaryOp /* binary_op */, T /* trash */)
@@ -74,7 +74,7 @@ struct test_transform_inclusive_scan_init
 {
     template <typename Policy, typename InputIterator, typename OutputIterator, typename Size, typename UnaryOp,
               typename T, typename BinaryOp>
-    ::std::enable_if_t<!TestUtils::isReverse<InputIterator>::value, void>
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator>::value>
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
                OutputIterator out_last, OutputIterator expected_first, OutputIterator /* expected_last */, Size n,
                UnaryOp unary_op, T init, BinaryOp binary_op, T trash)
@@ -90,7 +90,7 @@ struct test_transform_inclusive_scan_init
 
     template <typename Policy, typename InputIterator, typename OutputIterator, typename Size, typename UnaryOp,
               typename T, typename BinaryOp>
-    ::std::enable_if_t<TestUtils::isReverse<InputIterator>::value, void>
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator>::value>
     operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, OutputIterator /* out_first */,
                OutputIterator /* out_last */, OutputIterator /* expected_first */, OutputIterator /* expected_last */, Size /* n */,
                UnaryOp /* unary_op */, T /* init */, BinaryOp /* binary_op */, T /* trash */)
@@ -103,7 +103,7 @@ struct test_transform_inclusive_scan
 {
     template <typename Policy, typename InputIterator, typename OutputIterator, typename Size, typename UnaryOp,
               typename T, typename BinaryOp>
-    ::std::enable_if_t<!TestUtils::isReverse<InputIterator>::value, void>
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator>::value>
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
                OutputIterator out_last, OutputIterator expected_first, OutputIterator /* expected_last */, Size n,
                UnaryOp unary_op, T /* init */, BinaryOp binary_op, T trash)
@@ -122,7 +122,7 @@ struct test_transform_inclusive_scan
 
     template <typename Policy, typename InputIterator, typename OutputIterator, typename Size, typename UnaryOp,
               typename T, typename BinaryOp>
-    ::std::enable_if_t<TestUtils::isReverse<InputIterator>::value, void>
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator>::value>
     operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, OutputIterator /* out_first */,
                OutputIterator /* out_last */, OutputIterator /* expected_first */, OutputIterator /* expected_last */, Size /* n */,
                UnaryOp /* unary_op */, T /* init */, BinaryOp /* binary_op */, T /* trash */)

--- a/test/pstl_offload/algorithms/algorithms_redirection.pass.cpp
+++ b/test/pstl_offload/algorithms/algorithms_redirection.pass.cpp
@@ -48,7 +48,7 @@ struct not_iterator {
     using iterator_category = std::random_access_iterator_tag;
 };
 
-template <typename ExecutionPolicy, typename T>
+template <typename ExecutionPolicy, typename T = void>
 using test_enable_if_execution_policy = std::enable_if_t<
     oneapi::dpl::execution::is_execution_policy<std::decay_t<ExecutionPolicy>>::value, T>;
 
@@ -222,7 +222,7 @@ none_of(_ExecutionPolicy&& __exec, not_iterator __first, not_iterator __last, _P
 }
 
 template <typename _ExecutionPolicy, typename _Function>
-test_enable_if_execution_policy<_ExecutionPolicy, void>
+test_enable_if_execution_policy<_ExecutionPolicy>
 for_each(_ExecutionPolicy&& __exec, not_iterator __first, not_iterator __last, _Function __f)
 {
     store_id(algorithm_id::FOR_EACH);
@@ -230,7 +230,7 @@ for_each(_ExecutionPolicy&& __exec, not_iterator __first, not_iterator __last, _
 }
 
 template <typename _ExecutionPolicy, typename _Size, typename _Function>
-test_enable_if_execution_policy<_ExecutionPolicy, void>
+test_enable_if_execution_policy<_ExecutionPolicy>
 for_each_n(_ExecutionPolicy&& __exec, not_iterator __first, _Size __n, _Function __f)
 {
     store_id(algorithm_id::FOR_EACH_N);
@@ -438,7 +438,7 @@ transform(_ExecutionPolicy&& __exec, not_iterator __first, not_iterator __last, 
 }
 
 template <typename _ExecutionPolicy, typename _UnaryPredicate, typename _Tp>
-test_enable_if_execution_policy<_ExecutionPolicy, void>
+test_enable_if_execution_policy<_ExecutionPolicy>
 replace_if(_ExecutionPolicy&& __exec, not_iterator __first, not_iterator __last, _UnaryPredicate __pred,
            const _Tp& __new_value)
 {
@@ -447,7 +447,7 @@ replace_if(_ExecutionPolicy&& __exec, not_iterator __first, not_iterator __last,
 }
 
 template <typename _ExecutionPolicy, typename _Tp>
-test_enable_if_execution_policy<_ExecutionPolicy, void>
+test_enable_if_execution_policy<_ExecutionPolicy>
 replace(_ExecutionPolicy&& __exec, not_iterator __first, not_iterator __last, const _Tp& __old_value,
         const _Tp& __new_value)
 {
@@ -476,7 +476,7 @@ replace_copy(_ExecutionPolicy&& __exec, not_iterator __first, not_iterator __las
 }
 
 template <typename _ExecutionPolicy, typename _Tp>
-test_enable_if_execution_policy<_ExecutionPolicy, void>
+test_enable_if_execution_policy<_ExecutionPolicy>
 fill(_ExecutionPolicy&& __exec, not_iterator __first, not_iterator __last, const _Tp& __value)
 {
     store_id(algorithm_id::FILL);
@@ -493,7 +493,7 @@ fill_n(_ExecutionPolicy&& __exec, not_iterator __first, _Size __count, const _Tp
 }
 
 template <typename _ExecutionPolicy, typename _Generator>
-test_enable_if_execution_policy<_ExecutionPolicy, void>
+test_enable_if_execution_policy<_ExecutionPolicy>
 generate(_ExecutionPolicy&& __exec, not_iterator __first, not_iterator __last, _Generator __g)
 {
     store_id(algorithm_id::GENERATE);
@@ -585,7 +585,7 @@ unique_copy(_ExecutionPolicy&& __exec, not_iterator __first, not_iterator __last
 }
 
 template <typename _ExecutionPolicy>
-test_enable_if_execution_policy<_ExecutionPolicy, void>
+test_enable_if_execution_policy<_ExecutionPolicy>
 reverse(_ExecutionPolicy&& __exec, not_iterator __first, not_iterator __last)
 {
     store_id(algorithm_id::REVERSE);
@@ -659,7 +659,7 @@ partition_copy(_ExecutionPolicy&& __exec, not_iterator __first, not_iterator __l
 }
 
 template <typename _ExecutionPolicy, typename _Compare>
-test_enable_if_execution_policy<_ExecutionPolicy, void>
+test_enable_if_execution_policy<_ExecutionPolicy>
 sort(_ExecutionPolicy&& __exec, not_iterator __first, not_iterator __last, _Compare __comp)
 {
     store_id(algorithm_id::SORT_COMPARE);
@@ -667,7 +667,7 @@ sort(_ExecutionPolicy&& __exec, not_iterator __first, not_iterator __last, _Comp
 }
 
 template <typename _ExecutionPolicy>
-test_enable_if_execution_policy<_ExecutionPolicy, void>
+test_enable_if_execution_policy<_ExecutionPolicy>
 sort(_ExecutionPolicy&& __exec, not_iterator __first, not_iterator __last)
 {
     store_id(algorithm_id::SORT);
@@ -675,7 +675,7 @@ sort(_ExecutionPolicy&& __exec, not_iterator __first, not_iterator __last)
 }
 
 template <typename _ExecutionPolicy, typename _Compare>
-test_enable_if_execution_policy<_ExecutionPolicy, void>
+test_enable_if_execution_policy<_ExecutionPolicy>
 stable_sort(_ExecutionPolicy&& __exec, not_iterator __first, not_iterator __last, _Compare __comp)
 {
     store_id(algorithm_id::STABLE_SORT_COMPARE);
@@ -683,7 +683,7 @@ stable_sort(_ExecutionPolicy&& __exec, not_iterator __first, not_iterator __last
 }
 
 template <typename _ExecutionPolicy>
-test_enable_if_execution_policy<_ExecutionPolicy, void>
+test_enable_if_execution_policy<_ExecutionPolicy>
 stable_sort(_ExecutionPolicy&& __exec, not_iterator __first, not_iterator __last)
 {
     store_id(algorithm_id::STABLE_SORT);
@@ -777,7 +777,7 @@ move(_ExecutionPolicy&& __exec, not_iterator __first, not_iterator __last, _Forw
 }
 
 template <typename _ExecutionPolicy, typename _Compare>
-test_enable_if_execution_policy<_ExecutionPolicy, void>
+test_enable_if_execution_policy<_ExecutionPolicy>
 partial_sort(_ExecutionPolicy&& __exec, not_iterator __first, not_iterator __middle, not_iterator __last,
              _Compare __comp)
 {
@@ -786,7 +786,7 @@ partial_sort(_ExecutionPolicy&& __exec, not_iterator __first, not_iterator __mid
 }
 
 template <typename _ExecutionPolicy>
-test_enable_if_execution_policy<_ExecutionPolicy, void>
+test_enable_if_execution_policy<_ExecutionPolicy>
 partial_sort(_ExecutionPolicy&& __exec, not_iterator __first, not_iterator __middle, not_iterator __last)
 {
     store_id(algorithm_id::PARTIAL_SORT);
@@ -870,7 +870,7 @@ merge(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 _
 }
 
 template <typename _ExecutionPolicy, typename _Compare>
-test_enable_if_execution_policy<_ExecutionPolicy, void>
+test_enable_if_execution_policy<_ExecutionPolicy>
 inplace_merge(_ExecutionPolicy&& __exec, not_iterator __first, not_iterator __middle,
               not_iterator __last, _Compare __comp)
 {
@@ -879,7 +879,7 @@ inplace_merge(_ExecutionPolicy&& __exec, not_iterator __first, not_iterator __mi
 }
 
 template <typename _ExecutionPolicy>
-test_enable_if_execution_policy<_ExecutionPolicy, void>
+test_enable_if_execution_policy<_ExecutionPolicy>
 inplace_merge(_ExecutionPolicy&& __exec, not_iterator __first, not_iterator __middle,
               not_iterator __last)
 {
@@ -1078,7 +1078,7 @@ minmax_element(_ExecutionPolicy&& __exec, not_iterator __first, not_iterator __l
 }
 
 template <typename _ExecutionPolicy, typename _Compare>
-test_enable_if_execution_policy<_ExecutionPolicy, void>
+test_enable_if_execution_policy<_ExecutionPolicy>
 nth_element(_ExecutionPolicy&& __exec, not_iterator __first, not_iterator __nth, not_iterator __last, _Compare __comp)
 {
     store_id(algorithm_id::NTH_ELEMENT_COMPARE);
@@ -1086,7 +1086,7 @@ nth_element(_ExecutionPolicy&& __exec, not_iterator __first, not_iterator __nth,
 }
 
 template <typename _ExecutionPolicy>
-test_enable_if_execution_policy<_ExecutionPolicy, void>
+test_enable_if_execution_policy<_ExecutionPolicy>
 nth_element(_ExecutionPolicy&& __exec, not_iterator __first, not_iterator __nth, not_iterator __last)
 {
     store_id(algorithm_id::NTH_ELEMENT);
@@ -1172,7 +1172,7 @@ uninitialized_move_n(_ExecutionPolicy&& __exec, _InputIterator __first, _Size __
 }
 
 template <typename _ExecutionPolicy, typename _Tp>
-test_enable_if_execution_policy<_ExecutionPolicy, void>
+test_enable_if_execution_policy<_ExecutionPolicy>
 uninitialized_fill(_ExecutionPolicy&& __exec, not_iterator __first, not_iterator __last, const _Tp& __value)
 {
     store_id(algorithm_id::UNINITIALIZED_FILL);
@@ -1189,7 +1189,7 @@ uninitialized_fill_n(_ExecutionPolicy&& __exec, not_iterator __first, _Size __n,
 }
 
 template <typename _ExecutionPolicy>
-test_enable_if_execution_policy<_ExecutionPolicy, void>
+test_enable_if_execution_policy<_ExecutionPolicy>
 destroy(_ExecutionPolicy&& __exec, not_iterator __first, not_iterator __last)
 {
     store_id(algorithm_id::DESTROY);
@@ -1197,7 +1197,7 @@ destroy(_ExecutionPolicy&& __exec, not_iterator __first, not_iterator __last)
 }
 
 template <typename _ExecutionPolicy, typename _Size>
-test_enable_if_execution_policy<_ExecutionPolicy, void>
+test_enable_if_execution_policy<_ExecutionPolicy>
 destroy_n(_ExecutionPolicy&& __exec, not_iterator __first, _Size __n)
 {
     store_id(algorithm_id::DESTROY_N);
@@ -1205,7 +1205,7 @@ destroy_n(_ExecutionPolicy&& __exec, not_iterator __first, _Size __n)
 }
 
 template <typename _ExecutionPolicy>
-test_enable_if_execution_policy<_ExecutionPolicy, void>
+test_enable_if_execution_policy<_ExecutionPolicy>
 uninitialized_default_construct(_ExecutionPolicy&& __exec, not_iterator __first, not_iterator __last)
 {
     store_id(algorithm_id::UNINITIALIZED_DEFAULT_CONSTRUCT);
@@ -1213,7 +1213,7 @@ uninitialized_default_construct(_ExecutionPolicy&& __exec, not_iterator __first,
 }
 
 template <typename _ExecutionPolicy, typename _Size>
-test_enable_if_execution_policy<_ExecutionPolicy, void>
+test_enable_if_execution_policy<_ExecutionPolicy>
 uninitialized_default_construct_n(_ExecutionPolicy&& __exec, not_iterator __first, _Size __n)
 {
     store_id(algorithm_id::UNINITIALIZED_DEFAULT_CONSTRUCT_N);
@@ -1221,7 +1221,7 @@ uninitialized_default_construct_n(_ExecutionPolicy&& __exec, not_iterator __firs
 }
 
 template <typename _ExecutionPolicy>
-test_enable_if_execution_policy<_ExecutionPolicy, void>
+test_enable_if_execution_policy<_ExecutionPolicy>
 uninitialized_value_construct(_ExecutionPolicy&& __exec, not_iterator __first, not_iterator __last)
 {
     store_id(algorithm_id::UNINITIALIZED_VALUE_CONSTRUCT);
@@ -1229,7 +1229,7 @@ uninitialized_value_construct(_ExecutionPolicy&& __exec, not_iterator __first, n
 }
 
 template <typename _ExecutionPolicy, typename _Size>
-test_enable_if_execution_policy<_ExecutionPolicy, void>
+test_enable_if_execution_policy<_ExecutionPolicy>
 uninitialized_value_construct_n(_ExecutionPolicy&& __exec, not_iterator __first, _Size __n)
 {
     store_id(algorithm_id::UNINITIALIZED_VALUE_CONSTRUCT_N);

--- a/test/support/iterator_utils.h
+++ b/test/support/iterator_utils.h
@@ -340,7 +340,7 @@ struct iterator_invoker
     // A single iterator version which is used for non_const testcases
     template <typename Policy, typename Op, typename Iterator>
     ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag,
-                                                    Iterator>::value&& ::std::is_base_of<non_const_wrapper, Op>::value,
+                                                    Iterator>::value && ::std::is_base_of<non_const_wrapper, Op>::value,
                        void>
     operator()(Policy&& exec, Op op, Iterator iter)
     {
@@ -349,8 +349,8 @@ struct iterator_invoker
 
     // A version with 2 iterators which is used for non_const testcases
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value&& ::std::
-                           is_base_of<non_const_wrapper, Op>::value,
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value &&
+                           ::std::is_base_of<non_const_wrapper, Op>::value,
                        void>
     operator()(Policy&& exec, Op op, InputIterator input_iter, OutputIterator out_iter)
     {
@@ -432,7 +432,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     // A single iterator version which is used for non_const testcases
     template <typename Policy, typename Op, typename Iterator>
     ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag,
-                                                    Iterator>::value&& ::std::is_base_of<non_const_wrapper, Op>::value,
+                                                    Iterator>::value && ::std::is_base_of<non_const_wrapper, Op>::value,
                        void>
     operator()(Policy&& exec, Op op, Iterator iter)
     {

--- a/test/support/iterator_utils.h
+++ b/test/support/iterator_utils.h
@@ -340,8 +340,7 @@ struct iterator_invoker
     // A single iterator version which is used for non_const testcases
     template <typename Policy, typename Op, typename Iterator>
     ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
-                         ::std::is_base_of<non_const_wrapper, Op>::value,
-                       void>
+                         ::std::is_base_of<non_const_wrapper, Op>::value>
     operator()(Policy&& exec, Op op, Iterator iter)
     {
         op(::std::forward<Policy>(exec), make_iterator<Iterator>()(iter));
@@ -350,8 +349,7 @@ struct iterator_invoker
     // A version with 2 iterators which is used for non_const testcases
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator>
     ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value &&
-                         ::std::is_base_of<non_const_wrapper, Op>::value,
-                       void>
+                         ::std::is_base_of<non_const_wrapper, Op>::value>
     operator()(Policy&& exec, Op op, InputIterator input_iter, OutputIterator out_iter)
     {
         op(::std::forward<Policy>(exec), make_iterator<InputIterator>()(input_iter),
@@ -376,8 +374,7 @@ struct iterator_invoker
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
     ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
-                         !::std::is_base_of<non_const_wrapper, Op>::value,
-                       void>
+                         !::std::is_base_of<non_const_wrapper, Op>::value>
     operator()(Policy&& exec, Op op, Iterator inputBegin, Iterator inputEnd, Rest&&... rest)
     {
         invoke_if<Iterator>()(::std::distance(inputBegin, inputEnd) <= sizeLimit, op, exec,
@@ -432,8 +429,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     // A single iterator version which is used for non_const testcases
     template <typename Policy, typename Op, typename Iterator>
     ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
-                         ::std::is_base_of<non_const_wrapper, Op>::value,
-                       void>
+                         ::std::is_base_of<non_const_wrapper, Op>::value>
     operator()(Policy&& exec, Op op, Iterator iter)
     {
         op(::std::forward<Policy>(exec), make_iterator<Iterator>()(iter));
@@ -442,8 +438,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     // A version with 2 iterators which is used for non_const testcases
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator>
     ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value &&
-                         ::std::is_base_of<non_const_wrapper, Op>::value,
-                       void>
+                         ::std::is_base_of<non_const_wrapper, Op>::value>
     operator()(Policy&& exec, Op op, InputIterator input_iter, OutputIterator out_iter)
     {
         op(::std::forward<Policy>(exec), make_iterator<InputIterator>()(input_iter),
@@ -477,8 +472,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
     ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
-                         !::std::is_base_of<non_const_wrapper, Op>::value,
-                       void>
+                         !::std::is_base_of<non_const_wrapper, Op>::value>
     operator()(Policy&& exec, Op op, Iterator inputBegin, Iterator inputEnd, Rest&&... rest)
     {
         if (::std::distance(inputBegin, inputEnd) <= sizeLimit)

--- a/test/support/iterator_utils.h
+++ b/test/support/iterator_utils.h
@@ -230,8 +230,7 @@ struct iterator_traits_
 };
 
 template <typename Iter> // For iterators
-struct iterator_traits_<Iter,
-                        typename ::std::enable_if<!::std::is_void<typename Iter::iterator_category>::value, void>::type>
+struct iterator_traits_<Iter, ::std::enable_if_t<!::std::is_void<typename Iter::iterator_category>::value, void>>
 {
     typedef typename Iter::iterator_category iterator_category;
 };
@@ -285,29 +284,27 @@ template <typename Op, typename IteratorTag, bool IsPositiveCondition = true>
 struct non_const_wrapper_tagged : non_const_wrapper
 {
     template <typename Policy, typename Iterator>
-    typename ::std::enable_if<IsPositiveCondition == is_same_iterator_category<Iterator, IteratorTag>::value, void>::type
+    ::std::enable_if_t<IsPositiveCondition == is_same_iterator_category<Iterator, IteratorTag>::value, void>
     operator()(Policy&& exec, Iterator iter)
     {
         Op()(exec, iter);
     }
 
     template <typename Policy, typename InputIterator, typename OutputIterator>
-    typename ::std::enable_if<IsPositiveCondition == is_same_iterator_category<OutputIterator, IteratorTag>::value,
-                            void>::type
+    ::std::enable_if_t<IsPositiveCondition == is_same_iterator_category<OutputIterator, IteratorTag>::value, void>
     operator()(Policy&& exec, InputIterator input_iter, OutputIterator out_iter)
     {
         Op()(exec, input_iter, out_iter);
     }
 
     template <typename Policy, typename Iterator>
-    typename ::std::enable_if<IsPositiveCondition != is_same_iterator_category<Iterator, IteratorTag>::value, void>::type
+    ::std::enable_if_t<IsPositiveCondition != is_same_iterator_category<Iterator, IteratorTag>::value, void>
     operator()(Policy&& /*exec*/, Iterator /*iter*/)
     {
     }
 
     template <typename Policy, typename InputIterator, typename OutputIterator>
-    typename ::std::enable_if<IsPositiveCondition != is_same_iterator_category<OutputIterator, IteratorTag>::value,
-                            void>::type
+    ::std::enable_if_t<IsPositiveCondition != is_same_iterator_category<OutputIterator, IteratorTag>::value, void>
     operator()(Policy&& /*exec*/, InputIterator /*input_iter*/, OutputIterator /*out_iter*/)
     {
     }
@@ -342,9 +339,9 @@ struct iterator_invoker
 
     // A single iterator version which is used for non_const testcases
     template <typename Policy, typename Op, typename Iterator>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
-                                ::std::is_base_of<non_const_wrapper, Op>::value,
-                            void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag,
+                                                    Iterator>::value&& ::std::is_base_of<non_const_wrapper, Op>::value,
+                       void>
     operator()(Policy&& exec, Op op, Iterator iter)
     {
         op(::std::forward<Policy>(exec), make_iterator<Iterator>()(iter));
@@ -352,9 +349,9 @@ struct iterator_invoker
 
     // A version with 2 iterators which is used for non_const testcases
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value &&
-                                ::std::is_base_of<non_const_wrapper, Op>::value,
-                            void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value&& ::std::
+                           is_base_of<non_const_wrapper, Op>::value,
+                       void>
     operator()(Policy&& exec, Op op, InputIterator input_iter, OutputIterator out_iter)
     {
         op(::std::forward<Policy>(exec), make_iterator<InputIterator>()(input_iter),
@@ -362,8 +359,7 @@ struct iterator_invoker
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::bidirectional_iterator_tag,
-                                            Iterator>::value, void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::bidirectional_iterator_tag, Iterator>::value, void>
     operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n,
         Iterator expected, Rest&&... rest)
     {
@@ -371,7 +367,7 @@ struct iterator_invoker
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>
     operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n, Rest&&... rest)
     {
         invoke_if<Iterator>()(n <= sizeLimit, op, exec, make_iterator<Iterator>()(begin), n,
@@ -379,9 +375,9 @@ struct iterator_invoker
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
-                                !::std::is_base_of<non_const_wrapper, Op>::value,
-                            void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
+                           !::std::is_base_of<non_const_wrapper, Op>::value,
+                       void>
     operator()(Policy&& exec, Op op, Iterator inputBegin, Iterator inputEnd, Rest&&... rest)
     {
         invoke_if<Iterator>()(::std::distance(inputBegin, inputEnd) <= sizeLimit, op, exec,
@@ -390,8 +386,7 @@ struct iterator_invoker
     }
 
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator, typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value,
-                            void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value, void>
     operator()(Policy&& exec, Op op, InputIterator inputBegin, InputIterator inputEnd, OutputIterator outputBegin,
                Rest&&... rest)
     {
@@ -401,8 +396,7 @@ struct iterator_invoker
     }
 
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator, typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value,
-                            void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value, void>
     operator()(Policy&& exec, Op op, InputIterator inputBegin, InputIterator inputEnd, OutputIterator outputBegin,
                OutputIterator outputEnd, Rest&&... rest)
     {
@@ -414,8 +408,7 @@ struct iterator_invoker
 
     template <typename Policy, typename Op, typename InputIterator1, typename InputIterator2, typename OutputIterator,
               typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value,
-                            void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value, void>
     operator()(Policy&& exec, Op op, InputIterator1 inputBegin1, InputIterator1 inputEnd1, InputIterator2 inputBegin2,
                InputIterator2 inputEnd2, OutputIterator outputBegin, OutputIterator outputEnd, Rest&&... rest)
     {
@@ -438,9 +431,9 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
 
     // A single iterator version which is used for non_const testcases
     template <typename Policy, typename Op, typename Iterator>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
-                                ::std::is_base_of<non_const_wrapper, Op>::value,
-                            void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag,
+                                                    Iterator>::value&& ::std::is_base_of<non_const_wrapper, Op>::value,
+                       void>
     operator()(Policy&& exec, Op op, Iterator iter)
     {
         op(::std::forward<Policy>(exec), make_iterator<Iterator>()(iter));
@@ -448,9 +441,9 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
 
     // A version with 2 iterators which is used for non_const testcases
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value &&
-                                ::std::is_base_of<non_const_wrapper, Op>::value,
-                            void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value&& ::std::
+                           is_base_of<non_const_wrapper, Op>::value,
+                       void>
     operator()(Policy&& exec, Op op, InputIterator input_iter, OutputIterator out_iter)
     {
         op(::std::forward<Policy>(exec), make_iterator<InputIterator>()(input_iter),
@@ -458,7 +451,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>
     operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n, Rest&&... rest)
     {
         if (n <= sizeLimit)
@@ -466,7 +459,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>
     operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n, Iterator expected,
         Rest&&... rest)
     {
@@ -475,7 +468,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    typename ::std::enable_if<is_same_iterator_category<Iterator, ::std::bidirectional_iterator_tag>::value, void>::type
+    ::std::enable_if_t<is_same_iterator_category<Iterator, ::std::bidirectional_iterator_tag>::value, void>
     operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n, Iterator expected, Rest&&... rest)
     {
         if (n <= sizeLimit)
@@ -483,9 +476,9 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
-                                !::std::is_base_of<non_const_wrapper, Op>::value,
-                            void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
+                           !::std::is_base_of<non_const_wrapper, Op>::value,
+                       void>
     operator()(Policy&& exec, Op op, Iterator inputBegin, Iterator inputEnd, Rest&&... rest)
     {
         if (::std::distance(inputBegin, inputEnd) <= sizeLimit)
@@ -494,8 +487,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     }
 
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator, typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value,
-                            void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value, void>
     operator()(Policy&& exec, Op op, InputIterator inputBegin, InputIterator inputEnd, OutputIterator outputBegin,
                Rest&&... rest)
     {
@@ -505,8 +497,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     }
 
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator, typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value,
-                            void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value, void>
     operator()(Policy&& exec, Op op, InputIterator inputBegin, InputIterator inputEnd, OutputIterator outputBegin,
                OutputIterator outputEnd, Rest&&... rest)
     {
@@ -518,8 +509,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
 
     template <typename Policy, typename Op, typename InputIterator1, typename InputIterator2, typename OutputIterator,
               typename... Rest>
-    typename ::std::enable_if<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value,
-                            void>::type
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value, void>
     operator()(Policy&& exec, Op op, InputIterator1 inputBegin1, InputIterator1 inputEnd1, InputIterator2 inputBegin2,
                InputIterator2 inputEnd2, OutputIterator outputBegin, OutputIterator outputEnd, Rest&&... rest)
     {

--- a/test/support/iterator_utils.h
+++ b/test/support/iterator_utils.h
@@ -230,7 +230,7 @@ struct iterator_traits_
 };
 
 template <typename Iter> // For iterators
-struct iterator_traits_<Iter, ::std::enable_if_t<!::std::is_void<typename Iter::iterator_category>::value, void>>
+struct iterator_traits_<Iter, ::std::enable_if_t<!::std::is_void<typename Iter::iterator_category>::value>>
 {
     typedef typename Iter::iterator_category iterator_category;
 };
@@ -284,27 +284,27 @@ template <typename Op, typename IteratorTag, bool IsPositiveCondition = true>
 struct non_const_wrapper_tagged : non_const_wrapper
 {
     template <typename Policy, typename Iterator>
-    ::std::enable_if_t<IsPositiveCondition == is_same_iterator_category<Iterator, IteratorTag>::value, void>
+    ::std::enable_if_t<IsPositiveCondition == is_same_iterator_category<Iterator, IteratorTag>::value>
     operator()(Policy&& exec, Iterator iter)
     {
         Op()(exec, iter);
     }
 
     template <typename Policy, typename InputIterator, typename OutputIterator>
-    ::std::enable_if_t<IsPositiveCondition == is_same_iterator_category<OutputIterator, IteratorTag>::value, void>
+    ::std::enable_if_t<IsPositiveCondition == is_same_iterator_category<OutputIterator, IteratorTag>::value>
     operator()(Policy&& exec, InputIterator input_iter, OutputIterator out_iter)
     {
         Op()(exec, input_iter, out_iter);
     }
 
     template <typename Policy, typename Iterator>
-    ::std::enable_if_t<IsPositiveCondition != is_same_iterator_category<Iterator, IteratorTag>::value, void>
+    ::std::enable_if_t<IsPositiveCondition != is_same_iterator_category<Iterator, IteratorTag>::value>
     operator()(Policy&& /*exec*/, Iterator /*iter*/)
     {
     }
 
     template <typename Policy, typename InputIterator, typename OutputIterator>
-    ::std::enable_if_t<IsPositiveCondition != is_same_iterator_category<OutputIterator, IteratorTag>::value, void>
+    ::std::enable_if_t<IsPositiveCondition != is_same_iterator_category<OutputIterator, IteratorTag>::value>
     operator()(Policy&& /*exec*/, InputIterator /*input_iter*/, OutputIterator /*out_iter*/)
     {
     }
@@ -359,7 +359,7 @@ struct iterator_invoker
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::bidirectional_iterator_tag, Iterator>::value, void>
+    ::std::enable_if_t<is_base_of_iterator_category<::std::bidirectional_iterator_tag, Iterator>::value>
     operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n,
         Iterator expected, Rest&&... rest)
     {
@@ -367,7 +367,7 @@ struct iterator_invoker
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value>
     operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n, Rest&&... rest)
     {
         invoke_if<Iterator>()(n <= sizeLimit, op, exec, make_iterator<Iterator>()(begin), n,
@@ -386,7 +386,7 @@ struct iterator_invoker
     }
 
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator, typename... Rest>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value, void>
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value>
     operator()(Policy&& exec, Op op, InputIterator inputBegin, InputIterator inputEnd, OutputIterator outputBegin,
                Rest&&... rest)
     {
@@ -396,7 +396,7 @@ struct iterator_invoker
     }
 
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator, typename... Rest>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value, void>
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value>
     operator()(Policy&& exec, Op op, InputIterator inputBegin, InputIterator inputEnd, OutputIterator outputBegin,
                OutputIterator outputEnd, Rest&&... rest)
     {
@@ -408,7 +408,7 @@ struct iterator_invoker
 
     template <typename Policy, typename Op, typename InputIterator1, typename InputIterator2, typename OutputIterator,
               typename... Rest>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value, void>
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value>
     operator()(Policy&& exec, Op op, InputIterator1 inputBegin1, InputIterator1 inputEnd1, InputIterator2 inputBegin2,
                InputIterator2 inputEnd2, OutputIterator outputBegin, OutputIterator outputEnd, Rest&&... rest)
     {
@@ -451,7 +451,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value>
     operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n, Rest&&... rest)
     {
         if (n <= sizeLimit)
@@ -459,7 +459,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value, void>
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value>
     operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n, Iterator expected,
         Rest&&... rest)
     {
@@ -468,7 +468,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    ::std::enable_if_t<is_same_iterator_category<Iterator, ::std::bidirectional_iterator_tag>::value, void>
+    ::std::enable_if_t<is_same_iterator_category<Iterator, ::std::bidirectional_iterator_tag>::value>
     operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n, Iterator expected, Rest&&... rest)
     {
         if (n <= sizeLimit)
@@ -487,7 +487,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     }
 
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator, typename... Rest>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value, void>
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value>
     operator()(Policy&& exec, Op op, InputIterator inputBegin, InputIterator inputEnd, OutputIterator outputBegin,
                Rest&&... rest)
     {
@@ -497,7 +497,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     }
 
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator, typename... Rest>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value, void>
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value>
     operator()(Policy&& exec, Op op, InputIterator inputBegin, InputIterator inputEnd, OutputIterator outputBegin,
                OutputIterator outputEnd, Rest&&... rest)
     {
@@ -509,7 +509,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
 
     template <typename Policy, typename Op, typename InputIterator1, typename InputIterator2, typename OutputIterator,
               typename... Rest>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value, void>
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value>
     operator()(Policy&& exec, Op op, InputIterator1 inputBegin1, InputIterator1 inputEnd1, InputIterator2 inputBegin2,
                InputIterator2 inputEnd2, OutputIterator outputBegin, OutputIterator outputEnd, Rest&&... rest)
     {

--- a/test/support/iterator_utils.h
+++ b/test/support/iterator_utils.h
@@ -339,8 +339,8 @@ struct iterator_invoker
 
     // A single iterator version which is used for non_const testcases
     template <typename Policy, typename Op, typename Iterator>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag,
-                                                    Iterator>::value && ::std::is_base_of<non_const_wrapper, Op>::value,
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
+                         ::std::is_base_of<non_const_wrapper, Op>::value,
                        void>
     operator()(Policy&& exec, Op op, Iterator iter)
     {
@@ -350,7 +350,7 @@ struct iterator_invoker
     // A version with 2 iterators which is used for non_const testcases
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator>
     ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value &&
-                           ::std::is_base_of<non_const_wrapper, Op>::value,
+                         ::std::is_base_of<non_const_wrapper, Op>::value,
                        void>
     operator()(Policy&& exec, Op op, InputIterator input_iter, OutputIterator out_iter)
     {
@@ -376,7 +376,7 @@ struct iterator_invoker
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
     ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
-                           !::std::is_base_of<non_const_wrapper, Op>::value,
+                         !::std::is_base_of<non_const_wrapper, Op>::value,
                        void>
     operator()(Policy&& exec, Op op, Iterator inputBegin, Iterator inputEnd, Rest&&... rest)
     {
@@ -431,8 +431,8 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
 
     // A single iterator version which is used for non_const testcases
     template <typename Policy, typename Op, typename Iterator>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag,
-                                                    Iterator>::value && ::std::is_base_of<non_const_wrapper, Op>::value,
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
+                         ::std::is_base_of<non_const_wrapper, Op>::value,
                        void>
     operator()(Policy&& exec, Op op, Iterator iter)
     {
@@ -441,8 +441,8 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
 
     // A version with 2 iterators which is used for non_const testcases
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value&& ::std::
-                           is_base_of<non_const_wrapper, Op>::value,
+    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value &&
+                         ::std::is_base_of<non_const_wrapper, Op>::value,
                        void>
     operator()(Policy&& exec, Op op, InputIterator input_iter, OutputIterator out_iter)
     {
@@ -477,7 +477,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
     ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
-                           !::std::is_base_of<non_const_wrapper, Op>::value,
+                         !::std::is_base_of<non_const_wrapper, Op>::value,
                        void>
     operator()(Policy&& exec, Op op, Iterator inputBegin, Iterator inputEnd, Rest&&... rest)
     {

--- a/test/support/reduce_serial_impl.h
+++ b/test/support/reduce_serial_impl.h
@@ -22,8 +22,8 @@ reduce_by_segment_serial(RandAccessItKeysIn keys, RandAccessItValsIn vals,
     if (n < 1)
         return 0;
     
-    using ValT = typename ::std::decay<decltype(vals[0])>::type;
-    using KeyT = typename ::std::decay<decltype(keys[0])>::type;
+    using ValT = ::std::decay_t<decltype(vals[0])>;
+    using KeyT = ::std::decay_t<decltype(keys[0])>;
     KeyT tmp_key = keys[0];
     ValT tmp_val = vals[0];
     Size segment_count = 0;

--- a/test/support/test_complex.h
+++ b/test/support/test_complex.h
@@ -68,7 +68,7 @@ run_test()
 // Example:
 //     template <class T>
 //     void
-//     test(T x, typename std::enable_if<std::is_integral<T>::value>::type* = 0)
+//     test(T x, ::std::enable_if_t<std::is_integral<T>::value>* = 0)
 //     {
 //         static_assert((std::is_same<decltype(dpl::conj(x)), dpl::complex<double>>::value), "");
 //

--- a/test/support/utils_invoke.h
+++ b/test/support/utils_invoke.h
@@ -28,7 +28,7 @@ template <sycl::usm::alloc alloc_type>
 constexpr ::std::size_t
 uniq_kernel_index()
 {
-    return static_cast<typename ::std::underlying_type<sycl::usm::alloc>::type>(alloc_type);
+    return static_cast<::std::underlying_type_t<sycl::usm::alloc>>(alloc_type);
 }
 
 template <typename Op, ::std::size_t CallNumber>

--- a/test/support/utils_invoke.h
+++ b/test/support/utils_invoke.h
@@ -35,7 +35,7 @@ template <typename Op, ::std::size_t CallNumber>
 struct unique_kernel_name;
 
 template <typename Policy, int idx>
-using new_kernel_name = unique_kernel_name<typename ::std::decay<Policy>::type, idx>;
+using new_kernel_name = unique_kernel_name<::std::decay_t<Policy>, idx>;
 
 /**
  * make_policy functions test wrappers

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -372,36 +372,28 @@ test4buffers(int mult = kDefaultMultValue)
 }
 
 template <sycl::usm::alloc alloc_type, typename TestName>
-typename ::std::enable_if<
-    ::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value,
-    void>::type
+::std::enable_if_t<::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value, void>
 test1buffer()
 {
     test1buffer<alloc_type, typename TestName::UsedValueType, TestName>();
 }
 
 template <sycl::usm::alloc alloc_type, typename TestName>
-typename ::std::enable_if<
-    ::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value,
-    void>::type
+::std::enable_if_t<::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value, void>
 test2buffers()
 {
     test2buffers<alloc_type, typename TestName::UsedValueType, TestName>();
 }
 
 template <sycl::usm::alloc alloc_type, typename TestName>
-typename ::std::enable_if<
-    ::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value,
-    void>::type
+::std::enable_if_t<::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value, void>
 test3buffers(int mult = kDefaultMultValue)
 {
     test3buffers<alloc_type, typename TestName::UsedValueType, TestName>(mult);
 }
 
 template <sycl::usm::alloc alloc_type, typename TestName>
-typename ::std::enable_if<
-    ::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value,
-    void>::type
+::std::enable_if_t<::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value, void>
 test4buffers(int mult = kDefaultMultValue)
 {
     test4buffers<alloc_type, typename TestName::UsedValueType, TestName>(mult);

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -96,10 +96,10 @@ template <typename _NewKernelName, typename _Policy,
           oneapi::dpl::__internal::__enable_if_fpga_execution_policy<_Policy, int> = 0>
 auto
 make_new_policy(_Policy&& __policy)
-    -> decltype(TestUtils::make_fpga_policy<::std::decay<_Policy>::type::unroll_factor, _NewKernelName>(
+    -> decltype(TestUtils::make_fpga_policy<::std::decay_t<_Policy>::unroll_factor, _NewKernelName>(
         ::std::forward<_Policy>(__policy)))
 {
-    return TestUtils::make_fpga_policy<::std::decay<_Policy>::type::unroll_factor, _NewKernelName>(
+    return TestUtils::make_fpga_policy<::std::decay_t<_Policy>::unroll_factor, _NewKernelName>(
         ::std::forward<_Policy>(__policy));
 }
 #endif

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -372,28 +372,28 @@ test4buffers(int mult = kDefaultMultValue)
 }
 
 template <sycl::usm::alloc alloc_type, typename TestName>
-::std::enable_if_t<::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value, void>
+::std::enable_if_t<::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value>
 test1buffer()
 {
     test1buffer<alloc_type, typename TestName::UsedValueType, TestName>();
 }
 
 template <sycl::usm::alloc alloc_type, typename TestName>
-::std::enable_if_t<::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value, void>
+::std::enable_if_t<::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value>
 test2buffers()
 {
     test2buffers<alloc_type, typename TestName::UsedValueType, TestName>();
 }
 
 template <sycl::usm::alloc alloc_type, typename TestName>
-::std::enable_if_t<::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value, void>
+::std::enable_if_t<::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value>
 test3buffers(int mult = kDefaultMultValue)
 {
     test3buffers<alloc_type, typename TestName::UsedValueType, TestName>(mult);
 }
 
 template <sycl::usm::alloc alloc_type, typename TestName>
-::std::enable_if_t<::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value, void>
+::std::enable_if_t<::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value>
 test4buffers(int mult = kDefaultMultValue)
 {
     test4buffers<alloc_type, typename TestName::UsedValueType, TestName>(mult);

--- a/test/support/utils_test_base.h
+++ b/test/support/utils_test_base.h
@@ -420,6 +420,7 @@ create_test_obj(TestBaseData&)
 //--------------------------------------------------------------------------------------------------------------------//
 // Used with algorithms that have two input sequences and one output sequences
 template <typename T, typename TestName>
+//::std::enable_if_t<::std::is_base_of<test_base<T>, TestName>::value>
 void
 test_algo_three_sequences()
 {
@@ -456,6 +457,7 @@ test_algo_three_sequences()
 //--------------------------------------------------------------------------------------------------------------------//
 // Used with algorithms that have two input sequences and two output sequencess
 template <typename T, typename TestName>
+//::std::enable_if_t<::std::is_base_of<test_base<T>, TestName>::value>
 void
 test_algo_four_sequences()
 {

--- a/test/support/utils_test_base.h
+++ b/test/support/utils_test_base.h
@@ -456,7 +456,6 @@ test_algo_three_sequences()
 //--------------------------------------------------------------------------------------------------------------------//
 // Used with algorithms that have two input sequences and two output sequencess
 template <typename T, typename TestName>
-//::std::enable_if_t<::std::is_base_of<test_base<T>, TestName>::value>
 void
 test_algo_four_sequences()
 {

--- a/test/support/utils_test_base.h
+++ b/test/support/utils_test_base.h
@@ -447,7 +447,7 @@ test_algo_three_sequences()
 
 //--------------------------------------------------------------------------------------------------------------------//
 template <typename TestName>
-::std::enable_if_t<::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value, void>
+::std::enable_if_t<::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value>
 test_algo_three_sequences()
 {
     test_algo_three_sequences<typename TestName::UsedValueType, TestName>();
@@ -456,7 +456,7 @@ test_algo_three_sequences()
 //--------------------------------------------------------------------------------------------------------------------//
 // Used with algorithms that have two input sequences and two output sequencess
 template <typename T, typename TestName>
-//::std::enable_if_t<::std::is_base_of<test_base<T>, TestName>::value, void>
+//::std::enable_if_t<::std::is_base_of<test_base<T>, TestName>::value>
 void
 test_algo_four_sequences()
 {
@@ -487,7 +487,7 @@ test_algo_four_sequences()
 
 //--------------------------------------------------------------------------------------------------------------------//
 template <typename TestName>
-::std::enable_if_t<::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value, void>
+::std::enable_if_t<::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value>
 test_algo_four_sequences()
 {
     test_algo_four_sequences<typename TestName::UsedValueType, TestName>();

--- a/test/support/utils_test_base.h
+++ b/test/support/utils_test_base.h
@@ -404,14 +404,14 @@ void update_data(TTestDataTransfer& helper, Args&& ...args)
 
 //--------------------------------------------------------------------------------------------------------------------//
 template <typename T, typename TestName, typename TestBaseData>
-typename ::std::enable_if<::std::is_base_of<test_base<T>, TestName>::value, TestName>::type
+::std::enable_if_t<::std::is_base_of<test_base<T>, TestName>::value, TestName>
 create_test_obj(TestBaseData& data)
 {
     return TestName(data);
 }
 
 template <typename T, typename TestName, typename TestBaseData>
-typename ::std::enable_if<!::std::is_base_of<test_base<T>, TestName>::value, TestName>::type
+::std::enable_if_t<!::std::is_base_of<test_base<T>, TestName>::value, TestName>
 create_test_obj(TestBaseData&)
 {
     return TestName();
@@ -420,7 +420,6 @@ create_test_obj(TestBaseData&)
 //--------------------------------------------------------------------------------------------------------------------//
 // Used with algorithms that have two input sequences and one output sequences
 template <typename T, typename TestName>
-//typename ::std::enable_if<::std::is_base_of<test_base<T>, TestName>::value, void>::type
 void
 test_algo_three_sequences()
 {
@@ -448,9 +447,7 @@ test_algo_three_sequences()
 
 //--------------------------------------------------------------------------------------------------------------------//
 template <typename TestName>
-typename ::std::enable_if<
-    ::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value,
-    void>::type
+::std::enable_if_t<::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value, void>
 test_algo_three_sequences()
 {
     test_algo_three_sequences<typename TestName::UsedValueType, TestName>();
@@ -459,7 +456,6 @@ test_algo_three_sequences()
 //--------------------------------------------------------------------------------------------------------------------//
 // Used with algorithms that have two input sequences and two output sequencess
 template <typename T, typename TestName>
-//typename ::std::enable_if<::std::is_base_of<test_base<T>, TestName>::value, void>::type
 void
 test_algo_four_sequences()
 {
@@ -490,9 +486,7 @@ test_algo_four_sequences()
 
 //--------------------------------------------------------------------------------------------------------------------//
 template <typename TestName>
-typename ::std::enable_if<
-    ::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value,
-    void>::type
+::std::enable_if_t<::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value, void>
 test_algo_four_sequences()
 {
     test_algo_four_sequences<typename TestName::UsedValueType, TestName>();

--- a/test/support/utils_test_base.h
+++ b/test/support/utils_test_base.h
@@ -456,6 +456,7 @@ test_algo_three_sequences()
 //--------------------------------------------------------------------------------------------------------------------//
 // Used with algorithms that have two input sequences and two output sequencess
 template <typename T, typename TestName>
+//::std::enable_if_t<::std::is_base_of<test_base<T>, TestName>::value, void>
 void
 test_algo_four_sequences()
 {

--- a/test/support/utils_test_base.h
+++ b/test/support/utils_test_base.h
@@ -43,9 +43,9 @@ enum class UDTKind
 template <typename TEnum>
 auto
 enum_val_to_index(TEnum enumVal)
-    -> decltype(static_cast<typename ::std::underlying_type<TEnum>::type>(enumVal))
+    -> decltype(static_cast<::std::underlying_type_t<TEnum>>(enumVal))
 {
-    return static_cast<typename ::std::underlying_type<TEnum>::type>(enumVal);
+    return static_cast<::std::underlying_type_t<TEnum>>(enumVal);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/test/xpu_api/numerics/c.math/abs1.pass.cpp
+++ b/test/xpu_api/numerics/c.math/abs1.pass.cpp
@@ -18,7 +18,7 @@
 template<class T>
 struct correct_size_int
 {
-    typedef typename std::conditional<sizeof(T) < sizeof(int), int, T>::type type;
+    typedef std::conditional_t<sizeof(T) < sizeof(int), int, T> type;
 };
 
 template <class Source, class Result>
@@ -48,9 +48,7 @@ ONEDPL_TEST_NUM_MAIN
 {
     // On some systems char is unsigned.
     // If that is the case, we should just test signed char twice.
-    typedef std::conditional<
-        std::is_signed<char>::value, char, signed char
-    >::type SignedChar;
+    typedef ::std::conditional_t<std::is_signed<char>::value, char, signed char> SignedChar;
 
     // All types less than or equal to and not greater than int are promoted to int.
     test_abs<short int, int>();

--- a/test/xpu_api/numerics/complex.number/cases.h
+++ b/test/xpu_api/numerics/complex.number/cases.h
@@ -234,14 +234,14 @@ template <typename T>
 constexpr auto __tol = std::numeric_limits<T>::epsilon() * 1e5;
 
 template <typename X, typename Y>
-typename std::enable_if<!std::numeric_limits<X>::is_integer || !std::numeric_limits<Y>::is_integer, void>::type
+::std::enable_if_t<!std::numeric_limits<X>::is_integer || !std::numeric_limits<Y>::is_integer, void>
 is_about(X x, Y y, const X eps = __tol<X>)
 {
     assert(std::fabs(x - y) <= eps);
 }
 
 template <typename T>
-typename std::enable_if<!std::numeric_limits<T>::is_integer, void>::type
+::std::enable_if_t<!std::numeric_limits<T>::is_integer, void>
 is_about(const dpl::complex<T>& x, const dpl::complex<T>& y, const T eps = __tol<T>)
 {
     return is_about(::std::abs(y - x), T(0.), eps);

--- a/test/xpu_api/numerics/complex.number/cases.h
+++ b/test/xpu_api/numerics/complex.number/cases.h
@@ -234,14 +234,14 @@ template <typename T>
 constexpr auto __tol = std::numeric_limits<T>::epsilon() * 1e5;
 
 template <typename X, typename Y>
-::std::enable_if_t<!std::numeric_limits<X>::is_integer || !std::numeric_limits<Y>::is_integer, void>
+::std::enable_if_t<!std::numeric_limits<X>::is_integer || !std::numeric_limits<Y>::is_integer>
 is_about(X x, Y y, const X eps = __tol<X>)
 {
     assert(std::fabs(x - y) <= eps);
 }
 
 template <typename T>
-::std::enable_if_t<!std::numeric_limits<T>::is_integer, void>
+::std::enable_if_t<!std::numeric_limits<T>::is_integer>
 is_about(const dpl::complex<T>& x, const dpl::complex<T>& y, const T eps = __tol<T>)
 {
     return is_about(::std::abs(y - x), T(0.), eps);

--- a/test/xpu_api/numerics/complex.number/cmplx.over/arg.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/arg.pass.cpp
@@ -20,7 +20,7 @@
 
 template <class T>
 void
-test(T x, typename std::enable_if<std::is_integral<T>::value>::type* = 0)
+test(T x, ::std::enable_if_t<std::is_integral<T>::value>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::arg(x)), double>::value), "");
     assert(dpl::arg(x) == dpl::arg(dpl::complex<double>(static_cast<double>(x), 0)));
@@ -28,7 +28,7 @@ test(T x, typename std::enable_if<std::is_integral<T>::value>::type* = 0)
 
 template <class T>
 void
-test(T x, typename std::enable_if<!std::is_integral<T>::value>::type* = 0)
+test(T x, ::std::enable_if_t<!std::is_integral<T>::value>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::arg(x)), T>::value), "");
     assert(dpl::arg(x) == dpl::arg(dpl::complex<T>(x, 0)));

--- a/test/xpu_api/numerics/complex.number/cmplx.over/conj.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/conj.pass.cpp
@@ -20,7 +20,7 @@
 
 template <class T>
 void
-test(T x, typename std::enable_if<std::is_integral<T>::value>::type* = 0)
+test(T x, ::std::enable_if_t<std::is_integral<T>::value>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::conj(x)), dpl::complex<double> >::value), "");
     assert(dpl::conj(x) == dpl::conj(dpl::complex<double>(x, 0)));
@@ -28,7 +28,7 @@ test(T x, typename std::enable_if<std::is_integral<T>::value>::type* = 0)
 
 template <class T>
 void
-test(T x, typename std::enable_if<std::is_floating_point<T>::value>::type* = 0)
+test(T x, ::std::enable_if_t<std::is_floating_point<T>::value>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::conj(x)), dpl::complex<T>>::value), "");
     assert(dpl::conj(x) == dpl::conj(dpl::complex<T>(x, 0)));
@@ -36,8 +36,7 @@ test(T x, typename std::enable_if<std::is_floating_point<T>::value>::type* = 0)
 
 template <class T>
 void
-test(T x, typename std::enable_if<!std::is_integral<T>::value &&
-                                  !std::is_floating_point<T>::value>::type* = 0)
+test(T x, ::std::enable_if_t<!std::is_integral<T>::value && !std::is_floating_point<T>::value>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::conj(x)), dpl::complex<T>>::value), "");
     assert(dpl::conj(x) == dpl::conj(dpl::complex<T>(x, 0)));

--- a/test/xpu_api/numerics/complex.number/cmplx.over/imag.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/imag.pass.cpp
@@ -18,7 +18,7 @@
 
 template <class T, int x>
 void
-test(typename std::enable_if<std::is_integral<T>::value>::type* = 0)
+test(::std::enable_if_t<std::is_integral<T>::value>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::imag(T(x))), double>::value), "");
     assert(dpl::imag(x) == 0);
@@ -31,7 +31,7 @@ test(typename std::enable_if<std::is_integral<T>::value>::type* = 0)
 
 template <class T, int x>
 void
-test(typename std::enable_if<!std::is_integral<T>::value>::type* = 0)
+test(::std::enable_if_t<!std::is_integral<T>::value>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::imag(T(x))), T>::value), "");
     assert(dpl::imag(x) == 0);

--- a/test/xpu_api/numerics/complex.number/cmplx.over/norm.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/norm.pass.cpp
@@ -18,7 +18,7 @@
 
 template <class T>
 void
-test(T x, typename std::enable_if<std::is_integral<T>::value>::type* = 0)
+test(T x, ::std::enable_if_t<std::is_integral<T>::value>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::norm(x)), double>::value), "");
     assert(dpl::norm(x) == dpl::norm(dpl::complex<double>(static_cast<double>(x), 0)));
@@ -26,7 +26,7 @@ test(T x, typename std::enable_if<std::is_integral<T>::value>::type* = 0)
 
 template <class T>
 void
-test(T x, typename std::enable_if<!std::is_integral<T>::value>::type* = 0)
+test(T x, ::std::enable_if_t<!std::is_integral<T>::value>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::norm(x)), T>::value), "");
     assert(dpl::norm(x) == dpl::norm(dpl::complex<T>(x, 0)));

--- a/test/xpu_api/numerics/complex.number/cmplx.over/pow.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/pow.pass.cpp
@@ -28,7 +28,7 @@
 
 template <class T>
 double
-promote(T, typename std::enable_if<std::is_integral<T>::value>::type* = 0);
+promote(T, ::std::enable_if_t<std::is_integral<T>::value>* = 0);
 
 float promote(float);
 double promote(double);
@@ -63,7 +63,7 @@ test(const dpl::complex<T>& x, const dpl::complex<U>& y)
 
 template <class T, class U>
 void
-test(typename std::enable_if<std::is_integral<T>::value>::type* = 0, typename std::enable_if<!std::is_integral<U>::value>::type* = 0)
+test(::std::enable_if_t<std::is_integral<T>::value>* = 0, ::std::enable_if_t<!std::is_integral<U>::value>* = 0)
 {
     test(T(3), dpl::complex<U>(4, 5));
     test(dpl::complex<U>(3, 4), T(5));
@@ -71,7 +71,7 @@ test(typename std::enable_if<std::is_integral<T>::value>::type* = 0, typename st
 
 template <class T, class U>
 void
-test(typename std::enable_if<!std::is_integral<T>::value>::type* = 0, typename std::enable_if<!std::is_integral<U>::value>::type* = 0)
+test(::std::enable_if_t<!std::is_integral<T>::value>* = 0, ::std::enable_if_t<!std::is_integral<U>::value>* = 0)
 {
     test(T(3), dpl::complex<U>(4, 5));
     test(dpl::complex<T>(3, 4), U(5));

--- a/test/xpu_api/numerics/complex.number/cmplx.over/proj.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/proj.pass.cpp
@@ -20,7 +20,7 @@
 
 template <class T>
 void
-test(T x, typename std::enable_if<std::is_integral<T>::value>::type* = 0)
+test(T x, ::std::enable_if_t<std::is_integral<T>::value>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::proj(x)), dpl::complex<double> >::value), "");
     assert(dpl::proj(x) == dpl::proj(dpl::complex<double>(x, 0)));
@@ -28,7 +28,7 @@ test(T x, typename std::enable_if<std::is_integral<T>::value>::type* = 0)
 
 template <class T>
 void
-test(T x, typename std::enable_if<std::is_floating_point<T>::value>::type* = 0)
+test(T x, ::std::enable_if_t<std::is_floating_point<T>::value>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::proj(x)), dpl::complex<T> >::value), "");
     assert(dpl::proj(x) == dpl::proj(dpl::complex<T>(x, 0)));
@@ -36,8 +36,7 @@ test(T x, typename std::enable_if<std::is_floating_point<T>::value>::type* = 0)
 
 template <class T>
 void
-test(T x, typename std::enable_if<!std::is_integral<T>::value &&
-                                  !std::is_floating_point<T>::value>::type* = 0)
+test(T x, ::std::enable_if_t<!std::is_integral<T>::value && !std::is_floating_point<T>::value>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::proj(x)), dpl::complex<T> >::value), "");
     assert(dpl::proj(x) == dpl::proj(dpl::complex<T>(x, 0)));

--- a/test/xpu_api/numerics/complex.number/cmplx.over/real.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/real.pass.cpp
@@ -18,7 +18,7 @@
 
 template <class T, int x>
 void
-test(typename std::enable_if<std::is_integral<T>::value>::type* = 0)
+test(::std::enable_if_t<std::is_integral<T>::value>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::real(T(x))), double>::value), "");
     assert(dpl::real(x) == x);
@@ -31,7 +31,7 @@ test(typename std::enable_if<std::is_integral<T>::value>::type* = 0)
 
 template <class T, int x>
 void
-test(typename std::enable_if<!std::is_integral<T>::value>::type* = 0)
+test(::std::enable_if_t<!std::is_integral<T>::value>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::real(T(x))), T>::value), "");
     assert(dpl::real(x) == x);

--- a/test/xpu_api/random/interface_tests/distributions_methods.pass.cpp
+++ b/test/xpu_api/random/interface_tests/distributions_methods.pass.cpp
@@ -166,7 +166,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::bernoulli_distribution<typename Distr::result_type>>::value, void>
+::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::bernoulli_distribution<typename Distr::result_type>>::value>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{0.5};
@@ -174,7 +174,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::geometric_distribution<typename Distr::result_type>>::value, void>
+::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::geometric_distribution<typename Distr::result_type>>::value>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{0.5};
@@ -182,7 +182,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::weibull_distribution<typename Distr::result_type>>::value, void>
+::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::weibull_distribution<typename Distr::result_type>>::value>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{1.5, 3.0};
@@ -190,7 +190,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::lognormal_distribution<typename Distr::result_type>>::value, void>
+::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::lognormal_distribution<typename Distr::result_type>>::value>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{1.5, 3.5};
@@ -198,7 +198,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::normal_distribution<typename Distr::result_type>>::value, void>
+::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::normal_distribution<typename Distr::result_type>>::value>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{1.5, 3.5};
@@ -206,7 +206,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::cauchy_distribution<typename Distr::result_type>>::value, void>
+::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::cauchy_distribution<typename Distr::result_type>>::value>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{1.5, 3.5};

--- a/test/xpu_api/random/interface_tests/distributions_methods.pass.cpp
+++ b/test/xpu_api/random/interface_tests/distributions_methods.pass.cpp
@@ -139,8 +139,7 @@ check_params(oneapi::dpl::extreme_value_distribution<T>& distr)
 }
 
 template <typename Distr>
-::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::uniform_int_distribution<typename Distr::result_type>>::value,
-                   void>
+::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::uniform_int_distribution<typename Distr::result_type>>::value>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{0, 10};
@@ -148,8 +147,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::uniform_real_distribution<typename Distr::result_type>>::value,
-                   void>
+::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::uniform_real_distribution<typename Distr::result_type>>::value>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{1.5, 3.0};
@@ -157,8 +155,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::exponential_distribution<typename Distr::result_type>>::value,
-                   void>
+::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::exponential_distribution<typename Distr::result_type>>::value>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{1.5};
@@ -214,8 +211,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::extreme_value_distribution<typename Distr::result_type>>::value,
-                   void>
+::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::extreme_value_distribution<typename Distr::result_type>>::value>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{1.5, 3.5};

--- a/test/xpu_api/random/interface_tests/distributions_methods.pass.cpp
+++ b/test/xpu_api/random/interface_tests/distributions_methods.pass.cpp
@@ -139,8 +139,8 @@ check_params(oneapi::dpl::extreme_value_distribution<T>& distr)
 }
 
 template <typename Distr>
-typename ::std::enable_if<::std::is_same<Distr,
-        oneapi::dpl::uniform_int_distribution<typename Distr::result_type>>::value, void>::type
+::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::uniform_int_distribution<typename Distr::result_type>>::value,
+                   void>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{0, 10};
@@ -148,8 +148,8 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-typename ::std::enable_if<::std::is_same<Distr, 
-        oneapi::dpl::uniform_real_distribution<typename Distr::result_type>>::value, void>::type
+::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::uniform_real_distribution<typename Distr::result_type>>::value,
+                   void>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{1.5, 3.0};
@@ -157,8 +157,8 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-typename ::std::enable_if<::std::is_same<Distr, 
-        oneapi::dpl::exponential_distribution<typename Distr::result_type>>::value, void>::type
+::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::exponential_distribution<typename Distr::result_type>>::value,
+                   void>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{1.5};
@@ -166,8 +166,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-typename ::std::enable_if<::std::is_same<Distr, 
-        oneapi::dpl::bernoulli_distribution<typename Distr::result_type>>::value, void>::type
+::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::bernoulli_distribution<typename Distr::result_type>>::value, void>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{0.5};
@@ -175,8 +174,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-typename ::std::enable_if<::std::is_same<Distr, 
-        oneapi::dpl::geometric_distribution<typename Distr::result_type>>::value, void>::type
+::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::geometric_distribution<typename Distr::result_type>>::value, void>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{0.5};
@@ -184,8 +182,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-typename ::std::enable_if<::std::is_same<Distr, 
-        oneapi::dpl::weibull_distribution<typename Distr::result_type>>::value, void>::type
+::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::weibull_distribution<typename Distr::result_type>>::value, void>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{1.5, 3.0};
@@ -193,8 +190,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-typename ::std::enable_if<::std::is_same<Distr, 
-        oneapi::dpl::lognormal_distribution<typename Distr::result_type>>::value, void>::type
+::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::lognormal_distribution<typename Distr::result_type>>::value, void>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{1.5, 3.5};
@@ -202,8 +198,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-typename ::std::enable_if<::std::is_same<Distr, 
-        oneapi::dpl::normal_distribution<typename Distr::result_type>>::value, void>::type
+::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::normal_distribution<typename Distr::result_type>>::value, void>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{1.5, 3.5};
@@ -211,8 +206,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-typename ::std::enable_if<::std::is_same<Distr, 
-        oneapi::dpl::cauchy_distribution<typename Distr::result_type>>::value, void>::type
+::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::cauchy_distribution<typename Distr::result_type>>::value, void>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{1.5, 3.5};
@@ -220,8 +214,8 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-typename ::std::enable_if<::std::is_same<Distr, 
-        oneapi::dpl::extreme_value_distribution<typename Distr::result_type>>::value, void>::type
+::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::extreme_value_distribution<typename Distr::result_type>>::value,
+                   void>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{1.5, 3.5};


### PR DESCRIPTION
It's part 1/3 of linked PR's:
 - part 2 : #1173
 - part 3 : #1174

In this PR we make oneDPL code cleanup and simplification using STL features supported in C++17:
- remove ```void_type<T>``` from namespace ```oneapi::dpl::unseq_backend``` as unused;
- remove ```non_void_type<T>``` from namespace ```oneapi::dpl::unseq_backend``` as unused;
- remove ```void``` type from ```::std::enable_if<condition, void>```;
- remove ```std::decay_t``` from policy check like ```__enable_if_host_execution_policy<:::std::decay_t<Policy>>``` and so on;
- remove ```::type``` part - use helper types.
- inserted default type ```= void``` for some type aliases:
```template <class _ExecPolicy, class _T = void> using __enable_if_execution_policy```
```template <class _ExecPolicy, class _T = void> using __enable_if_host_execution_policy```
```template <class _ExecPolicy, const bool __condition, class _T = void> using __enable_if_host_execution_policy_conditional```
```template <typename _ExecPolicy, typename _T = void> using __enable_if_hetero_execution_policy```
```template <typename _ExecPolicy, typename _T = void> using __enable_if_fpga_execution_policy```
```template <typename ExecutionPolicy, typename T = void> using test_enable_if_execution_policy```
so we remove ```, void``` as last template param from calls.

| Previous variant | New variant | C++ | oneDPL | Tests |
|-------------------|--------------|-----------------------------------------|---|---|
| ```typename ::std::common_type<X>::type``` | ```::std::common_type_t<X>``` |  14 | + |  |
| ```typename ::std::conditional<X>::type``` | ```::std::conditional_t<X>``` | 14 | + | + |
| ```typename ::std::decay<X>::type``` | ```::std::decay_t<X>``` | 11 | + | + |
| ```typename ::std::enable_if<X>::type``` | ```::std::enable_if_t<X>``` | 14 | + | + |
| ```typename ::std::make_signed<X>::type``` | ```::std::make_signed_t<X>``` | 14 | + | + |
| ```typename ::std::make_unsigned<X>::type``` | ```::std::make_unsigned_t<X>``` | 14 | + |  |
| ```typename ::std::remove_cv<X>::type``` | ```::std::remove_cv_t<X>``` | 14 | + |  |
| ```typename ::std::remove_pointer<X>::type``` | ```::std::remove_pointer_t<X>``` | 14 | + |  |
| ```typename ::std::remove_reference<X>::type``` | ```::std::remove_reference_t<X>``` | 14 | + |  |
| ```typename ::std::tuple_element<X>::type``` | ```::std::tuple_element_t<X>``` | 14 | + |  |
| ```typename ::std::underlying_type<X>::type``` | ```::std::underlying_type_t<X>``` | 14 |  | + |
