### PR TITLE
[pstl-offload] Add SDL flags into libpstloffload build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,15 +13,15 @@ string(REGEX REPLACE ".*#define _PSTL_OFFLOAD_BINARY_VERSION_PATCH ([0-9]+).*" "
 
 add_library(pstloffload SHARED ${CMAKE_CURRENT_SOURCE_DIR}/pstl_offload.cpp)
 
-target_compile_options(pstloffload PUBLIC
+target_compile_options(pstloffload PRIVATE
             -fsycl
             -Wall -Wextra -Wformat -Wformat-security -Wremarks -Werror
             -fPIE -mretpoline
             )
 
-target_link_options(pstloffload PUBLIC -Wl,-z,relro)
+target_link_options(pstloffload PRIVATE -Wl,-z,relro)
 
-target_include_directories(pstloffload PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+target_include_directories(pstloffload PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 
 set_target_properties(pstloffload PROPERTIES
     VERSION ${_pstl_offload_version_major}.${_pstl_offload_version_minor}.${_pstl_offload_version_patch}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ target_compile_options(pstloffload PUBLIC
             $<$<CONFIG:Debug>:-Wextra>
             $<$<NOT:$<CONFIG:Debug>>:-Wremarks -Werror=format-security>
             )
+target_link_options(pstloffload PUBLIC -Wl,-z,relro)
 
 target_include_directories(pstloffload PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,11 +15,10 @@ add_library(pstloffload SHARED ${CMAKE_CURRENT_SOURCE_DIR}/pstl_offload.cpp)
 
 target_compile_options(pstloffload PUBLIC
             -fsycl
-            -Wall -Wformat -Wformat-security
+            -Wall -Wextra -Wformat -Wformat-security -Wremarks -Werror
             -fPIE -mretpoline
-            $<$<CONFIG:Debug>:-Wextra>
-            $<$<NOT:$<CONFIG:Debug>>:-Wremarks -Werror=format-security>
             )
+
 target_link_options(pstloffload PUBLIC -Wl,-z,relro)
 
 target_include_directories(pstloffload PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,7 +13,14 @@ string(REGEX REPLACE ".*#define _PSTL_OFFLOAD_BINARY_VERSION_PATCH ([0-9]+).*" "
 
 add_library(pstloffload SHARED ${CMAKE_CURRENT_SOURCE_DIR}/pstl_offload.cpp)
 
-target_compile_options(pstloffload PUBLIC "-fsycl")
+target_compile_options(pstloffload PUBLIC
+            -fsycl
+            -Wall -Wformat -Wformat-security
+            $<$<CONFIG:Debug>:-Wextra>
+            $<$<NOT:$<CONFIG:Debug>>:-Wremarks -Werror=format-security>
+            -fPIE
+            )
+
 target_include_directories(pstloffload PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)
 
 set_target_properties(pstloffload PROPERTIES

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,9 +16,9 @@ add_library(pstloffload SHARED ${CMAKE_CURRENT_SOURCE_DIR}/pstl_offload.cpp)
 target_compile_options(pstloffload PUBLIC
             -fsycl
             -Wall -Wformat -Wformat-security
+            -fPIE -mretpoline
             $<$<CONFIG:Debug>:-Wextra>
             $<$<NOT:$<CONFIG:Debug>>:-Wremarks -Werror=format-security>
-            -fPIE -mretpoline
             )
 
 target_include_directories(pstloffload PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,7 @@ target_compile_options(pstloffload PUBLIC
             -Wall -Wformat -Wformat-security
             $<$<CONFIG:Debug>:-Wextra>
             $<$<NOT:$<CONFIG:Debug>>:-Wremarks -Werror=format-security>
-            -fPIE
+            -fPIE -mretpoline
             )
 
 target_include_directories(pstloffload PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../include)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ target_compile_options(pstloffload PRIVATE
             -fsycl
             -Wall -Wextra -Wformat -Wformat-security -Wremarks -Werror
             -fPIE -mretpoline
+            -fstack-protector
             )
 
 target_link_options(pstloffload PRIVATE -Wl,-z,relro)


### PR DESCRIPTION
Flags that were not added:

* `-ipo` caused link-time issues on `icpx` because some required library not found in the compiler package. Investigation required.
* `-fsanitize=cfi` causes a warning that the option is ignored as unsupported for SPIRV.
* `-pie` causes a warning that the argument is unused

No performance degradations detected