### PR TITLE
oneDPL code cleanup and simplification - values

### DIFF
--- a/include/oneapi/dpl/internal/gcd_impl.h
+++ b/include/oneapi/dpl/internal/gcd_impl.h
@@ -63,10 +63,9 @@ template <typename _Mn, typename _Nn>
 constexpr ::std::common_type_t<_Mn, _Nn>
 gcd(_Mn __m, _Nn __n)
 {
-    static_assert((::std::is_integral<_Mn>::value && ::std::is_integral<_Nn>::value),
-                  "Arguments to gcd must be integer types");
-    static_assert((!::std::is_same<::std::remove_cv_t<_Mn>, bool>::value), "First argument to gcd cannot be bool");
-    static_assert((!::std::is_same<::std::remove_cv_t<_Nn>, bool>::value), "Second argument to gcd cannot be bool");
+    static_assert((::std::is_integral_v<_Mn> && ::std::is_integral_v<_Nn>), "Arguments to gcd must be integer types");
+    static_assert((!::std::is_same_v<::std::remove_cv_t<_Mn>, bool>), "First argument to gcd cannot be bool");
+    static_assert((!::std::is_same_v<::std::remove_cv_t<_Nn>, bool>), "Second argument to gcd cannot be bool");
     using _Rp = ::std::common_type_t<_Mn, _Nn>;
     using _Wp = ::std::make_unsigned_t<_Rp>;
     _Wp __m1 = static_cast<_Wp>(oneapi::dpl::internal::__get_abs<_Rp>(__m));
@@ -86,10 +85,9 @@ template <typename _Mn, typename _Nn>
 constexpr ::std::common_type_t<_Mn, _Nn>
 lcm(_Mn __m, _Nn __n)
 {
-    static_assert((::std::is_integral<_Mn>::value && ::std::is_integral<_Nn>::value),
-                  "Arguments to lcm must be integer types");
-    static_assert((!::std::is_same<::std::remove_cv_t<_Mn>, bool>::value), "First argument to lcm cannot be bool");
-    static_assert((!::std::is_same<::std::remove_cv_t<_Nn>, bool>::value), "Second argument to lcm cannot be bool");
+    static_assert((::std::is_integral_v<_Mn> && ::std::is_integral_v<_Nn>), "Arguments to lcm must be integer types");
+    static_assert((!::std::is_same_v<::std::remove_cv_t<_Mn>, bool>), "First argument to lcm cannot be bool");
+    static_assert((!::std::is_same_v<::std::remove_cv_t<_Nn>, bool>), "Second argument to lcm cannot be bool");
     if (__m == 0 || __n == 0)
         return 0;
     using _Rp = ::std::common_type_t<_Mn, _Nn>;

--- a/include/oneapi/dpl/internal/random_impl/bernoulli_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/bernoulli_distribution.h
@@ -133,7 +133,7 @@ class bernoulli_distribution
     static constexpr int size_of_type_ = internal::type_traits_t<result_type>::num_elems;
 
     // Static asserts
-    static_assert(::std::is_same<scalar_type, bool>::value,
+    static_assert(::std::is_same_v<scalar_type, bool>,
                   "oneapi::dpl::bernoulli_distribution. Error: unsupported data type");
 
     // Distribution parameters

--- a/include/oneapi/dpl/internal/random_impl/cauchy_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/cauchy_distribution.h
@@ -146,7 +146,7 @@ class cauchy_distribution
     static constexpr int size_of_type_ = internal::type_traits_t<result_type>::num_elems;
 
     // Static asserts
-    static_assert(::std::is_floating_point<scalar_type>::value,
+    static_assert(::std::is_floating_point_v<scalar_type>,
                   "oneapi::dpl::cauchy_distribution. Error: unsupported data type");
 
     // Distribution parameters

--- a/include/oneapi/dpl/internal/random_impl/exponential_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/exponential_distribution.h
@@ -133,7 +133,7 @@ class exponential_distribution
     static constexpr int size_of_type_ = internal::type_traits_t<result_type>::num_elems;
 
     // Static asserts
-    static_assert(::std::is_floating_point<scalar_type>::value,
+    static_assert(::std::is_floating_point_v<scalar_type>,
                   "oneapi::dpl::exponential_distribution. Error: unsupported data type");
 
     // Distribution parameters

--- a/include/oneapi/dpl/internal/random_impl/extreme_value_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/extreme_value_distribution.h
@@ -146,7 +146,7 @@ class extreme_value_distribution
     static constexpr int size_of_type_ = internal::type_traits_t<result_type>::num_elems;
 
     // Static asserts
-    static_assert(::std::is_floating_point<scalar_type>::value,
+    static_assert(::std::is_floating_point_v<scalar_type>,
                   "oneapi::dpl::extreme_value_distribution. Error: unsupported data type");
 
     // Distribution parameters

--- a/include/oneapi/dpl/internal/random_impl/geometric_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/geometric_distribution.h
@@ -133,7 +133,7 @@ class geometric_distribution
     static constexpr int size_of_type_ = internal::type_traits_t<result_type>::num_elems;
 
     // Static asserts
-    static_assert(::std::is_integral<scalar_type>::value,
+    static_assert(::std::is_integral_v<scalar_type>,
                   "oneapi::dpl::geometric_distribution. Error: unsupported data type");
 
     // Distribution parameters

--- a/include/oneapi/dpl/internal/random_impl/lognormal_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/lognormal_distribution.h
@@ -152,7 +152,7 @@ class lognormal_distribution
     using normal_distr_param_type = typename normal_distr::param_type;
 
     // Static asserts
-    static_assert(::std::is_floating_point<scalar_type>::value,
+    static_assert(::std::is_floating_point_v<scalar_type>,
                   "oneapi::dpl::lognormal_distribution. Error: unsupported data type");
 
     // Distribution parameters

--- a/include/oneapi/dpl/internal/random_impl/normal_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/normal_distribution.h
@@ -176,7 +176,7 @@ class normal_distribution
     scalar_type saved_u2_;
 
     // Static asserts
-    static_assert(::std::is_floating_point<scalar_type>::value,
+    static_assert(::std::is_floating_point_v<scalar_type>,
                   "oneapi::dpl::normal_distribution. Error: unsupported data type");
 
     // Real distribution for the conversion

--- a/include/oneapi/dpl/internal/random_impl/uniform_int_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/uniform_int_distribution.h
@@ -154,7 +154,7 @@ class uniform_int_distribution
     using RealType = ::std::conditional_t<size_of_type_ == 0, double, sycl::vec<double, size_of_type_>>;
 
     // Static asserts
-    static_assert(::std::is_integral<scalar_type>::value,
+    static_assert(::std::is_integral_v<scalar_type>,
                   "oneapi::dpl::uniform_int_distribution. Error: unsupported data type");
 
     // Distribution parameters

--- a/include/oneapi/dpl/internal/random_impl/uniform_real_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/uniform_real_distribution.h
@@ -149,7 +149,7 @@ class uniform_real_distribution
     static constexpr int size_of_type_ = internal::type_traits_t<result_type>::num_elems;
 
     // Static asserts
-    static_assert(::std::is_floating_point<scalar_type>::value,
+    static_assert(::std::is_floating_point_v<scalar_type>,
                   "oneapi::dpl::uniform_real_distribution. Error: unsupported data type");
 
     // Distribution parameters

--- a/include/oneapi/dpl/internal/random_impl/weibull_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/weibull_distribution.h
@@ -146,7 +146,7 @@ class weibull_distribution
     static constexpr int size_of_type_ = internal::type_traits_t<result_type>::num_elems;
 
     // Static asserts
-    static_assert(::std::is_floating_point<scalar_type>::value,
+    static_assert(::std::is_floating_point_v<scalar_type>,
                   "oneapi::dpl::weibull_distribution. Error: unsupported data type");
 
     // Distribution parameters

--- a/include/oneapi/dpl/pstl/execution_defs.h
+++ b/include/oneapi/dpl/pstl/execution_defs.h
@@ -177,8 +177,8 @@ struct __is_host_execution_policy<oneapi::dpl::execution::unsequenced_policy> : 
 };
 
 template <class _ExecPolicy, class _T = void>
-using __enable_if_execution_policy = ::std::enable_if_t<
-    oneapi::dpl::execution::is_execution_policy_v<::std::decay_t<_ExecPolicy>>, _T>;
+using __enable_if_execution_policy =
+    ::std::enable_if_t<oneapi::dpl::execution::is_execution_policy_v<::std::decay_t<_ExecPolicy>>, _T>;
 
 template <class _ExecPolicy, class _T = void>
 using __enable_if_host_execution_policy =

--- a/include/oneapi/dpl/pstl/execution_defs.h
+++ b/include/oneapi/dpl/pstl/execution_defs.h
@@ -177,8 +177,8 @@ struct __is_host_execution_policy<oneapi::dpl::execution::unsequenced_policy> : 
 };
 
 template <class _ExecPolicy, class _T = void>
-using __enable_if_execution_policy =
-    ::std::enable_if_t<oneapi::dpl::execution::is_execution_policy<::std::decay_t<_ExecPolicy>>::value, _T>;
+using __enable_if_execution_policy = ::std::enable_if_t<
+    oneapi::dpl::execution::is_execution_policy_v<::std::decay_t<_ExecPolicy>>, _T>;
 
 template <class _ExecPolicy, class _T = void>
 using __enable_if_host_execution_policy =

--- a/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
@@ -228,8 +228,8 @@ __pattern_for_loop(_ExecutionPolicy&& __exec, _Ip __first, _Ip __last, _Function
 }
 
 template <typename _Ip, typename _Function, typename _Sp, typename _Pack, typename _IndexType>
-::std::enable_if_t<::std::is_same<typename oneapi::dpl::__internal::__iterator_traits<_Ip>::iterator_category,
-                                  ::std::bidirectional_iterator_tag>::value,
+::std::enable_if_t<::std::is_same_v<typename oneapi::dpl::__internal::__iterator_traits<_Ip>::iterator_category,
+                                    ::std::bidirectional_iterator_tag>,
                    _IndexType>
 __execute_loop_strided(_Ip __first, _Ip __last, _Function __f, _Sp __stride, _Pack& __pack, _IndexType) noexcept
 {
@@ -265,10 +265,10 @@ __execute_loop_strided(_Ip __first, _Ip __last, _Function __f, _Sp __stride, _Pa
 }
 
 template <typename _Ip, typename _Function, typename _Sp, typename _Pack, typename _IndexType>
-::std::enable_if_t<::std::is_same<typename oneapi::dpl::__internal::__iterator_traits<_Ip>::iterator_category,
-                                  ::std::forward_iterator_tag>::value ||
-                       ::std::is_same<typename oneapi::dpl::__internal::__iterator_traits<_Ip>::iterator_category,
-                                      ::std::input_iterator_tag>::value,
+::std::enable_if_t<::std::is_same_v<typename oneapi::dpl::__internal::__iterator_traits<_Ip>::iterator_category,
+                                    ::std::forward_iterator_tag> ||
+                       ::std::is_same_v<typename oneapi::dpl::__internal::__iterator_traits<_Ip>::iterator_category,
+                                        ::std::input_iterator_tag>,
                    _IndexType>
 __execute_loop_strided(_Ip __first, _Ip __last, _Function __f, _Sp __stride, _Pack& __pack, _IndexType) noexcept
 {

--- a/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
@@ -38,14 +38,14 @@ namespace __internal
 
 // Generalization of ::std::advance to work with an argitraty integral type
 template <typename _Ip, typename _Diff>
-::std::enable_if_t<::std::is_integral<_Ip>::value>
+::std::enable_if_t<::std::is_integral_v<_Ip>>
 __advance(_Ip& __val, _Diff __diff)
 {
     __val += __diff;
 }
 
 template <typename _Ip, typename _Diff>
-::std::enable_if_t<!::std::is_integral<_Ip>::value>
+::std::enable_if_t<!::std::is_integral_v<_Ip>>
 __advance(_Ip& __val, _Diff __diff)
 {
     ::std::advance(__val, __diff);
@@ -56,14 +56,14 @@ template <typename _Ip, typename = void>
 struct __difference;
 
 template <typename _Ip>
-struct __difference<_Ip, ::std::enable_if_t<::std::is_integral<_Ip>::value>>
+struct __difference<_Ip, ::std::enable_if_t<::std::is_integral_v<_Ip>>>
 {
     // Define the type similar to C++20's incrementable_traits
     using __type = ::std::make_signed_t<decltype(::std::declval<_Ip>() - ::std::declval<_Ip>())>;
 };
 
 template <typename _Ip>
-struct __difference<_Ip, ::std::enable_if_t<!::std::is_integral<_Ip>::value>>
+struct __difference<_Ip, ::std::enable_if_t<!::std::is_integral_v<_Ip>>>
 {
     using __type = typename oneapi::dpl::__internal::__iterator_traits<_Ip>::difference_type;
 };
@@ -205,7 +205,7 @@ struct __is_random_access_or_integral : ::std::false_type
 };
 
 template <typename _Ip>
-struct __is_random_access_or_integral<_Ip, ::std::enable_if_t<::std::is_integral<_Ip>::value>> : ::std::true_type
+struct __is_random_access_or_integral<_Ip, ::std::enable_if_t<::std::is_integral_v<_Ip>>> : ::std::true_type
 {
 };
 
@@ -472,7 +472,7 @@ template <typename _Ip, typename = void>
 struct __use_par_vec_helper;
 
 template <typename _Ip>
-struct __use_par_vec_helper<_Ip, ::std::enable_if_t<::std::is_integral<_Ip>::value>>
+struct __use_par_vec_helper<_Ip, ::std::enable_if_t<::std::is_integral_v<_Ip>>>
 {
     template <typename _ExecutionPolicy>
     static constexpr auto
@@ -490,7 +490,7 @@ struct __use_par_vec_helper<_Ip, ::std::enable_if_t<::std::is_integral<_Ip>::val
 };
 
 template <typename _Ip>
-struct __use_par_vec_helper<_Ip, ::std::enable_if_t<!::std::is_integral<_Ip>::value>>
+struct __use_par_vec_helper<_Ip, ::std::enable_if_t<!::std::is_integral_v<_Ip>>>
 {
     template <typename _ExecutionPolicy>
     static constexpr auto

--- a/include/oneapi/dpl/pstl/experimental/internal/induction_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/induction_impl.h
@@ -32,9 +32,9 @@ namespace __internal
 // We're not interested in T&& here as the rvalue-ness is stripped from T before
 // construction the induction object
 template <typename _Tp>
-using __induction_value_type = ::std::conditional_t<::std::is_lvalue_reference<_Tp>::value &&
-                                                        !::std::is_const<::std::remove_reference_t<_Tp>>::value,
-                                                    _Tp, ::std::remove_cv_t<::std::remove_reference_t<_Tp>>>;
+using __induction_value_type = ::std::conditional_t<
+    ::std::is_lvalue_reference_v<_Tp> && !::std::is_const<::std::remove_reference_t<_Tp>>::value, _Tp,
+    ::std::remove_cv_t<::std::remove_reference_t<_Tp>>>;
 
 // Definition of induction_object structure to represent "induction" object.
 

--- a/include/oneapi/dpl/pstl/experimental/internal/induction_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/induction_impl.h
@@ -32,9 +32,9 @@ namespace __internal
 // We're not interested in T&& here as the rvalue-ness is stripped from T before
 // construction the induction object
 template <typename _Tp>
-using __induction_value_type = ::std::conditional_t<
-    ::std::is_lvalue_reference_v<_Tp> && !::std::is_const_v<::std::remove_reference_t<_Tp>>, _Tp,
-    ::std::remove_cv_t<::std::remove_reference_t<_Tp>>>;
+using __induction_value_type =
+    ::std::conditional_t<::std::is_lvalue_reference_v<_Tp> && !::std::is_const_v<::std::remove_reference_t<_Tp>>, _Tp,
+                         ::std::remove_cv_t<::std::remove_reference_t<_Tp>>>;
 
 // Definition of induction_object structure to represent "induction" object.
 

--- a/include/oneapi/dpl/pstl/experimental/internal/induction_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/induction_impl.h
@@ -33,7 +33,7 @@ namespace __internal
 // construction the induction object
 template <typename _Tp>
 using __induction_value_type = ::std::conditional_t<
-    ::std::is_lvalue_reference_v<_Tp> && !::std::is_const<::std::remove_reference_t<_Tp>>::value, _Tp,
+    ::std::is_lvalue_reference_v<_Tp> && !::std::is_const_v<::std::remove_reference_t<_Tp>>, _Tp,
     ::std::remove_cv_t<::std::remove_reference_t<_Tp>>>;
 
 // Definition of induction_object structure to represent "induction" object.

--- a/include/oneapi/dpl/pstl/experimental/internal/reduction_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/reduction_impl.h
@@ -29,7 +29,7 @@ namespace __internal
 template <typename _Tp, typename _Combiner>
 class __reduction_object
 {
-    static_assert(::std::is_copy_constructible<_Tp>::value, "_Tp shall be CopyConstructible");
+    static_assert(::std::is_copy_constructible_v<_Tp>, "_Tp shall be CopyConstructible");
     static_assert(::std::is_move_assignable<_Tp>::value, "_Tp shall be MoveAssignable");
 
     // Reference to the original variable. It's only used at the end of execution

--- a/include/oneapi/dpl/pstl/experimental/internal/reduction_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/reduction_impl.h
@@ -30,7 +30,7 @@ template <typename _Tp, typename _Combiner>
 class __reduction_object
 {
     static_assert(::std::is_copy_constructible_v<_Tp>, "_Tp shall be CopyConstructible");
-    static_assert(::std::is_move_assignable<_Tp>::value, "_Tp shall be MoveAssignable");
+    static_assert(::std::is_move_assignable_v<_Tp>, "_Tp shall be MoveAssignable");
 
     // Reference to the original variable. It's only used at the end of execution
     // when finalize method is called and accumulated value stored in acc is written

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -295,15 +295,15 @@ using __enable_if_fpga_execution_policy =
 template <typename _ExecPolicy, typename _T, typename _Op1, typename... _Events>
 using __enable_if_device_execution_policy_single_no_default =
     ::std::enable_if_t<oneapi::dpl::__internal::__is_device_execution_policy<::std::decay_t<_ExecPolicy>>::value &&
-                           !::std::is_convertible<_Op1, sycl::event>::value &&
+                           !::std::is_convertible_v<_Op1, sycl::event> &&
                            oneapi::dpl::__internal::__is_convertible_to_event<_Events...>,
                        _T>;
 
 template <typename _ExecPolicy, typename _T, typename _Op1, typename _Op2, typename... _Events>
 using __enable_if_device_execution_policy_double_no_default =
     ::std::enable_if_t<oneapi::dpl::__internal::__is_device_execution_policy<::std::decay_t<_ExecPolicy>>::value &&
-                           !::std::is_convertible<_Op1, sycl::event>::value &&
-                           !::std::is_convertible<_Op2, sycl::event>::value &&
+                           !::std::is_convertible_v<_Op1, sycl::event> &&
+                           !::std::is_convertible_v<_Op2, sycl::event> &&
                            oneapi::dpl::__internal::__is_convertible_to_event<_Events...>,
                        _T>;
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -302,8 +302,7 @@ using __enable_if_device_execution_policy_single_no_default =
 template <typename _ExecPolicy, typename _T, typename _Op1, typename _Op2, typename... _Events>
 using __enable_if_device_execution_policy_double_no_default =
     ::std::enable_if_t<oneapi::dpl::__internal::__is_device_execution_policy<::std::decay_t<_ExecPolicy>>::value &&
-                           !::std::is_convertible_v<_Op1, sycl::event> &&
-                           !::std::is_convertible_v<_Op2, sycl::event> &&
+                           !::std::is_convertible_v<_Op1, sycl::event> && !::std::is_convertible_v<_Op2, sycl::event> &&
                            oneapi::dpl::__internal::__is_convertible_to_event<_Events...>,
                        _T>;
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1079,7 +1079,7 @@ struct __early_exit_find_or
 template <typename _ExecutionPolicy, typename _Brick, typename _BrickTag, typename... _Ranges>
 oneapi::dpl::__internal::__enable_if_device_execution_policy<
     _ExecutionPolicy,
-    ::std::conditional_t<::std::is_same<_BrickTag, __parallel_or_tag>::value, bool,
+    ::std::conditional_t<::std::is_same_v<_BrickTag, __parallel_or_tag>, bool,
                          oneapi::dpl::__internal::__difference_t<
                              typename oneapi::dpl::__ranges::__get_first_range_type<_Ranges...>::type>>>
 __parallel_find_or(_ExecutionPolicy&& __exec, _Brick __f, _BrickTag __brick_tag, _Ranges&&... __rngs)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1784,8 +1784,8 @@ struct __is_radix_sort_usable_for_type
 {
     static constexpr bool value =
 #if _USE_RADIX_SORT
-        ::std::is_arithmetic<_T>::value && (__internal::__is_comp_ascending<__decay_t<_Compare>>::value ||
-                                            __internal::__is_comp_descending<__decay_t<_Compare>>::value);
+        ::std::is_arithmetic_v<_T> && (__internal::__is_comp_ascending<__decay_t<_Compare>>::value ||
+                                       __internal::__is_comp_descending<__decay_t<_Compare>>::value);
 #else
         false;
 #endif

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
@@ -181,7 +181,7 @@ __parallel_scan_copy(_ExecutionPolicy&& __exec, _InRng&& __in_rng, _OutRng&& __o
 template <typename _ExecutionPolicy, typename _Brick, typename _BrickTag, typename... _Ranges>
 oneapi::dpl::__internal::__enable_if_fpga_execution_policy<
     _ExecutionPolicy,
-    ::std::conditional_t<::std::is_same<_BrickTag, __parallel_or_tag>::value, bool,
+    ::std::conditional_t<::std::is_same_v<_BrickTag, __parallel_or_tag>, bool,
                          oneapi::dpl::__internal::__difference_t<
                              typename oneapi::dpl::__ranges::__get_first_range_type<_Ranges...>::type>>>
 __parallel_find_or(_ExecutionPolicy&& __exec, _Brick __f, _BrickTag __brick_tag, _Ranges&&... __rngs)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -200,9 +200,9 @@ namespace __internal
 template <typename _CustomName>
 struct _HasDefaultName
 {
-    static constexpr bool value = ::std::is_same<_CustomName, oneapi::dpl::execution::DefaultKernelName>::value
+    static constexpr bool value = ::std::is_same_v<_CustomName, oneapi::dpl::execution::DefaultKernelName>
 #if _ONEDPL_FPGA_DEVICE
-                                  || ::std::is_same<_CustomName, oneapi::dpl::execution::DefaultKernelNameFPGA>::value
+                                  || ::std::is_same_v<_CustomName, oneapi::dpl::execution::DefaultKernelNameFPGA>
 #endif
         ;
 };

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -201,8 +201,8 @@ struct is_temp_buff : ::std::false_type
 };
 
 template <typename _Iter>
-struct is_temp_buff<_Iter, ::std::enable_if_t<!is_hetero_it<_Iter>::value && !::std::is_pointer<_Iter>::value &&
-                                              !is_passed_directly_it<_Iter>::value>> : ::std::true_type
+struct is_temp_buff<_Iter, ::std::enable_if_t<!is_hetero_it<_Iter>::value && !::std::is_pointer_v<_Iter> &&
+                                                  !is_passed_directly_it<_Iter>::value>> : ::std::true_type
 {
 };
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -202,7 +202,7 @@ struct is_temp_buff : ::std::false_type
 
 template <typename _Iter>
 struct is_temp_buff<_Iter, ::std::enable_if_t<!is_hetero_it<_Iter>::value && !::std::is_pointer_v<_Iter> &&
-                                                  !is_passed_directly_it<_Iter>::value>> : ::std::true_type
+                                              !is_passed_directly_it<_Iter>::value>> : ::std::true_type
 {
 };
 

--- a/include/oneapi/dpl/pstl/iterator_defs.h
+++ b/include/oneapi/dpl/pstl/iterator_defs.h
@@ -99,7 +99,7 @@ struct is_passed_directly<Iter, ::std::enable_if_t<Iter::is_passed_directly::val
 };
 
 template <typename Iter> // for pointers to objects on device
-struct is_passed_directly<Iter, ::std::enable_if_t<::std::is_pointer<Iter>::value>> : ::std::true_type
+struct is_passed_directly<Iter, ::std::enable_if_t<::std::is_pointer_v<Iter>>> : ::std::true_type
 {
 };
 

--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -150,7 +150,7 @@ namespace dpl
 template <typename _Ip>
 class counting_iterator
 {
-    static_assert(::std::is_integral<_Ip>::value, "Cannot instantiate counting_iterator with a non-integer type");
+    static_assert(::std::is_integral_v<_Ip>, "Cannot instantiate counting_iterator with a non-integer type");
 
   public:
     typedef ::std::make_signed_t<_Ip> difference_type;

--- a/include/oneapi/dpl/pstl/numeric_fwd.h
+++ b/include/oneapi/dpl/pstl/numeric_fwd.h
@@ -114,8 +114,8 @@ __pattern_transform_scan(_ExecutionPolicy&&, _RandomAccessIterator, _RandomAcces
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _OutputIterator, class _UnaryOperation, class _Tp,
           class _BinaryOperation, class _Inclusive, class _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy_conditional<
-    _ExecutionPolicy, ::std::is_floating_point_v<_Tp>, _OutputIterator>
+oneapi::dpl::__internal::__enable_if_host_execution_policy_conditional<_ExecutionPolicy,
+                                                                       ::std::is_floating_point_v<_Tp>, _OutputIterator>
 __pattern_transform_scan(_ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _OutputIterator,
                          _UnaryOperation, _Tp, _BinaryOperation, _Inclusive, _IsVector,
                          /*is_parallel=*/::std::true_type);

--- a/include/oneapi/dpl/pstl/numeric_fwd.h
+++ b/include/oneapi/dpl/pstl/numeric_fwd.h
@@ -107,7 +107,7 @@ __pattern_transform_scan(_ExecutionPolicy&&, _ForwardIterator, _ForwardIterator,
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _OutputIterator, class _UnaryOperation, class _Tp,
           class _BinaryOperation, class _Inclusive, class _IsVector>
 oneapi::dpl::__internal::__enable_if_host_execution_policy_conditional<
-    _ExecutionPolicy, !::std::is_floating_point<_Tp>::value, _OutputIterator>
+    _ExecutionPolicy, !::std::is_floating_point_v<_Tp>, _OutputIterator>
 __pattern_transform_scan(_ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _OutputIterator,
                          _UnaryOperation, _Tp, _BinaryOperation, _Inclusive, _IsVector,
                          /*is_parallel=*/::std::true_type);
@@ -115,7 +115,7 @@ __pattern_transform_scan(_ExecutionPolicy&&, _RandomAccessIterator, _RandomAcces
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _OutputIterator, class _UnaryOperation, class _Tp,
           class _BinaryOperation, class _Inclusive, class _IsVector>
 oneapi::dpl::__internal::__enable_if_host_execution_policy_conditional<
-    _ExecutionPolicy, ::std::is_floating_point<_Tp>::value, _OutputIterator>
+    _ExecutionPolicy, ::std::is_floating_point_v<_Tp>, _OutputIterator>
 __pattern_transform_scan(_ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _OutputIterator,
                          _UnaryOperation, _Tp, _BinaryOperation, _Inclusive, _IsVector,
                          /*is_parallel=*/::std::true_type);

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -271,8 +271,8 @@ __pattern_transform_scan(_ExecutionPolicy&& __exec, _RandomAccessIterator __firs
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _OutputIterator, class _UnaryOperation, class _Tp,
           class _BinaryOperation, class _Inclusive, class _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy_conditional<
-    _ExecutionPolicy, ::std::is_floating_point_v<_Tp>, _OutputIterator>
+oneapi::dpl::__internal::__enable_if_host_execution_policy_conditional<_ExecutionPolicy,
+                                                                       ::std::is_floating_point_v<_Tp>, _OutputIterator>
 __pattern_transform_scan(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last,
                          _OutputIterator __result, _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op,
                          _Inclusive, _IsVector __is_vector, /*is_parallel=*/::std::true_type)

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -241,7 +241,7 @@ __pattern_transform_scan(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardI
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _OutputIterator, class _UnaryOperation, class _Tp,
           class _BinaryOperation, class _Inclusive, class _IsVector>
 oneapi::dpl::__internal::__enable_if_host_execution_policy_conditional<
-    _ExecutionPolicy, !::std::is_floating_point<_Tp>::value, _OutputIterator>
+    _ExecutionPolicy, !::std::is_floating_point_v<_Tp>, _OutputIterator>
 __pattern_transform_scan(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last,
                          _OutputIterator __result, _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op,
                          _Inclusive, _IsVector __is_vector, /*is_parallel=*/::std::true_type)
@@ -272,7 +272,7 @@ __pattern_transform_scan(_ExecutionPolicy&& __exec, _RandomAccessIterator __firs
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _OutputIterator, class _UnaryOperation, class _Tp,
           class _BinaryOperation, class _Inclusive, class _IsVector>
 oneapi::dpl::__internal::__enable_if_host_execution_policy_conditional<
-    _ExecutionPolicy, ::std::is_floating_point<_Tp>::value, _OutputIterator>
+    _ExecutionPolicy, ::std::is_floating_point_v<_Tp>, _OutputIterator>
 __pattern_transform_scan(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last,
                          _OutputIterator __result, _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op,
                          _Inclusive, _IsVector __is_vector, /*is_parallel=*/::std::true_type)

--- a/include/oneapi/dpl/pstl/omp/util.h
+++ b/include/oneapi/dpl/pstl/omp/util.h
@@ -83,7 +83,7 @@ class __buffer
 constexpr std::size_t __default_chunk_size = 2048;
 
 // Convenience function to determine when we should run serial.
-template <typename _Iterator, std::enable_if_t<!std::is_integral<_Iterator>::value, bool> = true>
+template <typename _Iterator, std::enable_if_t<!std::is_integral_v<_Iterator>, bool> = true>
 constexpr auto
 __should_run_serial(_Iterator __first, _Iterator __last) -> bool
 {
@@ -92,7 +92,7 @@ __should_run_serial(_Iterator __first, _Iterator __last) -> bool
     return __size <= static_cast<_difference_type>(__default_chunk_size);
 }
 
-template <typename _Index, std::enable_if_t<std::is_integral<_Index>::value, bool> = true>
+template <typename _Index, std::enable_if_t<std::is_integral_v<_Index>, bool> = true>
 constexpr auto
 __should_run_serial(_Index __first, _Index __last) -> bool
 {

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -58,8 +58,8 @@ struct __serial_move_merge
                _RandomAccessIterator2 __ye, _RandomAccessIterator3 __zs, _Compare __comp, _MoveValueX __move_value_x,
                _MoveValueY __move_value_y, _MoveSequenceX __move_sequence_x, _MoveSequenceY __move_sequence_y)
     {
-        constexpr bool __same_move_val = ::std::is_same<_MoveValueX, _MoveValueY>::value;
-        constexpr bool __same_move_seq = ::std::is_same<_MoveSequenceX, _MoveSequenceY>::value;
+        constexpr bool __same_move_val = ::std::is_same_v<_MoveValueX, _MoveValueY>;
+        constexpr bool __same_move_seq = ::std::is_same_v<_MoveSequenceX, _MoveSequenceY>;
 
         auto __n = _M_nmerge;
         assert(__n > 0);

--- a/include/oneapi/dpl/pstl/tuple_impl.h
+++ b/include/oneapi/dpl/pstl/tuple_impl.h
@@ -82,7 +82,7 @@ get_tuple_tail(const ::std::tuple<T1, T...>& other)
 // Maps an incoming type for tuplewrapper to simplify tuple-related handling.
 // as it doesn't work well with rvalue refs.
 // T& -> T&, T&& -> T, T -> T
-template <typename _Tp, bool = ::std::is_lvalue_reference<_Tp>::value>
+template <typename _Tp, bool = ::std::is_lvalue_reference_v<_Tp>>
 struct __lvref_or_val
 {
     using __type = _Tp&&;

--- a/include/oneapi/dpl/pstl/tuple_impl.h
+++ b/include/oneapi/dpl/pstl/tuple_impl.h
@@ -266,7 +266,7 @@ struct __value_holder
 
 // Necessary to make tuple trivially_copy_assignable. This type decided
 // if it's needed to have user-defined operator=.
-template <typename _Tp, bool = ::std::is_trivially_copy_assignable<oneapi::dpl::__internal::__value_holder<_Tp>>::value>
+template <typename _Tp, bool = ::std::is_trivially_copy_assignable_v<oneapi::dpl::__internal::__value_holder<_Tp>>>
 struct __copy_assignable_holder : oneapi::dpl::__internal::__value_holder<_Tp>
 {
     using oneapi::dpl::__internal::__value_holder<_Tp>::__value_holder;

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -527,8 +527,8 @@ using __is_const_callable_object =
 struct __next_to_last
 {
     template <typename _Iterator>
-    ::std::enable_if_t<::std::is_base_of<::std::random_access_iterator_tag,
-                                         typename ::std::iterator_traits<_Iterator>::iterator_category>::value,
+    ::std::enable_if_t<::std::is_base_of_v<::std::random_access_iterator_tag,
+                                           typename ::std::iterator_traits<_Iterator>::iterator_category>,
                        _Iterator>
     operator()(_Iterator __it, _Iterator __last, typename ::std::iterator_traits<_Iterator>::difference_type __n)
     {
@@ -536,8 +536,8 @@ struct __next_to_last
     }
 
     template <typename _Iterator>
-    ::std::enable_if_t<!::std::is_base_of<::std::random_access_iterator_tag,
-                                          typename ::std::iterator_traits<_Iterator>::iterator_category>::value,
+    ::std::enable_if_t<!::std::is_base_of_v<::std::random_access_iterator_tag,
+                                            typename ::std::iterator_traits<_Iterator>::iterator_category>,
                        _Iterator>
     operator()(_Iterator __it, _Iterator __last, typename ::std::iterator_traits<_Iterator>::difference_type __n)
     {

--- a/test/general/sycl_iterator/sycl_iterator_for.pass.cpp
+++ b/test/general/sycl_iterator/sycl_iterator_for.pass.cpp
@@ -260,7 +260,7 @@ DEFINE_TEST(test_destroy)
 
         ::std::destroy(make_new_policy<policy_name_wrapper<new_kernel_name<Policy, 0>, T1>>(exec), first1 + (n / 3),
                        first1 + (n / 2));
-        if (!::std::is_trivially_destructible<T1>::value)
+        if (!::std::is_trivially_destructible_v<T1>)
             value = T1{-2};
         wait_and_throw(exec);
 
@@ -287,7 +287,7 @@ DEFINE_TEST(test_destroy_n)
         host_keys.update_data();
 
         ::std::destroy_n(make_new_policy<policy_name_wrapper<new_kernel_name<Policy, 0>, T1>>(exec), first1, n);
-        if(!::std::is_trivially_destructible<T1>::value)
+        if(!::std::is_trivially_destructible_v<T1>)
             value = T1{-2};
         wait_and_throw(exec);
 

--- a/test/general/test_policies.pass.cpp
+++ b/test/general/test_policies.pass.cpp
@@ -89,7 +89,7 @@ main()
     test_policy_instance(device_policy<class Kernel_24>(sycl::queue(dpcpp_default))); // conversion to sycl::queue
     test_policy_instance(device_policy<>{});
     class Kernel_25;
-    static_assert(std::is_same<device_policy<Kernel_25>::kernel_name, Kernel_25>::value, "wrong result for kernel_name (device_policy)");
+    static_assert(std::is_same_v<device_policy<Kernel_25>::kernel_name, Kernel_25>, "wrong result for kernel_name (device_policy)");
 
 #if ONEDPL_FPGA_DEVICE
     static_assert(is_execution_policy<fpga_policy</*unroll_factor =*/ 1, class Kernel_0>>::value, "wrong result for is_execution_policy<fpga_policy>");
@@ -109,7 +109,7 @@ main()
     test_policy_instance(fpga_policy</*unroll_factor =*/ 2, class Kernel_42>(sycl::device{TestUtils::default_selector}));
     test_policy_instance(fpga_policy</*unroll_factor =*/ 4, class Kernel_43>(dpcpp_fpga));
     test_policy_instance(fpga_policy</*unroll_factor =*/ 8, class Kernel_44>{});
-    static_assert(std::is_same<fpga_policy</*unroll_factor =*/ 8, Kernel_25>::kernel_name, Kernel_25>::value, "wrong result for kernel_name (fpga_policy)");
+    static_assert(std::is_same_v<fpga_policy</*unroll_factor =*/ 8, Kernel_25>::kernel_name, Kernel_25>, "wrong result for kernel_name (fpga_policy)");
     static_assert(fpga_policy</*unroll_factor =*/ 16, class Kernel_45>::unroll_factor == 16, "wrong unroll_factor");
 #endif // ONEDPL_FPGA_DEVICE
 

--- a/test/general/type_requirements.pass.cpp
+++ b/test/general/type_requirements.pass.cpp
@@ -24,7 +24,7 @@
 template <typename... Args>
 void CheckTuple() {
     static_assert(::std::is_trivially_copyable_v<oneapi::dpl::__internal::tuple<Args...>>, "");
-    static_assert(::std::is_standard_layout<oneapi::dpl::__internal::tuple<Args...>>::value, "");
+    static_assert(::std::is_standard_layout_v<oneapi::dpl::__internal::tuple<Args...>>, "");
 };
 
 #endif

--- a/test/general/type_requirements.pass.cpp
+++ b/test/general/type_requirements.pass.cpp
@@ -23,7 +23,7 @@
 
 template <typename... Args>
 void CheckTuple() {
-    static_assert(::std::is_trivially_copyable<oneapi::dpl::__internal::tuple<Args...>>::value, "");
+    static_assert(::std::is_trivially_copyable_v<oneapi::dpl::__internal::tuple<Args...>>, "");
     static_assert(::std::is_standard_layout<oneapi::dpl::__internal::tuple<Args...>>::value, "");
 };
 

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition.pass.cpp
@@ -54,14 +54,14 @@ struct DataType
 };
 
 template <typename Iterator>
-::std::enable_if_t<::std::is_trivial<typename ::std::iterator_traits<Iterator>::value_type>::value, bool>
+::std::enable_if_t<::std::is_trivial_v<typename ::std::iterator_traits<Iterator>::value_type>, bool>
 is_equal(Iterator first, Iterator last, Iterator d_first)
 {
     return ::std::equal(first, last, d_first);
 }
 
 template <typename Iterator>
-::std::enable_if_t<!::std::is_trivial<typename ::std::iterator_traits<Iterator>::value_type>::value, bool>
+::std::enable_if_t<!::std::is_trivial_v<typename ::std::iterator_traits<Iterator>::value_type>, bool>
 is_equal(Iterator /* first */, Iterator /* last */, Iterator /* d_first */)
 {
     return true;

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/stable_partition.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/stable_partition.pass.cpp
@@ -54,14 +54,14 @@ struct DataType
 };
 
 template <typename Iterator>
-::std::enable_if_t<::std::is_trivial<typename ::std::iterator_traits<Iterator>::value_type>::value, bool>
+::std::enable_if_t<::std::is_trivial_v<typename ::std::iterator_traits<Iterator>::value_type>, bool>
 is_equal(Iterator first, Iterator last, Iterator d_first)
 {
     return ::std::equal(first, last, d_first);
 }
 
 template <typename Iterator>
-::std::enable_if_t<!::std::is_trivial<typename ::std::iterator_traits<Iterator>::value_type>::value, bool>
+::std::enable_if_t<!::std::is_trivial_v<typename ::std::iterator_traits<Iterator>::value_type>, bool>
 is_equal(Iterator /* first */, Iterator /* last */, Iterator /* d_first */)
 {
     return true;

--- a/test/parallel_api/algorithm/alg.modifying.operations/replace.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/replace.pass.cpp
@@ -84,7 +84,7 @@ struct test_replace
     }
 
     template <typename T, typename Iterator1>
-    ::std::enable_if_t<::std::is_same<T, copy_int>::value, bool>
+    ::std::enable_if_t<::std::is_same_v<T, copy_int>, bool>
     check(Iterator1 b, Iterator1 e)
     {
         return ::std::all_of(b, e, [](const copy_int& elem) { return elem.copied_times == 0; });

--- a/test/parallel_api/algorithm/alg.modifying.operations/rotate.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/rotate.pass.cpp
@@ -103,8 +103,8 @@ struct test_one_policy
     template <typename ExecutionPolicy, typename Iterator, typename Size>
     ::std::enable_if_t<
         is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
-        !::std::is_same<ExecutionPolicy, oneapi::dpl::execution::sequenced_policy>::value &&
-        ::std::is_same<typename ::std::iterator_traits<Iterator>::value_type, wrapper<float32_t>>::value,
+        !::std::is_same_v<ExecutionPolicy, oneapi::dpl::execution::sequenced_policy> &&
+        ::std::is_same_v<typename ::std::iterator_traits<Iterator>::value_type, wrapper<float32_t>>,
         bool>
     check_move(ExecutionPolicy&& /* exec */, Iterator b, Iterator e, Size shift)
     {
@@ -119,8 +119,8 @@ struct test_one_policy
     template <typename ExecutionPolicy, typename Iterator, typename Size>
     ::std::enable_if_t<
         !(is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
-        !::std::is_same<ExecutionPolicy, oneapi::dpl::execution::sequenced_policy>::value &&
-        ::std::is_same<typename ::std::iterator_traits<Iterator>::value_type, wrapper<float32_t>>::value),
+        !::std::is_same_v<ExecutionPolicy, oneapi::dpl::execution::sequenced_policy> &&
+        ::std::is_same_v<typename ::std::iterator_traits<Iterator>::value_type, wrapper<float32_t>>),
         bool>
     check_move(ExecutionPolicy&& /* exec */, Iterator /* b */, Iterator /* e */, Size /* shift */)
     {

--- a/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
@@ -47,7 +47,7 @@ struct test_shift
     template <typename Policy, typename It, typename Algo>
     std::enable_if_t<oneapi::dpl::__internal::__is_host_execution_policy<std::decay_t<Policy>>::value
 #if __SYCL_PSTL_OFFLOAD__
-                     || std::is_same<std::decay_t<Policy>, std::execution::parallel_unsequenced_policy>::value
+                     || std::is_same_v<std::decay_t<Policy>, std::execution::parallel_unsequenced_policy>
 #endif
                      >
     operator()(Policy&& exec, It first, typename ::std::iterator_traits<It>::difference_type m,

--- a/test/parallel_api/algorithm/alg.modifying.operations/transform_binary.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/transform_binary.pass.cpp
@@ -47,7 +47,7 @@ check_and_reset(InputIterator1 first1, InputIterator1 last1, InputIterator2 firs
         // check
         Out expected = Out(1.5) + *first1 - *first2;
         Out actual = *out_first;
-        if (::std::is_floating_point<Out>::value)
+        if (::std::is_floating_point_v<Out>)
         {
             EXPECT_TRUE((expected > actual ? expected - actual : actual - expected) < Out(1e-7),
                         "wrong value in output sequence");

--- a/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
@@ -269,7 +269,7 @@ template <typename Policy, typename InputIterator, typename OutputIterator, type
           typename... Compare>
 std::enable_if_t<oneapi::dpl::__internal::__is_host_execution_policy<std::decay_t<Policy>>::value
 #if __SYCL_PSTL_OFFLOAD__
-                 || std::is_same<std::decay_t<Policy>, std::execution::parallel_unsequenced_policy>::value
+                 || std::is_same_v<std::decay_t<Policy>, std::execution::parallel_unsequenced_policy>
 #endif
                  >
 run_test(Policy&& exec, OutputIterator tmp_first, OutputIterator tmp_last, OutputIterator2 expected_first,

--- a/test/parallel_api/experimental/for_loop.pass.cpp
+++ b/test/parallel_api/experimental/for_loop.pass.cpp
@@ -231,7 +231,7 @@ struct test_for_loop_impl
 
 template <typename Policy, typename Iterator, typename Size, typename S>
 ::std::enable_if_t<
-    !::std::is_same<typename ::std::iterator_traits<Iterator>::iterator_category, ::std::forward_iterator_tag>::value>
+    !::std::is_same_v<typename ::std::iterator_traits<Iterator>::iterator_category, ::std::forward_iterator_tag>>
 test_body_for_loop_strided_neg(Policy&& exec, Iterator first, Iterator /* last */, Iterator expected_first,
                                Iterator /* expected_last */, Size n, S loop_stride)
 {
@@ -256,7 +256,7 @@ test_body_for_loop_strided_neg(Policy&& exec, Iterator first, Iterator /* last *
 
 template <typename Policy, typename Iterator, typename Size, typename S>
 ::std::enable_if_t<
-    ::std::is_same<typename ::std::iterator_traits<Iterator>::iterator_category, ::std::forward_iterator_tag>::value>
+    ::std::is_same_v<typename ::std::iterator_traits<Iterator>::iterator_category, ::std::forward_iterator_tag>>
 test_body_for_loop_strided_neg(Policy&& /* exec */, Iterator /* first */, Iterator /* last */, Iterator /* expected_first */,
                                Iterator /* expected_last */, Size /* n */, S /* loop_stride */)
 {

--- a/test/parallel_api/experimental/for_loop_induction.pass.cpp
+++ b/test/parallel_api/experimental/for_loop_induction.pass.cpp
@@ -29,7 +29,7 @@ test_body_induction(Policy&& exec, Iterator /* first */, Iterator /* last */, It
                     Iterator /* expected_last */, Size n)
 {
     using T = typename ::std::iterator_traits<Iterator>::value_type;
-    static_assert(::std::is_arithmetic<T>::value, "Currently the testcase only works with arithmetic types");
+    static_assert(::std::is_arithmetic_v<T>, "Currently the testcase only works with arithmetic types");
 
     // Init with different arbitrary values on each iteration
     const T ind_init = n % 97;
@@ -72,7 +72,7 @@ test_body_induction_strided(Policy&& exec, Iterator first, Iterator last, Iterat
                             Iterator /* expected_last */, Size n)
 {
     using T = typename ::std::iterator_traits<Iterator>::value_type;
-    static_assert(::std::is_arithmetic<T>::value, "Currently the testcase only works with arithmetic types");
+    static_assert(::std::is_arithmetic_v<T>, "Currently the testcase only works with arithmetic types");
 
     for (int loop_stride : {-1, 1, 10, -5})
     {

--- a/test/parallel_api/experimental/for_loop_induction.pass.cpp
+++ b/test/parallel_api/experimental/for_loop_induction.pass.cpp
@@ -96,7 +96,7 @@ test_body_induction_strided(Policy&& exec, Iterator first, Iterator last, Iterat
 
         // Negative strides are not allowed with forward iterators
         if (loop_stride < 0 &&
-            ::std::is_same<typename ::std::iterator_traits<Iterator>::iterator_category, ::std::forward_iterator_tag>::value)
+            ::std::is_same_v<typename ::std::iterator_traits<Iterator>::iterator_category, ::std::forward_iterator_tag>)
             continue;
 
         auto new_first = first;

--- a/test/parallel_api/experimental/for_loop_reduction.pass.cpp
+++ b/test/parallel_api/experimental/for_loop_reduction.pass.cpp
@@ -29,7 +29,7 @@ test_body_reduction(Policy&& exec, Iterator first, Iterator last, Iterator /* ex
                     Iterator /* expected_last */, Size n)
 {
     using T = typename ::std::iterator_traits<Iterator>::value_type;
-    static_assert(::std::is_arithmetic<T>::value, "Currently the testcase only works with arithmetic types");
+    static_assert(::std::is_arithmetic_v<T>, "Currently the testcase only works with arithmetic types");
 
     // Init with different arbitrary values on each iteration
     const T var1_init = n % 11;
@@ -90,7 +90,7 @@ struct test_body_predefined
                Size /* n */)
     {
         using T = typename ::std::iterator_traits<Iterator>::value_type;
-        static_assert(::std::is_arithmetic<T>::value, "Currently the testcase only works with arithmetic types");
+        static_assert(::std::is_arithmetic_v<T>, "Currently the testcase only works with arithmetic types");
 
         // Initialize with arbitrary values
         T plus_var = 10, plus_exp = 10;
@@ -132,7 +132,7 @@ struct test_body_predefined_bits
                Size /* n */)
     {
         using T = typename ::std::iterator_traits<Iterator>::value_type;
-        static_assert(::std::is_arithmetic<T>::value, "Currently the testcase only works with arithmetic types");
+        static_assert(::std::is_arithmetic_v<T>, "Currently the testcase only works with arithmetic types");
 
         // Initialize with arbitrary values
         T bit_or_var = 10, bit_or_exp = 10;

--- a/test/parallel_api/experimental/for_loop_reduction.pass.cpp
+++ b/test/parallel_api/experimental/for_loop_reduction.pass.cpp
@@ -127,7 +127,7 @@ struct test_body_predefined
 struct test_body_predefined_bits
 {
     template <typename Policy, typename Iterator, typename Size>
-    ::std::enable_if_t<!::std::is_floating_point<typename ::std::iterator_traits<Iterator>::value_type>::value>
+    ::std::enable_if_t<!::std::is_floating_point_v<typename ::std::iterator_traits<Iterator>::value_type>>
     operator()(Policy&& exec, Iterator first, Iterator last, Iterator /*expected_first*/, Iterator /*expected_last*/,
                Size /* n */)
     {
@@ -161,7 +161,7 @@ struct test_body_predefined_bits
     }
 
     template <typename Policy, typename Iterator, typename Size>
-    ::std::enable_if_t<::std::is_floating_point<typename ::std::iterator_traits<Iterator>::value_type>::value>
+    ::std::enable_if_t<::std::is_floating_point_v<typename ::std::iterator_traits<Iterator>::value_type>>
     operator()(Policy&& /* exec */, Iterator /* first */, Iterator /* last */, Iterator /*expected_first*/, Iterator /*expected_last*/,
                Size /* n */)
     {

--- a/test/parallel_api/iterator/iterators.pass.cpp
+++ b/test/parallel_api/iterator/iterators.pass.cpp
@@ -274,7 +274,7 @@ struct test_transform_iterator {
         auto test_lambda = [](T2& x){ return x + 1; };
         auto new_transform_iterator = oneapi::dpl::make_transform_iterator(in2.begin(), test_lambda);
         EXPECT_TRUE(_it1.base() == in1.begin(), "wrong result from transform_iterator::base");
-        static_assert(::std::is_same<decltype(new_transform_iterator.functor()), decltype(test_lambda)>::value,
+        static_assert(::std::is_same_v<decltype(new_transform_iterator.functor()), decltype(test_lambda)>,
             "wrong result from transform_iterator::functor");
         test_random_iterator(_it2);
     }

--- a/test/parallel_api/iterator/iterators.pass.cpp
+++ b/test/parallel_api/iterator/iterators.pass.cpp
@@ -43,7 +43,7 @@ void test_random_iterator(const RandomIt& it) {
         [[maybe_unused]] auto t4 = typename RandomIt::iterator_category{};
     }
 
-    static_assert(::std::is_default_constructible<RandomIt>::value, "iterator is not default constructible");
+    static_assert(::std::is_default_constructible_v<RandomIt>, "iterator is not default constructible");
 
     EXPECT_TRUE(  it == it,      "== returned false negative");
     EXPECT_TRUE(!(it == it + 1), "== returned false positive");

--- a/test/parallel_api/iterator/zip_iterator.pass.cpp
+++ b/test/parallel_api/iterator/zip_iterator.pass.cpp
@@ -369,10 +369,10 @@ DEFINE_TEST(test_equal_structured_binding)
             const auto& [a, b] = tuple_first1;
             const auto& [c, d] = tuple_first2;
 
-            static_assert(::std::is_reference<decltype(a)>::value, "tuple element type is not a reference");
-            static_assert(::std::is_reference<decltype(b)>::value, "tuple element type is not a reference");
-            static_assert(::std::is_reference<decltype(c)>::value, "tuple element type is not a reference");
-            static_assert(::std::is_reference<decltype(d)>::value, "tuple element type is not a reference");
+            static_assert(::std::is_reference_v<decltype(a)>, "tuple element type is not a reference");
+            static_assert(::std::is_reference_v<decltype(b)>, "tuple element type is not a reference");
+            static_assert(::std::is_reference_v<decltype(c)>, "tuple element type is not a reference");
+            static_assert(::std::is_reference_v<decltype(d)>, "tuple element type is not a reference");
 
             return (a == c) && (b == d);
         };

--- a/test/parallel_api/numeric/numeric.ops/adjacent_difference.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/adjacent_difference.pass.cpp
@@ -62,7 +62,7 @@ compare(const wrapper<T>& a, const wrapper<T>& b)
 }
 
 template <typename Iterator1, typename Iterator2, typename T, typename Function>
-::std::enable_if_t<!::std::is_floating_point<T>::value, bool>
+::std::enable_if_t<!::std::is_floating_point_v<T>, bool>
 compute_and_check(Iterator1 first, Iterator1 last, Iterator2 d_first, T, Function f)
 {
     using T2 = typename ::std::iterator_traits<Iterator2>::value_type;
@@ -89,7 +89,7 @@ compute_and_check(Iterator1 first, Iterator1 last, Iterator2 d_first, T, Functio
 // we don't want to check equality here
 // because we can't be sure it will be strictly equal for floating point types
 template <typename Iterator1, typename Iterator2, typename T, typename Function>
-::std::enable_if_t<::std::is_floating_point<T>::value, bool>
+::std::enable_if_t<::std::is_floating_point_v<T>, bool>
 compute_and_check(Iterator1 /* first */, Iterator1 /* last */, Iterator2 /* d_first */, T, Function)
 {
     return true;

--- a/test/pstl_offload/headers/headers.dpl/oneapi_dpl_type_traits.pass.cpp
+++ b/test/pstl_offload/headers/headers.dpl/oneapi_dpl_type_traits.pass.cpp
@@ -11,7 +11,6 @@
 #include "support/utils.h"
 
 int main() {
-    static_assert(oneapi::dpl::is_same<int, int>::value);
     static_assert(oneapi::dpl::is_same_v<int, int>);
     return TestUtils::done();
 }

--- a/test/pstl_offload/headers/headers.dpl/oneapi_dpl_type_traits.pass.cpp
+++ b/test/pstl_offload/headers/headers.dpl/oneapi_dpl_type_traits.pass.cpp
@@ -12,5 +12,6 @@
 
 int main() {
     static_assert(oneapi::dpl::is_same<int, int>::value);
+    static_assert(oneapi::dpl::is_same_v<int, int>);
     return TestUtils::done();
 }

--- a/test/support/iterator_utils.h
+++ b/test/support/iterator_utils.h
@@ -44,7 +44,7 @@ class ForwardIterator
     reference operator*() const { return *my_iterator; }
     pointer operator->() const
     {
-        if constexpr (::std::is_pointer<Iterator>::value)
+        if constexpr (::std::is_pointer_v<Iterator>)
         {
             return my_iterator;
         }

--- a/test/support/iterator_utils.h
+++ b/test/support/iterator_utils.h
@@ -230,7 +230,7 @@ struct iterator_traits_
 };
 
 template <typename Iter> // For iterators
-struct iterator_traits_<Iter, ::std::enable_if_t<!::std::is_void<typename Iter::iterator_category>::value>>
+struct iterator_traits_<Iter, ::std::enable_if_t<!::std::is_void_v<typename Iter::iterator_category>>>
 {
     typedef typename Iter::iterator_category iterator_category;
 };

--- a/test/support/iterator_utils.h
+++ b/test/support/iterator_utils.h
@@ -340,7 +340,7 @@ struct iterator_invoker
     // A single iterator version which is used for non_const testcases
     template <typename Policy, typename Op, typename Iterator>
     ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
-                         ::std::is_base_of<non_const_wrapper, Op>::value>
+                         ::std::is_base_of_v<non_const_wrapper, Op>>
     operator()(Policy&& exec, Op op, Iterator iter)
     {
         op(::std::forward<Policy>(exec), make_iterator<Iterator>()(iter));
@@ -349,7 +349,7 @@ struct iterator_invoker
     // A version with 2 iterators which is used for non_const testcases
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator>
     ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value &&
-                         ::std::is_base_of<non_const_wrapper, Op>::value>
+                         ::std::is_base_of_v<non_const_wrapper, Op>>
     operator()(Policy&& exec, Op op, InputIterator input_iter, OutputIterator out_iter)
     {
         op(::std::forward<Policy>(exec), make_iterator<InputIterator>()(input_iter),
@@ -374,7 +374,7 @@ struct iterator_invoker
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
     ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
-                         !::std::is_base_of<non_const_wrapper, Op>::value>
+                           !::std::is_base_of_v<non_const_wrapper, Op>>
     operator()(Policy&& exec, Op op, Iterator inputBegin, Iterator inputEnd, Rest&&... rest)
     {
         invoke_if<Iterator>()(::std::distance(inputBegin, inputEnd) <= sizeLimit, op, exec,
@@ -429,7 +429,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     // A single iterator version which is used for non_const testcases
     template <typename Policy, typename Op, typename Iterator>
     ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
-                         ::std::is_base_of<non_const_wrapper, Op>::value>
+                         ::std::is_base_of_v<non_const_wrapper, Op>>
     operator()(Policy&& exec, Op op, Iterator iter)
     {
         op(::std::forward<Policy>(exec), make_iterator<Iterator>()(iter));
@@ -438,7 +438,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     // A version with 2 iterators which is used for non_const testcases
     template <typename Policy, typename Op, typename InputIterator, typename OutputIterator>
     ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, OutputIterator>::value &&
-                         ::std::is_base_of<non_const_wrapper, Op>::value>
+                         ::std::is_base_of_v<non_const_wrapper, Op>>
     operator()(Policy&& exec, Op op, InputIterator input_iter, OutputIterator out_iter)
     {
         op(::std::forward<Policy>(exec), make_iterator<InputIterator>()(input_iter),
@@ -472,7 +472,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
     ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
-                         !::std::is_base_of<non_const_wrapper, Op>::value>
+                         !::std::is_base_of_v<non_const_wrapper, Op>>
     operator()(Policy&& exec, Op op, Iterator inputBegin, Iterator inputEnd, Rest&&... rest)
     {
         if (::std::distance(inputBegin, inputEnd) <= sizeLimit)

--- a/test/support/test_complex.h
+++ b/test/support/test_complex.h
@@ -68,7 +68,7 @@ run_test()
 // Example:
 //     template <class T>
 //     void
-//     test(T x, ::std::enable_if_t<std::is_integral<T>::value>* = 0)
+//     test(T x, ::std::enable_if_t<std::is_integral_v<T>>* = 0)
 //     {
 //         static_assert((std::is_same<decltype(dpl::conj(x)), dpl::complex<double>>::value), "");
 //

--- a/test/support/test_complex.h
+++ b/test/support/test_complex.h
@@ -70,7 +70,7 @@ run_test()
 //     void
 //     test(T x, ::std::enable_if_t<std::is_integral_v<T>>* = 0)
 //     {
-//         static_assert((std::is_same<decltype(dpl::conj(x)), dpl::complex<double>>::value), "");
+//         static_assert((std::is_same_v<decltype(dpl::conj(x)), dpl::complex<double>>), "");
 //
 //         // HERE IS THE CODE WHICH CALL WE SHOULD AVOID IF DOUBLE IS NOT SUPPORTED ON DEVICE
 //         assert(dpl::conj(x) == dpl::conj(dpl::complex<double>(x, 0)));

--- a/test/support/test_iterators.h
+++ b/test/support/test_iterators.h
@@ -100,7 +100,7 @@ class input_iterator
     reference operator*() const { return *it_; }
     pointer operator->() const 
     {
-        if constexpr (::std::is_pointer<It>::value)
+        if constexpr (::std::is_pointer_v<It>)
         {
             return it_;
         }
@@ -184,7 +184,7 @@ class forward_iterator
     reference operator*() const { return *it_; }
     pointer operator->() const 
     {
-        if constexpr (::std::is_pointer<It>::value)
+        if constexpr (::std::is_pointer_v<It>)
         {
             return it_;
         }
@@ -268,7 +268,7 @@ class bidirectional_iterator
     reference operator*() const { return *it_; }
     pointer operator->() const 
     {
-        if constexpr (::std::is_pointer<It>::value)
+        if constexpr (::std::is_pointer_v<It>)
         {
             return it_;
         }
@@ -355,7 +355,7 @@ class random_access_iterator
     reference operator*() const { return *it_; }
     pointer operator->() const 
     {
-        if constexpr (::std::is_pointer<It>::value)
+        if constexpr (::std::is_pointer_v<It>)
         {
             return it_;
         }

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -372,28 +372,28 @@ test4buffers(int mult = kDefaultMultValue)
 }
 
 template <sycl::usm::alloc alloc_type, typename TestName>
-::std::enable_if_t<::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value>
+::std::enable_if_t<::std::is_base_of_v<test_base<typename TestName::UsedValueType>, TestName>>
 test1buffer()
 {
     test1buffer<alloc_type, typename TestName::UsedValueType, TestName>();
 }
 
 template <sycl::usm::alloc alloc_type, typename TestName>
-::std::enable_if_t<::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value>
+::std::enable_if_t<::std::is_base_of_v<test_base<typename TestName::UsedValueType>, TestName>>
 test2buffers()
 {
     test2buffers<alloc_type, typename TestName::UsedValueType, TestName>();
 }
 
 template <sycl::usm::alloc alloc_type, typename TestName>
-::std::enable_if_t<::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value>
+::std::enable_if_t<::std::is_base_of_v<test_base<typename TestName::UsedValueType>, TestName>>
 test3buffers(int mult = kDefaultMultValue)
 {
     test3buffers<alloc_type, typename TestName::UsedValueType, TestName>(mult);
 }
 
 template <sycl::usm::alloc alloc_type, typename TestName>
-::std::enable_if_t<::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value>
+::std::enable_if_t<::std::is_base_of_v<test_base<typename TestName::UsedValueType>, TestName>>
 test4buffers(int mult = kDefaultMultValue)
 {
     test4buffers<alloc_type, typename TestName::UsedValueType, TestName>(mult);

--- a/test/support/utils_test_base.h
+++ b/test/support/utils_test_base.h
@@ -404,14 +404,14 @@ void update_data(TTestDataTransfer& helper, Args&& ...args)
 
 //--------------------------------------------------------------------------------------------------------------------//
 template <typename T, typename TestName, typename TestBaseData>
-::std::enable_if_t<::std::is_base_of<test_base<T>, TestName>::value, TestName>
+::std::enable_if_t<::std::is_base_of_v<test_base<T>, TestName>, TestName>
 create_test_obj(TestBaseData& data)
 {
     return TestName(data);
 }
 
 template <typename T, typename TestName, typename TestBaseData>
-::std::enable_if_t<!::std::is_base_of<test_base<T>, TestName>::value, TestName>
+::std::enable_if_t<!::std::is_base_of_v<test_base<T>, TestName>, TestName>
 create_test_obj(TestBaseData&)
 {
     return TestName();
@@ -448,7 +448,7 @@ test_algo_three_sequences()
 
 //--------------------------------------------------------------------------------------------------------------------//
 template <typename TestName>
-::std::enable_if_t<::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value>
+::std::enable_if_t<::std::is_base_of_v<test_base<typename TestName::UsedValueType>, TestName>>
 test_algo_three_sequences()
 {
     test_algo_three_sequences<typename TestName::UsedValueType, TestName>();
@@ -488,7 +488,7 @@ test_algo_four_sequences()
 
 //--------------------------------------------------------------------------------------------------------------------//
 template <typename TestName>
-::std::enable_if_t<::std::is_base_of<test_base<typename TestName::UsedValueType>, TestName>::value>
+::std::enable_if_t<::std::is_base_of_v<test_base<typename TestName::UsedValueType>, TestName>>
 test_algo_four_sequences()
 {
     test_algo_four_sequences<typename TestName::UsedValueType, TestName>();

--- a/test/xpu_api/numerics/c.math/abs1.pass.cpp
+++ b/test/xpu_api/numerics/c.math/abs1.pass.cpp
@@ -28,7 +28,7 @@ void test_abs()
     Source pos_val = 5;
     Result res = 5;
 
-    static_assert(::std::is_same<decltype(dpl::abs(neg_val)), Result>::value);
+    static_assert(::std::is_same_v<decltype(dpl::abs(neg_val)), Result>);
 
     assert(dpl::abs(neg_val) == res);
     assert(dpl::abs(pos_val) == res);

--- a/test/xpu_api/numerics/c.math/abs1.pass.cpp
+++ b/test/xpu_api/numerics/c.math/abs1.pass.cpp
@@ -48,7 +48,7 @@ ONEDPL_TEST_NUM_MAIN
 {
     // On some systems char is unsigned.
     // If that is the case, we should just test signed char twice.
-    typedef ::std::conditional_t<std::is_signed<char>::value, char, signed char> SignedChar;
+    typedef ::std::conditional_t<std::is_signed_v<char>, char, signed char> SignedChar;
 
     // All types less than or equal to and not greater than int are promoted to int.
     test_abs<short int, int>();

--- a/test/xpu_api/numerics/c.math/cmath.pass.cpp
+++ b/test/xpu_api/numerics/c.math/cmath.pass.cpp
@@ -78,25 +78,25 @@ void test_abs()
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wabsolute-value"
 #endif
-    static_assert((std::is_same<decltype(dpl::abs((float)0)), float>::value), "");
-    static_assert((std::is_same<decltype(dpl::abs((int)0)), int>::value), "");
-    static_assert((std::is_same<decltype(dpl::abs((long)0)), long>::value), "");
-    static_assert((std::is_same<decltype(dpl::abs((long long)0)), long long>::value), "");
-    static_assert((std::is_same<decltype(dpl::abs((unsigned char)0)), int>::value), "");
-    static_assert((std::is_same<decltype(dpl::abs((unsigned short)0)), int>::value), "");
-    static_assert((std::is_same<decltype(dpl::abs((signed char)0)), int>::value), "");
-    static_assert((std::is_same<decltype(dpl::abs((short)0)), int>::value), "");
-    static_assert((std::is_same<decltype(dpl::abs((unsigned char)0)), int>::value), "");
-    static_assert((std::is_same<decltype(dpl::abs((char)0)), int>::value), "");
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::abs(Ambiguous())), Ambiguous>::value), ""))
+    static_assert((std::is_same_v<decltype(dpl::abs((float)0)), float>), "");
+    static_assert((std::is_same_v<decltype(dpl::abs((int)0)), int>), "");
+    static_assert((std::is_same_v<decltype(dpl::abs((long)0)), long>), "");
+    static_assert((std::is_same_v<decltype(dpl::abs((long long)0)), long long>), "");
+    static_assert((std::is_same_v<decltype(dpl::abs((unsigned char)0)), int>), "");
+    static_assert((std::is_same_v<decltype(dpl::abs((unsigned short)0)), int>), "");
+    static_assert((std::is_same_v<decltype(dpl::abs((signed char)0)), int>), "");
+    static_assert((std::is_same_v<decltype(dpl::abs((short)0)), int>), "");
+    static_assert((std::is_same_v<decltype(dpl::abs((unsigned char)0)), int>), "");
+    static_assert((std::is_same_v<decltype(dpl::abs((char)0)), int>), "");
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::abs(Ambiguous())), Ambiguous>), ""))
 
-    static_assert(!has_abs<unsigned>::value, "");
-    static_assert(!has_abs<unsigned long>::value, "");
-    static_assert(!has_abs<unsigned long long>::value, "");
-    static_assert(!has_abs<size_t>::value, "");
+    static_assert(!has_abs<unsigned>, "");
+    static_assert(!has_abs<unsigned long>, "");
+    static_assert(!has_abs<unsigned long long>, "");
+    static_assert(!has_abs<size_t>, "");
 
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::abs((double)0)), double>::value), ""))
-    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::abs((long double)0)), long double>::value), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::abs((double)0)), double>), ""))
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::abs((long double)0)), long double>), ""))
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif
@@ -107,76 +107,76 @@ void test_abs()
 ONEDPL_TEST_DECLARE
 void test_ceil()
 {
-    static_assert((std::is_same<decltype(dpl::ceil((float)0)), float>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::ceil((float)0)), float>), "");
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::ceil((bool)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::ceil((unsigned short)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::ceil((int)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::ceil((unsigned int)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::ceil((long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::ceil((unsigned long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::ceil((long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::ceil((unsigned long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::ceil((double)0)), double>::value), ""))
-    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::ceil((long double)0)), long double>::value), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::ceil(Ambiguous())), Ambiguous>::value), "");
+        static_assert((std::is_same_v<decltype(dpl::ceil((bool)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::ceil((unsigned short)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::ceil((int)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::ceil((unsigned int)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::ceil((long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::ceil((unsigned long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::ceil((long long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::ceil((unsigned long long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::ceil((double)0)), double>), ""))
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::ceil((long double)0)), long double>), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::ceil(Ambiguous())), Ambiguous>), "");
                       assert(dpl::ceil(0) == 0))
 }
 
 ONEDPL_TEST_DECLARE
 void test_exp()
 {
-    static_assert((std::is_same<decltype(dpl::exp((float)0)), float>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::exp((float)0)), float>), "");
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::exp((bool)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::exp((unsigned short)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::exp((int)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::exp((unsigned int)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::exp((long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::exp((unsigned long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::exp((long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::exp((unsigned long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::exp((double)0)), double>::value), ""))
-    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::exp((long double)0)), long double>::value), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::exp(Ambiguous())), Ambiguous>::value), "");
+        static_assert((std::is_same_v<decltype(dpl::exp((bool)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::exp((unsigned short)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::exp((int)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::exp((unsigned int)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::exp((long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::exp((unsigned long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::exp((long long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::exp((unsigned long long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::exp((double)0)), double>), ""))
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::exp((long double)0)), long double>), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::exp(Ambiguous())), Ambiguous>), "");
                       assert(dpl::exp(0) == 1))
 }
 
 ONEDPL_TEST_DECLARE
 void test_fabs()
 {
-    static_assert((std::is_same<decltype(dpl::fabs((float)0)), float>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::fabs((float)0)), float>), "");
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::fabs((bool)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fabs((unsigned short)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fabs((int)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fabs((unsigned int)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fabs((long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fabs((unsigned long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fabs((long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fabs((unsigned long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fabs((double)0)), double>::value), ""))
-    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::fabs((long double)0)), long double>::value), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::fabs(Ambiguous())), Ambiguous>::value), "");
+        static_assert((std::is_same_v<decltype(dpl::fabs((bool)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fabs((unsigned short)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fabs((int)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fabs((unsigned int)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fabs((long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fabs((unsigned long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fabs((long long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fabs((unsigned long long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fabs((double)0)), double>), ""))
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::fabs((long double)0)), long double>), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::fabs(Ambiguous())), Ambiguous>), "");
                       assert(dpl::fabs(-1) == 1));
 }
 
 ONEDPL_TEST_DECLARE
 void test_floor()
 {
-    static_assert((std::is_same<decltype(dpl::floor((float)0)), float>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::floor((float)0)), float>), "");
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::floor((bool)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::floor((unsigned short)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::floor((int)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::floor((unsigned int)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::floor((long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::floor((unsigned long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::floor((long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::floor((unsigned long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::floor((double)0)), double>::value), ""))
-    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::floor((long double)0)), long double>::value), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::floor(Ambiguous())), Ambiguous>::value), "");
+        static_assert((std::is_same_v<decltype(dpl::floor((bool)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::floor((unsigned short)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::floor((int)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::floor((unsigned int)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::floor((long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::floor((unsigned long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::floor((long long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::floor((unsigned long long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::floor((double)0)), double>), ""))
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::floor((long double)0)), long double>), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::floor(Ambiguous())), Ambiguous>), "");
                       assert(dpl::floor(1) == 1))
 }
 
@@ -186,19 +186,19 @@ void test_isgreater()
 #ifdef isgreater
 #error isgreater defined
 #endif
-    static_assert((std::is_same<decltype(dpl::isgreater((float)0, (float)0)), bool>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::isgreater((float)0, (float)0)), bool>), "");
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::isgreater((float)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isgreater((double)0, (float)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isgreater((double)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isgreater(0, (double)0)), bool>::value), ""))
+        static_assert((std::is_same_v<decltype(dpl::isgreater((float)0, (double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isgreater((double)0, (float)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isgreater((double)0, (double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isgreater(0, (double)0)), bool>), ""))
     IF_LONG_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::isgreater((float)0, (long double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isgreater((double)0, (long double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isgreater((long double)0, (float)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isgreater((long double)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isgreater((long double)0, (long double)0)), bool>::value), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::isgreater(Ambiguous(), Ambiguous())), Ambiguous>::value), "");
+        static_assert((std::is_same_v<decltype(dpl::isgreater((float)0, (long double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isgreater((double)0, (long double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isgreater((long double)0, (float)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isgreater((long double)0, (double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isgreater((long double)0, (long double)0)), bool>), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::isgreater(Ambiguous(), Ambiguous())), Ambiguous>), "");
                       assert(dpl::isgreater(-1.0, 0.F) == false))
 }
 
@@ -208,19 +208,19 @@ void test_isgreaterequal()
 #ifdef isgreaterequal
 #error isgreaterequal defined
 #endif
-    static_assert((std::is_same<decltype(dpl::isgreaterequal((float)0, (float)0)), bool>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::isgreaterequal((float)0, (float)0)), bool>), "");
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::isgreaterequal((float)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isgreaterequal((double)0, (float)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isgreaterequal((double)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isgreaterequal(0, (double)0)), bool>::value), ""))
+        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((float)0, (double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((double)0, (float)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((double)0, (double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isgreaterequal(0, (double)0)), bool>), ""))
     IF_LONG_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::isgreaterequal((float)0, (long double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isgreaterequal((double)0, (long double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isgreaterequal((long double)0, (float)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isgreaterequal((long double)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isgreaterequal((long double)0, (long double)0)), bool>::value), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::isgreaterequal(Ambiguous(), Ambiguous())), Ambiguous>::value), "");
+        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((float)0, (long double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((double)0, (long double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((long double)0, (float)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((long double)0, (double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((long double)0, (long double)0)), bool>), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::isgreaterequal(Ambiguous(), Ambiguous())), Ambiguous>), "");
                       assert(dpl::isgreaterequal(-1.0, 0.F) == false))
 }
 
@@ -236,25 +236,25 @@ void test_isinf()
 #pragma clang diagnostic ignored "-Wtautological-constant-compare"
 #endif
 
-    static_assert((std::is_same<decltype(dpl::isinf((float)0)), bool>::value), "");
-    static_assert((std::is_same<decltype(dpl::isinf(0)), bool>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::isinf((float)0)), bool>), "");
+    static_assert((std::is_same_v<decltype(dpl::isinf(0)), bool>), "");
 
     auto fnc = []()
     {
         typedef decltype(dpl::isinf((double)0)) DoubleRetType;
 #if !defined(__linux__) || defined(__clang__)
-        static_assert((std::is_same<DoubleRetType, bool>::value), "");
+        static_assert((std::is_same_v<DoubleRetType, bool>), "");
 #else
         // GLIBC < 2.23 defines 'isinf(double)' with a return type of 'int' in
         // all C++ dialects. The test should tolerate this when libc++ can't work
         // around it.
         // See: https://sourceware.org/bugzilla/show_bug.cgi?id=19439
-        static_assert((std::is_same<DoubleRetType, bool>::value || std::is_same<DoubleRetType, int>::value), "");
+        static_assert((std::is_same_v<DoubleRetType, bool> || std::is_same_v<DoubleRetType, int>), "");
 #endif
     };
     IF_DOUBLE_SUPPORT_L(fnc)
 
-    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::isinf((long double)0)), bool>::value), ""))
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::isinf((long double)0)), bool>), ""))
     IF_DOUBLE_SUPPORT(assert(dpl::isinf(-1.0) == false))
 #if !_PSTL_ICC_TEST_COMPLEX_ISINF_BROKEN
     assert(dpl::isinf(0) == false);
@@ -275,19 +275,19 @@ void test_isless()
 #ifdef isless
 #error isless defined
 #endif
-    static_assert((std::is_same<decltype(dpl::isless((float)0, (float)0)), bool>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::isless((float)0, (float)0)), bool>), "");
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::isless((float)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isless((double)0, (float)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isless((double)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isless(0, (double)0)), bool>::value), ""))
+        static_assert((std::is_same_v<decltype(dpl::isless((float)0, (double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isless((double)0, (float)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isless((double)0, (double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isless(0, (double)0)), bool>), ""))
     IF_LONG_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::isless((float)0, (long double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isless((double)0, (long double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isless((long double)0, (float)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isless((long double)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isless((long double)0, (long double)0)), bool>::value), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::isless(Ambiguous(), Ambiguous())), Ambiguous>::value), "");
+        static_assert((std::is_same_v<decltype(dpl::isless((float)0, (long double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isless((double)0, (long double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isless((long double)0, (float)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isless((long double)0, (double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isless((long double)0, (long double)0)), bool>), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::isless(Ambiguous(), Ambiguous())), Ambiguous>), "");
                       assert(dpl::isless(-1.0, 0.F) == true))
 }
 
@@ -297,19 +297,19 @@ void test_islessequal()
 #ifdef islessequal
 #error islessequal defined
 #endif
-    static_assert((std::is_same<decltype(dpl::islessequal((float)0, (float)0)), bool>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::islessequal((float)0, (float)0)), bool>), "");
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::islessequal((float)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::islessequal((double)0, (float)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::islessequal((double)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::islessequal(0, (double)0)), bool>::value), ""))
+        static_assert((std::is_same_v<decltype(dpl::islessequal((float)0, (double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::islessequal((double)0, (float)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::islessequal((double)0, (double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::islessequal(0, (double)0)), bool>), ""))
     IF_LONG_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::islessequal((float)0, (long double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::islessequal((double)0, (long double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::islessequal((long double)0, (float)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::islessequal((long double)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::islessequal((long double)0, (long double)0)), bool>::value), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::islessequal(Ambiguous(), Ambiguous())), Ambiguous>::value), "");
+        static_assert((std::is_same_v<decltype(dpl::islessequal((float)0, (long double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::islessequal((double)0, (long double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::islessequal((long double)0, (float)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::islessequal((long double)0, (double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::islessequal((long double)0, (long double)0)), bool>), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::islessequal(Ambiguous(), Ambiguous())), Ambiguous>), "");
                       assert(dpl::islessequal(-1.0, 0.F) == true));
 }
 
@@ -324,25 +324,25 @@ void test_isnan()
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wtautological-constant-compare"
 #endif
-    static_assert((std::is_same<decltype(dpl::isnan((float)0)), bool>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::isnan((float)0)), bool>), "");
 
     auto fnc = []()
     {
         typedef decltype(dpl::isnan((double)0)) DoubleRetType;
 #if !defined(__linux__) || defined(__clang__)
-        static_assert((std::is_same<DoubleRetType, bool>::value), "");
+        static_assert((std::is_same_v<DoubleRetType, bool>), "");
 #else
         // GLIBC < 2.23 defines 'isinf(double)' with a return type of 'int' in
         // all C++ dialects. The test should tolerate this when libc++ can't work
         // around it.
         // See: https://sourceware.org/bugzilla/show_bug.cgi?id=19439
-        static_assert((std::is_same<DoubleRetType, bool>::value || std::is_same<DoubleRetType, int>::value), "");
+        static_assert((std::is_same_v<DoubleRetType, bool> || std::is_same_v<DoubleRetType, int>), "");
 #endif
     };
     IF_DOUBLE_SUPPORT_L(fnc)
 
-    static_assert((std::is_same<decltype(dpl::isnan(0)), bool>::value), "");
-    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::isnan((long double)0)), bool>::value), ""))
+    static_assert((std::is_same_v<decltype(dpl::isnan(0)), bool>), "");
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::isnan((long double)0)), bool>), ""))
     IF_DOUBLE_SUPPORT(assert(dpl::isnan(-1.0) == false))
 #if !_PSTL_ICC_TEST_COMPLEX_ISNAN_BROKEN
     assert(dpl::isnan(0) == false);
@@ -363,142 +363,142 @@ void test_isunordered()
 #ifdef isunordered
 #error isunordered defined
 #endif
-    static_assert((std::is_same<decltype(dpl::isunordered((float)0, (float)0)), bool>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::isunordered((float)0, (float)0)), bool>), "");
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::isunordered((float)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isunordered((double)0, (float)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isunordered((double)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isunordered(0, (double)0)), bool>::value), ""))
+        static_assert((std::is_same_v<decltype(dpl::isunordered((float)0, (double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isunordered((double)0, (float)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isunordered((double)0, (double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isunordered(0, (double)0)), bool>), ""))
     IF_LONG_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::isunordered((float)0, (long double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isunordered((double)0, (long double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isunordered((long double)0, (float)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isunordered((long double)0, (double)0)), bool>::value), "");
-        static_assert((std::is_same<decltype(dpl::isunordered((long double)0, (long double)0)), bool>::value), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::isunordered(Ambiguous(), Ambiguous())), Ambiguous>::value), "");
+        static_assert((std::is_same_v<decltype(dpl::isunordered((float)0, (long double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isunordered((double)0, (long double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isunordered((long double)0, (float)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isunordered((long double)0, (double)0)), bool>), "");
+        static_assert((std::is_same_v<decltype(dpl::isunordered((long double)0, (long double)0)), bool>), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::isunordered(Ambiguous(), Ambiguous())), Ambiguous>), "");
                       assert(dpl::isunordered(-1.0, 0.F) == false));
 }
 
 ONEDPL_TEST_DECLARE
 void test_copysign()
 {
-    static_assert((std::is_same<decltype(dpl::copysign((float)0, (float)0)), float>::value), "");
-    static_assert((std::is_same<decltype(dpl::copysign((float)0, (unsigned int)0)), double>::value), "");
-    static_assert((std::is_same<decltype(dpl::copysignf(0,0)), float>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::copysign((float)0, (float)0)), float>), "");
+    static_assert((std::is_same_v<decltype(dpl::copysign((float)0, (unsigned int)0)), double>), "");
+    static_assert((std::is_same_v<decltype(dpl::copysignf(0,0)), float>), "");
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::copysign((bool)0, (float)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::copysign((unsigned short)0, (double)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::copysign((double)0, (long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::copysign((int)0, (unsigned long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::copysign((double)0, (double)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::copysign((float)0, (double)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::copysign((int)0, (int)0)), double>::value), ""))
+        static_assert((std::is_same_v<decltype(dpl::copysign((bool)0, (float)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::copysign((unsigned short)0, (double)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::copysign((double)0, (long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::copysign((int)0, (unsigned long long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::copysign((double)0, (double)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::copysign((float)0, (double)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::copysign((int)0, (int)0)), double>), ""))
     IF_LONG_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::copysign((int)0, (long double)0)), long double>::value), "");
-        static_assert((std::is_same<decltype(dpl::copysign((long double)0, (unsigned long)0)), long double>::value), "");
-        static_assert((std::is_same<decltype(dpl::copysign((int)0, (long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::copysign((long double)0, (long double)0)), long double>::value), "");
-        static_assert((std::is_same<decltype(dpl::copysign((float)0, (long double)0)), long double>::value), "");
-        static_assert((std::is_same<decltype(dpl::copysign((double)0, (long double)0)), long double>::value), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::copysign(Ambiguous(), Ambiguous())), Ambiguous>::value), "");
+        static_assert((std::is_same_v<decltype(dpl::copysign((int)0, (long double)0)), long double>), "");
+        static_assert((std::is_same_v<decltype(dpl::copysign((long double)0, (unsigned long)0)), long double>), "");
+        static_assert((std::is_same_v<decltype(dpl::copysign((int)0, (long long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::copysign((long double)0, (long double)0)), long double>), "");
+        static_assert((std::is_same_v<decltype(dpl::copysign((float)0, (long double)0)), long double>), "");
+        static_assert((std::is_same_v<decltype(dpl::copysign((double)0, (long double)0)), long double>), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::copysign(Ambiguous(), Ambiguous())), Ambiguous>), "");
                       assert(dpl::copysign(1,1) == 1))
 }
 
 ONEDPL_TEST_DECLARE
 void test_fmax()
 {
-    static_assert((std::is_same<decltype(dpl::fmax((float)0, (float)0)), float>::value), "");
-    static_assert((std::is_same<decltype(dpl::fmax((float)0, (unsigned int)0)), double>::value), "");
-    static_assert((std::is_same<decltype(dpl::fmaxf(0,0)), float>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::fmax((float)0, (float)0)), float>), "");
+    static_assert((std::is_same_v<decltype(dpl::fmax((float)0, (unsigned int)0)), double>), "");
+    static_assert((std::is_same_v<decltype(dpl::fmaxf(0,0)), float>), "");
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::fmax((bool)0, (float)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmax((unsigned short)0, (double)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmax((int)0, (long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmax((int)0, (unsigned long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmax((double)0, (long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmax((double)0, (double)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmax((float)0, (double)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmax((int)0, (int)0)), double>::value), ""))
+        static_assert((std::is_same_v<decltype(dpl::fmax((bool)0, (float)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmax((unsigned short)0, (double)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmax((int)0, (long long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmax((int)0, (unsigned long long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmax((double)0, (long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmax((double)0, (double)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmax((float)0, (double)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmax((int)0, (int)0)), double>), ""))
     IF_LONG_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::fmax((int)0, (long double)0)), long double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmax((long double)0, (unsigned long)0)), long double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmax((long double)0, (long double)0)), long double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmax((float)0, (long double)0)), long double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmax((double)0, (long double)0)), long double>::value), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::fmax(Ambiguous(), Ambiguous())), Ambiguous>::value), "");
+        static_assert((std::is_same_v<decltype(dpl::fmax((int)0, (long double)0)), long double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmax((long double)0, (unsigned long)0)), long double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmax((long double)0, (long double)0)), long double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmax((float)0, (long double)0)), long double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmax((double)0, (long double)0)), long double>), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::fmax(Ambiguous(), Ambiguous())), Ambiguous>), "");
                       assert(dpl::fmax(1,0) == 1))
 }
 
 ONEDPL_TEST_DECLARE
 void test_fmin()
 {
-    static_assert((std::is_same<decltype(dpl::fmin((float)0, (float)0)), float>::value), "");
-    static_assert((std::is_same<decltype(dpl::fminf(0, 0)), float>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::fmin((float)0, (float)0)), float>), "");
+    static_assert((std::is_same_v<decltype(dpl::fminf(0, 0)), float>), "");
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::fmin((bool)0, (float)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmin((unsigned short)0, (double)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmin((float)0, (unsigned int)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmin((double)0, (long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmin((int)0, (unsigned long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmin((double)0, (double)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmin((float)0, (double)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmin((int)0, (int)0)), double>::value), ""))
+        static_assert((std::is_same_v<decltype(dpl::fmin((bool)0, (float)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmin((unsigned short)0, (double)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmin((float)0, (unsigned int)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmin((double)0, (long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmin((int)0, (unsigned long long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmin((double)0, (double)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmin((float)0, (double)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmin((int)0, (int)0)), double>), ""))
     IF_LONG_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::fmin((int)0, (long double)0)), long double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmin((long double)0, (unsigned long)0)), long double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmin((int)0, (long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmin((long double)0, (long double)0)), long double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmin((float)0, (long double)0)), long double>::value), "");
-        static_assert((std::is_same<decltype(dpl::fmin((double)0, (long double)0)), long double>::value), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::fmin(Ambiguous(), Ambiguous())), Ambiguous>::value), "");
+        static_assert((std::is_same_v<decltype(dpl::fmin((int)0, (long double)0)), long double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmin((long double)0, (unsigned long)0)), long double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmin((int)0, (long long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmin((long double)0, (long double)0)), long double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmin((float)0, (long double)0)), long double>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmin((double)0, (long double)0)), long double>), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::fmin(Ambiguous(), Ambiguous())), Ambiguous>), "");
                       assert(dpl::fmin(1,0) == 0))
 }
 
 ONEDPL_TEST_DECLARE
 void test_nan()
 {
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::nan("")), double>::value), ""))
-    static_assert((std::is_same<decltype(dpl::nanf("")), float>::value), "");
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::nan("")), double>), ""))
+    static_assert((std::is_same_v<decltype(dpl::nanf("")), float>), "");
 }
 
 ONEDPL_TEST_DECLARE
 void test_round()
 {
-    static_assert((std::is_same<decltype(dpl::round((float)0)), float>::value), "");
-    static_assert((std::is_same<decltype(dpl::roundf(0)), float>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::round((float)0)), float>), "");
+    static_assert((std::is_same_v<decltype(dpl::roundf(0)), float>), "");
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::round((bool)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::round((unsigned short)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::round((int)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::round((unsigned int)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::round((long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::round((unsigned long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::round((unsigned long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::round((double)0)), double>::value), ""))
+        static_assert((std::is_same_v<decltype(dpl::round((bool)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::round((unsigned short)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::round((int)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::round((unsigned int)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::round((long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::round((unsigned long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::round((unsigned long long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::round((double)0)), double>), ""))
     IF_LONG_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::round((long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::round((long double)0)), long double>::value), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::round(Ambiguous())), Ambiguous>::value), "");
+        static_assert((std::is_same_v<decltype(dpl::round((long long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::round((long double)0)), long double>), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::round(Ambiguous())), Ambiguous>), "");
                       assert(dpl::round(1) == 1))
 }
 
 ONEDPL_TEST_DECLARE
 void test_trunc()
 {
-    static_assert((std::is_same<decltype(dpl::trunc((float)0)), float>::value), "");
-    static_assert((std::is_same<decltype(dpl::truncf(0)), float>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::trunc((float)0)), float>), "");
+    static_assert((std::is_same_v<decltype(dpl::truncf(0)), float>), "");
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same<decltype(dpl::trunc((bool)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::trunc((unsigned short)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::trunc((int)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::trunc((unsigned int)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::trunc((long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::trunc((unsigned long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::trunc((long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::trunc((unsigned long long)0)), double>::value), "");
-        static_assert((std::is_same<decltype(dpl::trunc((double)0)), double>::value), ""))
-    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::trunc((long double)0)), long double>::value), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same<decltype(dpl::trunc(Ambiguous())), Ambiguous>::value), "");
+        static_assert((std::is_same_v<decltype(dpl::trunc((bool)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::trunc((unsigned short)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::trunc((int)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::trunc((unsigned int)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::trunc((long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::trunc((unsigned long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::trunc((long long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::trunc((unsigned long long)0)), double>), "");
+        static_assert((std::is_same_v<decltype(dpl::trunc((double)0)), double>), ""))
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::trunc((long double)0)), long double>), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::trunc(Ambiguous())), Ambiguous>), "");
                       assert(dpl::trunc(1) == 1))
 }
 

--- a/test/xpu_api/numerics/c.math/cmath.pass.cpp
+++ b/test/xpu_api/numerics/c.math/cmath.pass.cpp
@@ -90,10 +90,10 @@ void test_abs()
     static_assert((std::is_same_v<decltype(dpl::abs((char)0)), int>), "");
     IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::abs(Ambiguous())), Ambiguous>), ""))
 
-    static_assert(!has_abs<unsigned>, "");
-    static_assert(!has_abs<unsigned long>, "");
-    static_assert(!has_abs<unsigned long long>, "");
-    static_assert(!has_abs<size_t>, "");
+    static_assert(!has_abs<unsigned>::value, "");
+    static_assert(!has_abs<unsigned long>::value, "");
+    static_assert(!has_abs<unsigned long long>::value, "");
+    static_assert(!has_abs<size_t>::value, "");
 
     IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::abs((double)0)), double>), ""))
     IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::abs((long double)0)), long double>), ""))

--- a/test/xpu_api/numerics/complex.number/cmplx.over/arg.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/arg.pass.cpp
@@ -20,7 +20,7 @@
 
 template <class T>
 void
-test(T x, ::std::enable_if_t<std::is_integral<T>::value>* = 0)
+test(T x, ::std::enable_if_t<std::is_integral_v<T>>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::arg(x)), double>::value), "");
     assert(dpl::arg(x) == dpl::arg(dpl::complex<double>(static_cast<double>(x), 0)));
@@ -28,7 +28,7 @@ test(T x, ::std::enable_if_t<std::is_integral<T>::value>* = 0)
 
 template <class T>
 void
-test(T x, ::std::enable_if_t<!std::is_integral<T>::value>* = 0)
+test(T x, ::std::enable_if_t<!std::is_integral_v<T>>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::arg(x)), T>::value), "");
     assert(dpl::arg(x) == dpl::arg(dpl::complex<T>(x, 0)));

--- a/test/xpu_api/numerics/complex.number/cmplx.over/arg.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/arg.pass.cpp
@@ -22,7 +22,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<std::is_integral_v<T>>* = 0)
 {
-    static_assert((std::is_same<decltype(dpl::arg(x)), double>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::arg(x)), double>), "");
     assert(dpl::arg(x) == dpl::arg(dpl::complex<double>(static_cast<double>(x), 0)));
 }
 
@@ -30,7 +30,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<!std::is_integral_v<T>>* = 0)
 {
-    static_assert((std::is_same<decltype(dpl::arg(x)), T>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::arg(x)), T>), "");
     assert(dpl::arg(x) == dpl::arg(dpl::complex<T>(x, 0)));
 }
 

--- a/test/xpu_api/numerics/complex.number/cmplx.over/conj.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/conj.pass.cpp
@@ -22,7 +22,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<std::is_integral_v<T>>* = 0)
 {
-    static_assert((std::is_same<decltype(dpl::conj(x)), dpl::complex<double> >::value), "");
+    static_assert((std::is_same_v<decltype(dpl::conj(x)), dpl::complex<double> >), "");
     assert(dpl::conj(x) == dpl::conj(dpl::complex<double>(x, 0)));
 }
 
@@ -30,7 +30,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<std::is_floating_point_v<T>>* = 0)
 {
-    static_assert((std::is_same<decltype(dpl::conj(x)), dpl::complex<T>>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::conj(x)), dpl::complex<T>>), "");
     assert(dpl::conj(x) == dpl::conj(dpl::complex<T>(x, 0)));
 }
 
@@ -38,7 +38,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<!std::is_integral_v<T> && !std::is_floating_point_v<T>>* = 0)
 {
-    static_assert((std::is_same<decltype(dpl::conj(x)), dpl::complex<T>>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::conj(x)), dpl::complex<T>>), "");
     assert(dpl::conj(x) == dpl::conj(dpl::complex<T>(x, 0)));
 }
 

--- a/test/xpu_api/numerics/complex.number/cmplx.over/conj.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/conj.pass.cpp
@@ -28,7 +28,7 @@ test(T x, ::std::enable_if_t<std::is_integral_v<T>>* = 0)
 
 template <class T>
 void
-test(T x, ::std::enable_if_t<std::is_floating_point<T>::value>* = 0)
+test(T x, ::std::enable_if_t<std::is_floating_point_v<T>>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::conj(x)), dpl::complex<T>>::value), "");
     assert(dpl::conj(x) == dpl::conj(dpl::complex<T>(x, 0)));
@@ -36,7 +36,7 @@ test(T x, ::std::enable_if_t<std::is_floating_point<T>::value>* = 0)
 
 template <class T>
 void
-test(T x, ::std::enable_if_t<!std::is_integral_v<T> && !std::is_floating_point<T>::value>* = 0)
+test(T x, ::std::enable_if_t<!std::is_integral_v<T> && !std::is_floating_point_v<T>>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::conj(x)), dpl::complex<T>>::value), "");
     assert(dpl::conj(x) == dpl::conj(dpl::complex<T>(x, 0)));

--- a/test/xpu_api/numerics/complex.number/cmplx.over/conj.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/conj.pass.cpp
@@ -20,7 +20,7 @@
 
 template <class T>
 void
-test(T x, ::std::enable_if_t<std::is_integral<T>::value>* = 0)
+test(T x, ::std::enable_if_t<std::is_integral_v<T>>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::conj(x)), dpl::complex<double> >::value), "");
     assert(dpl::conj(x) == dpl::conj(dpl::complex<double>(x, 0)));
@@ -36,7 +36,7 @@ test(T x, ::std::enable_if_t<std::is_floating_point<T>::value>* = 0)
 
 template <class T>
 void
-test(T x, ::std::enable_if_t<!std::is_integral<T>::value && !std::is_floating_point<T>::value>* = 0)
+test(T x, ::std::enable_if_t<!std::is_integral_v<T> && !std::is_floating_point<T>::value>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::conj(x)), dpl::complex<T>>::value), "");
     assert(dpl::conj(x) == dpl::conj(dpl::complex<T>(x, 0)));

--- a/test/xpu_api/numerics/complex.number/cmplx.over/imag.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/imag.pass.cpp
@@ -20,7 +20,7 @@ template <class T, int x>
 void
 test(::std::enable_if_t<std::is_integral_v<T>>* = 0)
 {
-    static_assert((std::is_same<decltype(dpl::imag(T(x))), double>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::imag(T(x))), double>), "");
     assert(dpl::imag(x) == 0);
 
     constexpr T val {x};
@@ -33,7 +33,7 @@ template <class T, int x>
 void
 test(::std::enable_if_t<!std::is_integral_v<T>>* = 0)
 {
-    static_assert((std::is_same<decltype(dpl::imag(T(x))), T>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::imag(T(x))), T>), "");
     assert(dpl::imag(x) == 0);
 
     constexpr T val {x};

--- a/test/xpu_api/numerics/complex.number/cmplx.over/imag.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/imag.pass.cpp
@@ -18,7 +18,7 @@
 
 template <class T, int x>
 void
-test(::std::enable_if_t<std::is_integral<T>::value>* = 0)
+test(::std::enable_if_t<std::is_integral_v<T>>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::imag(T(x))), double>::value), "");
     assert(dpl::imag(x) == 0);
@@ -31,7 +31,7 @@ test(::std::enable_if_t<std::is_integral<T>::value>* = 0)
 
 template <class T, int x>
 void
-test(::std::enable_if_t<!std::is_integral<T>::value>* = 0)
+test(::std::enable_if_t<!std::is_integral_v<T>>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::imag(T(x))), T>::value), "");
     assert(dpl::imag(x) == 0);

--- a/test/xpu_api/numerics/complex.number/cmplx.over/norm.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/norm.pass.cpp
@@ -18,7 +18,7 @@
 
 template <class T>
 void
-test(T x, ::std::enable_if_t<std::is_integral<T>::value>* = 0)
+test(T x, ::std::enable_if_t<std::is_integral_v<T>>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::norm(x)), double>::value), "");
     assert(dpl::norm(x) == dpl::norm(dpl::complex<double>(static_cast<double>(x), 0)));
@@ -26,7 +26,7 @@ test(T x, ::std::enable_if_t<std::is_integral<T>::value>* = 0)
 
 template <class T>
 void
-test(T x, ::std::enable_if_t<!std::is_integral<T>::value>* = 0)
+test(T x, ::std::enable_if_t<!std::is_integral_v<T>>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::norm(x)), T>::value), "");
     assert(dpl::norm(x) == dpl::norm(dpl::complex<T>(x, 0)));

--- a/test/xpu_api/numerics/complex.number/cmplx.over/norm.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/norm.pass.cpp
@@ -20,7 +20,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<std::is_integral_v<T>>* = 0)
 {
-    static_assert((std::is_same<decltype(dpl::norm(x)), double>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::norm(x)), double>), "");
     assert(dpl::norm(x) == dpl::norm(dpl::complex<double>(static_cast<double>(x), 0)));
 }
 
@@ -28,7 +28,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<!std::is_integral_v<T>>* = 0)
 {
-    static_assert((std::is_same<decltype(dpl::norm(x)), T>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::norm(x)), T>), "");
     assert(dpl::norm(x) == dpl::norm(dpl::complex<T>(x, 0)));
 }
 

--- a/test/xpu_api/numerics/complex.number/cmplx.over/pow.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/pow.pass.cpp
@@ -39,7 +39,7 @@ void
 test(T x, const dpl::complex<U>& y)
 {
     typedef decltype(promote(x) + promote(dpl::real(y))) V;
-    static_assert((std::is_same<decltype(dpl::pow(x, y)), dpl::complex<V> >::value), "");
+    static_assert((std::is_same_v<decltype(dpl::pow(x, y)), dpl::complex<V> >), "");
     is_about(dpl::pow(x, y), dpl::pow(dpl::complex<V>(x, 0), dpl::complex<V>(y)));
 }
 
@@ -48,7 +48,7 @@ void
 test(const dpl::complex<T>& x, U y)
 {
     typedef decltype(promote(dpl::real(x)) + promote(y)) V;
-    static_assert((std::is_same<decltype(dpl::pow(x, y)), dpl::complex<V> >::value), "");
+    static_assert((std::is_same_v<decltype(dpl::pow(x, y)), dpl::complex<V> >), "");
     is_about(dpl::pow(x, y), dpl::pow(dpl::complex<V>(x), dpl::complex<V>(y, 0)));
 }
 
@@ -57,7 +57,7 @@ void
 test(const dpl::complex<T>& x, const dpl::complex<U>& y)
 {
     typedef decltype(promote(dpl::real(x)) + promote(dpl::real(y))) V;
-    static_assert((std::is_same<decltype(dpl::pow(x, y)), dpl::complex<V> >::value), "");
+    static_assert((std::is_same_v<decltype(dpl::pow(x, y)), dpl::complex<V> >), "");
     assert(dpl::pow(x, y) == dpl::pow(dpl::complex<V>(x), dpl::complex<V>(y)));
 }
 

--- a/test/xpu_api/numerics/complex.number/cmplx.over/pow.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/pow.pass.cpp
@@ -28,7 +28,7 @@
 
 template <class T>
 double
-promote(T, ::std::enable_if_t<std::is_integral<T>::value>* = 0);
+promote(T, ::std::enable_if_t<std::is_integral_v<T>>* = 0);
 
 float promote(float);
 double promote(double);
@@ -63,7 +63,7 @@ test(const dpl::complex<T>& x, const dpl::complex<U>& y)
 
 template <class T, class U>
 void
-test(::std::enable_if_t<std::is_integral<T>::value>* = 0, ::std::enable_if_t<!std::is_integral<U>::value>* = 0)
+test(::std::enable_if_t<std::is_integral_v<T>>* = 0, ::std::enable_if_t<!std::is_integral_v<U>>* = 0)
 {
     test(T(3), dpl::complex<U>(4, 5));
     test(dpl::complex<U>(3, 4), T(5));
@@ -71,7 +71,7 @@ test(::std::enable_if_t<std::is_integral<T>::value>* = 0, ::std::enable_if_t<!st
 
 template <class T, class U>
 void
-test(::std::enable_if_t<!std::is_integral<T>::value>* = 0, ::std::enable_if_t<!std::is_integral<U>::value>* = 0)
+test(::std::enable_if_t<!std::is_integral_v<T>>* = 0, ::std::enable_if_t<!std::is_integral_v<U>>* = 0)
 {
     test(T(3), dpl::complex<U>(4, 5));
     test(dpl::complex<T>(3, 4), U(5));

--- a/test/xpu_api/numerics/complex.number/cmplx.over/proj.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/proj.pass.cpp
@@ -20,7 +20,7 @@
 
 template <class T>
 void
-test(T x, ::std::enable_if_t<std::is_integral<T>::value>* = 0)
+test(T x, ::std::enable_if_t<std::is_integral_v<T>>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::proj(x)), dpl::complex<double> >::value), "");
     assert(dpl::proj(x) == dpl::proj(dpl::complex<double>(x, 0)));
@@ -36,7 +36,7 @@ test(T x, ::std::enable_if_t<std::is_floating_point<T>::value>* = 0)
 
 template <class T>
 void
-test(T x, ::std::enable_if_t<!std::is_integral<T>::value && !std::is_floating_point<T>::value>* = 0)
+test(T x, ::std::enable_if_t<!std::is_integral_v<T> && !std::is_floating_point<T>::value>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::proj(x)), dpl::complex<T> >::value), "");
     assert(dpl::proj(x) == dpl::proj(dpl::complex<T>(x, 0)));

--- a/test/xpu_api/numerics/complex.number/cmplx.over/proj.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/proj.pass.cpp
@@ -22,7 +22,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<std::is_integral_v<T>>* = 0)
 {
-    static_assert((std::is_same<decltype(dpl::proj(x)), dpl::complex<double> >::value), "");
+    static_assert((std::is_same_v<decltype(dpl::proj(x)), dpl::complex<double> >), "");
     assert(dpl::proj(x) == dpl::proj(dpl::complex<double>(x, 0)));
 }
 
@@ -30,7 +30,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<std::is_floating_point_v<T>>* = 0)
 {
-    static_assert((std::is_same<decltype(dpl::proj(x)), dpl::complex<T> >::value), "");
+    static_assert((std::is_same_v<decltype(dpl::proj(x)), dpl::complex<T> >), "");
     assert(dpl::proj(x) == dpl::proj(dpl::complex<T>(x, 0)));
 }
 
@@ -38,7 +38,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<!std::is_integral_v<T> && !std::is_floating_point_v<T>>* = 0)
 {
-    static_assert((std::is_same<decltype(dpl::proj(x)), dpl::complex<T> >::value), "");
+    static_assert((std::is_same_v<decltype(dpl::proj(x)), dpl::complex<T> >), "");
     assert(dpl::proj(x) == dpl::proj(dpl::complex<T>(x, 0)));
 }
 

--- a/test/xpu_api/numerics/complex.number/cmplx.over/proj.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/proj.pass.cpp
@@ -28,7 +28,7 @@ test(T x, ::std::enable_if_t<std::is_integral_v<T>>* = 0)
 
 template <class T>
 void
-test(T x, ::std::enable_if_t<std::is_floating_point<T>::value>* = 0)
+test(T x, ::std::enable_if_t<std::is_floating_point_v<T>>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::proj(x)), dpl::complex<T> >::value), "");
     assert(dpl::proj(x) == dpl::proj(dpl::complex<T>(x, 0)));
@@ -36,7 +36,7 @@ test(T x, ::std::enable_if_t<std::is_floating_point<T>::value>* = 0)
 
 template <class T>
 void
-test(T x, ::std::enable_if_t<!std::is_integral_v<T> && !std::is_floating_point<T>::value>* = 0)
+test(T x, ::std::enable_if_t<!std::is_integral_v<T> && !std::is_floating_point_v<T>>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::proj(x)), dpl::complex<T> >::value), "");
     assert(dpl::proj(x) == dpl::proj(dpl::complex<T>(x, 0)));

--- a/test/xpu_api/numerics/complex.number/cmplx.over/real.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/real.pass.cpp
@@ -20,7 +20,7 @@ template <class T, int x>
 void
 test(::std::enable_if_t<std::is_integral_v<T>>* = 0)
 {
-    static_assert((std::is_same<decltype(dpl::real(T(x))), double>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::real(T(x))), double>), "");
     assert(dpl::real(x) == x);
 
     constexpr T val {x};
@@ -33,7 +33,7 @@ template <class T, int x>
 void
 test(::std::enable_if_t<!std::is_integral_v<T>>* = 0)
 {
-    static_assert((std::is_same<decltype(dpl::real(T(x))), T>::value), "");
+    static_assert((std::is_same_v<decltype(dpl::real(T(x))), T>), "");
     assert(dpl::real(x) == x);
 
     constexpr T val {x};

--- a/test/xpu_api/numerics/complex.number/cmplx.over/real.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/real.pass.cpp
@@ -18,7 +18,7 @@
 
 template <class T, int x>
 void
-test(::std::enable_if_t<std::is_integral<T>::value>* = 0)
+test(::std::enable_if_t<std::is_integral_v<T>>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::real(T(x))), double>::value), "");
     assert(dpl::real(x) == x);
@@ -31,7 +31,7 @@ test(::std::enable_if_t<std::is_integral<T>::value>* = 0)
 
 template <class T, int x>
 void
-test(::std::enable_if_t<!std::is_integral<T>::value>* = 0)
+test(::std::enable_if_t<!std::is_integral_v<T>>* = 0)
 {
     static_assert((std::is_same<decltype(dpl::real(T(x))), T>::value), "");
     assert(dpl::real(x) == x);

--- a/test/xpu_api/numerics/complex.number/complex.literals/literals.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.literals/literals.pass.cpp
@@ -16,12 +16,12 @@ ONEDPL_TEST_NUM_MAIN
     using namespace std::literals::complex_literals;
 
 //  Make sure the types are right
-    IF_LONG_DOUBLE_SUPPORT(static_assert ( std::is_same<decltype( 3.0il ), dpl::complex<long double>>::value, "" ))
-    IF_LONG_DOUBLE_SUPPORT(static_assert ( std::is_same<decltype( 3il   ), dpl::complex<long double>>::value, "" ))
-    IF_DOUBLE_SUPPORT(static_assert(std::is_same<decltype(3.0i), dpl::complex<double>>::value, ""))
-    IF_DOUBLE_SUPPORT(static_assert(std::is_same<decltype(3i), dpl::complex<double>>::value, ""))
-    static_assert ( std::is_same<decltype( 3.0if ), dpl::complex<float>>::value, "" );
-    static_assert ( std::is_same<decltype( 3if   ), dpl::complex<float>>::value, "" );
+    IF_LONG_DOUBLE_SUPPORT(static_assert ( std::is_same_v<decltype( 3.0il ), dpl::complex<long double>>, "" ))
+    IF_LONG_DOUBLE_SUPPORT(static_assert ( std::is_same_v<decltype( 3il   ), dpl::complex<long double>>, "" ))
+    IF_DOUBLE_SUPPORT(static_assert(std::is_same_v<decltype(3.0i), dpl::complex<double>>, ""))
+    IF_DOUBLE_SUPPORT(static_assert(std::is_same_v<decltype(3i), dpl::complex<double>>, ""))
+    static_assert ( std::is_same_v<decltype( 3.0if ), dpl::complex<float>>, "" );
+    static_assert ( std::is_same_v<decltype( 3if   ), dpl::complex<float>>, "" );
 
     IF_LONG_DOUBLE_SUPPORT(dpl::complex<long double> c1 = 3.0il;
                            assert(c1 == dpl::complex<long double>(0, 3.0));

--- a/test/xpu_api/numerics/complex.number/complex/types.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex/types.pass.cpp
@@ -23,7 +23,7 @@ void
 test()
 {
     typedef dpl::complex<T> C;
-    static_assert((std::is_same<typename C::value_type, T>::value), "");
+    static_assert((std::is_same_v<typename C::value_type, T>), "");
 }
 
 ONEDPL_TEST_NUM_MAIN

--- a/test/xpu_api/numerics/numeric.ops/numeric.ops.gcd/xpu_gcd.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/numeric.ops.gcd/xpu_gcd.pass.cpp
@@ -30,8 +30,8 @@ test0(int in1, int in2, int out)
 {
     auto value1 = static_cast<Input1>(in1);
     auto value2 = static_cast<Input2>(in2);
-    static_assert(oneapi::dpl::is_same<Output, decltype(oneapi::dpl::gcd(value1, value2))>::value, "");
-    static_assert(oneapi::dpl::is_same<Output, decltype(oneapi::dpl::gcd(value2, value1))>::value, "");
+    static_assert(oneapi::dpl::is_same_v<Output, decltype(oneapi::dpl::gcd(value1, value2))>, "");
+    static_assert(oneapi::dpl::is_same_v<Output, decltype(oneapi::dpl::gcd(value2, value1))>, "");
     return (static_cast<Output>(out) == oneapi::dpl::gcd(value1, value2));
 }
 

--- a/test/xpu_api/numerics/numeric.ops/numeric.ops.lcm/xpu_lcm.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/numeric.ops.lcm/xpu_lcm.pass.cpp
@@ -21,7 +21,7 @@
 #include <cassert>
 #include <iostream>
 
-using oneapi::dpl::is_same;
+using oneapi::dpl::is_same_v;
 using oneapi::dpl::lcm;
 
 template <typename T1, typename T2>
@@ -33,8 +33,8 @@ test0(int in1, int in2, int out)
 {
     auto value1 = static_cast<Input1>(in1);
     auto value2 = static_cast<Input2>(in2);
-    static_assert(is_same<Output, decltype(lcm(value1, value2))>::value, "");
-    static_assert(is_same<Output, decltype(lcm(value2, value1))>::value, "");
+    static_assert(is_same_v<Output, decltype(lcm(value1, value2))>, "");
+    static_assert(is_same_v<Output, decltype(lcm(value2, value1))>, "");
     return static_cast<Output>(out) == lcm(value1, value2);
 }
 

--- a/test/xpu_api/random/device_tests/common_for_device_tests.h
+++ b/test/xpu_api/random/device_tests/common_for_device_tests.h
@@ -35,7 +35,7 @@ int comparison(Fp* r0, Fp* r1, std::uint32_t length) {
     Fp coeff;
     int numErrors = 0;
     for (size_t i = 0; i < length; ++i) {
-        if constexpr (std::is_integral<Fp>::value) {
+        if constexpr (std::is_integral_v<Fp>) {
             if (((int)r0[i] - (int)r1[i]) > 1 || ((int)r1[i] - (int)r0[i]) > 1) {
                 std::cout << "mismatch in " << i << " element: " << r0[i] << " " << r1[i] << std::endl;
                 ++numErrors;

--- a/test/xpu_api/random/interface_tests/distributions_methods.pass.cpp
+++ b/test/xpu_api/random/interface_tests/distributions_methods.pass.cpp
@@ -139,7 +139,7 @@ check_params(oneapi::dpl::extreme_value_distribution<T>& distr)
 }
 
 template <typename Distr>
-::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::uniform_int_distribution<typename Distr::result_type>>::value>
+::std::enable_if_t<::std::is_same_v<Distr, oneapi::dpl::uniform_int_distribution<typename Distr::result_type>>>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{0, 10};
@@ -147,7 +147,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::uniform_real_distribution<typename Distr::result_type>>::value>
+::std::enable_if_t<::std::is_same_v<Distr, oneapi::dpl::uniform_real_distribution<typename Distr::result_type>>>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{1.5, 3.0};
@@ -155,7 +155,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::exponential_distribution<typename Distr::result_type>>::value>
+::std::enable_if_t<::std::is_same_v<Distr, oneapi::dpl::exponential_distribution<typename Distr::result_type>>>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{1.5};
@@ -163,7 +163,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::bernoulli_distribution<typename Distr::result_type>>::value>
+::std::enable_if_t<::std::is_same_v<Distr, oneapi::dpl::bernoulli_distribution<typename Distr::result_type>>>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{0.5};
@@ -171,7 +171,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::geometric_distribution<typename Distr::result_type>>::value>
+::std::enable_if_t<::std::is_same_v<Distr, oneapi::dpl::geometric_distribution<typename Distr::result_type>>>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{0.5};
@@ -179,7 +179,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::weibull_distribution<typename Distr::result_type>>::value>
+::std::enable_if_t<::std::is_same_v<Distr, oneapi::dpl::weibull_distribution<typename Distr::result_type>>>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{1.5, 3.0};
@@ -187,7 +187,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::lognormal_distribution<typename Distr::result_type>>::value>
+::std::enable_if_t<::std::is_same_v<Distr, oneapi::dpl::lognormal_distribution<typename Distr::result_type>>>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{1.5, 3.5};
@@ -195,7 +195,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::normal_distribution<typename Distr::result_type>>::value>
+::std::enable_if_t<::std::is_same_v<Distr, oneapi::dpl::normal_distribution<typename Distr::result_type>>>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{1.5, 3.5};
@@ -203,7 +203,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::cauchy_distribution<typename Distr::result_type>>::value>
+::std::enable_if_t<::std::is_same_v<Distr, oneapi::dpl::cauchy_distribution<typename Distr::result_type>>>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{1.5, 3.5};
@@ -211,7 +211,7 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
 }
 
 template <typename Distr>
-::std::enable_if_t<::std::is_same<Distr, oneapi::dpl::extreme_value_distribution<typename Distr::result_type>>::value>
+::std::enable_if_t<::std::is_same_v<Distr, oneapi::dpl::extreme_value_distribution<typename Distr::result_type>>>
 make_param(typename Distr::param_type& params1, typename Distr::param_type& params2)
 {
     params1 = typename Distr::param_type{1.5, 3.5};


### PR DESCRIPTION
It's part 2/3 of linked PR's:
 - part 1 : #1172
 - part 3 : #1174

In this PR we make oneDPL code cleanup and simplification using STL features supported in C++17:
- remove ```::value``` part - use helper variable templates;

| Previous variant | New variant | C++ | oneDPL | Tests |
|-------------------|--------------|-----------------------------------------|---|---|
| ```::std::is_arithmetic<X>::value``` | ```::std::is_arithmetic_v<X>``` | 17 | + | + |
| ```::std::is_base_of<X>::value``` | ```::std::is_base_of_v<X>``` | 17 | + | + |
| ```::std::is_const<X>::value``` | ```::std::is_const_v<X>``` | 17 | + |  |
| ```::std::is_convertible<X>::value``` | ```::std::is_convertible_v<X>``` | 17 | + |  |
| ```::std::is_copy_constructible<X>::value``` | ```::std::is_copy_constructible_v<X>``` | 17 | + |  |
| ```::std::is_default_constructible<X>::value``` | ```::std::is_default_constructible_v<X>``` | 17 |  | + |
| ```::std::is_default_constructible<X>::value``` | ```::std::is_default_constructible_v<X>``` | 17 |  | + |
| ```::std::is_floating_point<X>::value``` | ```::std::is_floating_point_v<X>``` | 17 | + | + |
| ```::std::is_integral<X>::value``` | ```::std::is_integral_v<X>``` | 17 | + | + |
| ```::std::is_lvalue_reference<X>::value``` | ```::std::is_lvalue_reference_v<X>``` | 17 | + |  |
| ```::std::is_move_assignable<X>::value``` | ```::std::is_move_assignable_v<X>``` | 17 | + |  |
| ```::std::is_pointer<X>::value``` | ```::std::is_pointer_v<X>``` | 17 | + | + |
| ```::std::is_reference<X>::value``` | ```::std::is_reference_v<X>``` | 17 |  | + |
| ```::std::is_same<X>::value``` | ```::std::is_same_v<X>``` | 17 | + | + |
| ```::std::is_standard_layout<X>::value``` | ```::std::is_standard_layout_v<X>``` | 17 |  | + |
| ```::std::is_signed<X>::value``` | ```::std::is_signed_v<X>``` | 17 |  | + |
| ```::std::is_trivial<X>::value``` | ```::std::is_trivial_v<X>``` | 17 |  | + |
| ```::std::is_trivially_copy_assignable<X>::value``` | ```::std::is_trivially_copy_assignable_v<X>``` | 17 | + |  |
| ```::std::is_trivially_copyable<X>::value``` | ```::std::is_trivially_copyable_v<X>``` | 17 |  | + |
| ```::std::is_trivially_destructible<X>::value``` | ```::std::is_trivially_destructible_v<X>``` | 17 |  | + |
| ```::std::is_void<X>::value``` | ```::std::is_void_v<X>``` | 17 | + | + |
| ```is_execution_policy<X>::value``` | ```is_execution_policy_v<X>``` | 14 | + | + |
