### PR TITLE
[Tests] Fix xpu_api/random tests

### DIFF
--- a/test/xpu_api/random/device_tests/common_for_device_tests.h
+++ b/test/xpu_api/random/device_tests/common_for_device_tests.h
@@ -45,8 +45,8 @@ int comparison(Fp* r0, Fp* r1, std::uint32_t length) {
             auto norm = std::fmax(fabs(r0[i]), fabs(r1[i]));
             if (diff > norm * 1000 * 16 * std::numeric_limits<Fp>::epsilon()) {
                 std::cout <<  "mismatch in " << i << " element: "  << std::endl;
-                std::cout << std::setprecision (15) << r0[i]  << std::endl; 
-                std::cout << std::setprecision (15) << r1[i] << std::endl; 
+                std::cout << std::setprecision (15) << r0[i]  << std::endl;
+                std::cout << std::setprecision (15) << r1[i] << std::endl;
                 ++numErrors;
             }
         }
@@ -59,7 +59,7 @@ int device_copyable_test(sycl::queue& queue) {
 
     using result_type = typename Distr::result_type;
     using scalar_type = typename Distr::scalar_type;
-    
+
     Engine engine(seed);
     Distr distr;
 
@@ -87,7 +87,7 @@ int device_copyable_test(sycl::queue& queue) {
                 Distr device_distr(distr);
                 device_engine.discard(offset);
                 result_type res = device_distr(device_engine);
-                res.store(idx.get_linear_id(), __dpl_sycl::__get_accessor_ptr(acc));
+                res.store(idx.get_linear_id(), acc);
             });
         });
     }
@@ -100,7 +100,7 @@ int device_copyable_test(sycl::queue& queue) {
             r_host[i*num_elems + j] = res[j];
     }
 
-    // compare    
+    // compare
     return comparison(r_dev, r_host, N);
 }
 

--- a/test/xpu_api/random/statistics_tests/bernoulli_distribution_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/bernoulli_distribution_test.pass.cpp
@@ -69,7 +69,7 @@ test(sycl::queue& queue, double p, int nsamples)
                 oneapi::dpl::bernoulli_distribution<BoolType> distr(p);
 
                 sycl::vec<bool, num_elems> res = distr(engine);
-                res.store(idx.get_linear_id(), __dpl_sycl::__get_accessor_ptr(acc));
+                res.store(idx.get_linear_id(), acc);
             });
         });
     }
@@ -116,7 +116,7 @@ test_portion(sycl::queue& queue, double p, int nsamples, unsigned int part)
 
                 sycl::vec<bool, num_elems> res = distr(engine, part);
                 for (int i = 0; i < n_elems; ++i)
-                    __dpl_sycl::__get_accessor_ptr(acc)[idx.get_linear_id() * n_elems + i] = res[i];
+                    acc[idx.get_linear_id() * n_elems + i] = res[i];
             });
         });
         queue.wait_and_throw();

--- a/test/xpu_api/random/statistics_tests/exponential_distribution_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/exponential_distribution_test.pass.cpp
@@ -69,7 +69,7 @@ test(sycl::queue& queue, oneapi::dpl::internal::element_type_t<RealType> lambda,
                 oneapi::dpl::exponential_distribution<RealType> distr(lambda);
 
                 sycl::vec<oneapi::dpl::internal::element_type_t<RealType>, num_elems> res = distr(engine);
-                res.store(idx.get_linear_id(), __dpl_sycl::__get_accessor_ptr(acc));
+                res.store(idx.get_linear_id(), acc);
             });
         });
     }
@@ -114,7 +114,7 @@ test_portion(sycl::queue& queue, oneapi::dpl::internal::element_type_t<RealType>
 
                 sycl::vec<oneapi::dpl::internal::element_type_t<RealType>, num_elems> res = distr(engine, part);
                 for (int i = 0; i < n_elems; ++i)
-                    __dpl_sycl::__get_accessor_ptr(acc)[offset + i] = res[i];
+                    acc[offset + i] = res[i];
             });
         });
         queue.wait_and_throw();

--- a/test/xpu_api/random/statistics_tests/extreme_value_distribution_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/extreme_value_distribution_test.pass.cpp
@@ -72,7 +72,7 @@ test(sycl::queue& queue, oneapi::dpl::internal::element_type_t<RealType> _a,  on
                 oneapi::dpl::extreme_value_distribution<RealType> distr(_a, _b);
 
                 sycl::vec<oneapi::dpl::internal::element_type_t<RealType>, num_elems> res = distr(engine);
-                res.store(idx.get_linear_id(), __dpl_sycl::__get_accessor_ptr(acc));
+                res.store(idx.get_linear_id(), acc);
             });
         });
     }
