### PR TITLE
Use SYCL_IMPLEMENTATION_INTEL macro

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -30,9 +30,9 @@ namespace dpl
 namespace unseq_backend
 {
 
-#if _USE_GROUP_ALGOS && _ONEDPL_SYCL_INTEL_COMPILER
+#if _USE_GROUP_ALGOS && defined(SYCL_IMPLEMENTATION_INTEL)
 //This optimization depends on Intel(R) oneAPI DPC++ Compiler implementation such as support of binary operators from std namespace.
-//We need to use _ONEDPL_SYCL_INTEL_COMPILER macro as a guard.
+//We need to use defined(SYCL_IMPLEMENTATION_INTEL) macro as a guard.
 
 //TODO: To change __has_known_identity implementation as soon as the Intel(R) oneAPI DPC++ Compiler implementation issues related to
 //std::multiplies, std::bit_or, std::bit_and and std::bit_xor operations will be fixed.
@@ -60,12 +60,12 @@ using __has_known_identity =
                            ::std::is_same<::std::decay_t<_BinaryOp>, __dpl_sycl::__plus<void>>>>;
 #    endif //_ONEDPL_LIBSYCL_VERSION >= 50200
 
-#else //_USE_GROUP_ALGOS && _ONEDPL_SYCL_INTEL_COMPILER
+#else //_USE_GROUP_ALGOS && defined(SYCL_IMPLEMENTATION_INTEL)
 
 template <typename _BinaryOp, typename _Tp>
 using __has_known_identity = std::false_type;
 
-#endif //_USE_GROUP_ALGOS && _ONEDPL_SYCL_INTEL_COMPILER
+#endif //_USE_GROUP_ALGOS && defined(SYCL_IMPLEMENTATION_INTEL)
 
 template <typename _BinaryOp, typename _Tp>
 struct __known_identity_for_plus

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -299,7 +299,7 @@
 
 // When compile with Intel(R) oneAPI DPC++ Compiler macro is on
 // We need this macro to use compiler specific implementation of SYCL
-#if defined(SYCL_IMPLEMENTATION_INTEL)
+#if defined(__INTEL_LLVM_COMPILER) && defined(SYCL_LANGUAGE_VERSION)
 #    define _ONEDPL_SYCL_INTEL_COMPILER 1
 #endif
 

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -297,12 +297,6 @@
 
 #define _ONEDPL_BUILT_IN_STABLE_NAME_PRESENT __has_builtin(__builtin_sycl_unique_stable_name)
 
-// When compile with Intel(R) oneAPI DPC++ Compiler macro is on
-// We need this macro to use compiler specific implementation of SYCL
-#if defined(__INTEL_LLVM_COMPILER) && defined(SYCL_LANGUAGE_VERSION)
-#    define _ONEDPL_SYCL_INTEL_COMPILER 1
-#endif
-
 #if defined(_MSC_VER) && __INTEL_LLVM_COMPILER < 20240100
 #    define _ONEDPL_ICPX_OMP_SIMD_DESTROY_WINDOWS_BROKEN 1
 #else

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -299,7 +299,7 @@
 
 // When compile with Intel(R) oneAPI DPC++ Compiler macro is on
 // We need this macro to use compiler specific implementation of SYCL
-#if defined(__INTEL_LLVM_COMPILER) && defined(SYCL_LANGUAGE_VERSION)
+#if defined(SYCL_IMPLEMENTATION_INTEL)
 #    define _ONEDPL_SYCL_INTEL_COMPILER 1
 #endif
 


### PR DESCRIPTION
This PR updates how `_ONEDPL_SYCL_INTEL_COMPILER` is not defined for the open source DPC++ compiler this means that for `has_known_identity` incorrectly evaluates to false in all cases.

I propose using the `SYCL_IMPLEMENTATION_INTEL` macro instead of `_ONEDPL_SYCL_INTEL_COMPILER` which is defined in the SYCL specification and is used by the open source compiler. This change is not for performance reasons but instead having the expected and correct code path used on opensource DPC++.