### PR TITLE
Remove clang-format check from post-merge action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ env:
 
 jobs:
   clang-format:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -30,8 +31,8 @@ jobs:
         run: sudo apt-get install -yqq clang-format
       - name: Applying clang-format for changed files
         run: |
-          GIT_HEAD=${{ github.event.pull_request.head.sha || github.event.push.after }}
-          GIT_BASE=${{ github.event.pull_request.base.sha || github.event.push.before }}
+          GIT_HEAD=${{ github.event.pull_request.head.sha }}
+          GIT_BASE=${{ github.event.pull_request.base.sha }}
           MERGE_BASE=$(git merge-base $GIT_HEAD $GIT_BASE)
           FILES=$(git diff --diff-filter=d --name-only $MERGE_BASE | grep ^include | grep -v nanorange\.hpp\$ || true)
           CLANG_FORMAT_DIFF_PATH=$(which clang-format-diff)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,13 @@ env:
 
 jobs:
   clang-format:
-    if: github.event_name == 'push'
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          ref:  ${{ github.event.pull_request.head.sha || github.event.push.after }}
+          ref:  ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-python@v3
         with:
           python-version: '3.x' 
@@ -31,9 +31,7 @@ jobs:
         run: sudo apt-get install -yqq clang-format
       - name: Applying clang-format for changed files
         run: |
-          GIT_HEAD=${{ github.event.pull_request.head.sha }}
-          GIT_BASE=${{ github.event.pull_request.base.sha }}
-          MERGE_BASE=$(git merge-base $GIT_HEAD $GIT_BASE)
+          MERGE_BASE=$(git merge-base ${{ github.event.pull_request.head.sha }} ${{ github.event.pull_request.base.sha }})
           FILES=$(git diff --diff-filter=d --name-only $MERGE_BASE | grep ^include | grep -v nanorange\.hpp\$ || true)
           CLANG_FORMAT_DIFF_PATH=$(which clang-format-diff)
           echo $FILES | xargs -n1 -t -r git diff -U0 --no-color --relative $MERGE_BASE | python3 $CLANG_FORMAT_DIFF_PATH -i -p1 -style file


### PR DESCRIPTION
This PR changes the clang-format check to only run on `pull_request` events (commits to an active pull request or creation of one).  The CI will skip the job for post-merge push events to main.

A couple previous PRs (#1207 #1211) attempted to fix the post-merge version of this clang-format job without success, after some operations were added in #1205 requiring specific git commit hashes which broke it post-merge.  With additional thought, it seems that this job is unnecessary in the context of the post-merge CI action.   In fact, the way it was written, before #1205 (and even before #715) it would just pass unconditionally post-merge because the diff would be empty.

The clang-format check is a tool to help us craft better PRs, so let us run it in that context, but not otherwise.