@@ -118,7 +118,7 @@ test_portion(sycl::queue& queue, oneapi::dpl::internal::element_type_t<RealType>
 
                 sycl::vec<oneapi::dpl::internal::element_type_t<RealType>, num_elems> res = distr(engine, part);
                 for (int i = 0; i < n_elems; ++i)
-                    __dpl_sycl::__get_accessor_ptr(acc)[offset + i] = res[i];
+                    acc[offset + i] = res[i];
             });
         });
         queue.wait_and_throw();

--- a/test/xpu_api/random/statistics_tests/geometric_distribution_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/geometric_distribution_test.pass.cpp
@@ -69,7 +69,7 @@ test(sycl::queue& queue, double p, int nsamples)
                 oneapi::dpl::geometric_distribution<IntType> distr(p);
 
                 sycl::vec<oneapi::dpl::internal::element_type_t<IntType>, num_elems> res = distr(engine);
-                res.store(idx.get_linear_id(), __dpl_sycl::__get_accessor_ptr(acc));
+                res.store(idx.get_linear_id(), acc);
             });
         });
     }
@@ -116,7 +116,7 @@ test_portion(sycl::queue& queue, double p, int nsamples, unsigned int part)
 
                 sycl::vec<oneapi::dpl::internal::element_type_t<IntType>, num_elems> res = distr(engine, part);
                 for (int i = 0; i < n_elems; ++i)
-                    __dpl_sycl::__get_accessor_ptr(acc)[idx.get_linear_id() * n_elems + i] = res[i];
+                    acc[idx.get_linear_id() * n_elems + i] = res[i];
             });
         });
         queue.wait_and_throw();

--- a/test/xpu_api/random/statistics_tests/lognormal_distribution_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/lognormal_distribution_test.pass.cpp
@@ -67,7 +67,7 @@ int test(sycl::queue& queue, oneapi::dpl::internal::element_type_t<RealType> mea
                 oneapi::dpl::lognormal_distribution<RealType> distr(mean, stddev);
 
                 sycl::vec<oneapi::dpl::internal::element_type_t<RealType>, num_elems> res = distr(engine);
-                res.store(idx.get_linear_id(), __dpl_sycl::__get_accessor_ptr(acc));
+                res.store(idx.get_linear_id(), acc);
             });
         });
         queue.wait();
@@ -111,7 +111,7 @@ int test_portion(sycl::queue& queue, oneapi::dpl::internal::element_type_t<RealT
 
                 sycl::vec<oneapi::dpl::internal::element_type_t<RealType>, num_elems> res = distr(engine, part);
                 for(int i = 0; i < n_elems; ++i)
-                    __dpl_sycl::__get_accessor_ptr(acc)[idx.get_linear_id() * n_elems + i] = res[i];
+                    acc[idx.get_linear_id() * n_elems + i] = res[i];
             });
         });
         queue.wait_and_throw();

--- a/test/xpu_api/random/statistics_tests/normal_distribution_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/normal_distribution_test.pass.cpp
@@ -68,7 +68,7 @@ int test(sycl::queue& queue, oneapi::dpl::internal::element_type_t<RealType> mea
                 oneapi::dpl::normal_distribution<RealType> distr(mean, stddev);
 
                 sycl::vec<oneapi::dpl::internal::element_type_t<RealType>, num_elems> res = distr(engine);
-                res.store(idx.get_linear_id(), __dpl_sycl::__get_accessor_ptr(acc));
+                res.store(idx.get_linear_id(), acc);
             });
         });
         queue.wait();
@@ -113,7 +113,7 @@ int test_portion(sycl::queue& queue, oneapi::dpl::internal::element_type_t<RealT
 
                 sycl::vec<oneapi::dpl::internal::element_type_t<RealType>, num_elems> res = distr(engine, part);
                 for(int i = 0; i < n_elems; ++i)
-                    __dpl_sycl::__get_accessor_ptr(acc)[idx.get_linear_id() * n_elems + i] = res[i];
+                    acc[idx.get_linear_id() * n_elems + i] = res[i];
             });
         });
         queue.wait_and_throw();

