### PR TITLE
Remove usm based `class __buffer_impl'

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -381,15 +381,12 @@ struct __local_buffer<sycl::buffer<::std::tuple<_T...>, __dim, _AllocT>>
     using type = sycl::buffer<oneapi::dpl::__internal::tuple<_T...>, __dim, _AllocT>;
 };
 
-template <typename _ExecutionPolicy, typename _T, typename _Container>
-class __buffer_impl;
-
 // impl for sycl::buffer<...>
-template <typename _ExecutionPolicy, typename _T, typename _BValueT, int __dim, typename _AllocT>
-class __buffer_impl<_ExecutionPolicy, _T, sycl::buffer<_BValueT, __dim, _AllocT>>
+template <typename _ExecutionPolicy, typename _Container>
+class __buffer_impl
 {
   private:
-    using __container_t = typename __local_buffer<sycl::buffer<_T, __dim, _AllocT>>::type;
+    using __container_t = typename __local_buffer<_Container>::type;
 
     __container_t __container;
 
@@ -456,8 +453,8 @@ struct __memobj_traits<_T*>
 
 } // namespace __internal
 
-template <typename _ExecutionPolicy, typename _T, typename _Container = sycl::buffer<_T, 1>>
-using __buffer = __internal::__buffer_impl<::std::decay_t<_ExecutionPolicy>, _T, _Container>;
+template <typename _ExecutionPolicy, typename _T>
+using __buffer = __internal::__buffer_impl<::std::decay_t<_ExecutionPolicy>, sycl::buffer<_T>>;
 
 template <typename T>
 struct __repacked_tuple

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -382,10 +382,11 @@ struct __local_buffer<sycl::buffer<::std::tuple<_T...>, __dim, _AllocT>>
 };
 
 // impl for sycl::buffer<...>
-template <typename _ExecutionPolicy, typename _Container>
+template <typename _ExecutionPolicy, typename _T>
 class __buffer_impl
 {
   private:
+    using _Container = sycl::buffer<_T>;
     using __container_t = typename __local_buffer<_Container>::type;
 
     __container_t __container;
@@ -454,7 +455,7 @@ struct __memobj_traits<_T*>
 } // namespace __internal
 
 template <typename _ExecutionPolicy, typename _T>
-using __buffer = __internal::__buffer_impl<::std::decay_t<_ExecutionPolicy>, sycl::buffer<_T>>;
+using __buffer = __internal::__buffer_impl<::std::decay_t<_ExecutionPolicy>, _T>;
 
 template <typename T>
 struct __repacked_tuple

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -438,38 +438,6 @@ struct __sycl_usm_alloc
     }
 };
 
-// impl for USM pointer
-template <typename _ExecutionPolicy, typename _T, typename _BValueT>
-class __buffer_impl<_ExecutionPolicy, _T, _BValueT*>
-{
-  private:
-    using __container_t = ::std::unique_ptr<_T, __sycl_usm_free<_ExecutionPolicy, _T>>;
-    using __alloc_t = sycl::usm::alloc;
-
-    __container_t __container;
-
-  public:
-    static_assert(::std::is_same_v<_ExecutionPolicy, ::std::decay_t<_ExecutionPolicy>>);
-
-    __buffer_impl(_ExecutionPolicy __exec, ::std::size_t __n_elements)
-        : __container(__sycl_usm_alloc<_ExecutionPolicy, _T, __alloc_t::shared>{__exec}(__n_elements),
-                      __sycl_usm_free<_ExecutionPolicy, _T>{__exec})
-    {
-    }
-
-    _T*
-    get() const
-    {
-        return __container.get();
-    }
-
-    _T*
-    get_buffer() const
-    {
-        return __container.get();
-    }
-};
-
 //-----------------------------------------------------------------------
 // type traits for objects granting access to some value objects
 //-----------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -386,8 +386,7 @@ template <typename _ExecutionPolicy, typename _T>
 class __buffer_impl
 {
   private:
-    using _Container = sycl::buffer<_T>;
-    using __container_t = typename __local_buffer<_Container>::type;
+    using __container_t = typename __local_buffer<sycl::buffer<_T>>::type;
 
     __container_t __container;
 


### PR DESCRIPTION
As discussed at https://github.com/oneapi-src/oneDPL/pull/1197#discussion_r1348717655
this `class __buffer_impl` based on USM memory is not required anymore as unused in oneDPL code and has been deleted in this PR:
```C++
// impl for USM pointer
template <typename _ExecutionPolicy, typename _T, typename _BValueT>
class __buffer_impl<_ExecutionPolicy, _T, _BValueT*>
{
    // ...
};
```

Also in this PR we simplify the definitions of `__internal::__buffer_impl` and `__buffer` [alias template](https://en.cppreference.com/w/cpp/language/type_alias):
```C++
// impl for sycl::buffer<...>
template <typename _ExecutionPolicy, typename _T>
class __buffer_impl
{
  private:
    using _Container = sycl::buffer<_T>;
    using __container_t = typename __local_buffer<_Container>::type;

    // ....
};

template <typename _ExecutionPolicy, typename _T>
using __buffer = __internal::__buffer_impl<::std::decay_t<_ExecutionPolicy>, _T>;
```
Please see [sycl::buffer](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#subsec:buffers) documentation for details.