### PR TITLE
[oneDPL] [test] Fix heap use after free in uninitialized_fill_destroy.pass

### DIFF
--- a/test/parallel_api/memory/specialized.algorithms/uninitialized_fill_destroy.pass.cpp
+++ b/test/parallel_api/memory/specialized.algorithms/uninitialized_fill_destroy.pass.cpp
@@ -29,6 +29,7 @@
 #include "support/utils.h"
 
 #include <memory>
+#include <cstdlib>
 
 using namespace TestUtils;
 
@@ -173,8 +174,7 @@ test_uninitialized_fill_destroy_by_type()
     for (size_t n = 0; n <= N; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
 #if !TEST_DPCPP_BACKEND_PRESENT
-        ::std::unique_ptr<T[]> p(new T[n]);
-        auto p_begin = p.get();
+        auto p_begin = static_cast<T*>(::std::malloc(sizeof(T) * n));
 #else
         Sequence<T> p(n, [](size_t){ return T{}; });
         auto p_begin = p.begin();
@@ -198,6 +198,7 @@ test_uninitialized_fill_destroy_by_type()
         invoke_on_all_policies<>()(test_destroy_n<T>(), p_begin, p_end, T(), n,
                                    ::std::is_trivial<T>());
 #endif
+        ::std::free(p_begin);
 #endif
     }
 }

--- a/test/parallel_api/memory/specialized.algorithms/uninitialized_fill_destroy.pass.cpp
+++ b/test/parallel_api/memory/specialized.algorithms/uninitialized_fill_destroy.pass.cpp
@@ -174,9 +174,12 @@ test_uninitialized_fill_destroy_by_type()
     for (size_t n = 0; n <= N; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
 #if !TEST_DPCPP_BACKEND_PRESENT
+        // We use malloc / free for allocation / deallocation, so the memory is passed to the test
+        // uninitialized and deallocation does not attempt to destroy objects already destroyed
+        // in the test.
         auto free_allocation = [](auto ptr) { ::std::free(ptr); };
-        std::unique_ptr<T[], decltype(free_allocation)> p(static_cast<T*>(::std::malloc(sizeof(T) * n)),
-                                                          free_allocation);
+        ::std::unique_ptr<T[], decltype(free_allocation)> p(static_cast<T*>(::std::malloc(sizeof(T) * n)),
+                                                            free_allocation);
         auto p_begin = p.get();
 #else
         Sequence<T> p(n, [](size_t){ return T{}; });

--- a/test/parallel_api/memory/specialized.algorithms/uninitialized_fill_destroy.pass.cpp
+++ b/test/parallel_api/memory/specialized.algorithms/uninitialized_fill_destroy.pass.cpp
@@ -174,9 +174,8 @@ test_uninitialized_fill_destroy_by_type()
     for (size_t n = 0; n <= N; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
 #if !TEST_DPCPP_BACKEND_PRESENT
-        // We use malloc / free for allocation / deallocation, so the memory is passed to the test
-        // uninitialized and deallocation does not attempt to destroy objects already destroyed
-        // in the test.
+        // We use malloc / free instead of a typical approach with operator new T[] and a smart pointer (which calls
+        // operator delete[] within its destructor) to avoid double creation/destroy the elements of type T in the test.
         auto free_allocation = [](auto ptr) { ::std::free(ptr); };
         ::std::unique_ptr<T[], decltype(free_allocation)> p(static_cast<T*>(::std::malloc(sizeof(T) * n)),
                                                             free_allocation);


### PR DESCRIPTION
In `uninitialized_fill_destroy.pass.cpp`, we currently allocate memory into a smart pointer to manage its lifetime. However, there are two issues with this: since the memory is allocated with `new` it is already initialized when it is passed to the test function, and the test object's destructor will be called a second time after the `std::destroy` test before deallocation. This has crashes in this test on certain OSs (certain test configs with MacOS) and can be observed with address sanitizers elsewhere.

This fix manually allocates the memory with `malloc` so it is passed uninitialized to the test and manually deallocates it with `free`.