### PR TITLE
[pstl-offload] Add workaround for TBB headers tests failures

### DIFF
--- a/include/pstl_offload/execution
+++ b/include/pstl_offload/execution
@@ -22,4 +22,8 @@
 #    undef _ONEDPL_PSTL_OFFLOAD_TOP_LEVEL
 #endif // _ONEDPL_PSTL_OFFLOAD_TOP_LEVEL_EXECUTION
 
+#include <algorithm>
+#include <memory>
+#include <numeric>
+
 #endif // _ONEDPL_PSTL_OFFLOAD_TOP_LEVEL_EXECUTION

--- a/include/pstl_offload/internal/usm_memory_replacement.h
+++ b/include/pstl_offload/internal/usm_memory_replacement.h
@@ -21,7 +21,9 @@
 
 #include <sycl/sycl.hpp>
 
-#include <oneapi/dpl/execution>
+#include <oneapi/dpl/internal/common_config.h>
+#include <oneapi/dpl/pstl/onedpl_config.h>
+#include <oneapi/dpl/pstl/execution_defs.h>
 
 #include "usm_memory_replacement_common.h"
 

--- a/test/pstl_offload/headers/headers.tbb/algorithms/oneapi_tbb_collaborative_call_once_h.pass.cpp
+++ b/test/pstl_offload/headers/headers.tbb/algorithms/oneapi_tbb_collaborative_call_once_h.pass.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <execution>
 #include <oneapi/tbb/collaborative_call_once.h>
 #include "support/utils.h"
 

--- a/test/pstl_offload/headers/headers.tbb/algorithms/oneapi_tbb_parallel_for_each_h.pass.cpp
+++ b/test/pstl_offload/headers/headers.tbb/algorithms/oneapi_tbb_parallel_for_each_h.pass.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <execution>
 #include <oneapi/tbb/parallel_for_each.h>
 #include "support/utils.h"
 

--- a/test/pstl_offload/headers/headers.tbb/algorithms/oneapi_tbb_parallel_for_h.pass.cpp
+++ b/test/pstl_offload/headers/headers.tbb/algorithms/oneapi_tbb_parallel_for_h.pass.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <execution>
 #include <oneapi/tbb/parallel_for.h>
 #include "support/utils.h"
 

--- a/test/pstl_offload/headers/headers.tbb/algorithms/oneapi_tbb_parallel_invoke_h.pass.cpp
+++ b/test/pstl_offload/headers/headers.tbb/algorithms/oneapi_tbb_parallel_invoke_h.pass.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <execution>
 #include <oneapi/tbb/parallel_invoke.h>
 #include "support/utils.h"
 

--- a/test/pstl_offload/headers/headers.tbb/algorithms/oneapi_tbb_parallel_pipeline_h.pass.cpp
+++ b/test/pstl_offload/headers/headers.tbb/algorithms/oneapi_tbb_parallel_pipeline_h.pass.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <execution>
 #include <oneapi/tbb/parallel_pipeline.h>
 #include "support/utils.h"
 

--- a/test/pstl_offload/headers/headers.tbb/algorithms/oneapi_tbb_parallel_reduce_h.pass.cpp
+++ b/test/pstl_offload/headers/headers.tbb/algorithms/oneapi_tbb_parallel_reduce_h.pass.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <execution>
 #include <oneapi/tbb/parallel_reduce.h>
 #include <oneapi/tbb/blocked_range.h>
 #include "support/utils.h"

--- a/test/pstl_offload/headers/headers.tbb/algorithms/oneapi_tbb_parallel_scan_h.pass.cpp
+++ b/test/pstl_offload/headers/headers.tbb/algorithms/oneapi_tbb_parallel_scan_h.pass.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <execution>
 #include <oneapi/tbb/parallel_scan.h>
 #include <oneapi/tbb/blocked_range.h>
 #include "support/utils.h"

--- a/test/pstl_offload/headers/headers.tbb/algorithms/oneapi_tbb_parallel_sort_h.pass.cpp
+++ b/test/pstl_offload/headers/headers.tbb/algorithms/oneapi_tbb_parallel_sort_h.pass.cpp
@@ -7,11 +7,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <execution>
 #include <oneapi/tbb/parallel_sort.h>
 #include "support/utils.h"
 
 int main() {
-    int array[3];
+    int array[3] = {3, 2, 1};
     oneapi::tbb::parallel_sort(array, array + 3);
     return TestUtils::done();
 }

--- a/test/pstl_offload/headers/headers.tbb/algorithms/oneapi_tbb_partitioner_h.pass.cpp
+++ b/test/pstl_offload/headers/headers.tbb/algorithms/oneapi_tbb_partitioner_h.pass.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <execution>
 #include <oneapi/tbb/partitioner.h>
 #include "support/utils.h"
 

--- a/test/pstl_offload/headers/headers.tbb/containers/oneapi_tbb_concurrent_hash_map_h.pass.cpp
+++ b/test/pstl_offload/headers/headers.tbb/containers/oneapi_tbb_concurrent_hash_map_h.pass.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <execution>
 #include <oneapi/tbb/concurrent_hash_map.h>
 #include "support/utils.h"
 

--- a/test/pstl_offload/headers/headers.tbb/containers/oneapi_tbb_concurrent_map_h.pass.cpp
+++ b/test/pstl_offload/headers/headers.tbb/containers/oneapi_tbb_concurrent_map_h.pass.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <execution>
 #include <oneapi/tbb/concurrent_map.h>
 #include "support/utils.h"
 

