### PR TITLE
clang-format fix for github push actions (post merge to main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,11 @@ jobs:
       - name: Applying clang-format for changed files
         run: |
           if [["${{ github.event_name }}" == "pull_request"]]; then
+            echo pull_request event
             GIT_HEAD=${{ github.event.pull_request.head.sha }}
             GIT_BASE=${{ github.event.pull_request.base.sha }}
           else
+            echo push event
             GIT_HEAD=${{ github.event.push.head.sha }}
             GIT_BASE=${{ github.event.push.base.sha }}
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Applying clang-format for changed files
         shell: bash
         run: |
-          if [["${{ github.event_name }}" == "pull_request"]]; then
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo Setting up git hashes for pull_request event
             GIT_HEAD=${{ github.event.pull_request.head.sha }}
             GIT_BASE=${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
         run: sudo apt-get install -yqq clang-format
       - name: Applying clang-format for changed files
         run: |
-          if [[${{ github.event_name }} == 'pull_request']]; then
+          if [["${{ github.event_name }}" == "pull_request"]]; then
             GIT_HEAD=${{ github.event.pull_request.head.sha }}
             GIT_BASE=${{ github.event.pull_request.base.sha }}
           else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,22 @@ jobs:
           python-version: '3.x' 
       - name: Get clang-format
         run: sudo apt-get install -yqq clang-format
+      - name: Setup Git Hashes for Pull Request
+        run: |
+          GIT_HEAD=${{ github.event.pull_request.head.sha }}
+          GIT_BASE=${{ github.event.pull_request.base.sha }}
+        if: github.event_name == 'pull_request'
+      - name: Setup Git Hashes for Push
+        run: |
+          GIT_HEAD=${{ github.event.push.head.sha }}
+          GIT_BASE=${{ github.event.push.base.sha }}
+        if: github.event_name == 'push'
+      - name: Setup Merge Base for diff
+        run: 
+          MERGE_BASE=$(git merge-base $GIT_HEAD $GIT_BASE)
+        if: github.event_name == 'pull_request' || github.event_name == 'push'
       - name: Applying clang-format for changed files
         run: |
-          MERGE_BASE=$(git merge-base ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.base.sha }})
           FILES=$(git diff --diff-filter=d --name-only $MERGE_BASE | grep ^include | grep -v nanorange\.hpp\$ || true)
           CLANG_FORMAT_DIFF_PATH=$(which clang-format-diff)
           echo $FILES | xargs -n1 -t -r git diff -U0 --no-color --relative $MERGE_BASE | python3 $CLANG_FORMAT_DIFF_PATH -i -p1 -style file

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,25 +28,20 @@ jobs:
           python-version: '3.x' 
       - name: Get clang-format
         run: sudo apt-get install -yqq clang-format
-      - name: Setup git hashes for pull request
-        run: |
-          GIT_HEAD=${{ github.event.pull_request.head.sha }}
-          GIT_BASE=${{ github.event.pull_request.base.sha }}
-        if: github.event_name == 'pull_request'
-      - name: Setup git hashes for push
-        run: |
-          GIT_HEAD=${{ github.event.push.head.sha }}
-          GIT_BASE=${{ github.event.push.base.sha }}
-        if: github.event_name == 'push'
-      - name: Setup merge base for diff
-        run: 
-          MERGE_BASE=$(git merge-base $GIT_HEAD $GIT_BASE)
-        if: github.event_name == 'pull_request' || github.event_name == 'push'
       - name: Applying clang-format for changed files
         run: |
+          if [[${{ github.event_name }} == 'pull_request']]; then
+            GIT_HEAD=${{ github.event.pull_request.head.sha }}
+            GIT_BASE=${{ github.event.pull_request.base.sha }}
+          else
+            GIT_HEAD=${{ github.event.push.head.sha }}
+            GIT_BASE=${{ github.event.push.base.sha }}
+          fi
+          MERGE_BASE=$(git merge-base $GIT_HEAD $GIT_BASE)
           FILES=$(git diff --diff-filter=d --name-only $MERGE_BASE | grep ^include | grep -v nanorange\.hpp\$ || true)
           CLANG_FORMAT_DIFF_PATH=$(which clang-format-diff)
           echo $FILES | xargs -n1 -t -r git diff -U0 --no-color --relative $MERGE_BASE | python3 $CLANG_FORMAT_DIFF_PATH -i -p1 -style file
+        if: github.event_name == 'pull_request' || github.event_name == 'push'
       - name: Creating diff
         run: git diff > clang-format.diff
       - name: Checking if diff is empty

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,17 +28,17 @@ jobs:
           python-version: '3.x' 
       - name: Get clang-format
         run: sudo apt-get install -yqq clang-format
-      - name: Setup Git Hashes for Pull Request
+      - name: Setup git hashes for pull request
         run: |
           GIT_HEAD=${{ github.event.pull_request.head.sha }}
           GIT_BASE=${{ github.event.pull_request.base.sha }}
         if: github.event_name == 'pull_request'
-      - name: Setup Git Hashes for Push
+      - name: Setup git hashes for push
         run: |
           GIT_HEAD=${{ github.event.push.head.sha }}
           GIT_BASE=${{ github.event.push.base.sha }}
         if: github.event_name == 'push'
-      - name: Setup Merge Base for diff
+      - name: Setup merge base for diff
         run: 
           MERGE_BASE=$(git merge-base $GIT_HEAD $GIT_BASE)
         if: github.event_name == 'pull_request' || github.event_name == 'push'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,14 @@ jobs:
       - name: Get clang-format
         run: sudo apt-get install -yqq clang-format
       - name: Applying clang-format for changed files
+        shell: bash
         run: |
           if [["${{ github.event_name }}" == "pull_request"]]; then
-            echo pull_request event
+            echo Setting up git hashes for pull_request event
             GIT_HEAD=${{ github.event.pull_request.head.sha }}
             GIT_BASE=${{ github.event.pull_request.base.sha }}
           else
-            echo push event
+            echo Setting up git hashes for push event
             GIT_HEAD=${{ github.event.push.head.sha }}
             GIT_BASE=${{ github.event.push.base.sha }}
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/*
 .vs/*
 out/*
 CMakeSettings.json
+build-tbb/*

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,3 @@ build/*
 .vs/*
 out/*
 CMakeSettings.json
-build-tbb/*


### PR DESCRIPTION
This PR fixes the clang-format github action to handle both `pull_request` event and `push` event appropriately, as either can trigger this workflow.  

When one is the trigger, the other's variables are the empty string.  For a `push` event, `github.event.pull_request.[head,base].sha` are the empty string, resulting in an error from the `git merge-base` call unless we branch and set that event up accordingly.

Without this PR, a passing clang-format CI for the pull request will fail the clang-format CI when run after merge (as the merge triggers a `push` event).

Also added in this change is that clang-format checks will only only be processed for `pull_request` and `push` events.  Currently these are the only workflows enabled by this test, but if any other events are added, they will omit the formatting part of this check, resulting in an empty report and a successful check.  