### PR TITLE
Clarify naming of USM host or buffer storage

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -114,7 +114,8 @@ struct __parallel_transform_reduce_small_submitter<_Tp, __work_group_size, __ite
         const _Size __n_items = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __iters_per_work_item);
 
         const bool __use_usm = __use_USM_host_allocations(__exec.queue());
-        __storage __res_container = __storage<_ExecutionPolicy, _Tp>(__exec, __use_usm, 1);
+        __usm_host_or_buffer_storage __res_container =
+            __usm_host_or_buffer_storage<_ExecutionPolicy, _Tp>(__exec, __use_usm, 1);
 
         sycl::event __reduce_event = __exec.queue().submit([&, __n, __n_items](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...); // get an access to data under SYCL buffer
@@ -229,7 +230,8 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<_Tp, __work_group
         const _Size __n_items = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __iters_per_work_item);
 
         const bool __use_usm = __use_USM_host_allocations(__exec.queue());
-        __storage __res_container = __storage<_ExecutionPolicy, _Tp>(__exec, __use_usm, 1);
+        __usm_host_or_buffer_storage __res_container =
+            __usm_host_or_buffer_storage<_ExecutionPolicy, _Tp>(__exec, __use_usm, 1);
 
         __reduce_event = __exec.queue().submit([&, __n, __n_items](sycl::handler& __cgh) {
             __cgh.depends_on(__reduce_event);
@@ -325,7 +327,8 @@ struct __parallel_transform_reduce_impl
         // Create temporary global buffers to store temporary values
         sycl::buffer<_Tp> __temp(sycl::range<1>(2 * __n_groups));
         const bool __use_usm = __use_USM_host_allocations(__exec.queue());
-        __storage __res_container = __storage<_ExecutionPolicy, _Tp>(__exec, __use_usm, 1);
+        __usm_host_or_buffer_storage __res_container =
+            __usm_host_or_buffer_storage<_ExecutionPolicy, _Tp>(__exec, __use_usm, 1);
         // __is_first == true. Reduce over each work_group
         // __is_first == false. Reduce between work groups
         bool __is_first = true;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -510,7 +510,7 @@ template <typename _ContainerOrIterable>
 using __value_t = typename __internal::__memobj_traits<_ContainerOrIterable>::value_type;
 
 template <typename _T>
-struct __accessor
+struct __usm_host_or_buffer_accessor
 {
   private:
     using __accessor_t = sycl::accessor<_T, 1, sycl::access::mode::read_write, __dpl_sycl::__target_device,
@@ -522,8 +522,8 @@ struct __accessor
   public:
 // A buffer is used by default. Supporting compilers use the unified future on top of USM host memory or a buffer.
 #if _ONEDPL_SYCL_USM_HOST_PRESENT
-    __accessor(sycl::handler& __cgh, bool __u, ::std::shared_ptr<sycl::buffer<_T, 1>> __sycl_buf,
-               ::std::shared_ptr<_T> __usm_buf)
+    __usm_host_or_buffer_accessor(sycl::handler& __cgh, bool __u, ::std::shared_ptr<sycl::buffer<_T, 1>> __sycl_buf,
+                                  ::std::shared_ptr<_T> __usm_buf)
         : __usm(__u)
     {
         if (__usm)
@@ -532,8 +532,8 @@ struct __accessor
             __acc = sycl::accessor(*__sycl_buf, __cgh, sycl::read_write, __dpl_sycl::__no_init{});
     }
 #else
-    __accessor(sycl::handler& __cgh, bool, ::std::shared_ptr<sycl::buffer<_T, 1>> __sycl_buf,
-               ::std::shared_ptr<_T> __usm_buf)
+    __usm_host_or_buffer_accessor(sycl::handler& __cgh, bool, ::std::shared_ptr<sycl::buffer<_T, 1>> __sycl_buf,
+                                  ::std::shared_ptr<_T> __usm_buf)
         : __usm(false), __acc(sycl::accessor(*__sycl_buf, __cgh, sycl::read_write, __dpl_sycl::__no_init{}))
     {
     }
@@ -547,7 +547,7 @@ struct __accessor
 };
 
 template <typename _ExecutionPolicy, typename _T>
-struct __storage
+struct __usm_host_or_buffer_storage
 {
   private:
     using __sycl_buffer_t = sycl::buffer<_T, 1>;
@@ -556,7 +556,7 @@ struct __storage
     bool __usm;
 
   public:
-    __storage(_ExecutionPolicy& __exec, bool __u, ::std::size_t __n) : __usm(__u)
+    __usm_host_or_buffer_storage(_ExecutionPolicy& __exec, bool __u, ::std::size_t __n) : __usm(__u)
     {
         if (__usm)
         {
@@ -571,7 +571,7 @@ struct __storage
     auto
     __get_acc(sycl::handler& __cgh)
     {
-        return __accessor<_T>(__cgh, __usm, __sycl_buf, __usm_buf);
+        return __usm_host_or_buffer_accessor<_T>(__cgh, __usm, __sycl_buf, __usm_buf);
     }
 
     auto
@@ -587,7 +587,7 @@ struct __storage
     }
 };
 
-//A contract for future class: <sycl::event or other event, a value, sycl::buffers..., or __storage (USM or buffer)>
+//A contract for future class: <sycl::event or other event, a value, sycl::buffers..., or __usm_host_or_buffer_storage>
 //Impl details: inheritance (private) instead of aggregation for enabling the empty base optimization.
 template <typename _Event, typename... _Args>
 class __future : private std::tuple<_Args...>
@@ -604,7 +604,7 @@ class __future : private std::tuple<_Args...>
 
     template <typename _ExecutionPolicy, typename _T>
     constexpr auto
-    __wait_and_get_value(__storage<_ExecutionPolicy, _T>& __buf)
+    __wait_and_get_value(__usm_host_or_buffer_storage<_ExecutionPolicy, _T>& __buf)
     {
         // Explicit wait in case of USM memory. Buffer accessors are synchronous.
         if (__buf.__get_usm())


### PR DESCRIPTION
Discussions with @SergeyKopienko and changes in #1197 brought up the ambiguity of the naming of the `__storage` struct that supports USM host memory or a buffer. This feature was added in #874. This PR proposes to rename `__storage` to `__usm_host_or_buffer_storage` to clarify what it entails. Consecutively, the used `__accessor` struct should be renamed to `__usm_host_or_buffer_accessor`. @SergeyKopienko proposed `__kernel_result_storage` as an alternative name to clarify its current use as a small return storage. We are open to other suggestions as well.