--- a/test/xpu_api/random/statistics_tests/uniform_int_distribution_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/uniform_int_distribution_test.pass.cpp
@@ -70,7 +70,7 @@ int test(sycl::queue& queue, oneapi::dpl::internal::element_type_t<IntType> left
                 oneapi::dpl::uniform_int_distribution<IntType> distr(left, right);
 
                 sycl::vec<oneapi::dpl::internal::element_type_t<IntType>, num_elems> res = distr(engine);
-                res.store(idx.get_linear_id(), __dpl_sycl::__get_accessor_ptr(acc));
+                res.store(idx.get_linear_id(), acc);
             });
         });
         queue.wait();
@@ -114,7 +114,7 @@ int test_portion(sycl::queue& queue, oneapi::dpl::internal::element_type_t<IntTy
 
                 sycl::vec<oneapi::dpl::internal::element_type_t<IntType>, num_elems> res = distr(engine, part);
                 for(int i = 0; i < n_elems; ++i)
-                    __dpl_sycl::__get_accessor_ptr(acc)[offset + i] = res[i];
+                    acc[offset + i] = res[i];
             });
         });
         queue.wait_and_throw();

--- a/test/xpu_api/random/statistics_tests/uniform_real_distribution_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/uniform_real_distribution_test.pass.cpp
@@ -67,7 +67,7 @@ int test(sycl::queue& queue, oneapi::dpl::internal::element_type_t<RealType> lef
                 oneapi::dpl::uniform_real_distribution<RealType> distr(left, right);
 
                 sycl::vec<oneapi::dpl::internal::element_type_t<RealType>, num_elems> res = distr(engine);
-                res.store(idx.get_linear_id(), __dpl_sycl::__get_accessor_ptr(acc));
+                res.store(idx.get_linear_id(), acc);
             });
         });
         queue.wait();
@@ -111,7 +111,7 @@ int test_portion(sycl::queue& queue, oneapi::dpl::internal::element_type_t<RealT
 
                 sycl::vec<oneapi::dpl::internal::element_type_t<RealType>, num_elems> res = distr(engine, part);
                 for(int i = 0; i < n_elems; ++i)
-                    __dpl_sycl::__get_accessor_ptr(acc)[offset + i] = res[i];
+                    acc[offset + i] = res[i];
             });
         });
         queue.wait_and_throw();

--- a/test/xpu_api/random/statistics_tests/weibull_distribution_test.pass.cpp
+++ b/test/xpu_api/random/statistics_tests/weibull_distribution_test.pass.cpp
@@ -73,7 +73,7 @@ test(sycl::queue& queue, oneapi::dpl::internal::element_type_t<RealType> _a,  on
                 oneapi::dpl::weibull_distribution<RealType> distr(_a, _b);
 
                 sycl::vec<oneapi::dpl::internal::element_type_t<RealType>, num_elems> res = distr(engine);
-                res.store(idx.get_linear_id(), __dpl_sycl::__get_accessor_ptr(acc));
+                res.store(idx.get_linear_id(), acc);
             });
         });
     }
@@ -95,7 +95,7 @@ test(sycl::queue& queue, oneapi::dpl::internal::element_type_t<RealType> _a,  on
 
 template <class RealType, class UIntType>
 int
-test_portion(sycl::queue& queue, oneapi::dpl::internal::element_type_t<RealType> _a,  oneapi::dpl::internal::element_type_t<RealType> _b, 
+test_portion(sycl::queue& queue, oneapi::dpl::internal::element_type_t<RealType> _a,  oneapi::dpl::internal::element_type_t<RealType> _b,
                     int nsamples, unsigned int part)
 {
     // memory allocation
@@ -119,7 +119,7 @@ test_portion(sycl::queue& queue, oneapi::dpl::internal::element_type_t<RealType>
 
                 sycl::vec<oneapi::dpl::internal::element_type_t<RealType>, num_elems> res = distr(engine, part);
                 for (int i = 0; i < n_elems; ++i)
-                    __dpl_sycl::__get_accessor_ptr(acc)[offset + i] = res[i];
+                    acc[offset + i] = res[i];
             });
         });
         queue.wait_and_throw();

