### PR TITLE
[DOC] Add 2 new known limitations for oneDPL 2022.3 documentation

### DIFF
--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -95,8 +95,8 @@ Known Limitations
 *****************
 
 * When compiled with ``-fsycl-pstl-offload`` option of Intel oneAPI DPC++/C++ compiler and with
-  libstdc++ version 8 or libc++, ``oneapi::dpl::execution::par_unseq`` behaves similar to
-  ``std::execution::par_unseq``, offloading standard parallel algorithms to the SYCL device
+  ``libstdc++`` version 8 or ``libc++``, ``oneapi::dpl::execution::par_unseq`` offloads
+  standard parallel algorithms to the SYCL device similarly to ``std::execution::par_unseq``
   in accordance with the ``-fsycl-pstl-offload`` option value.
 * For ``transform_exclusive_scan`` and ``exclusive_scan`` to run in-place (that is, with the same data
   used for both input and destination) and with an execution policy of ``unseq`` or ``par_unseq``, 

--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -102,7 +102,7 @@ Known Limitations
   used for both input and destination) and with an execution policy of ``unseq`` or ``par_unseq``, 
   it is required that the provided input and destination iterators are equality comparable.
   Furthermore, the equality comparison of the input and destination iterator must evaluate to true.
-  If these conditions are not met, the result of these algorithm calls are undefined.
+  If these conditions are not met, the result of these algorithm calls is undefined.
 * For ``transform_exclusive_scan``, ``transform_inclusive_scan`` algorithms the result of the unary operation should be
   convertible to the type of the initial value if one is provided, otherwise it is convertible to the type of values
   in the processed data sequence: ``std::iterator_traits<IteratorType>::value_type``.

--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -94,10 +94,12 @@ When called with |dpcpp_short| execution policies, |onedpl_short| algorithms app
 Known Limitations
 *****************
 
-* When compiling with DPC++ compiler option, libstdc++ version 8 or libc++, and with ``-fsycl-pstl-offload`` option,
-  parallel algorithms from std namespace called with ``oneapi::dpl::parallel_unsequenced_policy`` would be
-  offloaded to the SYCL device in accordance with ``-fsycl-pstl-offload`` option value.
-* For ``transform_exclusive_scan`` and ``exclusive_scan`` with overlapping input and destination sequences and an execution policy of ``unseq`` or ``par_unseq``,
+* When compiled with ``-fsycl-pstl-offload`` option of Intel oneAPI DPC++/C++ compiler and with
+  libstdc++ version 8 or libc++, ``oneapi::dpl::execution::par_unseq`` behaves similar to
+  ``std::execution::par_unseq``, offloading standard parallel algorithms to the SYCL device
+  in accordance with the ``-fsycl-pstl-offload`` option value.
+* For ``transform_exclusive_scan`` and ``exclusive_scan`` to run in-place (that is, with the same data
+  used for both input and destination) and with an execution policy of ``unseq`` or ``par_unseq``, 
   it is required that the provided input and destination iterators are equality comparable.
   Furthermore, the equality comparison of the input and destination iterator must evaluate to true.
   If these conditions are not met, the result of these algorithm calls are undefined.

--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -94,6 +94,13 @@ When called with |dpcpp_short| execution policies, |onedpl_short| algorithms app
 Known Limitations
 *****************
 
+* When compiling with DPC++ compiler option, libstdc++ version 8 or libc++, and with ``-fsycl-pstl-offload`` option,
+  parallel algorithms from std namespace called with ``oneapi::dpl::parallel_unsequenced_policy`` would be
+  offloaded to the SYCL device in accordance with ``-fsycl-pstl-offload`` option value.
+* For ``transform_exclusive_scan`` and ``exclusive_scan`` with overlapping input and destination sequences,
+  it is required that the provided input and destination iterators are equality comparable.
+  Furthermore, the equality comparison of the input and destination iterator must evaluate to true.
+  If these conditions are not met, the result of these algorithm calls are undefined.
 * For ``transform_exclusive_scan``, ``transform_inclusive_scan`` algorithms the result of the unary operation should be
   convertible to the type of the initial value if one is provided, otherwise it is convertible to the type of values
   in the processed data sequence: ``std::iterator_traits<IteratorType>::value_type``.

--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -97,7 +97,7 @@ Known Limitations
 * When compiling with DPC++ compiler option, libstdc++ version 8 or libc++, and with ``-fsycl-pstl-offload`` option,
   parallel algorithms from std namespace called with ``oneapi::dpl::parallel_unsequenced_policy`` would be
   offloaded to the SYCL device in accordance with ``-fsycl-pstl-offload`` option value.
-* For ``transform_exclusive_scan`` and ``exclusive_scan`` with overlapping input and destination sequences,
+* For ``transform_exclusive_scan`` and ``exclusive_scan`` with overlapping input and destination sequences and an execution policy of ``unseq`` or ``par_unseq``,
   it is required that the provided input and destination iterators are equality comparable.
   Furthermore, the equality comparison of the input and destination iterator must evaluate to true.
   If these conditions are not met, the result of these algorithm calls are undefined.


### PR DESCRIPTION
Added 2 new long-term known limitations introduced in oneDPL 2022.3.
They are duplicated in oneDPL 2022.3 release notes for users notification.