### PR TITLE
oneDPL code cleanup and simplification - misc

### DIFF
--- a/include/oneapi/dpl/internal/reduce_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/reduce_by_segment_impl.h
@@ -369,7 +369,7 @@ __sycl_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2&& 
 
                 ::std::size_t __max_end = 0;
                 ::std::size_t __item_segments = 0;
-                auto __identity = __dpl_sycl::__known_identity<_BinaryOperator, __val_type>::value;
+                auto __identity = __dpl_sycl::__known_identity_v<_BinaryOperator, __val_type>;
 
                 __val_type __accumulator = __identity;
                 for (::std::size_t __i = __start; __i < __end; ++__i)
@@ -485,7 +485,7 @@ __sycl_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2&& 
                     ::std::size_t __item_segments = 0;
 
                     ::std::int64_t __wg_agg_idx = __group_id - 1;
-                    __val_type __agg_collector = __dpl_sycl::__known_identity<_BinaryOperator, __val_type>::value;
+                    __val_type __agg_collector = __dpl_sycl::__known_identity_v<_BinaryOperator, __val_type>;
 
                     bool __ag_exists = false;
                     // 3a. Check to see if an aggregate exists and compute that value in the first
@@ -497,13 +497,11 @@ __sycl_reduce_by_segment(_ExecutionPolicy&& __exec, _Range1&& __keys, _Range2&& 
                         constexpr ::std::int32_t __vals_to_explore = 16;
                         bool __last_it = false;
                         __loc_seg_ends_acc[__local_id] = false;
-                        __loc_partials_acc[__local_id] =
-                            __dpl_sycl::__known_identity<_BinaryOperator, __val_type>::value;
+                        __loc_partials_acc[__local_id] = __dpl_sycl::__known_identity_v<_BinaryOperator, __val_type>;
                         for (::std::int32_t __i = __wg_agg_idx - __vals_to_explore * __local_id; !__last_it;
                              __i -= __wgroup_size * __vals_to_explore)
                         {
-                            __val_type __local_collector =
-                                __dpl_sycl::__known_identity<_BinaryOperator, __val_type>::value;
+                            __val_type __local_collector = __dpl_sycl::__known_identity_v<_BinaryOperator, __val_type>;
                             // exploration phase
                             for (::std::int32_t __j = __i;
                                  __j > __dpl_sycl::__maximum<::std::int32_t>{}(-1L, __i - __vals_to_explore); --__j)

--- a/include/oneapi/dpl/pstl/algorithm_fwd.h
+++ b/include/oneapi/dpl/pstl/algorithm_fwd.h
@@ -71,14 +71,14 @@ __pattern_walk1(_ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _Functio
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Function, class _IsVector>
 oneapi::dpl::__internal::__enable_if_host_execution_policy_conditional<
-    _ExecutionPolicy, __is_random_access_iterator<_RandomAccessIterator>::value>
+    _ExecutionPolicy, __is_random_access_iterator_v<_RandomAccessIterator>>
 __pattern_walk1(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Function __f,
                 _IsVector __is_vector,
                 /*parallel=*/::std::true_type);
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Function, class _IsVector>
 oneapi::dpl::__internal::__enable_if_host_execution_policy_conditional<
-    _ExecutionPolicy, !__is_random_access_iterator<_RandomAccessIterator>::value>
+    _ExecutionPolicy, !__is_random_access_iterator_v<_RandomAccessIterator>>
 __pattern_walk1(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Function __f,
                 _IsVector __is_vector,
                 /*parallel=*/::std::true_type);
@@ -155,14 +155,14 @@ __pattern_walk2(_ExecutionPolicy&&, _ForwardIterator1, _ForwardIterator1, _Forwa
 template <class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2, class _Function,
           class _IsVector>
 oneapi::dpl::__internal::__enable_if_host_execution_policy_conditional<
-    _ExecutionPolicy, __is_random_access_iterator<_RandomAccessIterator1, _RandomAccessIterator2>::value,
+    _ExecutionPolicy, __is_random_access_iterator_v<_RandomAccessIterator1, _RandomAccessIterator2>,
     _RandomAccessIterator2>
 __pattern_walk2(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1,
                 _RandomAccessIterator2 __first2, _Function __f, _IsVector __is_vector, /*parallel=*/::std::true_type);
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Function, class _IsVector>
 oneapi::dpl::__internal::__enable_if_host_execution_policy_conditional<
-    _ExecutionPolicy, !__is_random_access_iterator<_ForwardIterator1, _ForwardIterator2>::value, _ForwardIterator2>
+    _ExecutionPolicy, !__is_random_access_iterator_v<_ForwardIterator1, _ForwardIterator2>, _ForwardIterator2>
 __pattern_walk2(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
                 _ForwardIterator2 __first2, _Function __f, _IsVector __is_vector, /*parallel=*/::std::true_type);
 
@@ -185,14 +185,14 @@ __pattern_walk2_brick(_ExecutionPolicy&&, _ForwardIterator1, _ForwardIterator1, 
 
 template <class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2, class _Brick>
 oneapi::dpl::__internal::__enable_if_host_execution_policy_conditional<
-    _ExecutionPolicy, __is_random_access_iterator<_RandomAccessIterator1, _RandomAccessIterator2>::value,
+    _ExecutionPolicy, __is_random_access_iterator_v<_RandomAccessIterator1, _RandomAccessIterator2>,
     _RandomAccessIterator2>
 __pattern_walk2_brick(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1,
                       _RandomAccessIterator2 __first2, _Brick __brick, /*parallel=*/::std::true_type);
 
 template <class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2, class _Brick>
 oneapi::dpl::__internal::__enable_if_host_execution_policy_conditional<
-    _ExecutionPolicy, !__is_random_access_iterator<_RandomAccessIterator1, _RandomAccessIterator2>::value,
+    _ExecutionPolicy, !__is_random_access_iterator_v<_RandomAccessIterator1, _RandomAccessIterator2>,
     _RandomAccessIterator2>
 __pattern_walk2_brick(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1,
                       _RandomAccessIterator2 __first2, _Brick __brick, /*parallel=*/::std::true_type);
@@ -233,7 +233,7 @@ template <class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAcc
           class _RandomAccessIterator3, class _Function, class _IsVector>
 oneapi::dpl::__internal::__enable_if_host_execution_policy_conditional<
     _ExecutionPolicy,
-    __is_random_access_iterator<_RandomAccessIterator1, _RandomAccessIterator2, _RandomAccessIterator3>::value,
+    __is_random_access_iterator_v<_RandomAccessIterator1, _RandomAccessIterator2, _RandomAccessIterator3>,
     _RandomAccessIterator3>
 __pattern_walk3(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1,
                 _RandomAccessIterator2 __first2, _RandomAccessIterator3 __first3, _Function __f, _IsVector __is_vector,
@@ -243,7 +243,7 @@ template <class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAcc
           class _RandomAccessIterator3, class _Function, class _IsVector>
 oneapi::dpl::__internal::__enable_if_host_execution_policy_conditional<
     _ExecutionPolicy,
-    !__is_random_access_iterator<_RandomAccessIterator1, _RandomAccessIterator2, _RandomAccessIterator3>::value,
+    !__is_random_access_iterator_v<_RandomAccessIterator1, _RandomAccessIterator2, _RandomAccessIterator3>,
     _RandomAccessIterator3>
 __pattern_walk3(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1,
                 _RandomAccessIterator2 __first2, _RandomAccessIterator3 __first3, _Function __f, _IsVector __is_vector,

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -145,7 +145,7 @@ __pattern_walk1(_ExecutionPolicy&&, _ForwardIterator __first, _ForwardIterator _
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Function, class _IsVector>
 oneapi::dpl::__internal::__enable_if_host_execution_policy_conditional<
-    _ExecutionPolicy, __is_random_access_iterator<_RandomAccessIterator>::value>
+    _ExecutionPolicy, __is_random_access_iterator_v<_RandomAccessIterator>>
 __pattern_walk1(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Function __f,
                 _IsVector __is_vector,
                 /*parallel=*/::std::true_type)
@@ -160,7 +160,7 @@ __pattern_walk1(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _Rando
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Function, class _IsVector>
 oneapi::dpl::__internal::__enable_if_host_execution_policy_conditional<
-    _ExecutionPolicy, !__is_random_access_iterator<_ForwardIterator>::value>
+    _ExecutionPolicy, !__is_random_access_iterator_v<_ForwardIterator>>
 __pattern_walk1(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Function __f, _IsVector,
                 /*parallel=*/::std::true_type)
 {
@@ -310,7 +310,7 @@ __pattern_walk2(_ExecutionPolicy&&, _ForwardIterator1 __first1, _ForwardIterator
 template <class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2, class _Function,
           class _IsVector>
 oneapi::dpl::__internal::__enable_if_host_execution_policy_conditional<
-    _ExecutionPolicy, __is_random_access_iterator<_RandomAccessIterator1, _RandomAccessIterator2>::value,
+    _ExecutionPolicy, __is_random_access_iterator_v<_RandomAccessIterator1, _RandomAccessIterator2>,
     _RandomAccessIterator2>
 __pattern_walk2(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1,
                 _RandomAccessIterator2 __first2, _Function __f, _IsVector __is_vector, /*parallel=*/::std::true_type)
@@ -327,7 +327,7 @@ __pattern_walk2(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1, _Ran
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Function, class _IsVector>
 oneapi::dpl::__internal::__enable_if_host_execution_policy_conditional<
-    _ExecutionPolicy, !__is_random_access_iterator<_ForwardIterator1, _ForwardIterator2>::value, _ForwardIterator2>
+    _ExecutionPolicy, !__is_random_access_iterator_v<_ForwardIterator1, _ForwardIterator2>, _ForwardIterator2>
 __pattern_walk2(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
                 _ForwardIterator2 __first2, _Function __f, _IsVector, /*parallel=*/::std::true_type)
 {
@@ -383,7 +383,7 @@ __pattern_walk2_brick(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _Fo
 
 template <class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2, class _Brick>
 oneapi::dpl::__internal::__enable_if_host_execution_policy_conditional<
-    _ExecutionPolicy, __is_random_access_iterator<_RandomAccessIterator1, _RandomAccessIterator2>::value,
+    _ExecutionPolicy, __is_random_access_iterator_v<_RandomAccessIterator1, _RandomAccessIterator2>,
     _RandomAccessIterator2>
 __pattern_walk2_brick(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1,
                       _RandomAccessIterator2 __first2, _Brick __brick, /*parallel=*/::std::true_type)
@@ -405,7 +405,7 @@ __pattern_walk2_brick(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1
 //TODO: it postponed till adding more or less effective parallel implementation
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Brick>
 oneapi::dpl::__internal::__enable_if_host_execution_policy_conditional<
-    _ExecutionPolicy, !__is_random_access_iterator<_ForwardIterator1, _ForwardIterator2>::value, _ForwardIterator2>
+    _ExecutionPolicy, !__is_random_access_iterator_v<_ForwardIterator1, _ForwardIterator2>, _ForwardIterator2>
 __pattern_walk2_brick(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
                       _ForwardIterator2 __first2, _Brick __brick, /*parallel=*/::std::true_type)
 {
@@ -497,7 +497,7 @@ template <class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAcc
           class _RandomAccessIterator3, class _Function, class _IsVector>
 oneapi::dpl::__internal::__enable_if_host_execution_policy_conditional<
     _ExecutionPolicy,
-    __is_random_access_iterator<_RandomAccessIterator1, _RandomAccessIterator2, _RandomAccessIterator3>::value,
+    __is_random_access_iterator_v<_RandomAccessIterator1, _RandomAccessIterator2, _RandomAccessIterator3>,
     _RandomAccessIterator3>
 __pattern_walk3(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1,
                 _RandomAccessIterator2 __first2, _RandomAccessIterator3 __first3, _Function __f, _IsVector __is_vector,
@@ -517,7 +517,7 @@ __pattern_walk3(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __first1, _Ran
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator3,
           class _Function, class _IsVector>
 oneapi::dpl::__internal::__enable_if_host_execution_policy_conditional<
-    _ExecutionPolicy, !__is_random_access_iterator<_ForwardIterator1, _ForwardIterator2, _ForwardIterator3>::value,
+    _ExecutionPolicy, !__is_random_access_iterator_v<_ForwardIterator1, _ForwardIterator2, _ForwardIterator3>,
     _ForwardIterator3>
 __pattern_walk3(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1,
                 _ForwardIterator2 __first2, _ForwardIterator3 __first3, _Function __f, _IsVector,
@@ -1187,7 +1187,7 @@ __brick_calc_mask_1(_ForwardIterator __first, _ForwardIterator __last, bool* __r
     auto __count_true = _DifferenceType(0);
     auto __size = __last - __first;
 
-    static_assert(__is_random_access_iterator<_ForwardIterator>::value,
+    static_assert(__is_random_access_iterator_v<_ForwardIterator>,
                   "Pattern-brick error. Should be a random access iterator.");
 
     for (; __first != __last; ++__first, ++__mask)
@@ -2816,7 +2816,7 @@ _RandomAccessIterator
 __pattern_generate_n(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _Size __count, _Generator __g,
                      /*is_parallel=*/::std::true_type, _IsVector __is_vector)
 {
-    static_assert(__is_random_access_iterator<_RandomAccessIterator>::value,
+    static_assert(__is_random_access_iterator_v<_RandomAccessIterator>,
                   "Pattern-brick error. Should be a random access iterator.");
     return __internal::__pattern_generate(::std::forward<_ExecutionPolicy>(__exec), __first, __first + __count, __g,
                                           ::std::true_type(), __is_vector);

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -159,8 +159,8 @@ __pattern_walk1(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _Rando
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Function, class _IsVector>
-oneapi::dpl::__internal::__enable_if_host_execution_policy_conditional<
-    _ExecutionPolicy, !__is_random_access_iterator_v<_ForwardIterator>>
+oneapi::dpl::__internal::__enable_if_host_execution_policy_conditional<_ExecutionPolicy,
+                                                                       !__is_random_access_iterator_v<_ForwardIterator>>
 __pattern_walk1(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Function __f, _IsVector,
                 /*parallel=*/::std::true_type)
 {

--- a/include/oneapi/dpl/pstl/execution_impl.h
+++ b/include/oneapi/dpl/pstl/execution_impl.h
@@ -131,7 +131,7 @@ template <typename policy, typename... _IteratorTypes>
 struct __prefer_unsequenced_tag
 {
     static constexpr bool value = __internal::__allow_unsequenced<policy>::value &&
-                                  __internal::__is_random_access_iterator<_IteratorTypes...>::value;
+                                  __internal::__is_random_access_iterator_v<_IteratorTypes...>;
     typedef ::std::integral_constant<bool, value> type;
 };
 
@@ -139,7 +139,7 @@ template <typename policy, typename... _IteratorTypes>
 struct __prefer_parallel_tag
 {
     static constexpr bool value = __internal::__allow_parallel<policy>::value &&
-                                  __internal::__is_random_access_iterator<_IteratorTypes...>::value;
+                                  __internal::__is_random_access_iterator_v<_IteratorTypes...>;
     typedef ::std::integral_constant<bool, value> type;
 };
 

--- a/include/oneapi/dpl/pstl/execution_impl.h
+++ b/include/oneapi/dpl/pstl/execution_impl.h
@@ -130,16 +130,16 @@ __is_parallelization_preferred(_ExecutionPolicy& __exec)
 template <typename policy, typename... _IteratorTypes>
 struct __prefer_unsequenced_tag
 {
-    static constexpr bool value = __internal::__allow_unsequenced<policy>::value &&
-                                  __internal::__is_random_access_iterator_v<_IteratorTypes...>;
+    static constexpr bool value =
+        __internal::__allow_unsequenced<policy>::value && __internal::__is_random_access_iterator_v<_IteratorTypes...>;
     typedef ::std::integral_constant<bool, value> type;
 };
 
 template <typename policy, typename... _IteratorTypes>
 struct __prefer_parallel_tag
 {
-    static constexpr bool value = __internal::__allow_parallel<policy>::value &&
-                                  __internal::__is_random_access_iterator_v<_IteratorTypes...>;
+    static constexpr bool value =
+        __internal::__allow_parallel<policy>::value && __internal::__is_random_access_iterator_v<_IteratorTypes...>;
     typedef ::std::integral_constant<bool, value> type;
 };
 

--- a/include/oneapi/dpl/pstl/execution_impl.h
+++ b/include/oneapi/dpl/pstl/execution_impl.h
@@ -111,20 +111,20 @@ template <typename _ExecutionPolicy, typename... _IteratorTypes>
 auto
 __is_vectorization_preferred(_ExecutionPolicy& __exec)
     -> decltype(__internal::__lazy_and(__exec.__allow_vector(),
-                                       typename __internal::__is_random_access_iterator<_IteratorTypes...>::type()))
+                                       __internal::__is_random_access_iterator_t<_IteratorTypes...>()))
 {
     return __internal::__lazy_and(__exec.__allow_vector(),
-                                  typename __internal::__is_random_access_iterator<_IteratorTypes...>::type());
+                                  __internal::__is_random_access_iterator_t<_IteratorTypes...>());
 }
 
 template <typename _ExecutionPolicy, typename... _IteratorTypes>
 auto
 __is_parallelization_preferred(_ExecutionPolicy& __exec)
     -> decltype(__internal::__lazy_and(__exec.__allow_parallel(),
-                                       typename __internal::__is_random_access_iterator<_IteratorTypes...>::type()))
+                                       __internal::__is_random_access_iterator_t<_IteratorTypes...>()))
 {
     return __internal::__lazy_and(__exec.__allow_parallel(),
-                                  typename __internal::__is_random_access_iterator<_IteratorTypes...>::type());
+                                  __internal::__is_random_access_iterator_t<_IteratorTypes...>());
 }
 
 template <typename policy, typename... _IteratorTypes>

--- a/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
@@ -215,9 +215,12 @@ struct __is_random_access_or_integral<
 {
 };
 
+template <typename _Ip>
+inline constexpr bool __is_random_access_or_integral_v = __is_random_access_or_integral<_Ip>::value;
+
 // Sequenced version of for_loop for RAI and integral types
 template <typename _ExecutionPolicy, typename _Ip, typename _Function, typename _Sp, typename... _Rest>
-::std::enable_if_t<__is_random_access_or_integral<_Ip>::value>
+::std::enable_if_t<__is_random_access_or_integral_v<_Ip>>
 __pattern_for_loop(_ExecutionPolicy&& __exec, _Ip __first, _Ip __last, _Function __f, _Sp __stride,
                    /*vector=*/::std::false_type, /*parallel=*/::std::false_type, _Rest&&... __rest) noexcept
 {
@@ -290,7 +293,7 @@ __execute_loop_strided(_Ip __first, _Ip __last, _Function __f, _Sp __stride, _Pa
 
 // Sequenced version of for_loop for non-RAI and non-integral types
 template <typename _ExecutionPolicy, typename _Ip, typename _Function, typename... _Rest>
-::std::enable_if_t<!__is_random_access_or_integral<_Ip>::value>
+::std::enable_if_t<!__is_random_access_or_integral_v<_Ip>>
 __pattern_for_loop(_ExecutionPolicy&&, _Ip __first, _Ip __last, _Function __f, __single_stride_type,
                    /*vector=*/::std::false_type, /*parallel=*/::std::false_type, _Rest&&... __rest) noexcept
 {
@@ -308,7 +311,7 @@ __pattern_for_loop(_ExecutionPolicy&&, _Ip __first, _Ip __last, _Function __f, _
 }
 
 template <typename _ExecutionPolicy, typename _Ip, typename _Function, typename _Sp, typename... _Rest>
-::std::enable_if_t<!__is_random_access_or_integral<_Ip>::value>
+::std::enable_if_t<!__is_random_access_or_integral_v<_Ip>>
 __pattern_for_loop(_ExecutionPolicy&&, _Ip __first, _Ip __last, _Function __f, _Sp __stride,
                    /*vector=*/::std::false_type, /*parallel=*/::std::false_type, _Rest&&... __rest) noexcept
 {

--- a/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
@@ -211,7 +211,7 @@ struct __is_random_access_or_integral<_Ip, ::std::enable_if_t<::std::is_integral
 
 template <typename _Ip>
 struct __is_random_access_or_integral<
-    _Ip, ::std::enable_if_t<oneapi::dpl::__internal::__is_random_access_iterator<_Ip>::value>> : ::std::true_type
+    _Ip, ::std::enable_if_t<oneapi::dpl::__internal::__is_random_access_iterator_v<_Ip>>> : ::std::true_type
 {
 };
 

--- a/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
@@ -210,8 +210,9 @@ struct __is_random_access_or_integral<_Ip, ::std::enable_if_t<::std::is_integral
 };
 
 template <typename _Ip>
-struct __is_random_access_or_integral<
-    _Ip, ::std::enable_if_t<oneapi::dpl::__internal::__is_random_access_iterator_v<_Ip>>> : ::std::true_type
+struct __is_random_access_or_integral<_Ip,
+                                      ::std::enable_if_t<oneapi::dpl::__internal::__is_random_access_iterator_v<_Ip>>>
+    : ::std::true_type
 {
 };
 

--- a/include/oneapi/dpl/pstl/glue_algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_impl.h
@@ -393,10 +393,9 @@ replace_copy_if(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIt
         ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
         oneapi::dpl::__internal::__replace_copy_functor<
             oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _Tp>,
-            ::std::conditional_t<oneapi::dpl::__internal::__is_const_callable_object<_UnaryPredicate>::value,
-                                 _UnaryPredicate,
-                                 oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, _UnaryPredicate>>>(
-            __new_value, __pred),
+            ::std::conditional_t<
+                oneapi::dpl::__internal::__is_const_callable_object_v<_UnaryPredicate>, _UnaryPredicate,
+                oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, _UnaryPredicate>>>(__new_value, __pred),
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(
             __exec),
         oneapi::dpl::__internal::__is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(

--- a/include/oneapi/dpl/pstl/glue_algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_impl.h
@@ -393,9 +393,10 @@ replace_copy_if(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIt
         ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
         oneapi::dpl::__internal::__replace_copy_functor<
             oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _Tp>,
-            ::std::conditional_t<
-                oneapi::dpl::__internal::__is_const_callable_object_v<_UnaryPredicate>, _UnaryPredicate,
-                oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, _UnaryPredicate>>>(__new_value, __pred),
+            ::std::conditional_t<oneapi::dpl::__internal::__is_const_callable_object_v<_UnaryPredicate>,
+                                 _UnaryPredicate,
+                                 oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, _UnaryPredicate>>>(
+            __new_value, __pred),
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(
             __exec),
         oneapi::dpl::__internal::__is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -436,10 +436,9 @@ replace_copy_if(_ExecutionPolicy&& __exec, _Range1&& __rng, _Range2&& __result, 
         ::std::forward<_ExecutionPolicy>(__exec),
         oneapi::dpl::__internal::__replace_copy_functor<
             oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _Tp>,
-            ::std::conditional_t<oneapi::dpl::__internal::__is_const_callable_object<_UnaryPredicate>::value,
-                                 _UnaryPredicate,
-                                 oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, _UnaryPredicate>>>(
-            __new_value, __pred),
+            ::std::conditional_t<
+                oneapi::dpl::__internal::__is_const_callable_object_v<_UnaryPredicate>, _UnaryPredicate,
+                oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, _UnaryPredicate>>>(__new_value, __pred),
         __src, views::all_write(::std::forward<_Range2>(__result)));
     return __src.size();
 }

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -436,9 +436,10 @@ replace_copy_if(_ExecutionPolicy&& __exec, _Range1&& __rng, _Range2&& __result, 
         ::std::forward<_ExecutionPolicy>(__exec),
         oneapi::dpl::__internal::__replace_copy_functor<
             oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, const _Tp>,
-            ::std::conditional_t<
-                oneapi::dpl::__internal::__is_const_callable_object_v<_UnaryPredicate>, _UnaryPredicate,
-                oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, _UnaryPredicate>>>(__new_value, __pred),
+            ::std::conditional_t<oneapi::dpl::__internal::__is_const_callable_object_v<_UnaryPredicate>,
+                                 _UnaryPredicate,
+                                 oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, _UnaryPredicate>>>(
+            __new_value, __pred),
         __src, views::all_write(::std::forward<_Range2>(__result)));
     return __src.size();
 }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -231,6 +231,9 @@ struct __is_hetero_execution_policy<execution::device_policy<PolicyParams...>> :
 {
 };
 
+template <typename... PolicyParams>
+inline constexpr bool __is_hetero_execution_policy_v = __is_hetero_execution_policy<PolicyParams...>::value;
+
 template <typename _T>
 struct __is_device_execution_policy : ::std::false_type
 {
@@ -286,7 +289,7 @@ using __enable_if_device_execution_policy =
 
 template <typename _ExecPolicy, typename _T = void>
 using __enable_if_hetero_execution_policy =
-    ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<_ExecPolicy>>::value, _T>;
+    ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy_v<::std::decay_t<_ExecPolicy>>, _T>;
 
 template <typename _ExecPolicy, typename _T = void>
 using __enable_if_fpga_execution_policy =

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -244,6 +244,9 @@ struct __is_device_execution_policy<execution::device_policy<PolicyParams...>> :
 {
 };
 
+template <typename... PolicyParams>
+inline constexpr bool __is_device_execution_policy_v = __is_device_execution_policy<PolicyParams...>::value;
+
 template <typename _T>
 struct __is_fpga_execution_policy : ::std::false_type
 {
@@ -283,7 +286,7 @@ using __enable_if_convertible_to_events = ::std::enable_if_t<__is_convertible_to
 // Extension: execution policies type traits
 template <typename _ExecPolicy, typename _T, typename... _Events>
 using __enable_if_device_execution_policy =
-    ::std::enable_if_t<oneapi::dpl::__internal::__is_device_execution_policy<::std::decay_t<_ExecPolicy>>::value &&
+    ::std::enable_if_t<oneapi::dpl::__internal::__is_device_execution_policy_v<::std::decay_t<_ExecPolicy>> &&
                            oneapi::dpl::__internal::__is_convertible_to_event<_Events...>,
                        _T>;
 
@@ -297,14 +300,14 @@ using __enable_if_fpga_execution_policy =
 
 template <typename _ExecPolicy, typename _T, typename _Op1, typename... _Events>
 using __enable_if_device_execution_policy_single_no_default =
-    ::std::enable_if_t<oneapi::dpl::__internal::__is_device_execution_policy<::std::decay_t<_ExecPolicy>>::value &&
+    ::std::enable_if_t<oneapi::dpl::__internal::__is_device_execution_policy_v<::std::decay_t<_ExecPolicy>> &&
                            !::std::is_convertible_v<_Op1, sycl::event> &&
                            oneapi::dpl::__internal::__is_convertible_to_event<_Events...>,
                        _T>;
 
 template <typename _ExecPolicy, typename _T, typename _Op1, typename _Op2, typename... _Events>
 using __enable_if_device_execution_policy_double_no_default =
-    ::std::enable_if_t<oneapi::dpl::__internal::__is_device_execution_policy<::std::decay_t<_ExecPolicy>>::value &&
+    ::std::enable_if_t<oneapi::dpl::__internal::__is_device_execution_policy_v<::std::decay_t<_ExecPolicy>> &&
                            !::std::is_convertible_v<_Op1, sycl::event> && !::std::is_convertible_v<_Op2, sycl::event> &&
                            oneapi::dpl::__internal::__is_convertible_to_event<_Events...>,
                        _T>;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1813,8 +1813,9 @@ template <typename _ExecutionPolicy, typename _Range, typename _Compare, typenam
 auto
 __parallel_stable_sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp, _Proj __proj)
 {
-    auto __cmp_f = [__comp, __proj](const auto& __a, const auto& __b) mutable
-    { return __comp(__proj(__a), __proj(__b)); };
+    auto __cmp_f = [__comp, __proj](const auto& __a, const auto& __b) mutable {
+        return __comp(__proj(__a), __proj(__b));
+    };
     return __parallel_sort_impl(::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range>(__rng), __cmp_f);
 }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1793,7 +1793,7 @@ struct __is_radix_sort_usable_for_type
 
 #if _USE_RADIX_SORT
 template <typename _ExecutionPolicy, typename _Range, typename _Compare, typename _Proj,
-    __enable_if_t<oneapi::dpl::__internal::__is_device_execution_policy<__decay_t<_ExecutionPolicy>>::value &&
+    __enable_if_t<oneapi::dpl::__internal::__is_device_execution_policy_v<__decay_t<_ExecutionPolicy>> &&
     __is_radix_sort_usable_for_type<oneapi::dpl::__internal::__key_t<_Proj, _Range>, _Compare>::value, int> = 0>
 auto
 __parallel_stable_sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare, _Proj __proj)
@@ -1805,7 +1805,7 @@ __parallel_stable_sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare, _Pro
 
 template <
     typename _ExecutionPolicy, typename _Range, typename _Compare, typename _Proj,
-    __enable_if_t<oneapi::dpl::__internal::__is_device_execution_policy<__decay_t<_ExecutionPolicy>>::value &&
+    __enable_if_t<oneapi::dpl::__internal::__is_device_execution_policy_v<__decay_t<_ExecutionPolicy>> &&
     !__is_radix_sort_usable_for_type<oneapi::dpl::__internal::__key_t<_Proj, _Range>, _Compare>::value, int> = 0>
 auto
 __parallel_stable_sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp, _Proj __proj)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1793,8 +1793,10 @@ struct __is_radix_sort_usable_for_type
 
 #if _USE_RADIX_SORT
 template <typename _ExecutionPolicy, typename _Range, typename _Compare, typename _Proj,
-    __enable_if_t<oneapi::dpl::__internal::__is_device_execution_policy_v<::std::decay_t<_ExecutionPolicy>> &&
-    __is_radix_sort_usable_for_type<oneapi::dpl::__internal::__key_t<_Proj, _Range>, _Compare>::value, int> = 0>
+          ::std::enable_if_t<
+              oneapi::dpl::__internal::__is_device_execution_policy_v<::std::decay_t<_ExecutionPolicy>> &&
+                  __is_radix_sort_usable_for_type<oneapi::dpl::__internal::__key_t<_Proj, _Range>, _Compare>::value,
+              int> = 0>
 auto
 __parallel_stable_sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare, _Proj __proj)
 {
@@ -1803,16 +1805,16 @@ __parallel_stable_sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare, _Pro
 }
 #endif
 
-template <
-    typename _ExecutionPolicy, typename _Range, typename _Compare, typename _Proj,
-    __enable_if_t<oneapi::dpl::__internal::__is_device_execution_policy_v<::std::decay_t<_ExecutionPolicy>> &&
-    !__is_radix_sort_usable_for_type<oneapi::dpl::__internal::__key_t<_Proj, _Range>, _Compare>::value, int> = 0>
+template <typename _ExecutionPolicy, typename _Range, typename _Compare, typename _Proj,
+          ::std::enable_if_t<
+              oneapi::dpl::__internal::__is_device_execution_policy_v<::std::decay_t<_ExecutionPolicy>> &&
+                  !__is_radix_sort_usable_for_type<oneapi::dpl::__internal::__key_t<_Proj, _Range>, _Compare>::value,
+              int> = 0>
 auto
 __parallel_stable_sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp, _Proj __proj)
 {
-    auto __cmp_f = [__comp, __proj](const auto& __a, const auto& __b) mutable {
-        return __comp(__proj(__a), __proj(__b));
-    };
+    auto __cmp_f = [__comp, __proj](const auto& __a, const auto& __b) mutable
+    { return __comp(__proj(__a), __proj(__b)); };
     return __parallel_sort_impl(::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range>(__rng), __cmp_f);
 }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1784,8 +1784,8 @@ struct __is_radix_sort_usable_for_type
 {
     static constexpr bool value =
 #if _USE_RADIX_SORT
-        ::std::is_arithmetic_v<_T> && (__internal::__is_comp_ascending<__decay_t<_Compare>>::value ||
-                                       __internal::__is_comp_descending<__decay_t<_Compare>>::value);
+        ::std::is_arithmetic_v<_T> && (__internal::__is_comp_ascending<::std::decay_t<_Compare>>::value ||
+                                       __internal::__is_comp_descending<::std::decay_t<_Compare>>::value);
 #else
         false;
 #endif
@@ -1793,19 +1793,19 @@ struct __is_radix_sort_usable_for_type
 
 #if _USE_RADIX_SORT
 template <typename _ExecutionPolicy, typename _Range, typename _Compare, typename _Proj,
-    __enable_if_t<oneapi::dpl::__internal::__is_device_execution_policy_v<__decay_t<_ExecutionPolicy>> &&
+    __enable_if_t<oneapi::dpl::__internal::__is_device_execution_policy_v<::std::decay_t<_ExecutionPolicy>> &&
     __is_radix_sort_usable_for_type<oneapi::dpl::__internal::__key_t<_Proj, _Range>, _Compare>::value, int> = 0>
 auto
 __parallel_stable_sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare, _Proj __proj)
 {
-    return __parallel_radix_sort<__internal::__is_comp_ascending<__decay_t<_Compare>>::value>(
+    return __parallel_radix_sort<__internal::__is_comp_ascending<::std::decay_t<_Compare>>::value>(
         ::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range>(__rng), __proj);
 }
 #endif
 
 template <
     typename _ExecutionPolicy, typename _Range, typename _Compare, typename _Proj,
-    __enable_if_t<oneapi::dpl::__internal::__is_device_execution_policy_v<__decay_t<_ExecutionPolicy>> &&
+    __enable_if_t<oneapi::dpl::__internal::__is_device_execution_policy_v<::std::decay_t<_ExecutionPolicy>> &&
     !__is_radix_sort_usable_for_type<oneapi::dpl::__internal::__key_t<_Proj, _Range>, _Compare>::value, int> = 0>
 auto
 __parallel_stable_sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp, _Proj __proj)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -500,7 +500,7 @@ struct __parallel_transform_scan_static_single_group_submitter<_Inclusive, _Elem
 
 #if _ONEDPL_SYCL_SUB_GROUP_LOAD_STORE_PRESENT
                     constexpr bool __can_use_subgroup_load_store =
-                        _IsFullGroup && dpl::__internal::__range_has_raw_ptr_iterator<::std::decay_t<_InRng>>::value;
+                        _IsFullGroup && dpl::__internal::__range_has_raw_ptr_iterator_v<::std::decay_t<_InRng>>;
 #else
                     constexpr bool __can_use_subgroup_load_store = false;
 #endif
@@ -606,7 +606,7 @@ struct __parallel_copy_if_static_single_group_submitter<_Size, _ElemsPerItem, _W
 
 #if _ONEDPL_SYCL_SUB_GROUP_LOAD_STORE_PRESENT
                     constexpr bool __can_use_subgroup_load_store =
-                        _IsFullGroup && dpl::__internal::__range_has_raw_ptr_iterator<::std::decay_t<_InRng>>::value;
+                        _IsFullGroup && dpl::__internal::__range_has_raw_ptr_iterator_v<::std::decay_t<_InRng>>;
 #else
                     constexpr bool __can_use_subgroup_load_store = false;
 #endif

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -62,7 +62,7 @@ __order_preserving_cast(_UInt __val)
 }
 
 template <bool __is_ascending, typename _Int,
-          ::std::enable_if_t<::std::is_integral_v<_Int> && ::std::is_signed_v<_Int>, int> = 0>
+          ::std::enable_if_t<::std::is_integral_v<_Int>&& ::std::is_signed_v<_Int>, int> = 0>
 ::std::make_unsigned_t<_Int>
 __order_preserving_cast(_Int __val)
 {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -51,7 +51,7 @@ __order_preserving_cast(bool __val)
         return !__val;
 }
 
-template <bool __is_ascending, typename _UInt, __enable_if_t<::std::is_unsigned_v<_UInt>, int> = 0>
+template <bool __is_ascending, typename _UInt, ::std::enable_if_t<::std::is_unsigned_v<_UInt>, int> = 0>
 _UInt
 __order_preserving_cast(_UInt __val)
 {
@@ -62,7 +62,7 @@ __order_preserving_cast(_UInt __val)
 }
 
 template <bool __is_ascending, typename _Int,
-          __enable_if_t<::std::is_integral_v<_Int> && ::std::is_signed_v<_Int>, int> = 0>
+          ::std::enable_if_t<::std::is_integral_v<_Int>&& ::std::is_signed_v<_Int>, int> = 0>
 ::std::make_unsigned_t<_Int>
 __order_preserving_cast(_Int __val)
 {
@@ -74,7 +74,7 @@ __order_preserving_cast(_Int __val)
 }
 
 template <bool __is_ascending, typename _Float,
-          __enable_if_t<::std::is_floating_point_v<_Float> && sizeof(_Float) == sizeof(::std::uint32_t), int> = 0>
+          ::std::enable_if_t<::std::is_floating_point_v<_Float> && sizeof(_Float) == sizeof(::std::uint32_t), int> = 0>
 ::std::uint32_t
 __order_preserving_cast(_Float __val)
 {
@@ -89,7 +89,7 @@ __order_preserving_cast(_Float __val)
 }
 
 template <bool __is_ascending, typename _Float,
-          __enable_if_t<::std::is_floating_point_v<_Float> && sizeof(_Float) == sizeof(::std::uint64_t), int> = 0>
+          ::std::enable_if_t<::std::is_floating_point_v<_Float> && sizeof(_Float) == sizeof(::std::uint64_t), int> = 0>
 ::std::uint64_t
 __order_preserving_cast(_Float __val)
 {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -630,16 +630,18 @@ struct __parallel_radix_sort_iteration
     submit(_ExecutionPolicy&& __exec, ::std::size_t __segments, ::std::uint32_t __radix_iter, _InRange&& __in_rng,
            _OutRange&& __out_rng, _TmpBuf& __tmp_buf, sycl::event __dependency_event, _Proj __proj)
     {
-        using _CustomName = typename __decay_t<_ExecutionPolicy>::kernel_name;
-        using _RadixCountKernel = __internal::__kernel_name_generator<__count_phase, _CustomName, _ExecutionPolicy,
-                                                                      __decay_t<_InRange>, __decay_t<_TmpBuf>>;
-        using _RadixLocalScanKernel =
-             __internal::__kernel_name_generator<__local_scan_phase, _CustomName, _ExecutionPolicy, __decay_t<_TmpBuf>>;
+        using _CustomName = typename ::std::decay_t<_ExecutionPolicy>::kernel_name;
+        using _RadixCountKernel =
+            __internal::__kernel_name_generator<__count_phase, _CustomName, _ExecutionPolicy, ::std::decay_t<_InRange>,
+                                                ::std::decay_t<_TmpBuf>>;
+        using _RadixLocalScanKernel = __internal::__kernel_name_generator<__local_scan_phase, _CustomName,
+                                                                          _ExecutionPolicy, ::std::decay_t<_TmpBuf>>;
         using _RadixReorderPeerKernel =
             __internal::__kernel_name_generator<__reorder_peer_phase, _CustomName, _ExecutionPolicy,
-                                                __decay_t<_InRange>, __decay_t<_OutRange>>;
-        using _RadixReorderKernel = __internal::__kernel_name_generator<__reorder_phase, _CustomName, _ExecutionPolicy,
-                                                                         __decay_t<_InRange>, __decay_t<_OutRange>>;
+                                                ::std::decay_t<_InRange>, ::std::decay_t<_OutRange>>;
+        using _RadixReorderKernel =
+            __internal::__kernel_name_generator<__reorder_phase, _CustomName, _ExecutionPolicy,
+                                                ::std::decay_t<_InRange>, ::std::decay_t<_OutRange>>;
 
         ::std::size_t __max_sg_size = oneapi::dpl::__internal::__max_sub_group_size(__exec);
         ::std::size_t __reorder_sg_size = __max_sg_size;
@@ -667,7 +669,7 @@ struct __parallel_radix_sort_iteration
         const ::std::uint32_t __radix_states = 1 << __radix_bits;
 
         // correct __count_wg_size according to local memory limit in count phase
-        using _CounterType = typename __decay_t<_TmpBuf>::value_type;
+        using _CounterType = typename ::std::decay_t<_TmpBuf>::value_type;
         const auto __max_count_wg_size = oneapi::dpl::__internal::__slm_adjusted_work_group_size(
             __exec, sizeof(_CounterType) * __radix_states, __count_wg_size);
         __count_wg_size = static_cast<::std::size_t>((__max_count_wg_size / __radix_states)) * __radix_states;
@@ -747,7 +749,7 @@ __parallel_radix_sort(_ExecutionPolicy&& __exec, _Range&& __in_rng, _Proj __proj
     assert(__n > 1);
 
     // types
-    using _DecExecutionPolicy = __decay_t<_ExecutionPolicy>;
+    using _DecExecutionPolicy = ::std::decay_t<_ExecutionPolicy>;
     using _ValueT = oneapi::dpl::__internal::__value_t<_Range>;
     using _KeyT = oneapi::dpl::__internal::__key_t<_Proj, _Range>;
 
@@ -765,7 +767,7 @@ __parallel_radix_sort(_ExecutionPolicy&& __exec, _Range&& __in_rng, _Proj __proj
     constexpr auto __wg_size = 64;
 
     //TODO: with _RadixSortKernel also the following a couple of compile time constants is used for unique kernel name
-    using _RadixSortKernel = typename __decay_t<_ExecutionPolicy>::kernel_name;
+    using _RadixSortKernel = typename ::std::decay_t<_ExecutionPolicy>::kernel_name;
 
     if (__n <= 64 && __wg_size <= __max_wg_size)
         __event = __subgroup_radix_sort<_RadixSortKernel, __wg_size, 1, __radix_bits, __is_ascending>{}(

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -62,7 +62,7 @@ __order_preserving_cast(_UInt __val)
 }
 
 template <bool __is_ascending, typename _Int,
-          ::std::enable_if_t<::std::is_integral_v<_Int>&& ::std::is_signed_v<_Int>, int> = 0>
+          ::std::enable_if_t<::std::is_integral_v<_Int> && ::std::is_signed_v<_Int>, int> = 0>
 ::std::make_unsigned_t<_Int>
 __order_preserving_cast(_Int __val)
 {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -148,10 +148,6 @@ namespace __par_backend_hetero
 // aliases for faster access to modes
 using access_mode = sycl::access_mode;
 
-// substitution for C++17 convenience types
-template <bool __flag, typename _T = void>
-using __enable_if_t = ::std::enable_if_t<__flag, _T>;
-
 // function to simplify zip_iterator creation
 template <typename... T>
 oneapi::dpl::zip_iterator<T...>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -149,8 +149,6 @@ namespace __par_backend_hetero
 using access_mode = sycl::access_mode;
 
 // substitution for C++17 convenience types
-template <typename _T>
-using __decay_t = ::std::decay_t<_T>;
 template <bool __flag, typename _T = void>
 using __enable_if_t = ::std::enable_if_t<__flag, _T>;
 
@@ -167,10 +165,10 @@ template <template <typename> class _NewKernelName, typename _Policy,
           oneapi::dpl::__internal::__enable_if_device_execution_policy<_Policy, int> = 0>
 auto
 make_wrapped_policy(_Policy&& __policy)
-    -> decltype(oneapi::dpl::execution::make_device_policy<_NewKernelName<typename __decay_t<_Policy>::kernel_name>>(
-        ::std::forward<_Policy>(__policy)))
+    -> decltype(oneapi::dpl::execution::make_device_policy<
+                _NewKernelName<typename ::std::decay_t<_Policy>::kernel_name>>(::std::forward<_Policy>(__policy)))
 {
-    return oneapi::dpl::execution::make_device_policy<_NewKernelName<typename __decay_t<_Policy>::kernel_name>>(
+    return oneapi::dpl::execution::make_device_policy<_NewKernelName<typename ::std::decay_t<_Policy>::kernel_name>>(
         ::std::forward<_Policy>(__policy));
 }
 
@@ -179,12 +177,12 @@ template <template <typename> class _NewKernelName, typename _Policy,
           oneapi::dpl::__internal::__enable_if_fpga_execution_policy<_Policy, int> = 0>
 auto
 make_wrapped_policy(_Policy&& __policy)
-    -> decltype(oneapi::dpl::execution::make_fpga_policy<__decay_t<_Policy>::unroll_factor,
-                                                         _NewKernelName<typename __decay_t<_Policy>::kernel_name>>(
+    -> decltype(oneapi::dpl::execution::make_fpga_policy<::std::decay_t<_Policy>::unroll_factor,
+                                                         _NewKernelName<typename ::std::decay_t<_Policy>::kernel_name>>(
         ::std::forward<_Policy>(__policy)))
 {
-    return oneapi::dpl::execution::make_fpga_policy<__decay_t<_Policy>::unroll_factor,
-                                                    _NewKernelName<typename __decay_t<_Policy>::kernel_name>>(
+    return oneapi::dpl::execution::make_fpga_policy<::std::decay_t<_Policy>::unroll_factor,
+                                                    _NewKernelName<typename ::std::decay_t<_Policy>::kernel_name>>(
         ::std::forward<_Policy>(__policy));
 }
 #endif
@@ -396,7 +394,7 @@ template <typename _ExecutionPolicy, typename _T, typename _BValueT, int __dim, 
 struct __buffer<_ExecutionPolicy, _T, sycl::buffer<_BValueT, __dim, _AllocT>>
 {
   private:
-    using __exec_policy_t = __decay_t<_ExecutionPolicy>;
+    using __exec_policy_t = ::std::decay_t<_ExecutionPolicy>;
     using __container_t = typename __local_buffer<sycl::buffer<_T, __dim, _AllocT>>::type;
 
     __container_t __container;
@@ -447,7 +445,7 @@ template <typename _ExecutionPolicy, typename _T, typename _BValueT>
 struct __buffer<_ExecutionPolicy, _T, _BValueT*>
 {
   private:
-    using __exec_policy_t = __decay_t<_ExecutionPolicy>;
+    using __exec_policy_t = ::std::decay_t<_ExecutionPolicy>;
     using __container_t = ::std::unique_ptr<_T, __sycl_usm_free<__exec_policy_t, _T>>;
     using __alloc_t = sycl::usm::alloc;
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -111,6 +111,9 @@ template <typename _BinaryOp, typename _T>
 using __has_known_identity = sycl::ONEAPI::has_known_identity<_BinaryOp, _T>;
 #endif // _ONEDPL_SYCL2020_KNOWN_IDENTITY_PRESENT
 
+template <typename _BinaryOp, typename _T>
+inline constexpr auto __known_identity_v = __known_identity<_BinaryOp, _T>::value;
+
 #if _ONEDPL_SYCL2020_FUNCTIONAL_OBJECTS_PRESENT
 template <typename _T = void>
 using __plus = sycl::plus<_T>;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -191,6 +191,9 @@ template <typename _Iter>
 using is_hetero_it = oneapi::dpl::__internal::is_hetero_iterator<_Iter>;
 
 template <typename _Iter>
+inline constexpr bool is_hetero_it_v = is_hetero_it<_Iter>::value;
+
+template <typename _Iter>
 using is_passed_directly_it = oneapi::dpl::__internal::is_passed_directly<_Iter>;
 
 //struct for checking if it needs to create a temporary SYCL buffer or not
@@ -201,7 +204,7 @@ struct is_temp_buff : ::std::false_type
 };
 
 template <typename _Iter>
-struct is_temp_buff<_Iter, ::std::enable_if_t<!is_hetero_it<_Iter>::value && !::std::is_pointer_v<_Iter> &&
+struct is_temp_buff<_Iter, ::std::enable_if_t<!is_hetero_it_v<_Iter> && !::std::is_pointer_v<_Iter> &&
                                               !is_passed_directly_it<_Iter>::value>> : ::std::true_type
 {
 };
@@ -445,7 +448,7 @@ struct __get_sycl_range
 
   public:
     //specialization for permutation_iterator using sycl_iterator as source
-    template <typename _It, typename _Map, ::std::enable_if_t<is_hetero_it<_It>::value, int> = 0>
+    template <typename _It, typename _Map, ::std::enable_if_t<is_hetero_it_v<_It>, int> = 0>
     auto
     operator()(oneapi::dpl::permutation_iterator<_It, _Map> __first,
                oneapi::dpl::permutation_iterator<_It, _Map> __last)
@@ -464,7 +467,7 @@ struct __get_sycl_range
     // TODO Add specialization for general case, e.g., permutation_iterator using host
     // or another fancy iterator.
     //specialization for permutation_iterator using USM pointer as source
-    template <typename _It, typename _Map, ::std::enable_if_t<!is_hetero_it<_It>::value, int> = 0>
+    template <typename _It, typename _Map, ::std::enable_if_t<!is_hetero_it_v<_It>, int> = 0>
     auto
     operator()(oneapi::dpl::permutation_iterator<_It, _Map> __first,
                oneapi::dpl::permutation_iterator<_It, _Map> __last)
@@ -509,9 +512,9 @@ struct __get_sycl_range
     //specialization for hetero iterator
     template <typename _Iter>
     auto
-    operator()(_Iter __first, _Iter __last)
-        -> ::std::enable_if_t<is_hetero_it<_Iter>::value,
-                              __range_holder<oneapi::dpl::__ranges::all_view<val_t<_Iter>, AccMode>>>
+    operator()(_Iter __first, _Iter __last) ->
+        ::std::enable_if_t<is_hetero_it_v<_Iter>,
+                                  __range_holder<oneapi::dpl::__ranges::all_view<val_t<_Iter>, AccMode>>>
     {
         assert(__first < __last);
         using value_type = val_t<_Iter>;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -196,6 +196,9 @@ inline constexpr bool is_hetero_it_v = is_hetero_it<_Iter>::value;
 template <typename _Iter>
 using is_passed_directly_it = oneapi::dpl::__internal::is_passed_directly<_Iter>;
 
+template <typename _Iter>
+inline constexpr bool is_passed_directly_it_v = is_passed_directly_it<_Iter>::value;
+
 //struct for checking if it needs to create a temporary SYCL buffer or not
 
 template <typename _Iter, typename Void = void>
@@ -205,7 +208,7 @@ struct is_temp_buff : ::std::false_type
 
 template <typename _Iter>
 struct is_temp_buff<_Iter, ::std::enable_if_t<!is_hetero_it_v<_Iter> && !::std::is_pointer_v<_Iter> &&
-                                              !is_passed_directly_it<_Iter>::value>> : ::std::true_type
+                                              !is_passed_directly_it_v<_Iter>>> : ::std::true_type
 {
 };
 
@@ -501,7 +504,7 @@ struct __get_sycl_range
 
     // for raw pointers and direct pass objects (for example, counting_iterator, iterator of USM-containers)
     template <typename _Iter>
-    ::std::enable_if_t<is_passed_directly_it<_Iter>::value, __range_holder<oneapi::dpl::__ranges::guard_view<_Iter>>>
+    ::std::enable_if_t<is_passed_directly_it_v<_Iter>, __range_holder<oneapi::dpl::__ranges::guard_view<_Iter>>>
     operator()(_Iter __first, _Iter __last)
     {
         assert(__first < __last);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -435,7 +435,7 @@ struct __get_sycl_range
     }
 
     template <typename _R, typename _Map, typename _Size,
-              ::std::enable_if_t<oneapi::dpl::__internal::__is_random_access_iterator<_Map>::value, int> = 0>
+              ::std::enable_if_t<oneapi::dpl::__internal::__is_random_access_iterator_v<_Map>, int> = 0>
     auto
     __get_permutation_view(_R __r, _Map __m, _Size __s)
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -207,8 +207,9 @@ struct is_temp_buff : ::std::false_type
 };
 
 template <typename _Iter>
-struct is_temp_buff<_Iter, ::std::enable_if_t<!is_hetero_it_v<_Iter> && !::std::is_pointer_v<_Iter> &&
-                                              !is_passed_directly_it_v<_Iter>>> : ::std::true_type
+struct is_temp_buff<
+    _Iter, ::std::enable_if_t<!is_hetero_it_v<_Iter> && !::std::is_pointer_v<_Iter> && !is_passed_directly_it_v<_Iter>>>
+    : ::std::true_type
 {
 };
 
@@ -515,9 +516,9 @@ struct __get_sycl_range
     //specialization for hetero iterator
     template <typename _Iter>
     auto
-    operator()(_Iter __first, _Iter __last) ->
-        ::std::enable_if_t<is_hetero_it_v<_Iter>,
-                                  __range_holder<oneapi::dpl::__ranges::all_view<val_t<_Iter>, AccMode>>>
+    operator()(_Iter __first, _Iter __last)
+        -> ::std::enable_if_t<is_hetero_it_v<_Iter>,
+                              __range_holder<oneapi::dpl::__ranges::all_view<val_t<_Iter>, AccMode>>>
     {
         assert(__first < __last);
         using value_type = val_t<_Iter>;

--- a/include/oneapi/dpl/pstl/iterator_defs.h
+++ b/include/oneapi/dpl/pstl/iterator_defs.h
@@ -77,6 +77,9 @@ struct __is_random_access_iterator<_IteratorType> : __is_random_access_iterator_
 {
 };
 
+template <typename... _IteratorTypes>
+using __is_random_access_iterator_t = typename __is_random_access_iterator<_IteratorTypes...>::type;
+
 template <typename ..._IteratorTypes>
 inline constexpr bool __is_random_access_iterator_v = __is_random_access_iterator<_IteratorTypes...>::value;
 

--- a/include/oneapi/dpl/pstl/iterator_defs.h
+++ b/include/oneapi/dpl/pstl/iterator_defs.h
@@ -77,6 +77,9 @@ struct __is_random_access_iterator<_IteratorType> : __is_random_access_iterator_
 {
 };
 
+template <typename ..._IteratorTypes>
+inline constexpr bool __is_random_access_iterator_v = __is_random_access_iterator<_IteratorTypes...>::value;
+
 // struct for checking if iterator is heterogeneous or not
 template <typename Iter, typename Void = void> // for non-heterogeneous iterators
 struct is_hetero_iterator : ::std::false_type

--- a/include/oneapi/dpl/pstl/iterator_defs.h
+++ b/include/oneapi/dpl/pstl/iterator_defs.h
@@ -80,7 +80,7 @@ struct __is_random_access_iterator<_IteratorType> : __is_random_access_iterator_
 template <typename... _IteratorTypes>
 using __is_random_access_iterator_t = typename __is_random_access_iterator<_IteratorTypes...>::type;
 
-template <typename ..._IteratorTypes>
+template <typename... _IteratorTypes>
 inline constexpr bool __is_random_access_iterator_v = __is_random_access_iterator<_IteratorTypes...>::value;
 
 // struct for checking if iterator is heterogeneous or not

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -476,8 +476,11 @@ using is_arithmetic_plus = ::std::integral_constant<bool, ::std::is_arithmetic_v
                                                               (::std::is_same_v<_BinaryOperation, ::std::plus<_Tp>> ||
                                                                ::std::is_same_v<_BinaryOperation, ::std::plus<void>>)>;
 
+template <typename _Tp, typename _BinaryOperation>
+inline constexpr bool is_arithmetic_plus_v = is_arithmetic_plus<_Tp, _BinaryOperation>::value;
+
 template <typename _DifferenceType, typename _Tp, typename _BinaryOperation, typename _UnaryOperation>
-::std::enable_if_t<is_arithmetic_plus<_Tp, _BinaryOperation>::value, _Tp>
+::std::enable_if_t<is_arithmetic_plus_v<_Tp, _BinaryOperation>, _Tp>
 __simd_transform_reduce(_DifferenceType __n, _Tp __init, _BinaryOperation, _UnaryOperation __f) noexcept
 {
     _ONEDPL_PRAGMA_SIMD_REDUCTION(+ : __init)
@@ -487,7 +490,7 @@ __simd_transform_reduce(_DifferenceType __n, _Tp __init, _BinaryOperation, _Unar
 }
 
 template <typename _Size, typename _Tp, typename _BinaryOperation, typename _UnaryOperation>
-::std::enable_if_t<!is_arithmetic_plus<_Tp, _BinaryOperation>::value, _Tp>
+::std::enable_if_t<!is_arithmetic_plus_v<_Tp, _BinaryOperation>, _Tp>
 __simd_transform_reduce(_Size __n, _Tp __init, _BinaryOperation __binary_op, _UnaryOperation __f) noexcept
 {
     const _Size __block_size = __lane_size / sizeof(_Tp);
@@ -544,7 +547,7 @@ __simd_transform_reduce(_Size __n, _Tp __init, _BinaryOperation __binary_op, _Un
 // Exclusive scan for "+" and arithmetic types
 template <class _InputIterator, class _Size, class _OutputIterator, class _UnaryOperation, class _Tp,
           class _BinaryOperation>
-::std::enable_if_t<is_arithmetic_plus<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>
+::std::enable_if_t<is_arithmetic_plus_v<_Tp, _BinaryOperation>, ::std::pair<_OutputIterator, _Tp>>
 __simd_scan(_InputIterator __first, _Size __n, _OutputIterator __result, _UnaryOperation __unary_op, _Tp __init,
             _BinaryOperation, /*Inclusive*/ ::std::false_type)
 {
@@ -582,7 +585,7 @@ struct _Combiner
 // Exclusive scan for other binary operations and types
 template <class _InputIterator, class _Size, class _OutputIterator, class _UnaryOperation, class _Tp,
           class _BinaryOperation>
-::std::enable_if_t<!is_arithmetic_plus<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>
+::std::enable_if_t<!is_arithmetic_plus_v<_Tp, _BinaryOperation>, ::std::pair<_OutputIterator, _Tp>>
 __simd_scan(_InputIterator __first, _Size __n, _OutputIterator __result, _UnaryOperation __unary_op, _Tp __init,
             _BinaryOperation __binary_op, /*Inclusive*/ ::std::false_type)
 {
@@ -605,7 +608,7 @@ __simd_scan(_InputIterator __first, _Size __n, _OutputIterator __result, _UnaryO
 // Inclusive scan for "+" and arithmetic types
 template <class _InputIterator, class _Size, class _OutputIterator, class _UnaryOperation, class _Tp,
           class _BinaryOperation>
-::std::enable_if_t<is_arithmetic_plus<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>
+::std::enable_if_t<is_arithmetic_plus_v<_Tp, _BinaryOperation>, ::std::pair<_OutputIterator, _Tp>>
 __simd_scan(_InputIterator __first, _Size __n, _OutputIterator __result, _UnaryOperation __unary_op, _Tp __init,
             _BinaryOperation, /*Inclusive*/ ::std::true_type)
 {
@@ -622,7 +625,7 @@ __simd_scan(_InputIterator __first, _Size __n, _OutputIterator __result, _UnaryO
 // Inclusive scan for other binary operations and types
 template <class _InputIterator, class _Size, class _OutputIterator, class _UnaryOperation, class _Tp,
           class _BinaryOperation>
-::std::enable_if_t<!is_arithmetic_plus<_Tp, _BinaryOperation>::value, ::std::pair<_OutputIterator, _Tp>>
+::std::enable_if_t<!is_arithmetic_plus_v<_Tp, _BinaryOperation>, ::std::pair<_OutputIterator, _Tp>>
 __simd_scan(_InputIterator __first, _Size __n, _OutputIterator __result, _UnaryOperation __unary_op, _Tp __init,
             _BinaryOperation __binary_op, ::std::true_type)
 {

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -524,6 +524,9 @@ template <typename _Tp>
 using __is_const_callable_object =
     ::std::integral_constant<bool, __is_callable_object<_Tp>::value && __is_pointer_to_const_member<_Tp>::value>;
 
+template <typename _Tp>
+inline constexpr bool __is_const_callable_object_v = __is_const_callable_object<_Tp>::value;
+
 struct __next_to_last
 {
     template <typename _Iterator>

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -67,6 +67,9 @@ struct __range_has_raw_ptr_iterator<T, ::std::void_t<decltype(::std::declval<T&>
 {
 };
 
+template <typename T>
+inline constexpr bool __range_has_raw_ptr_iterator_v = __range_has_raw_ptr_iterator<T>::value;
+
 } //namespace __internal
 
 namespace __ranges

--- a/test/general/type_requirements.pass.cpp
+++ b/test/general/type_requirements.pass.cpp
@@ -23,8 +23,8 @@
 
 template <typename... Args>
 void CheckTuple() {
-    static_assert(::std::is_trivially_copyable_v<oneapi::dpl::__internal::tuple<Args...>>, "");
-    static_assert(::std::is_standard_layout_v<oneapi::dpl::__internal::tuple<Args...>>, "");
+    static_assert(::std::is_trivially_copyable_v<oneapi::dpl::__internal::tuple<Args...>>);
+    static_assert(::std::is_standard_layout_v<oneapi::dpl::__internal::tuple<Args...>>);
 };
 
 #endif

--- a/test/general/version.pass.cpp
+++ b/test/general/version.pass.cpp
@@ -22,15 +22,15 @@
 #include "support/utils.h"
 
 #if !__has_include(<execution>)
-static_assert(_PSTL_VERSION == 11000, "");
-static_assert(_PSTL_VERSION_MAJOR == 11, "");
-static_assert(_PSTL_VERSION_MINOR == 00, "");
-static_assert(_PSTL_VERSION_PATCH == 0, "");
+static_assert(_PSTL_VERSION == 11000);
+static_assert(_PSTL_VERSION_MAJOR == 11);
+static_assert(_PSTL_VERSION_MINOR == 00);
+static_assert(_PSTL_VERSION_PATCH == 0);
 #endif
 
-static_assert(ONEDPL_VERSION_MAJOR == 2022, "");
-static_assert(ONEDPL_VERSION_MINOR == 3, "");
-static_assert(ONEDPL_VERSION_PATCH == 0, "");
+static_assert(ONEDPL_VERSION_MAJOR == 2022);
+static_assert(ONEDPL_VERSION_MINOR == 3);
+static_assert(ONEDPL_VERSION_PATCH == 0);
 
 int main() {
 

--- a/test/parallel_api/algorithm/alg.merge/inplace_merge.pass.cpp
+++ b/test/parallel_api/algorithm/alg.merge/inplace_merge.pass.cpp
@@ -28,7 +28,7 @@ struct test_one_policy
     // inplace_merge works with bidirectional iterators at least
     template <typename Policy, typename BiDirIt1, typename Size, typename Generator1, typename Generator2,
               typename Compare>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt1>::value>
+    ::std::enable_if_t<is_base_of_iterator_category_v<::std::bidirectional_iterator_tag, BiDirIt1>>
     operator()(Policy&& exec, BiDirIt1 first1, BiDirIt1 last1, BiDirIt1 first2, BiDirIt1 last2, Size n, Size m,
                Generator1 generator1, Generator2 generator2, Compare comp)
     {
@@ -39,7 +39,7 @@ struct test_one_policy
     }
 
     template <typename Policy, typename BiDirIt1, typename Size, typename Generator1, typename Generator2>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt1>::value>
+    ::std::enable_if_t<is_base_of_iterator_category_v<::std::bidirectional_iterator_tag, BiDirIt1>>
     operator()(Policy&& exec, BiDirIt1 first1, BiDirIt1 last1, BiDirIt1 first2, BiDirIt1 last2, Size n, Size m,
                Generator1 generator1, Generator2 generator2)
     {
@@ -64,14 +64,14 @@ struct test_one_policy
     }
 
     template <typename Policy, typename BiDirIt1, typename Size, typename Generator1, typename Generator2>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt1>::value>
+    ::std::enable_if_t<!is_base_of_iterator_category_v<::std::bidirectional_iterator_tag, BiDirIt1>>
     operator()(Policy&& /* exec */, BiDirIt1 /* first1 */, BiDirIt1 /* last1 */, BiDirIt1 /* first2 */, BiDirIt1 /* last2 */, Size /* n */, Size /* m */,
                Generator1 /* generator1 */, Generator2 /* generator2 */)
     {
     }
     template <typename Policy, typename BiDirIt1, typename Size, typename Generator1, typename Generator2,
               typename Compare>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt1>::value>
+    ::std::enable_if_t<!is_base_of_iterator_category_v<::std::bidirectional_iterator_tag, BiDirIt1>>
     operator()(Policy&& /* exec */, BiDirIt1 /* first1 */, BiDirIt1 /* last1 */, BiDirIt1 /* first2 */, BiDirIt1 /* last2 */, Size /* n */, Size /* m */,
                Generator1 /* generator1 */, Generator2 /* generator2 */, Compare /* comp */)
     {

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/partition.pass.cpp
@@ -71,7 +71,7 @@ template<typename T>
 struct test_partition
 {
     template <typename Policy, typename BiDirIt, typename Size, typename UnaryOp, typename Generator>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt>::value>
+    ::std::enable_if_t<is_base_of_iterator_category_v<::std::bidirectional_iterator_tag, BiDirIt>>
     operator()(Policy&& exec, BiDirIt first, BiDirIt last, BiDirIt /* exp_first */, BiDirIt /* exp_last */, Size /* n */,
                UnaryOp unary_op, Generator generator)
     {
@@ -82,7 +82,7 @@ struct test_partition
     }
 
     template <typename Policy, typename BiDirIt, typename Size, typename UnaryOp, typename Generator>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt>::value>
+    ::std::enable_if_t<!is_base_of_iterator_category_v<::std::bidirectional_iterator_tag, BiDirIt>>
     operator()(Policy&& /* exec */, BiDirIt /* first */, BiDirIt /* last */, BiDirIt /* exp_first */, BiDirIt /* exp_last */, Size /* n */,
                UnaryOp /* unary_op */, Generator /* generator */)
     {

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/stable_partition.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.partitions/stable_partition.pass.cpp
@@ -71,7 +71,7 @@ template <typename T>
 struct test_stable_partition
 {
     template <typename Policy, typename BiDirIt, typename Size, typename UnaryOp, typename Generator>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt>::value>
+    ::std::enable_if_t<is_base_of_iterator_category_v<::std::bidirectional_iterator_tag, BiDirIt>>
     operator()(Policy&& exec, BiDirIt first, BiDirIt last, BiDirIt exp_first, BiDirIt exp_last, Size /* n */,
                UnaryOp unary_op, Generator generator)
     {
@@ -86,7 +86,7 @@ struct test_stable_partition
     }
 
     template <typename Policy, typename BiDirIt, typename Size, typename UnaryOp, typename Generator>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, BiDirIt>::value>
+    ::std::enable_if_t<!is_base_of_iterator_category_v<::std::bidirectional_iterator_tag, BiDirIt>>
     operator()(Policy&& /* exec */, BiDirIt /* first */, BiDirIt /* last */, BiDirIt /* exp_first */, BiDirIt /* exp_last */, Size /* n */,
                UnaryOp /* unary_op */, Generator /* generator */)
     {

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse.pass.cpp
@@ -29,14 +29,14 @@ struct test_one_policy
 {
 #if _PSTL_ICC_18_VC141_TEST_SIMD_LAMBDA_RELEASE_BROKEN // dummy specialization by policy type, in case of broken configuration
     template <typename Iterator1, typename Iterator2>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value>
+    ::std::enable_if_t<is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>>
     operator()(oneapi::dpl::execution::unsequenced_policy, Iterator1 data_b, Iterator1 data_e, Iterator2 actual_b,
                Iterator2 actual_e)
     {
     }
 
     template <typename Iterator1, typename Iterator2>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value>
+    ::std::enable_if_t<is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>>
     operator()(oneapi::dpl::execution::parallel_unsequenced_policy, Iterator1 data_b, Iterator1 data_e, Iterator2 actual_b,
                Iterator2 actual_e)
     {
@@ -44,7 +44,7 @@ struct test_one_policy
 #endif
 
     template <typename ExecutionPolicy, typename Iterator1, typename Iterator2>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::bidirectional_iterator_tag, Iterator1>::value>
+    ::std::enable_if_t<is_base_of_iterator_category_v<::std::bidirectional_iterator_tag, Iterator1>>
     operator()(ExecutionPolicy&& exec, Iterator1 data_b, Iterator1 data_e, Iterator2 actual_b, Iterator2 actual_e)
     {
         using namespace std;
@@ -59,7 +59,7 @@ struct test_one_policy
     }
 
     template <typename ExecutionPolicy, typename Iterator1, typename Iterator2>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, Iterator1>::value>
+    ::std::enable_if_t<!is_base_of_iterator_category_v<::std::bidirectional_iterator_tag, Iterator1>>
     operator()(ExecutionPolicy&& /* exec */, Iterator1 /* data_b */, Iterator1 /* data_e */, Iterator2 /* actual_b */, Iterator2 /* actual_e */)
     {
     }

--- a/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/alg.reverse/reverse_copy.pass.cpp
@@ -55,7 +55,7 @@ template<typename T1, typename T2>
 struct test_one_policy
 {
     template <typename ExecutionPolicy, typename Iterator1, typename Iterator2>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::bidirectional_iterator_tag, Iterator1>::value>
+    ::std::enable_if_t<is_base_of_iterator_category_v<::std::bidirectional_iterator_tag, Iterator1>>
     operator()(ExecutionPolicy&& exec, Iterator1 data_b, Iterator1 data_e, Iterator2 actual_b, Iterator2 actual_e)
     {
         using namespace std;
@@ -72,7 +72,7 @@ struct test_one_policy
     }
 
     template <typename ExecutionPolicy, typename Iterator1, typename Iterator2>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::bidirectional_iterator_tag, Iterator1>::value>
+    ::std::enable_if_t<!is_base_of_iterator_category_v<::std::bidirectional_iterator_tag, Iterator1>>
     operator()(ExecutionPolicy&& /* exec */, Iterator1 /* data_b */, Iterator1 /* data_e */, Iterator2 /* actual_b */, Iterator2 /* actual_e*/)
     {
     }

--- a/test/parallel_api/algorithm/alg.modifying.operations/rotate.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/rotate.pass.cpp
@@ -102,7 +102,7 @@ struct test_one_policy
 
     template <typename ExecutionPolicy, typename Iterator, typename Size>
     ::std::enable_if_t<
-        is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
+        is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator> &&
         !::std::is_same_v<ExecutionPolicy, oneapi::dpl::execution::sequenced_policy> &&
         ::std::is_same_v<typename ::std::iterator_traits<Iterator>::value_type, wrapper<float32_t>>,
         bool>
@@ -118,7 +118,7 @@ struct test_one_policy
 
     template <typename ExecutionPolicy, typename Iterator, typename Size>
     ::std::enable_if_t<
-        !(is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value &&
+        !(is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator> &&
         !::std::is_same_v<ExecutionPolicy, oneapi::dpl::execution::sequenced_policy> &&
         ::std::is_same_v<typename ::std::iterator_traits<Iterator>::value_type, wrapper<float32_t>>),
         bool>

--- a/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
@@ -155,21 +155,21 @@ struct shift_left_algo
 struct shift_right_algo
 {
     template <typename Policy, typename It>
-    ::std::enable_if_t<TestUtils::is_base_of_iterator_category<::std::bidirectional_iterator_tag, It>::value, It>
+    ::std::enable_if_t<TestUtils::is_base_of_iterator_category_v<::std::bidirectional_iterator_tag, It>, It>
     operator()(Policy&& exec, It first, It last, typename ::std::iterator_traits<It>::difference_type n)
     {
         return std::shift_right(::std::forward<Policy>(exec), first, last, n);
     }
     //skip the test for non-bidirectional iterator (forward iterator, etc)
     template <typename Policy, typename It>
-    ::std::enable_if_t<!TestUtils::is_base_of_iterator_category<::std::bidirectional_iterator_tag, It>::value, It>
+    ::std::enable_if_t<!TestUtils::is_base_of_iterator_category_v<::std::bidirectional_iterator_tag, It>, It>
     operator()(Policy&& exec, It first, It last, typename ::std::iterator_traits<It>::difference_type n)
     {
         return first;
     }
 
     template <typename It, typename ItExp>
-    ::std::enable_if_t<TestUtils::is_base_of_iterator_category<::std::bidirectional_iterator_tag, It>::value>
+    ::std::enable_if_t<TestUtils::is_base_of_iterator_category_v<::std::bidirectional_iterator_tag, It>>
     check(It res, It first, typename ::std::iterator_traits<It>::difference_type m, ItExp first_exp,
         typename ::std::iterator_traits<It>::difference_type n)
     {
@@ -189,7 +189,7 @@ struct shift_right_algo
     }
     //skip the check for non-bidirectional iterator (forward iterator, etc)
     template <typename It, typename ItExp>
-    ::std::enable_if_t<!TestUtils::is_base_of_iterator_category<::std::bidirectional_iterator_tag, It>::value>
+    ::std::enable_if_t<!TestUtils::is_base_of_iterator_category_v<::std::bidirectional_iterator_tag, It>>
     check(It res, It first, typename ::std::iterator_traits<It>::difference_type m, ItExp first_exp,
         typename ::std::iterator_traits<It>::difference_type n)
     {

--- a/test/parallel_api/algorithm/alg.nonmodifying/nth_element.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/nth_element.pass.cpp
@@ -77,7 +77,7 @@ struct test_without_compare
     // nth_element works only with random access iterators
     template <typename Policy, typename Iterator1, typename Size, typename Generator1, typename Generator2>
     ::std::enable_if_t<is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1> &&
-                           can_use_default_less_operator<Type>::value>
+                           can_use_default_less_operator_v<Type>>
     operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator1 first2, Iterator1 last2, Size n, Size m,
                Generator1 generator1, Generator2 generator2)
     {
@@ -100,7 +100,7 @@ struct test_without_compare
 
     template <typename Policy, typename Iterator1, typename Size, typename Generator1, typename Generator2>
     ::std::enable_if_t<!is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1> ||
-                           !can_use_default_less_operator<Type>::value>
+                           !can_use_default_less_operator_v<Type>>
     operator()(Policy&& /* exec */, Iterator1 /* first1 */, Iterator1 /* last1 */, Iterator1 /* first2 */, Iterator1 /* last2 */, Size /* n */, Size /* m */,
                Generator1 /* generator1 */, Generator2 /* generator2 */)
     {

--- a/test/parallel_api/algorithm/alg.nonmodifying/nth_element.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/nth_element.pass.cpp
@@ -76,8 +76,8 @@ struct test_without_compare
 {
     // nth_element works only with random access iterators
     template <typename Policy, typename Iterator1, typename Size, typename Generator1, typename Generator2>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value &&
-                       can_use_default_less_operator<Type>::value>
+    ::std::enable_if_t<is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1> &&
+                           can_use_default_less_operator<Type>::value>
     operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator1 first2, Iterator1 last2, Size n, Size m,
                Generator1 generator1, Generator2 generator2)
     {
@@ -99,8 +99,8 @@ struct test_without_compare
     }
 
     template <typename Policy, typename Iterator1, typename Size, typename Generator1, typename Generator2>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value ||
-                       !can_use_default_less_operator<Type>::value>
+    ::std::enable_if_t<!is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1> ||
+                           !can_use_default_less_operator<Type>::value>
     operator()(Policy&& /* exec */, Iterator1 /* first1 */, Iterator1 /* last1 */, Iterator1 /* first2 */, Iterator1 /* last2 */, Size /* n */, Size /* m */,
                Generator1 /* generator1 */, Generator2 /* generator2 */)
     {
@@ -113,7 +113,7 @@ struct test_with_compare
     // nth_element works only with random access iterators
     template <typename Policy, typename Iterator1, typename Size, typename Generator1, typename Generator2,
               typename Compare>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value>
+    ::std::enable_if_t<is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>>
     operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Iterator1 first2, Iterator1 last2, Size n, Size m,
                Generator1 generator1, Generator2 generator2, Compare comp)
     {
@@ -136,7 +136,7 @@ struct test_with_compare
 
     template <typename Policy, typename Iterator1, typename Size, typename Generator1, typename Generator2,
               typename Compare>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value>
+    ::std::enable_if_t<!is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>>
     operator()(Policy&& /* exec */, Iterator1 /* first1 */, Iterator1 /* last1 */, Iterator1 /* first2 */, Iterator1 /* last2 */, Size /* n */, Size /* m */,
                Generator1 /* generator1 */, Generator2 /* generator2 */, Compare /* comp */)
     {

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
@@ -55,7 +55,7 @@ DEFINE_TEST(test_binary_search)
 #if TEST_DPCPP_BACKEND_PRESENT
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
+    ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy_v<::std::decay_t<Policy>> &&
                            is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
@@ -93,7 +93,7 @@ DEFINE_TEST(test_binary_search)
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     ::std::enable_if_t<
 #if TEST_DPCPP_BACKEND_PRESENT
-        !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
+        !oneapi::dpl::__internal::__is_hetero_execution_policy_v<::std::decay_t<Policy>> &&
 #endif
             is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
@@ -56,7 +56,7 @@ DEFINE_TEST(test_binary_search)
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
-                       is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
+                           is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {
@@ -95,7 +95,7 @@ DEFINE_TEST(test_binary_search)
 #if TEST_DPCPP_BACKEND_PRESENT
         !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif
-            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
+            is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {
@@ -115,7 +115,7 @@ DEFINE_TEST(test_binary_search)
 
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
+    ::std::enable_if_t<!is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
@@ -51,7 +51,7 @@ DEFINE_TEST(test_lower_bound)
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
-                       is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
+                       is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {
@@ -90,7 +90,7 @@ DEFINE_TEST(test_lower_bound)
 #if TEST_DPCPP_BACKEND_PRESENT
         !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif
-            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
+            is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {
@@ -109,7 +109,7 @@ DEFINE_TEST(test_lower_bound)
 
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
+    ::std::enable_if_t<!is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
@@ -50,7 +50,7 @@ DEFINE_TEST(test_lower_bound)
 #if TEST_DPCPP_BACKEND_PRESENT
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
+    ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy_v<::std::decay_t<Policy>> &&
                        is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
@@ -88,7 +88,7 @@ DEFINE_TEST(test_lower_bound)
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     ::std::enable_if_t<
 #if TEST_DPCPP_BACKEND_PRESENT
-        !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
+        !oneapi::dpl::__internal::__is_hetero_execution_policy_v<::std::decay_t<Policy>> &&
 #endif
             is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
@@ -57,7 +57,7 @@ DEFINE_TEST(test_upper_bound)
 #if TEST_DPCPP_BACKEND_PRESENT
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
+    ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy_v<::std::decay_t<Policy>> &&
                        is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
@@ -95,7 +95,7 @@ DEFINE_TEST(test_upper_bound)
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     ::std::enable_if_t<
 #if TEST_DPCPP_BACKEND_PRESENT
-        !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
+        !oneapi::dpl::__internal::__is_hetero_execution_policy_v<::std::decay_t<Policy>> &&
 #endif
             is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
@@ -58,7 +58,7 @@ DEFINE_TEST(test_upper_bound)
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
-                       is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
+                       is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {
@@ -97,7 +97,7 @@ DEFINE_TEST(test_upper_bound)
 #if TEST_DPCPP_BACKEND_PRESENT
         !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif
-            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
+            is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {
@@ -116,7 +116,7 @@ DEFINE_TEST(test_upper_bound)
 
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
+    ::std::enable_if_t<!is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
     operator()(Policy&& exec, Iterator1 first, Iterator1 last, Iterator2 value_first, Iterator2 value_last,
                Iterator3 result_first, Iterator3 result_last, Size n)
     {

--- a/test/parallel_api/algorithm/alg.sorting/alg.heap.operations/is_heap.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.heap.operations/is_heap.pass.cpp
@@ -48,7 +48,7 @@ template <typename T>
 struct test_is_heap
 {
     template <typename Policy, typename Iterator>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value>
+    ::std::enable_if_t<is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator>>
     operator()(Policy&& exec, Iterator first, Iterator last)
     {
         using namespace std;
@@ -59,7 +59,7 @@ struct test_is_heap
 
     // is_heap works only with random access iterators
     template <typename Policy, typename Iterator>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value>
+    ::std::enable_if_t<!is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator>>
     operator()(Policy&& /* exec */, Iterator /* first */, Iterator /* last */)
     {
     }
@@ -69,7 +69,7 @@ template <typename T>
 struct test_is_heap_predicate
 {
     template <typename Policy, typename Iterator, typename Predicate>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value>
+    ::std::enable_if_t<is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator>>
     operator()(Policy&& exec, Iterator first, Iterator last, Predicate pred)
     {
         using namespace std;
@@ -80,7 +80,7 @@ struct test_is_heap_predicate
 
     // is_heap works only with random access iterators
     template <typename Policy, typename Iterator, typename Predicate>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value>
+    ::std::enable_if_t<!is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator>>
     operator()(Policy&& /* exec */, Iterator /* first */, Iterator /* last */, Predicate /* pred */)
     {
     }
@@ -90,7 +90,7 @@ template <typename T>
 struct test_is_heap_until
 {
     template <typename Policy, typename Iterator>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value>
+    ::std::enable_if_t<is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator>>
     operator()(Policy&& exec, Iterator first, Iterator last)
     {
         using namespace std;
@@ -101,7 +101,7 @@ struct test_is_heap_until
 
     // is_heap, is_heap_until works only with random access iterators
     template <typename Policy, typename Iterator>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value>
+    ::std::enable_if_t<!is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator>>
     operator()(Policy&& /* exec */, Iterator /* first */, Iterator /* last */)
     {
     }
@@ -111,7 +111,7 @@ template <typename T>
 struct test_is_heap_until_predicate
 {
     template <typename Policy, typename Iterator, typename Predicate>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value>
+    ::std::enable_if_t<is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator>>
     operator()(Policy&& exec, Iterator first, Iterator last, Predicate pred)
     {
         using namespace std;
@@ -122,7 +122,7 @@ struct test_is_heap_until_predicate
 
     // is_heap, is_heap_until works only with random access iterators
     template <typename Policy, typename Iterator, typename Predicate>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator>::value>
+    ::std::enable_if_t<!is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator>>
     operator()(Policy&& /* exec */, Iterator /* first */, Iterator /* last */, Predicate /* pred */)
     {
     }

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/max.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/max.pass.cpp
@@ -56,8 +56,8 @@ ONEDPL_TEST_NUM_MAIN
     {
     constexpr int x = 1;
     constexpr int y = 0;
-    static_assert(dpl::max(x, y) == x, "" );
-    static_assert(dpl::max(y, x) == x, "" );
+    static_assert(dpl::max(x, y) == x);
+    static_assert(dpl::max(y, x) == x);
     }
 #endif
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/max_comp.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/max_comp.pass.cpp
@@ -58,8 +58,8 @@ ONEDPL_TEST_NUM_MAIN
     {
     constexpr int x = 1;
     constexpr int y = 0;
-    static_assert(dpl::max(x, y, dpl::greater<int>()) == y, "");
-    static_assert(dpl::max(y, x, dpl::greater<int>()) == y, "");
+    static_assert(dpl::max(x, y, dpl::greater<int>()) == y);
+    static_assert(dpl::max(y, x, dpl::greater<int>()) == y);
     }
 #endif
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/max_init_list.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/max_init_list.pass.cpp
@@ -48,9 +48,9 @@ ONEDPL_TEST_NUM_MAIN
     assert(i == 3);
 #if TEST_STD_VER >= 14
     {
-    static_assert(dpl::max({1, 3, 2}) == 3, "");
-    static_assert(dpl::max({2, 1, 3}) == 3, "");
-    static_assert(dpl::max({3, 2, 1}) == 3, "");
+    static_assert(dpl::max({1, 3, 2}) == 3);
+    static_assert(dpl::max({2, 1, 3}) == 3);
+    static_assert(dpl::max({3, 2, 1}) == 3);
     }
 #endif
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/max_init_list_comp.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/max_init_list_comp.pass.cpp
@@ -44,9 +44,9 @@ ONEDPL_TEST_NUM_MAIN
     assert(i == 1);
 #if TEST_STD_VER >= 14
     {
-    static_assert(dpl::max({1, 3, 2}, dpl::greater<int>()) == 1, "");
-    static_assert(dpl::max({2, 1, 3}, dpl::greater<int>()) == 1, "");
-    static_assert(dpl::max({3, 2, 1}, dpl::greater<int>()) == 1, "");
+    static_assert(dpl::max({1, 3, 2}, dpl::greater<int>()) == 1);
+    static_assert(dpl::max({2, 1, 3}, dpl::greater<int>()) == 1);
+    static_assert(dpl::max({3, 2, 1}, dpl::greater<int>()) == 1);
     }
 #endif
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/min.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/min.pass.cpp
@@ -56,8 +56,8 @@ ONEDPL_TEST_NUM_MAIN
     {
     constexpr int x = 1;
     constexpr int y = 0;
-    static_assert(dpl::min(x, y) == y, "" );
-    static_assert(dpl::min(y, x) == y, "" );
+    static_assert(dpl::min(x, y) == y);
+    static_assert(dpl::min(y, x) == y);
     }
 #endif
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/min_comp.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/min_comp.pass.cpp
@@ -58,8 +58,8 @@ ONEDPL_TEST_NUM_MAIN
     {
     constexpr int x = 1;
     constexpr int y = 0;
-    static_assert(dpl::min(x, y, dpl::greater<int>()) == x, "" );
-    static_assert(dpl::min(y, x, dpl::greater<int>()) == x, "" );
+    static_assert(dpl::min(x, y, dpl::greater<int>()) == x);
+    static_assert(dpl::min(y, x, dpl::greater<int>()) == x);
     }
 #endif
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/min_init_list.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/min_init_list.pass.cpp
@@ -48,9 +48,9 @@ ONEDPL_TEST_NUM_MAIN
     assert(i == 1);
 #if TEST_STD_VER >= 14
     {
-    static_assert(dpl::min({1, 3, 2}) == 1, "");
-    static_assert(dpl::min({2, 1, 3}) == 1, "");
-    static_assert(dpl::min({3, 2, 1}) == 1, "");
+    static_assert(dpl::min({1, 3, 2}) == 1);
+    static_assert(dpl::min({2, 1, 3}) == 1);
+    static_assert(dpl::min({3, 2, 1}) == 1);
     }
 #endif
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.min.max/min_init_list_comp.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.min.max/min_init_list_comp.pass.cpp
@@ -44,9 +44,9 @@ ONEDPL_TEST_NUM_MAIN
     assert(i == 3);
 #if TEST_STD_VER >= 14
     {
-    static_assert(dpl::min({1, 3, 2}, dpl::greater<int>()) == 3, "");
-    static_assert(dpl::min({2, 1, 3}, dpl::greater<int>()) == 3, "");
-    static_assert(dpl::min({3, 2, 1}, dpl::greater<int>()) == 3, "");
+    static_assert(dpl::min({1, 3, 2}, dpl::greater<int>()) == 3);
+    static_assert(dpl::min({2, 1, 3}, dpl::greater<int>()) == 3);
+    static_assert(dpl::min({3, 2, 1}, dpl::greater<int>()) == 3);
     }
 #endif
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.set.operations/includes.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.set.operations/includes.pass.cpp
@@ -50,7 +50,7 @@ template <typename T>
 struct test_without_compare
 {
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value && can_use_default_less_operator_v<T>>
+    ::std::enable_if_t<!TestUtils::is_reverse_v<InputIterator1> && can_use_default_less_operator_v<T>>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2)
     {
         auto expect_res = ::std::includes(first1, last1, first2, last2);
@@ -60,7 +60,7 @@ struct test_without_compare
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value || !can_use_default_less_operator_v<T>>
+    ::std::enable_if_t<TestUtils::is_reverse_v<InputIterator1> || !can_use_default_less_operator_v<T>>
     operator()(Policy&& /* exec */, InputIterator1 /* first1 */, InputIterator1 /* last1 */, InputIterator2 /* first2 */, InputIterator2 /* last2 */)
     {
     }
@@ -70,7 +70,7 @@ template <typename T>
 struct test_with_compare
 {
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value>
+    ::std::enable_if_t<!TestUtils::is_reverse_v<InputIterator1>>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2,
                Compare comp)
     {
@@ -82,7 +82,7 @@ struct test_with_compare
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value>
+    ::std::enable_if_t<TestUtils::is_reverse_v<InputIterator1>>
     operator()(Policy&& /* exec */, InputIterator1 /* first1 */, InputIterator1 /* last1 */, InputIterator2 /* first2 */, InputIterator2 /* last2 */,
                Compare /* comp */)
     {

--- a/test/parallel_api/algorithm/alg.sorting/alg.set.operations/includes.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.set.operations/includes.pass.cpp
@@ -50,7 +50,7 @@ template <typename T>
 struct test_without_compare
 {
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value && can_use_default_less_operator<T>::value>
+    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value && can_use_default_less_operator_v<T>>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2)
     {
         auto expect_res = ::std::includes(first1, last1, first2, last2);
@@ -60,7 +60,7 @@ struct test_without_compare
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value || !can_use_default_less_operator<T>::value>
+    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value || !can_use_default_less_operator_v<T>>
     operator()(Policy&& /* exec */, InputIterator1 /* first1 */, InputIterator1 /* last1 */, InputIterator2 /* first2 */, InputIterator2 /* last2 */)
     {
     }

--- a/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_common.h
+++ b/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_common.h
@@ -85,7 +85,7 @@ template <typename Type>
 struct test_set_union
 {
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value>
+    ::std::enable_if_t<!TestUtils::is_reverse_v<InputIterator1>>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2,
                Compare comp)
     {
@@ -101,7 +101,7 @@ struct test_set_union
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value>
+    ::std::enable_if_t<!TestUtils::is_reverse_v<InputIterator1>>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2)
     {
         auto sequences = init(first1, last1, first2, last2);
@@ -115,13 +115,13 @@ struct test_set_union
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value>
+    ::std::enable_if_t<TestUtils::is_reverse_v<InputIterator1>>
     operator()(Policy&&, InputIterator1, InputIterator1, InputIterator2, InputIterator2)
     {
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value>
+    ::std::enable_if_t<TestUtils::is_reverse_v<InputIterator1>>
     operator()(Policy&&, InputIterator1, InputIterator1, InputIterator2, InputIterator2, Compare)
     {
     }
@@ -131,7 +131,7 @@ template <typename Type>
 struct test_set_intersection
 {
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value>
+    ::std::enable_if_t<!TestUtils::is_reverse_v<InputIterator1>>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2,
                Compare comp)
     {
@@ -146,7 +146,7 @@ struct test_set_intersection
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value>
+    ::std::enable_if_t<!TestUtils::is_reverse_v<InputIterator1>>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2)
     {
         auto sequences = init(first1, last1, first2, last2);
@@ -160,13 +160,13 @@ struct test_set_intersection
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value>
+    ::std::enable_if_t<TestUtils::is_reverse_v<InputIterator1>>
     operator()(Policy&&, InputIterator1, InputIterator1, InputIterator2, InputIterator2)
     {
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value>
+    ::std::enable_if_t<TestUtils::is_reverse_v<InputIterator1>>
     operator()(Policy&&, InputIterator1, InputIterator1, InputIterator2, InputIterator2, Compare)
     {
     }
@@ -176,7 +176,7 @@ template <typename Type>
 struct test_set_difference
 {
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value>
+    ::std::enable_if_t<!TestUtils::is_reverse_v<InputIterator1>>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2,
                Compare comp)
     {
@@ -191,7 +191,7 @@ struct test_set_difference
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value>
+    ::std::enable_if_t<!TestUtils::is_reverse_v<InputIterator1>>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2)
     {
         auto sequences = init(first1, last1, first2, last2);
@@ -207,13 +207,13 @@ struct test_set_difference
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value>
+    ::std::enable_if_t<TestUtils::is_reverse_v<InputIterator1>>
     operator()(Policy&&, InputIterator1, InputIterator1, InputIterator2, InputIterator2)
     {
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value>
+    ::std::enable_if_t<TestUtils::is_reverse_v<InputIterator1>>
     operator()(Policy&&, InputIterator1, InputIterator1, InputIterator2, InputIterator2, Compare)
     {
     }
@@ -223,7 +223,7 @@ template <typename Type>
 struct test_set_symmetric_difference
 {
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value>
+    ::std::enable_if_t<!TestUtils::is_reverse_v<InputIterator1>>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2,
                Compare comp)
     {
@@ -239,7 +239,7 @@ struct test_set_symmetric_difference
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    ::std::enable_if_t<!TestUtils::isReverse<InputIterator1>::value>
+    ::std::enable_if_t<!TestUtils::is_reverse_v<InputIterator1>>
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2)
     {
         auto sequences = init(first1, last1, first2, last2);
@@ -255,13 +255,13 @@ struct test_set_symmetric_difference
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2>
-    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value>
+    ::std::enable_if_t<TestUtils::is_reverse_v<InputIterator1>>
     operator()(Policy&&, InputIterator1, InputIterator1, InputIterator2, InputIterator2)
     {
     }
 
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename Compare>
-    ::std::enable_if_t<TestUtils::isReverse<InputIterator1>::value>
+    ::std::enable_if_t<TestUtils::is_reverse_v<InputIterator1>>
     operator()(Policy&&, InputIterator1, InputIterator1, InputIterator2, InputIterator2, Compare)
     {
     }

--- a/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
@@ -109,7 +109,7 @@ struct test_brick_partial_sort
 
     template <typename Policy, typename InputIterator>
     ::std::enable_if_t<is_base_of_iterator_category_v<::std::random_access_iterator_tag, InputIterator> &&
-                           can_use_default_less_operator<Type>::value>
+                           can_use_default_less_operator_v<Type>>
     operator()(Policy&& exec, InputIterator first, InputIterator last, InputIterator exp_first, InputIterator exp_last,
                InputIterator tmp_first, InputIterator tmp_last)
     {
@@ -130,7 +130,7 @@ struct test_brick_partial_sort
 
     template <typename Policy, typename InputIterator>
     ::std::enable_if_t<!is_base_of_iterator_category_v<::std::random_access_iterator_tag, InputIterator> ||
-                           !can_use_default_less_operator<Type>::value>
+                           !can_use_default_less_operator_v<Type>>
     operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, InputIterator /* exp_first */,
                InputIterator /* exp_last */, InputIterator /* tmp_first */, InputIterator /* tmp_last */)
     {

--- a/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/partial_sort.pass.cpp
@@ -58,7 +58,7 @@ template <typename Type>
 struct test_brick_partial_sort
 {
     template <typename Policy, typename InputIterator, typename Compare>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value>
+    ::std::enable_if_t<is_base_of_iterator_category_v<::std::random_access_iterator_tag, InputIterator>>
     operator()(Policy&& exec, InputIterator first, InputIterator last, InputIterator exp_first, InputIterator exp_last,
                InputIterator tmp_first, InputIterator tmp_last, Compare compare)
     {
@@ -101,14 +101,14 @@ struct test_brick_partial_sort
     }
 
     template <typename Policy, typename InputIterator, typename Compare>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value>
+    ::std::enable_if_t<!is_base_of_iterator_category_v<::std::random_access_iterator_tag, InputIterator>>
     operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, InputIterator /* exp_first */,
                InputIterator /* exp_last */, InputIterator /* tmp_first */, InputIterator /* tmp_last */, Compare /* compare */)
     {
     }
 
     template <typename Policy, typename InputIterator>
-    ::std::enable_if_t<is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value &&
+    ::std::enable_if_t<is_base_of_iterator_category_v<::std::random_access_iterator_tag, InputIterator> &&
                            can_use_default_less_operator<Type>::value>
     operator()(Policy&& exec, InputIterator first, InputIterator last, InputIterator exp_first, InputIterator exp_last,
                InputIterator tmp_first, InputIterator tmp_last)
@@ -129,7 +129,7 @@ struct test_brick_partial_sort
     }
 
     template <typename Policy, typename InputIterator>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value ||
+    ::std::enable_if_t<!is_base_of_iterator_category_v<::std::random_access_iterator_tag, InputIterator> ||
                            !can_use_default_less_operator<Type>::value>
     operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, InputIterator /* exp_first */,
                InputIterator /* exp_last */, InputIterator /* tmp_first */, InputIterator /* tmp_last */)

--- a/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
@@ -313,7 +313,7 @@ struct test_sort_op
     template <typename Policy, typename InputIterator, typename OutputIterator, typename OutputIterator2, typename Size,
               typename... Compare>
     ::std::enable_if_t<
-        TestUtils::is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value &&
+        TestUtils::is_base_of_iterator_category_v<::std::random_access_iterator_tag, InputIterator> &&
             (TestUtils::can_use_default_less_operator<T>::value || sizeof...(Compare) > 0)>
     operator()(Policy&& exec, OutputIterator tmp_first, OutputIterator tmp_last, OutputIterator2 expected_first,
                OutputIterator2 expected_last, InputIterator first, InputIterator last, Size n, Compare ...compare)
@@ -325,7 +325,7 @@ struct test_sort_op
     template <typename Policy, typename InputIterator, typename OutputIterator, typename OutputIterator2, typename Size,
               typename... Compare>
     ::std::enable_if_t<
-        !TestUtils::is_base_of_iterator_category<::std::random_access_iterator_tag, InputIterator>::value ||
+        !TestUtils::is_base_of_iterator_category_v<::std::random_access_iterator_tag, InputIterator> ||
             !(TestUtils::can_use_default_less_operator<T>::value || sizeof...(Compare) > 0)>
     operator()(Policy&& /* exec */, OutputIterator /* tmp_first */, OutputIterator /* tmp_last */,
                OutputIterator2 /* expected_first */, OutputIterator2 /* expected_last */, InputIterator /* first */,

--- a/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
@@ -314,7 +314,7 @@ struct test_sort_op
               typename... Compare>
     ::std::enable_if_t<
         TestUtils::is_base_of_iterator_category_v<::std::random_access_iterator_tag, InputIterator> &&
-            (TestUtils::can_use_default_less_operator<T>::value || sizeof...(Compare) > 0)>
+            (TestUtils::can_use_default_less_operator_v<T> || sizeof...(Compare) > 0)>
     operator()(Policy&& exec, OutputIterator tmp_first, OutputIterator tmp_last, OutputIterator2 expected_first,
                OutputIterator2 expected_last, InputIterator first, InputIterator last, Size n, Compare ...compare)
     {
@@ -326,7 +326,7 @@ struct test_sort_op
               typename... Compare>
     ::std::enable_if_t<
         !TestUtils::is_base_of_iterator_category_v<::std::random_access_iterator_tag, InputIterator> ||
-            !(TestUtils::can_use_default_less_operator<T>::value || sizeof...(Compare) > 0)>
+            !(TestUtils::can_use_default_less_operator_v<T> || sizeof...(Compare) > 0)>
     operator()(Policy&& /* exec */, OutputIterator /* tmp_first */, OutputIterator /* tmp_last */,
                OutputIterator2 /* expected_first */, OutputIterator2 /* expected_last */, InputIterator /* first */,
                InputIterator /* last */, Size /* n */, Compare .../*compare*/)

--- a/test/parallel_api/experimental/for_loop.pass.cpp
+++ b/test/parallel_api/experimental/for_loop.pass.cpp
@@ -98,7 +98,7 @@ test_body_for_loop_strided(Policy&& exec, Iterator first, Iterator last, Iterato
     using T = typename ::std::iterator_traits<Iterator>::value_type;
 
 #ifdef _PSTL_ICC_18_19_TEST_REVERSE_ITERATOR_WITH_STRIDE_BROKEN
-    if (isReverse<Iterator>::value)
+    if (is_reverse_v<Iterator>)
         return;
 #endif
 
@@ -186,7 +186,7 @@ test_body_for_loop_strided_n_integral(Policy&& exec, Iterator first, Iterator /*
     using T = typename ::std::iterator_traits<Iterator>::value_type;
 
 #ifdef _PSTL_ICC_18_19_TEST_REVERSE_ITERATOR_WITH_STRIDE_BROKEN
-    if (isReverse<Iterator>::value)
+    if (is_reverse_v<Iterator>)
         return;
 #endif
 

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
@@ -114,7 +114,7 @@ DEFINE_TEST_2(test_exclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
-                       is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
+                       is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 val_res_first, Iterator3 val_res_last, Size n)
     {
@@ -186,7 +186,7 @@ DEFINE_TEST_2(test_exclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
 #if TEST_DPCPP_BACKEND_PRESENT
         !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif // TEST_DPCPP_BACKEND_PRESENT
-            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
+            is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 val_res_first, Iterator3 val_res_last, Size n)
     {
@@ -223,7 +223,7 @@ DEFINE_TEST_2(test_exclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
 
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
+    ::std::enable_if_t<!is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 val_res_first, Iterator3 val_res_last, Size n)
     {

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
@@ -113,7 +113,7 @@ DEFINE_TEST_2(test_exclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
 #if TEST_DPCPP_BACKEND_PRESENT
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
+    ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy_v<::std::decay_t<Policy>> &&
                        is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 val_res_first, Iterator3 val_res_last, Size n)
@@ -184,7 +184,7 @@ DEFINE_TEST_2(test_exclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     ::std::enable_if_t<
 #if TEST_DPCPP_BACKEND_PRESENT
-        !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
+        !oneapi::dpl::__internal::__is_hetero_execution_policy_v<::std::decay_t<Policy>> &&
 #endif // TEST_DPCPP_BACKEND_PRESENT
             is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -110,7 +110,7 @@ DEFINE_TEST_2(test_inclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
 #if TEST_DPCPP_BACKEND_PRESENT
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
+    ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy_v<::std::decay_t<Policy>> &&
                        is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 val_res_first, Iterator3 val_res_last, Size n)
@@ -163,7 +163,7 @@ DEFINE_TEST_2(test_inclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     ::std::enable_if_t<
 #if TEST_DPCPP_BACKEND_PRESENT
-        !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
+        !oneapi::dpl::__internal::__is_hetero_execution_policy_v<::std::decay_t<Policy>> &&
 #endif
             is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -111,7 +111,7 @@ DEFINE_TEST_2(test_inclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
-                       is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
+                       is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 val_res_first, Iterator3 val_res_last, Size n)
     {
@@ -165,7 +165,7 @@ DEFINE_TEST_2(test_inclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
 #if TEST_DPCPP_BACKEND_PRESENT
         !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif
-            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
+            is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 val_res_first, Iterator3 val_res_last, Size n)
     {
@@ -191,7 +191,7 @@ DEFINE_TEST_2(test_inclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
 
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value>
+    ::std::enable_if_t<!is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3>>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 val_res_first, Iterator3 val_res_last, Size n)
     {

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -127,7 +127,7 @@ DEFINE_TEST_2(test_reduce_by_segment, BinaryPredicate, BinaryOperation)
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4,
               typename Size>
-    ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
+    ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy_v<::std::decay_t<Policy>> &&
                        is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3> &&
                        is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator4>>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
@@ -192,7 +192,7 @@ DEFINE_TEST_2(test_reduce_by_segment, BinaryPredicate, BinaryOperation)
               typename Size>
     ::std::enable_if_t<
 #if TEST_DPCPP_BACKEND_PRESENT
-        !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
+        !oneapi::dpl::__internal::__is_hetero_execution_policy_v<::std::decay_t<Policy>> &&
 #endif
             is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3> &&
             is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator4>>

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -128,8 +128,8 @@ DEFINE_TEST_2(test_reduce_by_segment, BinaryPredicate, BinaryOperation)
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4,
               typename Size>
     ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
-                       is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value &&
-                       is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator4>::value>
+                       is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3> &&
+                       is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator4>>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 key_res_first, Iterator3 key_res_last, Iterator4 val_res_first, Iterator4 val_res_last, Size n)
     {
@@ -194,8 +194,8 @@ DEFINE_TEST_2(test_reduce_by_segment, BinaryPredicate, BinaryOperation)
 #if TEST_DPCPP_BACKEND_PRESENT
         !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
 #endif
-            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value &&
-            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator4>::value>
+            is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3> &&
+            is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator4>>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 key_res_first, Iterator3 key_res_last, Iterator4 val_res_first, Iterator4 val_res_last, Size n)
     {
@@ -229,8 +229,8 @@ DEFINE_TEST_2(test_reduce_by_segment, BinaryPredicate, BinaryOperation)
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4,
               typename Size>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator3>::value ||
-                           !is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator4>::value>
+    ::std::enable_if_t<!is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator3> ||
+                           !is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator4>>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Iterator2 vals_first, Iterator2 vals_last,
                Iterator3 key_res_first, Iterator3 key_res_last, Iterator4 val_res_first, Iterator4 val_res_last, Size n)
     {

--- a/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan.pass.cpp
@@ -124,7 +124,7 @@ struct test_inclusive_scan_with_binary_op
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T,
               typename BinaryOp>
-    ::std::enable_if_t<!TestUtils::isReverse<Iterator1>::value>
+    ::std::enable_if_t<!TestUtils::is_reverse_v<Iterator1>>
     operator()(Policy&& exec, Iterator1 in_first, Iterator1 in_last, Iterator2 out_first, Iterator2 out_last,
                Iterator3 expected_first, Iterator3 /* expected_last */, Size n, T init, BinaryOp binary_op, T trash)
     {
@@ -140,7 +140,7 @@ struct test_inclusive_scan_with_binary_op
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T,
               typename BinaryOp>
-    ::std::enable_if_t<!TestUtils::isReverse<Iterator1>::value>
+    ::std::enable_if_t<!TestUtils::is_reverse_v<Iterator1>>
     operator()(Policy&& exec, Iterator1 in_first, Iterator1 in_last, Iterator2 out_first, Iterator2 out_last,
                Iterator3 expected_first, Iterator3 /* expected_last */, Size n, BinaryOp binary_op, T trash)
     {
@@ -156,7 +156,7 @@ struct test_inclusive_scan_with_binary_op
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T,
               typename BinaryOp>
-    ::std::enable_if_t<TestUtils::isReverse<Iterator1>::value>
+    ::std::enable_if_t<TestUtils::is_reverse_v<Iterator1>>
     operator()(Policy&& /* exec */, Iterator1 /* in_first */, Iterator1 /* in_last */, Iterator2 /* out_first */, Iterator2 /* out_last */,
                Iterator3 /* expected_first */, Iterator3 /* expected_last */, Size /* n */, BinaryOp /* binary_op */, T /* trash */)
     {
@@ -164,7 +164,7 @@ struct test_inclusive_scan_with_binary_op
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T,
               typename BinaryOp>
-    ::std::enable_if_t<TestUtils::isReverse<Iterator1>::value>
+    ::std::enable_if_t<TestUtils::is_reverse_v<Iterator1>>
     operator()(Policy&& /* exec */, Iterator1 /* in_first */, Iterator1 /* in_last */, Iterator2 /* out_first */, Iterator2 /* out_last */,
                Iterator3 /* expected_first */, Iterator3 /* expected_last */, Size /* n */, T /* init */, BinaryOp /* binary_op */, T /* trash */)
     {
@@ -176,7 +176,7 @@ struct test_exclusive_scan_with_binary_op
 {
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T,
               typename BinaryOp>
-    ::std::enable_if_t<!TestUtils::isReverse<Iterator1>::value>
+    ::std::enable_if_t<!TestUtils::is_reverse_v<Iterator1>>
     operator()(Policy&& exec, Iterator1 in_first, Iterator1 in_last, Iterator2 out_first, Iterator2 out_last,
                Iterator3 expected_first, Iterator3 /* expected_last */, Size n, T init, BinaryOp binary_op, T trash)
     {
@@ -193,7 +193,7 @@ struct test_exclusive_scan_with_binary_op
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size, typename T,
               typename BinaryOp>
-    ::std::enable_if_t<TestUtils::isReverse<Iterator1>::value>
+    ::std::enable_if_t<TestUtils::is_reverse_v<Iterator1>>
     operator()(Policy&& /* exec */, Iterator1 /* in_first */, Iterator1 /* in_last */, Iterator2 /* out_first */, Iterator2 /* out_last */,
                Iterator3 /* expected_first */, Iterator3 /* expected_last */, Size /* n */, T /* init */, BinaryOp /* binary_op */, T /* trash */)
     {

--- a/test/parallel_api/numeric/numeric.ops/scan_2.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan_2.pass.cpp
@@ -147,7 +147,7 @@ DEFINE_TEST_1(test_scan_non_inplace, TestingAlgoritm)
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     ::std::enable_if_t<
         oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
-            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value>
+            is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>>
     operator()(Policy&& exec,
                Iterator1 keys_first, Iterator1 keys_last,
                Iterator2 vals_first, Iterator2 vals_last,
@@ -194,7 +194,7 @@ DEFINE_TEST_1(test_scan_non_inplace, TestingAlgoritm)
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     ::std::enable_if_t<
         !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
-            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value>
+            is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>>
     operator()(Policy&& exec,
                Iterator1 keys_first, Iterator1 keys_last,
                Iterator2 vals_first, Iterator2 vals_last,
@@ -216,7 +216,7 @@ DEFINE_TEST_1(test_scan_non_inplace, TestingAlgoritm)
 
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value>
+    ::std::enable_if_t<!is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>>
     operator()(Policy&& exec,
                Iterator1 keys_first, Iterator1 keys_last,
                Iterator2 vals_first, Iterator2 vals_last,
@@ -233,7 +233,7 @@ DEFINE_TEST_1(test_scan_inplace, TestingAlgoritm)
     template <typename Policy, typename Iterator1, typename Size>
     ::std::enable_if_t<
         !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
-            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value>
+            is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Size n)
     {
         using KeyT = typename ::std::iterator_traits<Iterator1>::value_type;
@@ -256,7 +256,7 @@ DEFINE_TEST_1(test_scan_inplace, TestingAlgoritm)
     template <typename Policy, typename Iterator1, typename Size>
     ::std::enable_if_t<
         oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
-            is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value>
+            is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last,
                Size n)
     {
@@ -285,7 +285,7 @@ DEFINE_TEST_1(test_scan_inplace, TestingAlgoritm)
 
     // specialization for non-random_access iterators
     template <typename Policy, typename Iterator1, typename Size>
-    ::std::enable_if_t<!is_base_of_iterator_category<::std::random_access_iterator_tag, Iterator1>::value>
+    ::std::enable_if_t<!is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Size n)
     {
     }

--- a/test/parallel_api/numeric/numeric.ops/scan_2.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan_2.pass.cpp
@@ -146,7 +146,7 @@ DEFINE_TEST_1(test_scan_non_inplace, TestingAlgoritm)
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     ::std::enable_if_t<
-        oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
+        oneapi::dpl::__internal::__is_hetero_execution_policy_v<::std::decay_t<Policy>> &&
             is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>>
     operator()(Policy&& exec,
                Iterator1 keys_first, Iterator1 keys_last,
@@ -193,7 +193,7 @@ DEFINE_TEST_1(test_scan_non_inplace, TestingAlgoritm)
     // specialization for host execution policies
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     ::std::enable_if_t<
-        !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
+        !oneapi::dpl::__internal::__is_hetero_execution_policy_v<::std::decay_t<Policy>> &&
             is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>>
     operator()(Policy&& exec,
                Iterator1 keys_first, Iterator1 keys_last,
@@ -232,7 +232,7 @@ DEFINE_TEST_1(test_scan_inplace, TestingAlgoritm)
     // specialization for host execution policies
     template <typename Policy, typename Iterator1, typename Size>
     ::std::enable_if_t<
-        !oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
+        !oneapi::dpl::__internal::__is_hetero_execution_policy_v<::std::decay_t<Policy>> &&
             is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last, Size n)
     {
@@ -255,7 +255,7 @@ DEFINE_TEST_1(test_scan_inplace, TestingAlgoritm)
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Size>
     ::std::enable_if_t<
-        oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<Policy>>::value &&
+        oneapi::dpl::__internal::__is_hetero_execution_policy_v<::std::decay_t<Policy>> &&
             is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>>
     operator()(Policy&& exec, Iterator1 keys_first, Iterator1 keys_last,
                Size n)

--- a/test/parallel_api/numeric/numeric.ops/transform_scan.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/transform_scan.pass.cpp
@@ -45,7 +45,7 @@ struct test_transform_exclusive_scan
 {
     template <typename Policy, typename InputIterator, typename OutputIterator, typename Size, typename UnaryOp,
               typename T, typename BinaryOp>
-    ::std::enable_if_t<!TestUtils::isReverse<InputIterator>::value>
+    ::std::enable_if_t<!TestUtils::is_reverse_v<InputIterator>>
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
                OutputIterator out_last, OutputIterator expected_first, OutputIterator /* expected_last */, Size n,
                UnaryOp unary_op, T init, BinaryOp binary_op, T trash)
@@ -61,7 +61,7 @@ struct test_transform_exclusive_scan
 
     template <typename Policy, typename InputIterator, typename OutputIterator, typename Size, typename UnaryOp,
               typename T, typename BinaryOp>
-    ::std::enable_if_t<TestUtils::isReverse<InputIterator>::value>
+    ::std::enable_if_t<TestUtils::is_reverse_v<InputIterator>>
     operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, OutputIterator /* out_first */,
                OutputIterator /* out_last */, OutputIterator /* expected_first */, OutputIterator /* expected_last */, Size /* n */,
                UnaryOp /* unary_op */, T /* init */, BinaryOp /* binary_op */, T /* trash */)
@@ -74,7 +74,7 @@ struct test_transform_inclusive_scan_init
 {
     template <typename Policy, typename InputIterator, typename OutputIterator, typename Size, typename UnaryOp,
               typename T, typename BinaryOp>
-    ::std::enable_if_t<!TestUtils::isReverse<InputIterator>::value>
+    ::std::enable_if_t<!TestUtils::is_reverse_v<InputIterator>>
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
                OutputIterator out_last, OutputIterator expected_first, OutputIterator /* expected_last */, Size n,
                UnaryOp unary_op, T init, BinaryOp binary_op, T trash)
@@ -90,7 +90,7 @@ struct test_transform_inclusive_scan_init
 
     template <typename Policy, typename InputIterator, typename OutputIterator, typename Size, typename UnaryOp,
               typename T, typename BinaryOp>
-    ::std::enable_if_t<TestUtils::isReverse<InputIterator>::value>
+    ::std::enable_if_t<TestUtils::is_reverse_v<InputIterator>>
     operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, OutputIterator /* out_first */,
                OutputIterator /* out_last */, OutputIterator /* expected_first */, OutputIterator /* expected_last */, Size /* n */,
                UnaryOp /* unary_op */, T /* init */, BinaryOp /* binary_op */, T /* trash */)
@@ -103,7 +103,7 @@ struct test_transform_inclusive_scan
 {
     template <typename Policy, typename InputIterator, typename OutputIterator, typename Size, typename UnaryOp,
               typename T, typename BinaryOp>
-    ::std::enable_if_t<!TestUtils::isReverse<InputIterator>::value>
+    ::std::enable_if_t<!TestUtils::is_reverse_v<InputIterator>>
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
                OutputIterator out_last, OutputIterator expected_first, OutputIterator /* expected_last */, Size n,
                UnaryOp unary_op, T /* init */, BinaryOp binary_op, T trash)
@@ -122,7 +122,7 @@ struct test_transform_inclusive_scan
 
     template <typename Policy, typename InputIterator, typename OutputIterator, typename Size, typename UnaryOp,
               typename T, typename BinaryOp>
-    ::std::enable_if_t<TestUtils::isReverse<InputIterator>::value>
+    ::std::enable_if_t<TestUtils::is_reverse_v<InputIterator>>
     operator()(Policy&& /* exec */, InputIterator /* first */, InputIterator /* last */, OutputIterator /* out_first */,
                OutputIterator /* out_last */, OutputIterator /* expected_first */, OutputIterator /* expected_last */, Size /* n */,
                UnaryOp /* unary_op */, T /* init */, BinaryOp /* binary_op */, T /* trash */)

--- a/test/support/iterator_utils.h
+++ b/test/support/iterator_utils.h
@@ -248,6 +248,9 @@ struct iterator_traits_<T*>
 template <typename Iter, typename Tag>
 using is_same_iterator_category = ::std::is_same<typename iterator_traits_<Iter>::iterator_category, Tag>;
 
+template <typename Iter, typename Tag>
+inline constexpr bool is_same_iterator_category_v = is_same_iterator_category<Iter, Tag>::value;
+
 template <typename Tag, typename Iter>
 using is_base_of_iterator_category = ::std::is_base_of<Tag, typename iterator_traits_<Iter>::iterator_category>;
 
@@ -290,27 +293,27 @@ template <typename Op, typename IteratorTag, bool IsPositiveCondition = true>
 struct non_const_wrapper_tagged : non_const_wrapper
 {
     template <typename Policy, typename Iterator>
-    ::std::enable_if_t<IsPositiveCondition == is_same_iterator_category<Iterator, IteratorTag>::value>
+    ::std::enable_if_t<IsPositiveCondition == is_same_iterator_category_v<Iterator, IteratorTag>>
     operator()(Policy&& exec, Iterator iter)
     {
         Op()(exec, iter);
     }
 
     template <typename Policy, typename InputIterator, typename OutputIterator>
-    ::std::enable_if_t<IsPositiveCondition == is_same_iterator_category<OutputIterator, IteratorTag>::value>
+    ::std::enable_if_t<IsPositiveCondition == is_same_iterator_category_v<OutputIterator, IteratorTag>>
     operator()(Policy&& exec, InputIterator input_iter, OutputIterator out_iter)
     {
         Op()(exec, input_iter, out_iter);
     }
 
     template <typename Policy, typename Iterator>
-    ::std::enable_if_t<IsPositiveCondition != is_same_iterator_category<Iterator, IteratorTag>::value>
+    ::std::enable_if_t<IsPositiveCondition != is_same_iterator_category_v<Iterator, IteratorTag>>
     operator()(Policy&& /*exec*/, Iterator /*iter*/)
     {
     }
 
     template <typename Policy, typename InputIterator, typename OutputIterator>
-    ::std::enable_if_t<IsPositiveCondition != is_same_iterator_category<OutputIterator, IteratorTag>::value>
+    ::std::enable_if_t<IsPositiveCondition != is_same_iterator_category_v<OutputIterator, IteratorTag>>
     operator()(Policy&& /*exec*/, InputIterator /*input_iter*/, OutputIterator /*out_iter*/)
     {
     }
@@ -469,7 +472,7 @@ struct iterator_invoker<IteratorTag, /* IsReverse = */ ::std::true_type>
     }
 
     template <typename Policy, typename Op, typename Iterator, typename... Rest>
-    ::std::enable_if_t<is_same_iterator_category<Iterator, ::std::bidirectional_iterator_tag>::value>
+    ::std::enable_if_t<is_same_iterator_category_v<Iterator, ::std::bidirectional_iterator_tag>>
     operator()(Policy&& exec, Op op, Iterator begin, typename ::std::iterator_traits<Iterator>::difference_type n, Iterator expected, Rest&&... rest)
     {
         if (n <= sizeLimit)

--- a/test/support/iterator_utils.h
+++ b/test/support/iterator_utils.h
@@ -157,6 +157,9 @@ struct isReverse<::std::reverse_iterator<Iterator>> : ::std::true_type
 {
 };
 
+template <typename Iterator>
+inline constexpr bool is_reverse_v = isReverse<Iterator>::value;
+
 // Reverse adapter
 template <typename Iterator, typename IsReverse>
 struct ReverseAdapter

--- a/test/support/iterator_utils.h
+++ b/test/support/iterator_utils.h
@@ -148,17 +148,17 @@ struct BaseAdapter
 // Check if the iterator is reverse iterator
 // Note: it works only for iterators that created by ::std::reverse_iterator
 template <typename NotReverseIterator>
-struct isReverse : ::std::false_type
+struct is_reverse : ::std::false_type
 {
 };
 
 template <typename Iterator>
-struct isReverse<::std::reverse_iterator<Iterator>> : ::std::true_type
+struct is_reverse<::std::reverse_iterator<Iterator>> : ::std::true_type
 {
 };
 
 template <typename Iterator>
-inline constexpr bool is_reverse_v = isReverse<Iterator>::value;
+inline constexpr bool is_reverse_v = is_reverse<Iterator>::value;
 
 // Reverse adapter
 template <typename Iterator, typename IsReverse>

--- a/test/support/iterator_utils.h
+++ b/test/support/iterator_utils.h
@@ -248,6 +248,9 @@ using is_same_iterator_category = ::std::is_same<typename iterator_traits_<Iter>
 template <typename Tag, typename Iter>
 using is_base_of_iterator_category = ::std::is_base_of<Tag, typename iterator_traits_<Iter>::iterator_category>;
 
+template <typename Tag, typename Iter>
+inline constexpr bool is_base_of_iterator_category_v = is_base_of_iterator_category<Tag, Iter>::value;
+
 // if we run with reverse or const iterators we shouldn't test the large range
 template <typename IsReverse, typename IsConst>
 struct invoke_if_

--- a/test/support/test_complex.h
+++ b/test/support/test_complex.h
@@ -26,7 +26,7 @@
 #include <cassert>
 
 #if !_PSTL_MSVC_LESS_THAN_CPP20_COMPLEX_CONSTEXPR_BROKEN
-#    define STD_COMPLEX_TESTS_STATIC_ASSERT(arg, msg) static_assert(arg, msg)
+#    define STD_COMPLEX_TESTS_STATIC_ASSERT(arg) static_assert(arg)
 #else
 #    define STD_COMPLEX_TESTS_STATIC_ASSERT(arg) assert(arg)
 #endif // !_PSTL_MSVC_LESS_THAN_CPP20_COMPLEX_CONSTEXPR_BROKEN
@@ -70,7 +70,7 @@ run_test()
 //     void
 //     test(T x, ::std::enable_if_t<std::is_integral_v<T>>* = 0)
 //     {
-//         static_assert((std::is_same_v<decltype(dpl::conj(x)), dpl::complex<double>>), "");
+//         static_assert((std::is_same_v<decltype(dpl::conj(x)), dpl::complex<double>>));
 //
 //         // HERE IS THE CODE WHICH CALL WE SHOULD AVOID IF DOUBLE IS NOT SUPPORTED ON DEVICE
 //         assert(dpl::conj(x) == dpl::conj(dpl::complex<double>(x, 0)));

--- a/test/support/test_complex.h
+++ b/test/support/test_complex.h
@@ -28,7 +28,7 @@
 #if !_PSTL_MSVC_LESS_THAN_CPP20_COMPLEX_CONSTEXPR_BROKEN
 #    define STD_COMPLEX_TESTS_STATIC_ASSERT(arg, msg) static_assert(arg, msg)
 #else
-#    define STD_COMPLEX_TESTS_STATIC_ASSERT(arg, msg) assert(arg)
+#    define STD_COMPLEX_TESTS_STATIC_ASSERT(arg) assert(arg)
 #endif // !_PSTL_MSVC_LESS_THAN_CPP20_COMPLEX_CONSTEXPR_BROKEN
 
 #define ONEDPL_TEST_NUM_MAIN                                                                          \

--- a/test/support/test_macros.h
+++ b/test/support/test_macros.h
@@ -236,11 +236,11 @@
 #define LIBCPP_ASSERT_NOT_NOEXCEPT(...) ASSERT_NOT_NOEXCEPT(__VA_ARGS__)
 #define LIBCPP_ONLY(...) __VA_ARGS__
 #else
-#define LIBCPP_ASSERT(...) static_assert(true, "")
-#define LIBCPP_STATIC_ASSERT(...) static_assert(true, "")
-#define LIBCPP_ASSERT_NOEXCEPT(...) static_assert(true, "")
-#define LIBCPP_ASSERT_NOT_NOEXCEPT(...) static_assert(true, "")
-#define LIBCPP_ONLY(...) static_assert(true, "")
+#define LIBCPP_ASSERT(...) static_assert(true)
+#define LIBCPP_STATIC_ASSERT(...) static_assert(true)
+#define LIBCPP_ASSERT_NOEXCEPT(...) static_assert(true)
+#define LIBCPP_ASSERT_NOT_NOEXCEPT(...) static_assert(true)
+#define LIBCPP_ONLY(...) static_assert(true)
 #endif
 
 #define TEST_IGNORE_NODISCARD (void)

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -696,6 +696,9 @@ struct can_use_default_less_operator<T, decltype(::std::declval<T>() < ::std::de
 {
 };
 
+template <typename T>
+inline constexpr bool can_use_default_less_operator_v = can_use_default_less_operator<T>::value;
+
 // An arbitrary binary predicate to simulate a predicate the user providing
 // a custom predicate.
 template <typename _Tp>

--- a/test/xpu_api/numerics/c.math/cmath.pass.cpp
+++ b/test/xpu_api/numerics/c.math/cmath.pass.cpp
@@ -78,25 +78,25 @@ void test_abs()
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wabsolute-value"
 #endif
-    static_assert((std::is_same_v<decltype(dpl::abs((float)0)), float>), "");
-    static_assert((std::is_same_v<decltype(dpl::abs((int)0)), int>), "");
-    static_assert((std::is_same_v<decltype(dpl::abs((long)0)), long>), "");
-    static_assert((std::is_same_v<decltype(dpl::abs((long long)0)), long long>), "");
-    static_assert((std::is_same_v<decltype(dpl::abs((unsigned char)0)), int>), "");
-    static_assert((std::is_same_v<decltype(dpl::abs((unsigned short)0)), int>), "");
-    static_assert((std::is_same_v<decltype(dpl::abs((signed char)0)), int>), "");
-    static_assert((std::is_same_v<decltype(dpl::abs((short)0)), int>), "");
-    static_assert((std::is_same_v<decltype(dpl::abs((unsigned char)0)), int>), "");
-    static_assert((std::is_same_v<decltype(dpl::abs((char)0)), int>), "");
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::abs(Ambiguous())), Ambiguous>), ""))
+    static_assert((std::is_same_v<decltype(dpl::abs((float)0)), float>));
+    static_assert((std::is_same_v<decltype(dpl::abs((int)0)), int>));
+    static_assert((std::is_same_v<decltype(dpl::abs((long)0)), long>));
+    static_assert((std::is_same_v<decltype(dpl::abs((long long)0)), long long>));
+    static_assert((std::is_same_v<decltype(dpl::abs((unsigned char)0)), int>));
+    static_assert((std::is_same_v<decltype(dpl::abs((unsigned short)0)), int>));
+    static_assert((std::is_same_v<decltype(dpl::abs((signed char)0)), int>));
+    static_assert((std::is_same_v<decltype(dpl::abs((short)0)), int>));
+    static_assert((std::is_same_v<decltype(dpl::abs((unsigned char)0)), int>));
+    static_assert((std::is_same_v<decltype(dpl::abs((char)0)), int>));
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::abs(Ambiguous())), Ambiguous>)))
 
-    static_assert(!has_abs<unsigned>::value, "");
-    static_assert(!has_abs<unsigned long>::value, "");
-    static_assert(!has_abs<unsigned long long>::value, "");
-    static_assert(!has_abs<size_t>::value, "");
+    static_assert(!has_abs<unsigned>::value);
+    static_assert(!has_abs<unsigned long>::value);
+    static_assert(!has_abs<unsigned long long>::value);
+    static_assert(!has_abs<size_t>::value);
 
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::abs((double)0)), double>), ""))
-    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::abs((long double)0)), long double>), ""))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::abs((double)0)), double>)))
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::abs((long double)0)), long double>)))
 #ifdef __clang__
 #pragma clang diagnostic pop
 #endif
@@ -107,76 +107,76 @@ void test_abs()
 ONEDPL_TEST_DECLARE
 void test_ceil()
 {
-    static_assert((std::is_same_v<decltype(dpl::ceil((float)0)), float>), "");
+    static_assert((std::is_same_v<decltype(dpl::ceil((float)0)), float>));
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::ceil((bool)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::ceil((unsigned short)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::ceil((int)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::ceil((unsigned int)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::ceil((long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::ceil((unsigned long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::ceil((long long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::ceil((unsigned long long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::ceil((double)0)), double>), ""))
-    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::ceil((long double)0)), long double>), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::ceil(Ambiguous())), Ambiguous>), "");
+        static_assert((std::is_same_v<decltype(dpl::ceil((bool)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::ceil((unsigned short)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::ceil((int)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::ceil((unsigned int)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::ceil((long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::ceil((unsigned long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::ceil((long long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::ceil((unsigned long long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::ceil((double)0)), double>)))
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::ceil((long double)0)), long double>)))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::ceil(Ambiguous())), Ambiguous>));
                       assert(dpl::ceil(0) == 0))
 }
 
 ONEDPL_TEST_DECLARE
 void test_exp()
 {
-    static_assert((std::is_same_v<decltype(dpl::exp((float)0)), float>), "");
+    static_assert((std::is_same_v<decltype(dpl::exp((float)0)), float>));
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::exp((bool)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::exp((unsigned short)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::exp((int)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::exp((unsigned int)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::exp((long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::exp((unsigned long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::exp((long long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::exp((unsigned long long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::exp((double)0)), double>), ""))
-    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::exp((long double)0)), long double>), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::exp(Ambiguous())), Ambiguous>), "");
+        static_assert((std::is_same_v<decltype(dpl::exp((bool)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::exp((unsigned short)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::exp((int)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::exp((unsigned int)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::exp((long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::exp((unsigned long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::exp((long long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::exp((unsigned long long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::exp((double)0)), double>)))
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::exp((long double)0)), long double>)))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::exp(Ambiguous())), Ambiguous>));
                       assert(dpl::exp(0) == 1))
 }
 
 ONEDPL_TEST_DECLARE
 void test_fabs()
 {
-    static_assert((std::is_same_v<decltype(dpl::fabs((float)0)), float>), "");
+    static_assert((std::is_same_v<decltype(dpl::fabs((float)0)), float>));
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::fabs((bool)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fabs((unsigned short)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fabs((int)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fabs((unsigned int)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fabs((long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fabs((unsigned long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fabs((long long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fabs((unsigned long long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fabs((double)0)), double>), ""))
-    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::fabs((long double)0)), long double>), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::fabs(Ambiguous())), Ambiguous>), "");
+        static_assert((std::is_same_v<decltype(dpl::fabs((bool)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fabs((unsigned short)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fabs((int)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fabs((unsigned int)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fabs((long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fabs((unsigned long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fabs((long long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fabs((unsigned long long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fabs((double)0)), double>)))
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::fabs((long double)0)), long double>)))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::fabs(Ambiguous())), Ambiguous>));
                       assert(dpl::fabs(-1) == 1));
 }
 
 ONEDPL_TEST_DECLARE
 void test_floor()
 {
-    static_assert((std::is_same_v<decltype(dpl::floor((float)0)), float>), "");
+    static_assert((std::is_same_v<decltype(dpl::floor((float)0)), float>));
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::floor((bool)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::floor((unsigned short)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::floor((int)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::floor((unsigned int)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::floor((long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::floor((unsigned long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::floor((long long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::floor((unsigned long long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::floor((double)0)), double>), ""))
-    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::floor((long double)0)), long double>), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::floor(Ambiguous())), Ambiguous>), "");
+        static_assert((std::is_same_v<decltype(dpl::floor((bool)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::floor((unsigned short)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::floor((int)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::floor((unsigned int)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::floor((long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::floor((unsigned long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::floor((long long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::floor((unsigned long long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::floor((double)0)), double>)))
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::floor((long double)0)), long double>)))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::floor(Ambiguous())), Ambiguous>));
                       assert(dpl::floor(1) == 1))
 }
 
@@ -186,19 +186,19 @@ void test_isgreater()
 #ifdef isgreater
 #error isgreater defined
 #endif
-    static_assert((std::is_same_v<decltype(dpl::isgreater((float)0, (float)0)), bool>), "");
+    static_assert((std::is_same_v<decltype(dpl::isgreater((float)0, (float)0)), bool>));
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::isgreater((float)0, (double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isgreater((double)0, (float)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isgreater((double)0, (double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isgreater(0, (double)0)), bool>), ""))
+        static_assert((std::is_same_v<decltype(dpl::isgreater((float)0, (double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isgreater((double)0, (float)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isgreater((double)0, (double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isgreater(0, (double)0)), bool>)))
     IF_LONG_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::isgreater((float)0, (long double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isgreater((double)0, (long double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isgreater((long double)0, (float)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isgreater((long double)0, (double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isgreater((long double)0, (long double)0)), bool>), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::isgreater(Ambiguous(), Ambiguous())), Ambiguous>), "");
+        static_assert((std::is_same_v<decltype(dpl::isgreater((float)0, (long double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isgreater((double)0, (long double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isgreater((long double)0, (float)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isgreater((long double)0, (double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isgreater((long double)0, (long double)0)), bool>)))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::isgreater(Ambiguous(), Ambiguous())), Ambiguous>));
                       assert(dpl::isgreater(-1.0, 0.F) == false))
 }
 
@@ -208,19 +208,19 @@ void test_isgreaterequal()
 #ifdef isgreaterequal
 #error isgreaterequal defined
 #endif
-    static_assert((std::is_same_v<decltype(dpl::isgreaterequal((float)0, (float)0)), bool>), "");
+    static_assert((std::is_same_v<decltype(dpl::isgreaterequal((float)0, (float)0)), bool>));
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((float)0, (double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((double)0, (float)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((double)0, (double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isgreaterequal(0, (double)0)), bool>), ""))
+        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((float)0, (double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((double)0, (float)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((double)0, (double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isgreaterequal(0, (double)0)), bool>)))
     IF_LONG_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((float)0, (long double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((double)0, (long double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((long double)0, (float)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((long double)0, (double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((long double)0, (long double)0)), bool>), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::isgreaterequal(Ambiguous(), Ambiguous())), Ambiguous>), "");
+        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((float)0, (long double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((double)0, (long double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((long double)0, (float)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((long double)0, (double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isgreaterequal((long double)0, (long double)0)), bool>)))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::isgreaterequal(Ambiguous(), Ambiguous())), Ambiguous>));
                       assert(dpl::isgreaterequal(-1.0, 0.F) == false))
 }
 
@@ -236,25 +236,25 @@ void test_isinf()
 #pragma clang diagnostic ignored "-Wtautological-constant-compare"
 #endif
 
-    static_assert((std::is_same_v<decltype(dpl::isinf((float)0)), bool>), "");
-    static_assert((std::is_same_v<decltype(dpl::isinf(0)), bool>), "");
+    static_assert((std::is_same_v<decltype(dpl::isinf((float)0)), bool>));
+    static_assert((std::is_same_v<decltype(dpl::isinf(0)), bool>));
 
     auto fnc = []()
     {
         typedef decltype(dpl::isinf((double)0)) DoubleRetType;
 #if !defined(__linux__) || defined(__clang__)
-        static_assert((std::is_same_v<DoubleRetType, bool>), "");
+        static_assert((std::is_same_v<DoubleRetType, bool>));
 #else
         // GLIBC < 2.23 defines 'isinf(double)' with a return type of 'int' in
         // all C++ dialects. The test should tolerate this when libc++ can't work
         // around it.
         // See: https://sourceware.org/bugzilla/show_bug.cgi?id=19439
-        static_assert((std::is_same_v<DoubleRetType, bool> || std::is_same_v<DoubleRetType, int>), "");
+        static_assert((std::is_same_v<DoubleRetType, bool> || std::is_same_v<DoubleRetType, int>));
 #endif
     };
     IF_DOUBLE_SUPPORT_L(fnc)
 
-    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::isinf((long double)0)), bool>), ""))
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::isinf((long double)0)), bool>)))
     IF_DOUBLE_SUPPORT(assert(dpl::isinf(-1.0) == false))
 #if !_PSTL_ICC_TEST_COMPLEX_ISINF_BROKEN
     assert(dpl::isinf(0) == false);
@@ -275,19 +275,19 @@ void test_isless()
 #ifdef isless
 #error isless defined
 #endif
-    static_assert((std::is_same_v<decltype(dpl::isless((float)0, (float)0)), bool>), "");
+    static_assert((std::is_same_v<decltype(dpl::isless((float)0, (float)0)), bool>));
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::isless((float)0, (double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isless((double)0, (float)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isless((double)0, (double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isless(0, (double)0)), bool>), ""))
+        static_assert((std::is_same_v<decltype(dpl::isless((float)0, (double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isless((double)0, (float)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isless((double)0, (double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isless(0, (double)0)), bool>)))
     IF_LONG_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::isless((float)0, (long double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isless((double)0, (long double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isless((long double)0, (float)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isless((long double)0, (double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isless((long double)0, (long double)0)), bool>), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::isless(Ambiguous(), Ambiguous())), Ambiguous>), "");
+        static_assert((std::is_same_v<decltype(dpl::isless((float)0, (long double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isless((double)0, (long double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isless((long double)0, (float)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isless((long double)0, (double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isless((long double)0, (long double)0)), bool>)))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::isless(Ambiguous(), Ambiguous())), Ambiguous>));
                       assert(dpl::isless(-1.0, 0.F) == true))
 }
 
@@ -297,19 +297,19 @@ void test_islessequal()
 #ifdef islessequal
 #error islessequal defined
 #endif
-    static_assert((std::is_same_v<decltype(dpl::islessequal((float)0, (float)0)), bool>), "");
+    static_assert((std::is_same_v<decltype(dpl::islessequal((float)0, (float)0)), bool>));
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::islessequal((float)0, (double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::islessequal((double)0, (float)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::islessequal((double)0, (double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::islessequal(0, (double)0)), bool>), ""))
+        static_assert((std::is_same_v<decltype(dpl::islessequal((float)0, (double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::islessequal((double)0, (float)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::islessequal((double)0, (double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::islessequal(0, (double)0)), bool>)))
     IF_LONG_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::islessequal((float)0, (long double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::islessequal((double)0, (long double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::islessequal((long double)0, (float)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::islessequal((long double)0, (double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::islessequal((long double)0, (long double)0)), bool>), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::islessequal(Ambiguous(), Ambiguous())), Ambiguous>), "");
+        static_assert((std::is_same_v<decltype(dpl::islessequal((float)0, (long double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::islessequal((double)0, (long double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::islessequal((long double)0, (float)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::islessequal((long double)0, (double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::islessequal((long double)0, (long double)0)), bool>)))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::islessequal(Ambiguous(), Ambiguous())), Ambiguous>));
                       assert(dpl::islessequal(-1.0, 0.F) == true));
 }
 
@@ -324,25 +324,25 @@ void test_isnan()
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wtautological-constant-compare"
 #endif
-    static_assert((std::is_same_v<decltype(dpl::isnan((float)0)), bool>), "");
+    static_assert((std::is_same_v<decltype(dpl::isnan((float)0)), bool>));
 
     auto fnc = []()
     {
         typedef decltype(dpl::isnan((double)0)) DoubleRetType;
 #if !defined(__linux__) || defined(__clang__)
-        static_assert((std::is_same_v<DoubleRetType, bool>), "");
+        static_assert((std::is_same_v<DoubleRetType, bool>));
 #else
         // GLIBC < 2.23 defines 'isinf(double)' with a return type of 'int' in
         // all C++ dialects. The test should tolerate this when libc++ can't work
         // around it.
         // See: https://sourceware.org/bugzilla/show_bug.cgi?id=19439
-        static_assert((std::is_same_v<DoubleRetType, bool> || std::is_same_v<DoubleRetType, int>), "");
+        static_assert((std::is_same_v<DoubleRetType, bool> || std::is_same_v<DoubleRetType, int>));
 #endif
     };
     IF_DOUBLE_SUPPORT_L(fnc)
 
-    static_assert((std::is_same_v<decltype(dpl::isnan(0)), bool>), "");
-    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::isnan((long double)0)), bool>), ""))
+    static_assert((std::is_same_v<decltype(dpl::isnan(0)), bool>));
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::isnan((long double)0)), bool>)))
     IF_DOUBLE_SUPPORT(assert(dpl::isnan(-1.0) == false))
 #if !_PSTL_ICC_TEST_COMPLEX_ISNAN_BROKEN
     assert(dpl::isnan(0) == false);
@@ -363,142 +363,142 @@ void test_isunordered()
 #ifdef isunordered
 #error isunordered defined
 #endif
-    static_assert((std::is_same_v<decltype(dpl::isunordered((float)0, (float)0)), bool>), "");
+    static_assert((std::is_same_v<decltype(dpl::isunordered((float)0, (float)0)), bool>));
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::isunordered((float)0, (double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isunordered((double)0, (float)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isunordered((double)0, (double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isunordered(0, (double)0)), bool>), ""))
+        static_assert((std::is_same_v<decltype(dpl::isunordered((float)0, (double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isunordered((double)0, (float)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isunordered((double)0, (double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isunordered(0, (double)0)), bool>)))
     IF_LONG_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::isunordered((float)0, (long double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isunordered((double)0, (long double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isunordered((long double)0, (float)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isunordered((long double)0, (double)0)), bool>), "");
-        static_assert((std::is_same_v<decltype(dpl::isunordered((long double)0, (long double)0)), bool>), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::isunordered(Ambiguous(), Ambiguous())), Ambiguous>), "");
+        static_assert((std::is_same_v<decltype(dpl::isunordered((float)0, (long double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isunordered((double)0, (long double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isunordered((long double)0, (float)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isunordered((long double)0, (double)0)), bool>));
+        static_assert((std::is_same_v<decltype(dpl::isunordered((long double)0, (long double)0)), bool>)))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::isunordered(Ambiguous(), Ambiguous())), Ambiguous>));
                       assert(dpl::isunordered(-1.0, 0.F) == false));
 }
 
 ONEDPL_TEST_DECLARE
 void test_copysign()
 {
-    static_assert((std::is_same_v<decltype(dpl::copysign((float)0, (float)0)), float>), "");
-    static_assert((std::is_same_v<decltype(dpl::copysign((float)0, (unsigned int)0)), double>), "");
-    static_assert((std::is_same_v<decltype(dpl::copysignf(0,0)), float>), "");
+    static_assert((std::is_same_v<decltype(dpl::copysign((float)0, (float)0)), float>));
+    static_assert((std::is_same_v<decltype(dpl::copysign((float)0, (unsigned int)0)), double>));
+    static_assert((std::is_same_v<decltype(dpl::copysignf(0,0)), float>));
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::copysign((bool)0, (float)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::copysign((unsigned short)0, (double)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::copysign((double)0, (long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::copysign((int)0, (unsigned long long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::copysign((double)0, (double)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::copysign((float)0, (double)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::copysign((int)0, (int)0)), double>), ""))
+        static_assert((std::is_same_v<decltype(dpl::copysign((bool)0, (float)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::copysign((unsigned short)0, (double)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::copysign((double)0, (long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::copysign((int)0, (unsigned long long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::copysign((double)0, (double)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::copysign((float)0, (double)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::copysign((int)0, (int)0)), double>)))
     IF_LONG_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::copysign((int)0, (long double)0)), long double>), "");
-        static_assert((std::is_same_v<decltype(dpl::copysign((long double)0, (unsigned long)0)), long double>), "");
-        static_assert((std::is_same_v<decltype(dpl::copysign((int)0, (long long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::copysign((long double)0, (long double)0)), long double>), "");
-        static_assert((std::is_same_v<decltype(dpl::copysign((float)0, (long double)0)), long double>), "");
-        static_assert((std::is_same_v<decltype(dpl::copysign((double)0, (long double)0)), long double>), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::copysign(Ambiguous(), Ambiguous())), Ambiguous>), "");
+        static_assert((std::is_same_v<decltype(dpl::copysign((int)0, (long double)0)), long double>));
+        static_assert((std::is_same_v<decltype(dpl::copysign((long double)0, (unsigned long)0)), long double>));
+        static_assert((std::is_same_v<decltype(dpl::copysign((int)0, (long long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::copysign((long double)0, (long double)0)), long double>));
+        static_assert((std::is_same_v<decltype(dpl::copysign((float)0, (long double)0)), long double>));
+        static_assert((std::is_same_v<decltype(dpl::copysign((double)0, (long double)0)), long double>)))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::copysign(Ambiguous(), Ambiguous())), Ambiguous>));
                       assert(dpl::copysign(1,1) == 1))
 }
 
 ONEDPL_TEST_DECLARE
 void test_fmax()
 {
-    static_assert((std::is_same_v<decltype(dpl::fmax((float)0, (float)0)), float>), "");
-    static_assert((std::is_same_v<decltype(dpl::fmax((float)0, (unsigned int)0)), double>), "");
-    static_assert((std::is_same_v<decltype(dpl::fmaxf(0,0)), float>), "");
+    static_assert((std::is_same_v<decltype(dpl::fmax((float)0, (float)0)), float>));
+    static_assert((std::is_same_v<decltype(dpl::fmax((float)0, (unsigned int)0)), double>));
+    static_assert((std::is_same_v<decltype(dpl::fmaxf(0,0)), float>));
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::fmax((bool)0, (float)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmax((unsigned short)0, (double)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmax((int)0, (long long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmax((int)0, (unsigned long long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmax((double)0, (long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmax((double)0, (double)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmax((float)0, (double)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmax((int)0, (int)0)), double>), ""))
+        static_assert((std::is_same_v<decltype(dpl::fmax((bool)0, (float)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fmax((unsigned short)0, (double)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fmax((int)0, (long long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fmax((int)0, (unsigned long long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fmax((double)0, (long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fmax((double)0, (double)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fmax((float)0, (double)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fmax((int)0, (int)0)), double>)))
     IF_LONG_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::fmax((int)0, (long double)0)), long double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmax((long double)0, (unsigned long)0)), long double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmax((long double)0, (long double)0)), long double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmax((float)0, (long double)0)), long double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmax((double)0, (long double)0)), long double>), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::fmax(Ambiguous(), Ambiguous())), Ambiguous>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmax((int)0, (long double)0)), long double>));
+        static_assert((std::is_same_v<decltype(dpl::fmax((long double)0, (unsigned long)0)), long double>));
+        static_assert((std::is_same_v<decltype(dpl::fmax((long double)0, (long double)0)), long double>));
+        static_assert((std::is_same_v<decltype(dpl::fmax((float)0, (long double)0)), long double>));
+        static_assert((std::is_same_v<decltype(dpl::fmax((double)0, (long double)0)), long double>)))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::fmax(Ambiguous(), Ambiguous())), Ambiguous>));
                       assert(dpl::fmax(1,0) == 1))
 }
 
 ONEDPL_TEST_DECLARE
 void test_fmin()
 {
-    static_assert((std::is_same_v<decltype(dpl::fmin((float)0, (float)0)), float>), "");
-    static_assert((std::is_same_v<decltype(dpl::fminf(0, 0)), float>), "");
+    static_assert((std::is_same_v<decltype(dpl::fmin((float)0, (float)0)), float>));
+    static_assert((std::is_same_v<decltype(dpl::fminf(0, 0)), float>));
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::fmin((bool)0, (float)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmin((unsigned short)0, (double)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmin((float)0, (unsigned int)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmin((double)0, (long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmin((int)0, (unsigned long long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmin((double)0, (double)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmin((float)0, (double)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmin((int)0, (int)0)), double>), ""))
+        static_assert((std::is_same_v<decltype(dpl::fmin((bool)0, (float)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fmin((unsigned short)0, (double)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fmin((float)0, (unsigned int)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fmin((double)0, (long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fmin((int)0, (unsigned long long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fmin((double)0, (double)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fmin((float)0, (double)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fmin((int)0, (int)0)), double>)))
     IF_LONG_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::fmin((int)0, (long double)0)), long double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmin((long double)0, (unsigned long)0)), long double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmin((int)0, (long long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmin((long double)0, (long double)0)), long double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmin((float)0, (long double)0)), long double>), "");
-        static_assert((std::is_same_v<decltype(dpl::fmin((double)0, (long double)0)), long double>), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::fmin(Ambiguous(), Ambiguous())), Ambiguous>), "");
+        static_assert((std::is_same_v<decltype(dpl::fmin((int)0, (long double)0)), long double>));
+        static_assert((std::is_same_v<decltype(dpl::fmin((long double)0, (unsigned long)0)), long double>));
+        static_assert((std::is_same_v<decltype(dpl::fmin((int)0, (long long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::fmin((long double)0, (long double)0)), long double>));
+        static_assert((std::is_same_v<decltype(dpl::fmin((float)0, (long double)0)), long double>));
+        static_assert((std::is_same_v<decltype(dpl::fmin((double)0, (long double)0)), long double>)))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::fmin(Ambiguous(), Ambiguous())), Ambiguous>));
                       assert(dpl::fmin(1,0) == 0))
 }
 
 ONEDPL_TEST_DECLARE
 void test_nan()
 {
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::nan("")), double>), ""))
-    static_assert((std::is_same_v<decltype(dpl::nanf("")), float>), "");
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::nan("")), double>)))
+    static_assert((std::is_same_v<decltype(dpl::nanf("")), float>));
 }
 
 ONEDPL_TEST_DECLARE
 void test_round()
 {
-    static_assert((std::is_same_v<decltype(dpl::round((float)0)), float>), "");
-    static_assert((std::is_same_v<decltype(dpl::roundf(0)), float>), "");
+    static_assert((std::is_same_v<decltype(dpl::round((float)0)), float>));
+    static_assert((std::is_same_v<decltype(dpl::roundf(0)), float>));
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::round((bool)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::round((unsigned short)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::round((int)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::round((unsigned int)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::round((long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::round((unsigned long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::round((unsigned long long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::round((double)0)), double>), ""))
+        static_assert((std::is_same_v<decltype(dpl::round((bool)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::round((unsigned short)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::round((int)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::round((unsigned int)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::round((long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::round((unsigned long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::round((unsigned long long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::round((double)0)), double>)))
     IF_LONG_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::round((long long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::round((long double)0)), long double>), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::round(Ambiguous())), Ambiguous>), "");
+        static_assert((std::is_same_v<decltype(dpl::round((long long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::round((long double)0)), long double>)))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::round(Ambiguous())), Ambiguous>));
                       assert(dpl::round(1) == 1))
 }
 
 ONEDPL_TEST_DECLARE
 void test_trunc()
 {
-    static_assert((std::is_same_v<decltype(dpl::trunc((float)0)), float>), "");
-    static_assert((std::is_same_v<decltype(dpl::truncf(0)), float>), "");
+    static_assert((std::is_same_v<decltype(dpl::trunc((float)0)), float>));
+    static_assert((std::is_same_v<decltype(dpl::truncf(0)), float>));
     IF_DOUBLE_SUPPORT(
-        static_assert((std::is_same_v<decltype(dpl::trunc((bool)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::trunc((unsigned short)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::trunc((int)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::trunc((unsigned int)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::trunc((long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::trunc((unsigned long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::trunc((long long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::trunc((unsigned long long)0)), double>), "");
-        static_assert((std::is_same_v<decltype(dpl::trunc((double)0)), double>), ""))
-    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::trunc((long double)0)), long double>), ""))
-    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::trunc(Ambiguous())), Ambiguous>), "");
+        static_assert((std::is_same_v<decltype(dpl::trunc((bool)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::trunc((unsigned short)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::trunc((int)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::trunc((unsigned int)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::trunc((long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::trunc((unsigned long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::trunc((long long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::trunc((unsigned long long)0)), double>));
+        static_assert((std::is_same_v<decltype(dpl::trunc((double)0)), double>)))
+    IF_LONG_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::trunc((long double)0)), long double>)))
+    IF_DOUBLE_SUPPORT(static_assert((std::is_same_v<decltype(dpl::trunc(Ambiguous())), Ambiguous>));
                       assert(dpl::trunc(1) == 1))
 }
 

--- a/test/xpu_api/numerics/complex.number/cmplx.over/arg.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/arg.pass.cpp
@@ -22,7 +22,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<std::is_integral_v<T>>* = 0)
 {
-    static_assert((std::is_same_v<decltype(dpl::arg(x)), double>), "");
+    static_assert((std::is_same_v<decltype(dpl::arg(x)), double>));
     assert(dpl::arg(x) == dpl::arg(dpl::complex<double>(static_cast<double>(x), 0)));
 }
 
@@ -30,7 +30,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<!std::is_integral_v<T>>* = 0)
 {
-    static_assert((std::is_same_v<decltype(dpl::arg(x)), T>), "");
+    static_assert((std::is_same_v<decltype(dpl::arg(x)), T>));
     assert(dpl::arg(x) == dpl::arg(dpl::complex<T>(x, 0)));
 }
 

--- a/test/xpu_api/numerics/complex.number/cmplx.over/conj.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/conj.pass.cpp
@@ -22,7 +22,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<std::is_integral_v<T>>* = 0)
 {
-    static_assert((std::is_same_v<decltype(dpl::conj(x)), dpl::complex<double> >), "");
+    static_assert((std::is_same_v<decltype(dpl::conj(x)), dpl::complex<double> >));
     assert(dpl::conj(x) == dpl::conj(dpl::complex<double>(x, 0)));
 }
 
@@ -30,7 +30,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<std::is_floating_point_v<T>>* = 0)
 {
-    static_assert((std::is_same_v<decltype(dpl::conj(x)), dpl::complex<T>>), "");
+    static_assert((std::is_same_v<decltype(dpl::conj(x)), dpl::complex<T>>));
     assert(dpl::conj(x) == dpl::conj(dpl::complex<T>(x, 0)));
 }
 
@@ -38,7 +38,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<!std::is_integral_v<T> && !std::is_floating_point_v<T>>* = 0)
 {
-    static_assert((std::is_same_v<decltype(dpl::conj(x)), dpl::complex<T>>), "");
+    static_assert((std::is_same_v<decltype(dpl::conj(x)), dpl::complex<T>>));
     assert(dpl::conj(x) == dpl::conj(dpl::complex<T>(x, 0)));
 }
 

--- a/test/xpu_api/numerics/complex.number/cmplx.over/imag.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/imag.pass.cpp
@@ -20,26 +20,26 @@ template <class T, int x>
 void
 test(::std::enable_if_t<std::is_integral_v<T>>* = 0)
 {
-    static_assert((std::is_same_v<decltype(dpl::imag(T(x))), double>), "");
+    static_assert((std::is_same_v<decltype(dpl::imag(T(x))), double>));
     assert(dpl::imag(x) == 0);
 
     constexpr T val {x};
-    STD_COMPLEX_TESTS_STATIC_ASSERT(dpl::imag(val) == 0, "");
+    STD_COMPLEX_TESTS_STATIC_ASSERT(dpl::imag(val) == 0);
     constexpr dpl::complex<T> t{val, val};
-    STD_COMPLEX_TESTS_STATIC_ASSERT(t.imag() == x, "" );
+    STD_COMPLEX_TESTS_STATIC_ASSERT(t.imag() == x);
 }
 
 template <class T, int x>
 void
 test(::std::enable_if_t<!std::is_integral_v<T>>* = 0)
 {
-    static_assert((std::is_same_v<decltype(dpl::imag(T(x))), T>), "");
+    static_assert((std::is_same_v<decltype(dpl::imag(T(x))), T>));
     assert(dpl::imag(x) == 0);
 
     constexpr T val {x};
-    STD_COMPLEX_TESTS_STATIC_ASSERT(dpl::imag(val) == 0, "");
+    STD_COMPLEX_TESTS_STATIC_ASSERT(dpl::imag(val) == 0);
     constexpr dpl::complex<T> t{val, val};
-    STD_COMPLEX_TESTS_STATIC_ASSERT(t.imag() == x, "" );
+    STD_COMPLEX_TESTS_STATIC_ASSERT(t.imag() == x);
 }
 
 template <class T>

--- a/test/xpu_api/numerics/complex.number/cmplx.over/norm.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/norm.pass.cpp
@@ -20,7 +20,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<std::is_integral_v<T>>* = 0)
 {
-    static_assert((std::is_same_v<decltype(dpl::norm(x)), double>), "");
+    static_assert((std::is_same_v<decltype(dpl::norm(x)), double>));
     assert(dpl::norm(x) == dpl::norm(dpl::complex<double>(static_cast<double>(x), 0)));
 }
 
@@ -28,7 +28,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<!std::is_integral_v<T>>* = 0)
 {
-    static_assert((std::is_same_v<decltype(dpl::norm(x)), T>), "");
+    static_assert((std::is_same_v<decltype(dpl::norm(x)), T>));
     assert(dpl::norm(x) == dpl::norm(dpl::complex<T>(x, 0)));
 }
 

--- a/test/xpu_api/numerics/complex.number/cmplx.over/pow.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/pow.pass.cpp
@@ -39,7 +39,7 @@ void
 test(T x, const dpl::complex<U>& y)
 {
     typedef decltype(promote(x) + promote(dpl::real(y))) V;
-    static_assert((std::is_same_v<decltype(dpl::pow(x, y)), dpl::complex<V> >), "");
+    static_assert((std::is_same_v<decltype(dpl::pow(x, y)), dpl::complex<V> >));
     is_about(dpl::pow(x, y), dpl::pow(dpl::complex<V>(x, 0), dpl::complex<V>(y)));
 }
 
@@ -48,7 +48,7 @@ void
 test(const dpl::complex<T>& x, U y)
 {
     typedef decltype(promote(dpl::real(x)) + promote(y)) V;
-    static_assert((std::is_same_v<decltype(dpl::pow(x, y)), dpl::complex<V> >), "");
+    static_assert((std::is_same_v<decltype(dpl::pow(x, y)), dpl::complex<V> >));
     is_about(dpl::pow(x, y), dpl::pow(dpl::complex<V>(x), dpl::complex<V>(y, 0)));
 }
 
@@ -57,7 +57,7 @@ void
 test(const dpl::complex<T>& x, const dpl::complex<U>& y)
 {
     typedef decltype(promote(dpl::real(x)) + promote(dpl::real(y))) V;
-    static_assert((std::is_same_v<decltype(dpl::pow(x, y)), dpl::complex<V> >), "");
+    static_assert((std::is_same_v<decltype(dpl::pow(x, y)), dpl::complex<V> >));
     assert(dpl::pow(x, y) == dpl::pow(dpl::complex<V>(x), dpl::complex<V>(y)));
 }
 

--- a/test/xpu_api/numerics/complex.number/cmplx.over/proj.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/proj.pass.cpp
@@ -22,7 +22,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<std::is_integral_v<T>>* = 0)
 {
-    static_assert((std::is_same_v<decltype(dpl::proj(x)), dpl::complex<double> >), "");
+    static_assert((std::is_same_v<decltype(dpl::proj(x)), dpl::complex<double> >));
     assert(dpl::proj(x) == dpl::proj(dpl::complex<double>(x, 0)));
 }
 
@@ -30,7 +30,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<std::is_floating_point_v<T>>* = 0)
 {
-    static_assert((std::is_same_v<decltype(dpl::proj(x)), dpl::complex<T> >), "");
+    static_assert((std::is_same_v<decltype(dpl::proj(x)), dpl::complex<T> >));
     assert(dpl::proj(x) == dpl::proj(dpl::complex<T>(x, 0)));
 }
 
@@ -38,7 +38,7 @@ template <class T>
 void
 test(T x, ::std::enable_if_t<!std::is_integral_v<T> && !std::is_floating_point_v<T>>* = 0)
 {
-    static_assert((std::is_same_v<decltype(dpl::proj(x)), dpl::complex<T> >), "");
+    static_assert((std::is_same_v<decltype(dpl::proj(x)), dpl::complex<T> >));
     assert(dpl::proj(x) == dpl::proj(dpl::complex<T>(x, 0)));
 }
 

--- a/test/xpu_api/numerics/complex.number/cmplx.over/real.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/real.pass.cpp
@@ -20,26 +20,26 @@ template <class T, int x>
 void
 test(::std::enable_if_t<std::is_integral_v<T>>* = 0)
 {
-    static_assert((std::is_same_v<decltype(dpl::real(T(x))), double>), "");
+    static_assert((std::is_same_v<decltype(dpl::real(T(x))), double>));
     assert(dpl::real(x) == x);
 
     constexpr T val {x};
-    STD_COMPLEX_TESTS_STATIC_ASSERT(dpl::real(val) == val, "");
+    STD_COMPLEX_TESTS_STATIC_ASSERT(dpl::real(val) == val);
     constexpr dpl::complex<T> t{val, val};
-    STD_COMPLEX_TESTS_STATIC_ASSERT(t.real() == x, "" );
+    STD_COMPLEX_TESTS_STATIC_ASSERT(t.real() == x );
 }
 
 template <class T, int x>
 void
 test(::std::enable_if_t<!std::is_integral_v<T>>* = 0)
 {
-    static_assert((std::is_same_v<decltype(dpl::real(T(x))), T>), "");
+    static_assert((std::is_same_v<decltype(dpl::real(T(x))), T>));
     assert(dpl::real(x) == x);
 
     constexpr T val {x};
-    STD_COMPLEX_TESTS_STATIC_ASSERT(dpl::real(val) == val, "");
+    STD_COMPLEX_TESTS_STATIC_ASSERT(dpl::real(val) == val);
     constexpr dpl::complex<T> t{val, val};
-    STD_COMPLEX_TESTS_STATIC_ASSERT(t.real() == x, "" );
+    STD_COMPLEX_TESTS_STATIC_ASSERT(t.real() == x);
 }
 
 template <class T>

--- a/test/xpu_api/numerics/complex.number/complex.literals/literals.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.literals/literals.pass.cpp
@@ -16,12 +16,12 @@ ONEDPL_TEST_NUM_MAIN
     using namespace std::literals::complex_literals;
 
 //  Make sure the types are right
-    IF_LONG_DOUBLE_SUPPORT(static_assert ( std::is_same_v<decltype( 3.0il ), dpl::complex<long double>>, "" ))
-    IF_LONG_DOUBLE_SUPPORT(static_assert ( std::is_same_v<decltype( 3il   ), dpl::complex<long double>>, "" ))
-    IF_DOUBLE_SUPPORT(static_assert(std::is_same_v<decltype(3.0i), dpl::complex<double>>, ""))
-    IF_DOUBLE_SUPPORT(static_assert(std::is_same_v<decltype(3i), dpl::complex<double>>, ""))
-    static_assert ( std::is_same_v<decltype( 3.0if ), dpl::complex<float>>, "" );
-    static_assert ( std::is_same_v<decltype( 3if   ), dpl::complex<float>>, "" );
+    IF_LONG_DOUBLE_SUPPORT(static_assert ( std::is_same_v<decltype( 3.0il ), dpl::complex<long double>>))
+    IF_LONG_DOUBLE_SUPPORT(static_assert ( std::is_same_v<decltype( 3il   ), dpl::complex<long double>>))
+    IF_DOUBLE_SUPPORT(static_assert(std::is_same_v<decltype(3.0i), dpl::complex<double>>))
+    IF_DOUBLE_SUPPORT(static_assert(std::is_same_v<decltype(3i), dpl::complex<double>>))
+    static_assert ( std::is_same_v<decltype( 3.0if ), dpl::complex<float>>);
+    static_assert ( std::is_same_v<decltype( 3if   ), dpl::complex<float>>);
 
     IF_LONG_DOUBLE_SUPPORT(dpl::complex<long double> c1 = 3.0il;
                            assert(c1 == dpl::complex<long double>(0, 3.0));

--- a/test/xpu_api/numerics/complex.number/complex.members/construct.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.members/construct.pass.cpp
@@ -39,23 +39,23 @@ test()
 
     {
     constexpr dpl::complex<T> c;
-    STD_COMPLEX_TESTS_STATIC_ASSERT(c.real() == 0, "");
-    STD_COMPLEX_TESTS_STATIC_ASSERT(c.imag() == 0, "");
+    STD_COMPLEX_TESTS_STATIC_ASSERT(c.real() == 0);
+    STD_COMPLEX_TESTS_STATIC_ASSERT(c.imag() == 0);
     }
     {
     constexpr dpl::complex<T> c = 7.5;
-    STD_COMPLEX_TESTS_STATIC_ASSERT(c.real() == 7.5, "");
-    STD_COMPLEX_TESTS_STATIC_ASSERT(c.imag() == 0, "");
+    STD_COMPLEX_TESTS_STATIC_ASSERT(c.real() == 7.5);
+    STD_COMPLEX_TESTS_STATIC_ASSERT(c.imag() == 0);
     }
     {
     constexpr dpl::complex<T> c(8.5);
-    STD_COMPLEX_TESTS_STATIC_ASSERT(c.real() == 8.5, "");
-    STD_COMPLEX_TESTS_STATIC_ASSERT(c.imag() == 0, "");
+    STD_COMPLEX_TESTS_STATIC_ASSERT(c.real() == 8.5);
+    STD_COMPLEX_TESTS_STATIC_ASSERT(c.imag() == 0);
     }
     {
     constexpr dpl::complex<T> c(10.5, -9.5);
-    STD_COMPLEX_TESTS_STATIC_ASSERT(c.real() == 10.5, "");
-    STD_COMPLEX_TESTS_STATIC_ASSERT(c.imag() == -9.5, "");
+    STD_COMPLEX_TESTS_STATIC_ASSERT(c.real() == 10.5);
+    STD_COMPLEX_TESTS_STATIC_ASSERT(c.imag() == -9.5);
     }
 }
 

--- a/test/xpu_api/numerics/complex.number/complex.members/real_imag.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.members/real_imag.pass.cpp
@@ -18,14 +18,14 @@ void
 test_constexpr()
 {
     constexpr dpl::complex<T> c1;
-    STD_COMPLEX_TESTS_STATIC_ASSERT(c1.real() == 0, "");
-    STD_COMPLEX_TESTS_STATIC_ASSERT(c1.imag() == 0, "");
+    STD_COMPLEX_TESTS_STATIC_ASSERT(c1.real() == 0);
+    STD_COMPLEX_TESTS_STATIC_ASSERT(c1.imag() == 0);
     constexpr dpl::complex<T> c2(3);
-    STD_COMPLEX_TESTS_STATIC_ASSERT(c2.real() == 3, "");
-    STD_COMPLEX_TESTS_STATIC_ASSERT(c2.imag() == 0, "");
+    STD_COMPLEX_TESTS_STATIC_ASSERT(c2.real() == 3);
+    STD_COMPLEX_TESTS_STATIC_ASSERT(c2.imag() == 0);
     constexpr dpl::complex<T> c3(3, 4);
-    STD_COMPLEX_TESTS_STATIC_ASSERT(c3.real() == 3, "");
-    STD_COMPLEX_TESTS_STATIC_ASSERT(c3.imag() == 4, "");
+    STD_COMPLEX_TESTS_STATIC_ASSERT(c3.real() == 3);
+    STD_COMPLEX_TESTS_STATIC_ASSERT(c3.imag() == 4);
 }
 
 template <class T>

--- a/test/xpu_api/numerics/complex.number/complex.ops/complex_equals_complex.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.ops/complex_equals_complex.pass.cpp
@@ -21,12 +21,12 @@ test_constexpr()
     {
     constexpr dpl::complex<T> lhs(1.5,  2.5);
     constexpr dpl::complex<T> rhs(1.5, -2.5);
-    STD_COMPLEX_TESTS_STATIC_ASSERT( !(lhs == rhs), "");
+    STD_COMPLEX_TESTS_STATIC_ASSERT( !(lhs == rhs));
     }
     {
     constexpr dpl::complex<T> lhs(1.5, 2.5);
     constexpr dpl::complex<T> rhs(1.5, 2.5);
-    STD_COMPLEX_TESTS_STATIC_ASSERT(lhs == rhs, "");
+    STD_COMPLEX_TESTS_STATIC_ASSERT(lhs == rhs);
     }
 }
 

--- a/test/xpu_api/numerics/complex.number/complex.ops/complex_equals_scalar.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.ops/complex_equals_scalar.pass.cpp
@@ -21,22 +21,22 @@ test_constexpr()
     {
     constexpr dpl::complex<T> lhs(1.5, 2.5);
     constexpr T rhs(-2.5);
-    STD_COMPLEX_TESTS_STATIC_ASSERT(!(lhs == rhs), "");
+    STD_COMPLEX_TESTS_STATIC_ASSERT(!(lhs == rhs));
     }
     {
     constexpr dpl::complex<T> lhs(1.5, 0);
     constexpr T rhs(-2.5);
-    STD_COMPLEX_TESTS_STATIC_ASSERT(!(lhs == rhs), "");
+    STD_COMPLEX_TESTS_STATIC_ASSERT(!(lhs == rhs));
     }
     {
     constexpr dpl::complex<T> lhs(1.5, 2.5);
     constexpr T rhs(1.5);
-    STD_COMPLEX_TESTS_STATIC_ASSERT(!(lhs == rhs), "");
+    STD_COMPLEX_TESTS_STATIC_ASSERT(!(lhs == rhs));
     }
     {
     constexpr dpl::complex<T> lhs(1.5, 0);
     constexpr T rhs(1.5);
-    STD_COMPLEX_TESTS_STATIC_ASSERT( (lhs == rhs), "");
+    STD_COMPLEX_TESTS_STATIC_ASSERT( (lhs == rhs));
     }
 }
 

--- a/test/xpu_api/numerics/complex.number/complex.ops/complex_not_equals_complex.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.ops/complex_not_equals_complex.pass.cpp
@@ -21,12 +21,12 @@ test_constexpr()
     {
     constexpr dpl::complex<T> lhs(1.5,  2.5);
     constexpr dpl::complex<T> rhs(1.5, -2.5);
-    STD_COMPLEX_TESTS_STATIC_ASSERT(lhs != rhs, "");
+    STD_COMPLEX_TESTS_STATIC_ASSERT(lhs != rhs);
     }
     {
     constexpr dpl::complex<T> lhs(1.5, 2.5);
     constexpr dpl::complex<T> rhs(1.5, 2.5);
-    STD_COMPLEX_TESTS_STATIC_ASSERT(!(lhs != rhs), "" );
+    STD_COMPLEX_TESTS_STATIC_ASSERT(!(lhs != rhs));
     }
 }
 

--- a/test/xpu_api/numerics/complex.number/complex.ops/complex_not_equals_scalar.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.ops/complex_not_equals_scalar.pass.cpp
@@ -21,22 +21,22 @@ test_constexpr()
     {
     constexpr dpl::complex<T> lhs(1.5,  2.5);
     constexpr T rhs(-2.5);
-    STD_COMPLEX_TESTS_STATIC_ASSERT(lhs != rhs, "");
+    STD_COMPLEX_TESTS_STATIC_ASSERT(lhs != rhs);
     }
     {
     constexpr dpl::complex<T> lhs(1.5,  0);
     constexpr T rhs(-2.5);
-    STD_COMPLEX_TESTS_STATIC_ASSERT(lhs != rhs, "");
+    STD_COMPLEX_TESTS_STATIC_ASSERT(lhs != rhs);
     }
     {
     constexpr dpl::complex<T> lhs(1.5, 2.5);
     constexpr T rhs(1.5);
-    STD_COMPLEX_TESTS_STATIC_ASSERT(lhs != rhs, "");
+    STD_COMPLEX_TESTS_STATIC_ASSERT(lhs != rhs);
     }
     {
     constexpr dpl::complex<T> lhs(1.5, 0);
     constexpr T rhs(1.5);
-    STD_COMPLEX_TESTS_STATIC_ASSERT( !(lhs != rhs), "");
+    STD_COMPLEX_TESTS_STATIC_ASSERT( !(lhs != rhs));
     }
 }
 

--- a/test/xpu_api/numerics/complex.number/complex.ops/scalar_equals_complex.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.ops/scalar_equals_complex.pass.cpp
@@ -21,22 +21,22 @@ test_constexpr()
     {
     constexpr T lhs(-2.5);
     constexpr dpl::complex<T> rhs(1.5,  2.5);
-    STD_COMPLEX_TESTS_STATIC_ASSERT(!(lhs == rhs), "");
+    STD_COMPLEX_TESTS_STATIC_ASSERT(!(lhs == rhs));
     }
     {
     constexpr T lhs(-2.5);
     constexpr dpl::complex<T> rhs(1.5,  0);
-    STD_COMPLEX_TESTS_STATIC_ASSERT(!(lhs == rhs), "");
+    STD_COMPLEX_TESTS_STATIC_ASSERT(!(lhs == rhs));
     }
     {
     constexpr T lhs(1.5);
     constexpr dpl::complex<T> rhs(1.5, 2.5);
-    STD_COMPLEX_TESTS_STATIC_ASSERT(!(lhs == rhs), "");
+    STD_COMPLEX_TESTS_STATIC_ASSERT(!(lhs == rhs));
     }
     {
     constexpr T lhs(1.5);
     constexpr dpl::complex<T> rhs(1.5, 0);
-    STD_COMPLEX_TESTS_STATIC_ASSERT(lhs == rhs, "");
+    STD_COMPLEX_TESTS_STATIC_ASSERT(lhs == rhs);
     }
 }
 

--- a/test/xpu_api/numerics/complex.number/complex.ops/scalar_not_equals_complex.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.ops/scalar_not_equals_complex.pass.cpp
@@ -21,22 +21,22 @@ test_constexpr()
     {
     constexpr T lhs(-2.5);
     constexpr dpl::complex<T> rhs(1.5,  2.5);
-    STD_COMPLEX_TESTS_STATIC_ASSERT (lhs != rhs, "");
+    STD_COMPLEX_TESTS_STATIC_ASSERT (lhs != rhs);
     }
     {
     constexpr T lhs(-2.5);
     constexpr dpl::complex<T> rhs(1.5,  0);
-    STD_COMPLEX_TESTS_STATIC_ASSERT (lhs != rhs, "");
+    STD_COMPLEX_TESTS_STATIC_ASSERT (lhs != rhs);
     }
     {
     constexpr T lhs(1.5);
     constexpr dpl::complex<T> rhs(1.5, 2.5);
-    STD_COMPLEX_TESTS_STATIC_ASSERT (lhs != rhs, "");
+    STD_COMPLEX_TESTS_STATIC_ASSERT (lhs != rhs);
     }
     {
     constexpr T lhs(1.5);
     constexpr dpl::complex<T> rhs(1.5, 0);
-    STD_COMPLEX_TESTS_STATIC_ASSERT (!(lhs != rhs), "");
+    STD_COMPLEX_TESTS_STATIC_ASSERT (!(lhs != rhs));
     }
 }
 

--- a/test/xpu_api/numerics/complex.number/complex.special/double_float_explicit.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.special/double_float_explicit.pass.cpp
@@ -25,8 +25,8 @@ ONEDPL_TEST_NUM_MAIN
 
     IF_DOUBLE_SUPPORT(constexpr dpl::complex<float> cd(2.5f, 3.5f);
                       constexpr dpl::complex<double> cf(cd);
-                      STD_COMPLEX_TESTS_STATIC_ASSERT(cf.real() == cd.real(), "");
-                      STD_COMPLEX_TESTS_STATIC_ASSERT(cf.imag() == cd.imag(), ""))
+                      STD_COMPLEX_TESTS_STATIC_ASSERT(cf.real() == cd.real());
+                      STD_COMPLEX_TESTS_STATIC_ASSERT(cf.imag() == cd.imag()))
 
   return 0;
 }

--- a/test/xpu_api/numerics/complex.number/complex.special/double_float_implicit.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.special/double_float_implicit.pass.cpp
@@ -25,8 +25,8 @@ ONEDPL_TEST_NUM_MAIN
 
     IF_DOUBLE_SUPPORT(constexpr dpl::complex<float> cd(2.5, 3.5);
                       constexpr dpl::complex<double> cf = cd;
-                      STD_COMPLEX_TESTS_STATIC_ASSERT(cf.real() == cd.real(), "");
-                      STD_COMPLEX_TESTS_STATIC_ASSERT(cf.imag() == cd.imag(), ""))
+                      STD_COMPLEX_TESTS_STATIC_ASSERT(cf.real() == cd.real());
+                      STD_COMPLEX_TESTS_STATIC_ASSERT(cf.imag() == cd.imag()))
 
   return 0;
 }

--- a/test/xpu_api/numerics/complex.number/complex.special/double_long_double_explicit.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.special/double_long_double_explicit.pass.cpp
@@ -25,8 +25,8 @@ ONEDPL_TEST_NUM_MAIN
 
     IF_LONG_DOUBLE_SUPPORT(constexpr dpl::complex<long double> cd(2.5, 3.5);
                            constexpr dpl::complex<double> cf(cd);
-                           STD_COMPLEX_TESTS_STATIC_ASSERT(cf.real() == cd.real(), "");
-                           STD_COMPLEX_TESTS_STATIC_ASSERT(cf.imag() == cd.imag(), ""))
+                           STD_COMPLEX_TESTS_STATIC_ASSERT(cf.real() == cd.real());
+                           STD_COMPLEX_TESTS_STATIC_ASSERT(cf.imag() == cd.imag()))
 
   return 0;
 }

--- a/test/xpu_api/numerics/complex.number/complex.special/float_double_explicit.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.special/float_double_explicit.pass.cpp
@@ -25,8 +25,8 @@ ONEDPL_TEST_NUM_MAIN
 
     IF_DOUBLE_SUPPORT(constexpr dpl::complex<double> cd(2.5, 3.5);
                       constexpr dpl::complex<float> cf(cd);
-                      STD_COMPLEX_TESTS_STATIC_ASSERT(cf.real() == cd.real(), "");
-                      STD_COMPLEX_TESTS_STATIC_ASSERT(cf.imag() == cd.imag(), ""))
+                      STD_COMPLEX_TESTS_STATIC_ASSERT(cf.real() == cd.real());
+                      STD_COMPLEX_TESTS_STATIC_ASSERT(cf.imag() == cd.imag()))
 
   return 0;
 }

--- a/test/xpu_api/numerics/complex.number/complex.special/float_long_double_explicit.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.special/float_long_double_explicit.pass.cpp
@@ -25,8 +25,8 @@ ONEDPL_TEST_NUM_MAIN
 
     IF_LONG_DOUBLE_SUPPORT(constexpr dpl::complex<long double> cd(2.5, 3.5);
                            constexpr dpl::complex<float> cf(cd);
-                           STD_COMPLEX_TESTS_STATIC_ASSERT(cf.real() == cd.real(), "");
-                           STD_COMPLEX_TESTS_STATIC_ASSERT(cf.imag() == cd.imag(), ""))
+                           STD_COMPLEX_TESTS_STATIC_ASSERT(cf.real() == cd.real());
+                           STD_COMPLEX_TESTS_STATIC_ASSERT(cf.imag() == cd.imag()))
 
   return 0;
 }

--- a/test/xpu_api/numerics/complex.number/complex.special/long_double_double_explicit.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.special/long_double_double_explicit.pass.cpp
@@ -25,8 +25,8 @@ ONEDPL_TEST_NUM_MAIN
 
     IF_LONG_DOUBLE_SUPPORT(constexpr dpl::complex<double> cd(2.5, 3.5);
                            constexpr dpl::complex<long double> cf(cd);
-                           STD_COMPLEX_TESTS_STATIC_ASSERT(cf.real() == cd.real(), "");
-                           STD_COMPLEX_TESTS_STATIC_ASSERT(cf.imag() == cd.imag(), ""))
+                           STD_COMPLEX_TESTS_STATIC_ASSERT(cf.real() == cd.real());
+                           STD_COMPLEX_TESTS_STATIC_ASSERT(cf.imag() == cd.imag()))
 
   return 0;
 }

--- a/test/xpu_api/numerics/complex.number/complex.special/long_double_double_implicit.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.special/long_double_double_implicit.pass.cpp
@@ -25,8 +25,8 @@ ONEDPL_TEST_NUM_MAIN
 
     IF_LONG_DOUBLE_SUPPORT(constexpr dpl::complex<double> cd(2.5, 3.5);
                            constexpr dpl::complex<long double> cf = cd;
-                           STD_COMPLEX_TESTS_STATIC_ASSERT(cf.real() == cd.real(), "");
-                           STD_COMPLEX_TESTS_STATIC_ASSERT(cf.imag() == cd.imag(), ""))
+                           STD_COMPLEX_TESTS_STATIC_ASSERT(cf.real() == cd.real());
+                           STD_COMPLEX_TESTS_STATIC_ASSERT(cf.imag() == cd.imag()))
 
   return 0;
 }

--- a/test/xpu_api/numerics/complex.number/complex.special/long_double_float_explicit.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.special/long_double_float_explicit.pass.cpp
@@ -25,8 +25,8 @@ ONEDPL_TEST_NUM_MAIN
 
     IF_LONG_DOUBLE_SUPPORT(constexpr dpl::complex<float> cd(2.5, 3.5);
                            constexpr dpl::complex<long double> cf(cd);
-                           STD_COMPLEX_TESTS_STATIC_ASSERT(cf.real() == cd.real(), "");
-                           STD_COMPLEX_TESTS_STATIC_ASSERT(cf.imag() == cd.imag(), ""))
+                           STD_COMPLEX_TESTS_STATIC_ASSERT(cf.real() == cd.real());
+                           STD_COMPLEX_TESTS_STATIC_ASSERT(cf.imag() == cd.imag()))
 
   return 0;
 }

--- a/test/xpu_api/numerics/complex.number/complex.special/long_double_float_implicit.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex.special/long_double_float_implicit.pass.cpp
@@ -25,8 +25,8 @@ ONEDPL_TEST_NUM_MAIN
 
     IF_LONG_DOUBLE_SUPPORT(constexpr dpl::complex<float> cd(2.5, 3.5);
                            constexpr dpl::complex<long double> cf = cd;
-                           STD_COMPLEX_TESTS_STATIC_ASSERT(cf.real() == cd.real(), "");
-                           STD_COMPLEX_TESTS_STATIC_ASSERT(cf.imag() == cd.imag(), ""))
+                           STD_COMPLEX_TESTS_STATIC_ASSERT(cf.real() == cd.real());
+                           STD_COMPLEX_TESTS_STATIC_ASSERT(cf.imag() == cd.imag()))
 
   return 0;
 }

--- a/test/xpu_api/numerics/complex.number/complex/types.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/complex/types.pass.cpp
@@ -23,7 +23,7 @@ void
 test()
 {
     typedef dpl::complex<T> C;
-    static_assert((std::is_same_v<typename C::value_type, T>), "");
+    static_assert((std::is_same_v<typename C::value_type, T>));
 }
 
 ONEDPL_TEST_NUM_MAIN

--- a/test/xpu_api/numerics/numeric.ops/numeric.ops.gcd/xpu_gcd.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/numeric.ops.gcd/xpu_gcd.pass.cpp
@@ -30,8 +30,8 @@ test0(int in1, int in2, int out)
 {
     auto value1 = static_cast<Input1>(in1);
     auto value2 = static_cast<Input2>(in2);
-    static_assert(oneapi::dpl::is_same_v<Output, decltype(oneapi::dpl::gcd(value1, value2))>, "");
-    static_assert(oneapi::dpl::is_same_v<Output, decltype(oneapi::dpl::gcd(value2, value1))>, "");
+    static_assert(oneapi::dpl::is_same_v<Output, decltype(oneapi::dpl::gcd(value1, value2))>);
+    static_assert(oneapi::dpl::is_same_v<Output, decltype(oneapi::dpl::gcd(value2, value1))>);
     return (static_cast<Output>(out) == oneapi::dpl::gcd(value1, value2));
 }
 

--- a/test/xpu_api/numerics/numeric.ops/numeric.ops.lcm/xpu_lcm.pass.cpp
+++ b/test/xpu_api/numerics/numeric.ops/numeric.ops.lcm/xpu_lcm.pass.cpp
@@ -33,8 +33,8 @@ test0(int in1, int in2, int out)
 {
     auto value1 = static_cast<Input1>(in1);
     auto value2 = static_cast<Input2>(in2);
-    static_assert(is_same_v<Output, decltype(lcm(value1, value2))>, "");
-    static_assert(is_same_v<Output, decltype(lcm(value2, value1))>, "");
+    static_assert(is_same_v<Output, decltype(lcm(value1, value2))>);
+    static_assert(is_same_v<Output, decltype(lcm(value2, value1))>);
     return static_cast<Output>(out) == lcm(value1, value2);
 }
 


### PR DESCRIPTION
It's part 3/3 of linked PR's:
 - part 1 : #1172
 - part 2 : #1173
 
In this PR we make oneDPL code cleanup and simplification using STL features supported in C++17:
- use ```::std::decay_t``` instead of ```__decay_t``` and remove ```__decay_t``` as unused anymore;
- use ```::std::enable_if_t``` instead of ```__enable_if_t``` and remove ```__enable_if_t``` as unused anymore.
- introduced some new aliases for ```type``` :

| Previous variant | New variant | oneDPL | Tests |
|--------------------------------------------------|----------------------------------------------|---|---|
| ```typename __is_random_access_iterator<X>::type``` | ```__is_random_access_iterator_t<X>``` | + |  |

- introduced some new aliases for ```value``` :

| Previous variant | New variant | Type | oneDPL | Tests |
|--------------------------------------------------|----------------------------------------------|---|---|---|
| ```__is_const_callable_object<X>::value``` | ```__is_const_callable_object_v<X>``` | ```bool``` | + |  |
| ```__is_device_execution_policy<X>::value``` | ```__is_device_execution_policy_v<X>``` | ```bool``` | + |  |
| ```__is_hetero_execution_policy<X>::value``` | ```__is_hetero_execution_policy_v<X>``` | ```bool``` | + | + |
| ```__is_random_access_iterator<X>::value``` | ```__is_random_access_iterator_v<X>``` | ```bool``` | + |  |
| ```__known_identity<X>::value``` | ```__known_identity_v<X>``` | ```auto``` | + |  |
| ```__range_has_raw_ptr_iterator<X>::value``` | ```__range_has_raw_ptr_iterator_v<X>``` | ```bool``` | + |  |
| ```can_use_default_less_operator<X>::value``` | ```can_use_default_less_operator_v<X>``` | ```bool``` |  | + |
| ```is_arithmetic_plus<X>::value``` | ```is_arithmetic_plus_v<X>``` | ```bool``` | + |  |
| ```is_base_of_iterator_category<X>::value``` | ```is_base_of_iterator_category_v<X>``` | ```bool``` |  | + |
| ```is_hetero_it<X>::value``` | ```is_hetero_it_v<X>``` | ```bool``` | + |  |
| ```is_passed_directly_it<X>::value``` | ```is_passed_directly_it_v<X>``` | ```bool``` | + |  |
| ```is_same_iterator_category<X>::value``` | ```is_same_iterator_category_v<X>``` | ```bool``` |  | + |
| ```TestUtils::isReverse<X>::value``` | ```TestUtils::is_reverse_v<X>``` | ```bool``` |  | + |


inline constexpr auto __known_identity_v
- other:

| Previous variant | New variant | C++ version | oneDPL | Tests |
|-------------------|--------------|-----------------------------------------|---|---|
| ```static_assert(X, "")``` | ```static_assert(X)```  | 17 | + | + |

- renamed (in `namespace TestUtils`):
`template <typename Iterator>
struct isReverse`
->
`template <typename Iterator>
struct is_reverse`