--- a/test/xpu_api/random/template_tests/discard_block_std_template_test.pass.cpp
+++ b/test/xpu_api/random/template_tests/discard_block_std_template_test.pass.cpp
@@ -48,7 +48,7 @@ int test(sycl::queue& queue, oneapi::dpl::internal::element_type_t<typename Engi
                 Engine engine(seed, offset);
 
                 sycl::vec<oneapi::dpl::internal::element_type_t<typename Engine::result_type>, num_elems> res = engine();
-                res.store(idx.get_linear_id(), __dpl_sycl::__get_accessor_ptr(dpstd_acc));
+                res.store(idx.get_linear_id(), dpstd_acc);
             });
         });
         queue.wait();
@@ -104,7 +104,7 @@ int test_portion(sycl::queue& queue, oneapi::dpl::internal::element_type_t<typen
 
                 auto res = engine(part);
                 for(unsigned int i = 0; i < n_elems; ++i)
-                    __dpl_sycl::__get_accessor_ptr(dpstd_acc)[offset + i] = res[i];
+                    dpstd_acc[offset + i] = res[i];
             });
         });
         queue.wait();

--- a/test/xpu_api/random/template_tests/linear_congruential_std_template_test.pass.cpp
+++ b/test/xpu_api/random/template_tests/linear_congruential_std_template_test.pass.cpp
@@ -49,7 +49,7 @@ int test(sycl::queue& queue, oneapi::dpl::internal::element_type_t<UIntType> see
                 oneapi::dpl::linear_congruential_engine<UIntType, a, c, m> engine(seed, offset);
 
                 sycl::vec<oneapi::dpl::internal::element_type_t<UIntType>, num_elems> res = engine();
-                res.store(idx.get_linear_id(), __dpl_sycl::__get_accessor_ptr(dpstd_acc));
+                res.store(idx.get_linear_id(), dpstd_acc);
             });
         });
         queue.wait();
@@ -105,7 +105,7 @@ int test_portion(sycl::queue& queue, oneapi::dpl::internal::element_type_t<UIntT
 
                 auto res = engine(part);
                 for(int i = 0; i < n_elems; ++i)
-                    __dpl_sycl::__get_accessor_ptr(dpstd_acc)[offset + i] = res[i];
+                    dpstd_acc[offset + i] = res[i];
             });
         });
         queue.wait();

--- a/test/xpu_api/random/template_tests/subtract_with_carry_std_template_test.pass.cpp
+++ b/test/xpu_api/random/template_tests/subtract_with_carry_std_template_test.pass.cpp
@@ -48,7 +48,7 @@ int test(sycl::queue& queue, oneapi::dpl::internal::element_type_t<UIntType> see
                 oneapi::dpl::subtract_with_carry_engine<UIntType, w, s, r> engine(seed, offset);
 
                 sycl::vec<oneapi::dpl::internal::element_type_t<UIntType>, num_elems> res = engine();
-                res.store(idx.get_linear_id(), __dpl_sycl::__get_accessor_ptr(dpstd_acc));
+                res.store(idx.get_linear_id(), dpstd_acc);
             });
         });
         queue.wait();
@@ -104,7 +104,7 @@ int test_portion(sycl::queue& queue, oneapi::dpl::internal::element_type_t<UIntT
 
                 auto res = engine(part);
                 for(int i = 0; i < n_elems; ++i)
-                    __dpl_sycl::__get_accessor_ptr(dpstd_acc)[offset + i] = res[i];
+                    dpstd_acc[offset + i] = res[i];
             });
         });
         queue.wait();


### PR DESCRIPTION
Example of an error:
```
oneDPL/test/xpu_api/random/statistics_tests/weibull_distribution_test.pass.cpp:76:21: error: no matching member function for call to 'store'
...
bin/compiler/../../include/sycl/types.hpp:1033:8: note: candidate template ignored: could not match 'multi_ptr<DataT, Space, DecorateAddress>' (aka 'multi_ptr<float, Space, DecorateAddress>') against 'pointer' (aka 'float *')
```
 `__dpl_sycl::__get_accessor_ptr` returns a raw pointer, but `sycl::vec::store` uses `sycl::multi_ptr`. Raw pointer cannot be implicitly converted to `sycl::multi_ptr`. 
Also,  `__dpl_sycl::__get_accessor_ptr` is an internal oneDPL API and should not be used in the tests.

The PR has been verified with:
- Intel(R) oneAPI DPC++/C++ Compiler 2022.2.1
- Intel(R) oneAPI DPC++/C++ Compiler 2023.2.0

Please, review with "Hide whitespace" turned on to hide EOL changes. Some tests used LF and CRLF simultaneously. Now, if a repo cloned on Linux, all the EOLs will be LF.
