### PR TITLE
Fix compile error in test_internal_sycl_scheduler.pass with nightly compiler

### DIFF
--- a/test/parallel_api/dynamic_selection/sycl/test_internal_sycl_scheduler.pass.cpp
+++ b/test/parallel_api/dynamic_selection/sycl/test_internal_sycl_scheduler.pass.cpp
@@ -178,7 +178,6 @@ test_submit_and_wait_on_sync_single_element()
     std::cout << "wait_on_sync single element: OK\n";
     return 0;
 }
-#endif
 
 int
 test_submit_and_wait_on_sync_empty()
@@ -253,6 +252,7 @@ test_properties()
     std::cout << "properties: OK\n";
     return 0;
 }
+#endif
 
 int
 main()


### PR DESCRIPTION
The test `test_internal_sycl_scheduler.pass` fails to compile with the nightly intel/llvm compiler because the `TEST_DYNAMIC_SELECTION_AVAILABLE` macro evaluates to false, but some of the test cases are defined outside of the if guard.

This PR moves the affected tests within the if macro.