### PR TITLE
Use PSTL-prefixed macro along with ONEDPL one

### DIFF
--- a/include/oneapi/dpl/pstl/glue_memory_impl.h
+++ b/include/oneapi/dpl/pstl/glue_memory_impl.h
@@ -229,7 +229,7 @@ destroy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __
     const auto __is_parallel =
         oneapi::dpl::__internal::__is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
     using _is_vector_type =
-#if _ONEDPL_ICPX_OMP_SIMD_DESTROY_WINDOWS_BROKEN
+#if (_PSTL_ICPX_OMP_SIMD_DESTROY_WINDOWS_BROKEN || _ONEDPL_ICPX_OMP_SIMD_DESTROY_WINDOWS_BROKEN)
         ::std::conditional_t<
             oneapi::dpl::__internal::__is_host_execution_policy<::std::decay_t<_ExecutionPolicy>>::value,
             ::std::false_type,
@@ -237,7 +237,7 @@ destroy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __
                 __exec))>;
 #else
         decltype(oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
-#endif // _ONEDPL_ICPX_OMP_SIMD_DESTROY_WINDOWS_BROKEN
+#endif // _PSTL_ICPX_OMP_SIMD_DESTROY_WINDOWS_BROKEN || _ONEDPL_ICPX_OMP_SIMD_DESTROY_WINDOWS_BROKEN
     constexpr _is_vector_type __is_vector;
 
     if constexpr (!::std::is_trivially_destructible_v<_ValueType>)
@@ -258,7 +258,7 @@ destroy_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n)
     const auto __is_parallel =
         oneapi::dpl::__internal::__is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
     using _is_vector_type =
-#if _ONEDPL_ICPX_OMP_SIMD_DESTROY_WINDOWS_BROKEN
+#if (_PSTL_ICPX_OMP_SIMD_DESTROY_WINDOWS_BROKEN || _ONEDPL_ICPX_OMP_SIMD_DESTROY_WINDOWS_BROKEN)
         ::std::conditional_t<
             oneapi::dpl::__internal::__is_host_execution_policy<::std::decay_t<_ExecutionPolicy>>::value,
             ::std::false_type,
@@ -266,7 +266,7 @@ destroy_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n)
                 __exec))>;
 #else
         decltype(oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
-#endif // _ONEDPL_ICPX_OMP_SIMD_DESTROY_WINDOWS_BROKEN
+#endif // _PSTL_ICPX_OMP_SIMD_DESTROY_WINDOWS_BROKEN || _ONEDPL_ICPX_OMP_SIMD_DESTROY_WINDOWS_BROKEN
     constexpr _is_vector_type __is_vector;
 
     if constexpr (::std::is_trivially_destructible_v<_ValueType>)


### PR DESCRIPTION
This is a fix after #1182 PR to make these changes valid for a version where PSTL is used (upstream). It follows https://github.com/oneapi-src/oneDPL/pull/1182#discussion_r1329945495 advice. 