### PR TITLE
[KT] Limit SLM allocation to the used amount

### DIFF
--- a/test/kt/esimd_radix_sort.cpp
+++ b/test/kt/esimd_radix_sort.cpp
@@ -156,15 +156,17 @@ template <typename T, bool IsAscending, std::uint8_t RadixBits, typename KernelP
 void
 test_small_sizes(sycl::queue q, KernelParam param)
 {
-    std::vector<uint32_t> input = {5, 11, 0, 17, 0};
-    std::vector<uint32_t> ref(input);
+    constexpr int size = 8;
+    std::vector<T> input(size);
+    generate_data(input.data(), size, 42);
+    std::vector<T> ref(input);
 
-    oneapi::dpl::experimental::kt::esimd::radix_sort<Ascending, RadixBits>(q, oneapi::dpl::begin(input),
+    oneapi::dpl::experimental::kt::esimd::radix_sort<IsAscending, RadixBits>(q, oneapi::dpl::begin(input),
                                                                            oneapi::dpl::begin(input), param)
         .wait();
     EXPECT_EQ_RANGES(ref, input, "sort modified input data when size == 0");
 
-    oneapi::dpl::experimental::kt::esimd::radix_sort<Ascending, RadixBits>(q, oneapi::dpl::begin(input),
+    oneapi::dpl::experimental::kt::esimd::radix_sort<IsAscending, RadixBits>(q, oneapi::dpl::begin(input),
                                                                            oneapi::dpl::begin(input) + 1, param)
         .wait();
     EXPECT_EQ_RANGES(ref, input, "sort modified input data when size == 1");


### PR DESCRIPTION
This PR aims to solve several problems:

- Support of more GPUs: current impl limits SLM to max available on Intel® Data Center GPU Max. The limit might be different on other GPUs.
- Performance: hardcoding the SLM allocation to the max amount limits occupancy. Especially with smaller `WorkGroupSize` template values. 
- Usage: issues with the use of more SLM than the max hardcoded amount are hard to debug. 

This is a draft until full testing passes. The current results are:

```
92% tests passed, 15 tests failed out of 193

The following tests FAILED:
        344 - esimd_radix_sort_by_key (Subprocess aborted)
        360 - esimd_radix_sort_char_dpwi256_wgs64 (Failed)
        375 - esimd_radix_sort_char_dpwi512_wgs32 (Failed)
        376 - esimd_radix_sort_char_dpwi512_wgs64 (Failed)
        392 - esimd_radix_sort_uint16_dpwi256_wgs64 (Failed)
        407 - esimd_radix_sort_uint16_dpwi512_wgs32 (Failed)
        408 - esimd_radix_sort_uint16_dpwi512_wgs64 (Failed)
        424 - esimd_radix_sort_int_dpwi256_wgs64 (Failed)
        439 - esimd_radix_sort_int_dpwi512_wgs32 (Failed)
        448 - esimd_radix_sort_uint64_dpwi128_wgs64 (Failed)
        455 - esimd_radix_sort_uint64_dpwi256_wgs32 (Failed)
        488 - esimd_radix_sort_float_dpwi256_wgs64 (Failed)
        503 - esimd_radix_sort_float_dpwi512_wgs32 (Failed)
        512 - esimd_radix_sort_double_dpwi128_wgs64 (Failed)
        519 - esimd_radix_sort_double_dpwi256_wgs32 (Failed)
```
All the tests failed with "Exception: internal compiler error". It should be investigated.

Upd (18.10.2023): The issue with "Exception: internal compiler error" has been investigated and a workaround has been applied. This PR now results in new 2 failed cases instead of previous 15. 

```
The following tests FAILED:
	376 - esimd_radix_sort_char_dpwi512_wgs64 (Subprocess aborted)
	408 - esimd_radix_sort_uint16_dpwi512_wgs64 (Subprocess aborted)
```
The message is "LLVM ERROR: SLM size exceeds target limits" now. It should also be investigated. Probably, it's a compiler bug, because the amount of memory allocated with `slm_init` does not exceed Intel® Data Center GPU Max capacity; it is even less than in many other cases with wider types.  

Upd (25.10.2023): All the tests pass. There used to be a subtle issue with `test_small_sizes`: this case compiled kernels for `uint32_t` type which led to the issue with SLM. Now the test case uses the same type as other cases. 