### PR TITLE
clang-format fix for push event

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref:  ${{ github.event.pull_request.head.sha }}
+          ref:  ${{ github.event.pull_request.head.sha || github.event.push.after }}
       - uses: actions/setup-python@v3
         with:
           python-version: '3.x' 
@@ -31,7 +31,7 @@ jobs:
       - name: Applying clang-format for changed files
         shell: bash
         run: |
-          GIT_HEAD=${{ github.event.push.after || github.event.pull_request.head.sha }}
+          GIT_HEAD=${{ github.event.pull_request.head.sha || github.event.push.after }}
           GIT_BASE=${{ github.event.pull_request.base.sha || github.event.push.before }}
           MERGE_BASE=$(git merge-base $GIT_HEAD $GIT_BASE)
           FILES=$(git diff --diff-filter=d --name-only $MERGE_BASE | grep ^include | grep -v nanorange\.hpp\$ || true)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,15 +31,8 @@ jobs:
       - name: Applying clang-format for changed files
         shell: bash
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo Setting up git hashes for pull_request event
-            GIT_HEAD=${{ github.event.pull_request.head.sha }}
-            GIT_BASE=${{ github.event.pull_request.base.sha }}
-          else
-            echo Setting up git hashes for push event
-            GIT_HEAD=${{ github.event.push.head.sha }}
-            GIT_BASE=${{ github.event.push.base.sha }}
-          fi
+          GIT_HEAD=${{ github.event.push.after || github.event.pull_request.head.sha }}
+          GIT_BASE=${{ github.event.pull_request.base.sha || github.event.push.before }}
           MERGE_BASE=$(git merge-base $GIT_HEAD $GIT_BASE)
           FILES=$(git diff --diff-filter=d --name-only $MERGE_BASE | grep ^include | grep -v nanorange\.hpp\$ || true)
           CLANG_FORMAT_DIFF_PATH=$(which clang-format-diff)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,6 @@ jobs:
       - name: Get clang-format
         run: sudo apt-get install -yqq clang-format
       - name: Applying clang-format for changed files
-        shell: bash
         run: |
           GIT_HEAD=${{ github.event.pull_request.head.sha || github.event.push.after }}
           GIT_BASE=${{ github.event.pull_request.base.sha || github.event.push.before }}


### PR DESCRIPTION
Yet another fix for clang format post-merge.  This now gets the syntax for the `push` event commit hashes correct.

It also cleans up the code a little.

Here is the documentation:
https://docs.github.com/en/webhooks/webhook-events-and-payloads#push
This lists the structure of the event objects for `pull_request` and `push`, and supports the identifiers used here.


The link below supports the syntax to allow the code cleanup.  Specifically "Note: empty string returns 0." and their example for ternary below.
https://docs.github.com/en/actions/learn-github-actions/expressions#operators 

