### PR TITLE
Clang format merge-base fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: sudo apt-get install -yqq clang-format
       - name: Applying clang-format for changed files
         run: |
-          MERGE_BASE=git merge-base ${{github.event.pull_request.head.ref}} ${{ github.event.pull_request.base.ref }}
+          MERGE_BASE=$(git merge-base ${{ github.event.pull_request.head.ref }} ${{ github.event.pull_request.base.ref }})
           FILES=$(git diff --diff-filter=d --name-only $MERGE_BASE | grep ^include | grep -v nanorange\.hpp\$ || true)
           CLANG_FORMAT_DIFF_PATH=$(which clang-format-diff)
           echo $FILES | xargs -n1 -t -r git diff -U0 --no-color --relative $MERGE_BASE | python3 $CLANG_FORMAT_DIFF_PATH -i -p1 -style file

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: sudo apt-get install -yqq clang-format
       - name: Applying clang-format for changed files
         run: |
-          MERGE_BASE=$(git merge-base ${{ github.event.pull_request.head.ref }} ${{ github.event.pull_request.base.ref }})
+          MERGE_BASE=$(git merge-base ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.base.sha }})
           FILES=$(git diff --diff-filter=d --name-only $MERGE_BASE | grep ^include | grep -v nanorange\.hpp\$ || true)
           CLANG_FORMAT_DIFF_PATH=$(which clang-format-diff)
           echo $FILES | xargs -n1 -t -r git diff -U0 --no-color --relative $MERGE_BASE | python3 $CLANG_FORMAT_DIFF_PATH -i -p1 -style file

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: sudo apt-get install -yqq clang-format
       - name: Applying clang-format for changed files
         run: |
-          MERGE_BASE=${{ github.event.pull_request.base.sha }}
+          MERGE_BASE=git merge-base ${{github.event.pull_request.head.ref}} ${{ github.event.pull_request.base.ref }}
           FILES=$(git diff --diff-filter=d --name-only $MERGE_BASE | grep ^include | grep -v nanorange\.hpp\$ || true)
           CLANG_FORMAT_DIFF_PATH=$(which clang-format-diff)
           echo $FILES | xargs -n1 -t -r git diff -U0 --no-color --relative $MERGE_BASE | python3 $CLANG_FORMAT_DIFF_PATH -i -p1 -style file

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -405,7 +405,7 @@ struct replicate_start_view_simple
 template <typename _R, typename _F>
 struct transform_view_simple
 {
-    using value_type = ::std::decay_t<::std::invoke_result_t<_F& , decltype(::std::declval<_R&>()[0])>>;
+    using value_type = ::std::decay_t<::std::invoke_result_t<_F&, decltype(::std::declval<_R&>()[0])>>;
 
     _R __r;
     _F __f;

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -405,7 +405,7 @@ struct replicate_start_view_simple
 template <typename _R, typename _F>
 struct transform_view_simple
 {
-    using value_type = ::std::decay_t<::std::invoke_result_t<_F&, decltype(::std::declval<_R&>()[0])>>;
+    using value_type = ::std::decay_t<::std::invoke_result_t<_F& , decltype(::std::declval<_R&>()[0])>>;
 
     _R __r;
     _F __f;


### PR DESCRIPTION
This PR fixes the clang-format to compare against the actual `git merge-base` or "nearest common ancestor", rather than the current head of the target branch when the PR was created (`github.event.pull_request.base.sha`).

I've branched this commit off 2d943a309  (about 10 commits behind current HEAD).  There are clang-formatting issues with commits which have since been merged into main which would dirty this PR's report without this fix, but instead the clang-format check passes.

To prove that the clang-format check still accurately detects real formatting issues with the PR, please look at the following CI action link:
https://github.com/oneapi-src/oneDPL/actions/runs/6306998877/job/17122994749?pr=1205
I injected an intentional error into `utils_ranges.h`, and have since reverted it.