--- a/test/pstl_offload/headers/headers.tbb/containers/oneapi_tbb_concurrent_priority_queue_h.pass.cpp
+++ b/test/pstl_offload/headers/headers.tbb/containers/oneapi_tbb_concurrent_priority_queue_h.pass.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <execution>
 #include <oneapi/tbb/concurrent_priority_queue.h>
 #include "support/utils.h"
 

--- a/test/pstl_offload/headers/headers.tbb/containers/oneapi_tbb_concurrent_queue_h.pass.cpp
+++ b/test/pstl_offload/headers/headers.tbb/containers/oneapi_tbb_concurrent_queue_h.pass.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <execution>
 #include <oneapi/tbb/concurrent_queue.h>
 #include "support/utils.h"
 

--- a/test/pstl_offload/headers/headers.tbb/containers/oneapi_tbb_concurrent_set_h.pass.cpp
+++ b/test/pstl_offload/headers/headers.tbb/containers/oneapi_tbb_concurrent_set_h.pass.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <execution>
 #include <oneapi/tbb/concurrent_set.h>
 #include "support/utils.h"
 

--- a/test/pstl_offload/headers/headers.tbb/containers/oneapi_tbb_concurrent_unordered_map_h.pass.cpp
+++ b/test/pstl_offload/headers/headers.tbb/containers/oneapi_tbb_concurrent_unordered_map_h.pass.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <execution>
 #include <oneapi/tbb/concurrent_unordered_map.h>
 #include "support/utils.h"
 

--- a/test/pstl_offload/headers/headers.tbb/containers/oneapi_tbb_concurrent_unordered_set_h.pass.cpp
+++ b/test/pstl_offload/headers/headers.tbb/containers/oneapi_tbb_concurrent_unordered_set_h.pass.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <execution>
 #include <oneapi/tbb/concurrent_unordered_set.h>
 #include "support/utils.h"
 

--- a/test/pstl_offload/headers/headers.tbb/containers/oneapi_tbb_concurrent_vector_h.pass.cpp
+++ b/test/pstl_offload/headers/headers.tbb/containers/oneapi_tbb_concurrent_vector_h.pass.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <execution>
 #include <oneapi/tbb/concurrent_vector.h>
 #include "support/utils.h"
 

--- a/test/pstl_offload/headers/headers.tbb/task_scheduler/oneapi_tbb_global_control_h.pass.cpp
+++ b/test/pstl_offload/headers/headers.tbb/task_scheduler/oneapi_tbb_global_control_h.pass.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <execution>
 #include <oneapi/tbb/global_control.h>
 #include "support/utils.h"
 

--- a/test/pstl_offload/headers/headers.tbb/task_scheduler/oneapi_tbb_task_arena_h.pass.cpp
+++ b/test/pstl_offload/headers/headers.tbb/task_scheduler/oneapi_tbb_task_arena_h.pass.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <execution>
 #include <oneapi/tbb/task_arena.h>
 #include "support/utils.h"
 

--- a/test/pstl_offload/headers/headers.tbb/task_scheduler/oneapi_tbb_task_group_h.pass.cpp
+++ b/test/pstl_offload/headers/headers.tbb/task_scheduler/oneapi_tbb_task_group_h.pass.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <execution>
 #include <oneapi/tbb/task_group.h>
 #include "support/utils.h"
 

--- a/test/pstl_offload/headers/headers.tbb/task_scheduler/oneapi_tbb_task_h.pass.cpp
+++ b/test/pstl_offload/headers/headers.tbb/task_scheduler/oneapi_tbb_task_h.pass.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <execution>
 #include <oneapi/tbb/task.h>
 #include "support/utils.h"
 

--- a/test/pstl_offload/headers/headers.tbb/task_scheduler/oneapi_tbb_task_scheduler_observer_h.pass.cpp
+++ b/test/pstl_offload/headers/headers.tbb/task_scheduler/oneapi_tbb_task_scheduler_observer_h.pass.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <execution>
 #include <oneapi/tbb/task_scheduler_observer.h>
 #include "support/utils.h"
 

--- a/test/pstl_offload/headers/headers.tbb/tls/oneapi_tbb_combinable_h.pass.cpp
+++ b/test/pstl_offload/headers/headers.tbb/tls/oneapi_tbb_combinable_h.pass.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <execution>
 #include <oneapi/tbb/combinable.h>
 #include "support/utils.h"
 

--- a/test/pstl_offload/headers/headers.tbb/tls/oneapi_tbb_enumerable_thread_specific_h.pass.cpp
+++ b/test/pstl_offload/headers/headers.tbb/tls/oneapi_tbb_enumerable_thread_specific_h.pass.cpp
@@ -7,6 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <execution>
 #include <oneapi/tbb/enumerable_thread_specific.h>
 #include "support/utils.h"
 


### PR DESCRIPTION
Workaround for the compiler issue when including oneTBB headers in pstl-offload mode - include `<execution>` before any public oneTBB headers. 

This patch replaces `<onedpl/execution>` include in usm memory replacement with private headers (that fixes most of the TBB failing tests) and adds `#include <execution>` as a workaround for other failing tests.

The issue is expected to be fixed on the compiler side and additional macros around changes in this patch would be required.