### PR TITLE
Fix `dpl` namespace name to `oneapi::dpl`

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -500,7 +500,7 @@ struct __parallel_transform_scan_static_single_group_submitter<_Inclusive, _Elem
 
 #if _ONEDPL_SYCL_SUB_GROUP_LOAD_STORE_PRESENT
                     constexpr bool __can_use_subgroup_load_store =
-                        _IsFullGroup && dpl::__internal::__range_has_raw_ptr_iterator_v<::std::decay_t<_InRng>>;
+                        _IsFullGroup && oneapi::dpl::__internal::__range_has_raw_ptr_iterator_v<::std::decay_t<_InRng>>;
 #else
                     constexpr bool __can_use_subgroup_load_store = false;
 #endif
@@ -606,7 +606,7 @@ struct __parallel_copy_if_static_single_group_submitter<_Size, _ElemsPerItem, _W
 
 #if _ONEDPL_SYCL_SUB_GROUP_LOAD_STORE_PRESENT
                     constexpr bool __can_use_subgroup_load_store =
-                        _IsFullGroup && dpl::__internal::__range_has_raw_ptr_iterator_v<::std::decay_t<_InRng>>;
+                        _IsFullGroup && oneapi::dpl::__internal::__range_has_raw_ptr_iterator_v<::std::decay_t<_InRng>>;
 #else
                     constexpr bool __can_use_subgroup_load_store = false;
 #endif


### PR DESCRIPTION
In this PR we fix `dpl` namespace name to `oneapi::dpl` to be consistent with other places in the code.