### PR TITLE
Refactor USM host or buffer storage

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -114,7 +114,7 @@ struct __parallel_transform_reduce_small_submitter<_Tp, __work_group_size, __ite
         const _Size __n_items = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __iters_per_work_item);
 
         const bool __use_usm = __use_USM_host_allocations(__exec.queue());
-        __storage __res_container = __storage<_ExecutionPolicy, _Tp>(__exec, __use_usm, 1);
+        __storage<_ExecutionPolicy, _Tp> __res_container(__exec, __use_usm, 1);
 
         sycl::event __reduce_event = __exec.queue().submit([&, __n, __n_items](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...); // get an access to data under SYCL buffer
@@ -229,7 +229,7 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<_Tp, __work_group
         const _Size __n_items = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __iters_per_work_item);
 
         const bool __use_usm = __use_USM_host_allocations(__exec.queue());
-        __storage __res_container = __storage<_ExecutionPolicy, _Tp>(__exec, __use_usm, 1);
+        __storage<_ExecutionPolicy, _Tp> __res_container(__exec, __use_usm, 1);
 
         __reduce_event = __exec.queue().submit([&, __n, __n_items](sycl::handler& __cgh) {
             __cgh.depends_on(__reduce_event);
@@ -325,7 +325,7 @@ struct __parallel_transform_reduce_impl
         // Create temporary global buffers to store temporary values
         sycl::buffer<_Tp> __temp(sycl::range<1>(2 * __n_groups));
         const bool __use_usm = __use_USM_host_allocations(__exec.queue());
-        __storage __res_container = __storage<_ExecutionPolicy, _Tp>(__exec, __use_usm, 1);
+        __storage<_ExecutionPolicy, _Tp> __res_container(__exec, __use_usm, 1);
         // __is_first == true. Reduce over each work_group
         // __is_first == false. Reduce between work groups
         bool __is_first = true;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -114,7 +114,7 @@ struct __parallel_transform_reduce_small_submitter<_Tp, __work_group_size, __ite
         const _Size __n_items = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __iters_per_work_item);
 
         const bool __use_usm = __use_USM_host_allocations(__exec.queue());
-        __storage<_ExecutionPolicy, _Tp> __res_container(__exec, __use_usm, 1);
+        __storage __res_container = __storage<_ExecutionPolicy, _Tp>(__exec, __use_usm, 1);
 
         sycl::event __reduce_event = __exec.queue().submit([&, __n, __n_items](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...); // get an access to data under SYCL buffer
@@ -129,7 +129,7 @@ struct __parallel_transform_reduce_small_submitter<_Tp, __work_group_size, __ite
                 });
         });
 
-        return __future(__reduce_event, ::std::move(__res_container));
+        return __future(__reduce_event, __res_container);
     }
 }; // struct __parallel_transform_reduce_small_submitter
 
@@ -229,7 +229,7 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<_Tp, __work_group
         const _Size __n_items = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __iters_per_work_item);
 
         const bool __use_usm = __use_USM_host_allocations(__exec.queue());
-        __storage<_ExecutionPolicy, _Tp> __res_container(__exec, __use_usm, 1);
+        __storage __res_container = __storage<_ExecutionPolicy, _Tp>(__exec, __use_usm, 1);
 
         __reduce_event = __exec.queue().submit([&, __n, __n_items](sycl::handler& __cgh) {
             __cgh.depends_on(__reduce_event);
@@ -247,7 +247,7 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<_Tp, __work_group
                 });
         });
 
-        return __future(__reduce_event, ::std::move(__res_container));
+        return __future(__reduce_event, __res_container);
     }
 }; // struct __parallel_transform_reduce_work_group_kernel_submitter
 
@@ -325,7 +325,7 @@ struct __parallel_transform_reduce_impl
         // Create temporary global buffers to store temporary values
         sycl::buffer<_Tp> __temp(sycl::range<1>(2 * __n_groups));
         const bool __use_usm = __use_USM_host_allocations(__exec.queue());
-        __storage<_ExecutionPolicy, _Tp> __res_container(__exec, __use_usm, 1);
+        __storage __res_container = __storage<_ExecutionPolicy, _Tp>(__exec, __use_usm, 1);
         // __is_first == true. Reduce over each work_group
         // __is_first == false. Reduce between work groups
         bool __is_first = true;
@@ -388,7 +388,7 @@ struct __parallel_transform_reduce_impl
             __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __size_per_work_group);
         } while (__n > 1);
 
-        return __future(__reduce_event, ::std::move(__res_container));
+        return __future(__reduce_event, __res_container);
     }
 }; // struct __parallel_transform_reduce_impl
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -113,9 +113,7 @@ struct __parallel_transform_reduce_small_submitter<_Tp, __work_group_size, __ite
 
         const _Size __n_items = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __iters_per_work_item);
 
-        const bool __use_usm = __use_USM_host_allocations(__exec.queue());
-        __usm_host_or_buffer_storage __res_container =
-            __usm_host_or_buffer_storage<_ExecutionPolicy, _Tp>(__exec, __use_usm, 1);
+        __usm_host_or_buffer_storage __res_container = __usm_host_or_buffer_storage<_ExecutionPolicy, _Tp>(__exec, 1);
 
         sycl::event __reduce_event = __exec.queue().submit([&, __n, __n_items](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...); // get an access to data under SYCL buffer
@@ -229,9 +227,7 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<_Tp, __work_group
         }
         const _Size __n_items = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __iters_per_work_item);
 
-        const bool __use_usm = __use_USM_host_allocations(__exec.queue());
-        __usm_host_or_buffer_storage __res_container =
-            __usm_host_or_buffer_storage<_ExecutionPolicy, _Tp>(__exec, __use_usm, 1);
+        __usm_host_or_buffer_storage __res_container = __usm_host_or_buffer_storage<_ExecutionPolicy, _Tp>(__exec, 1);
 
         __reduce_event = __exec.queue().submit([&, __n, __n_items](sycl::handler& __cgh) {
             __cgh.depends_on(__reduce_event);
@@ -326,9 +322,7 @@ struct __parallel_transform_reduce_impl
 
         // Create temporary global buffers to store temporary values
         sycl::buffer<_Tp> __temp(sycl::range<1>(2 * __n_groups));
-        const bool __use_usm = __use_USM_host_allocations(__exec.queue());
-        __usm_host_or_buffer_storage __res_container =
-            __usm_host_or_buffer_storage<_ExecutionPolicy, _Tp>(__exec, __use_usm, 1);
+        __usm_host_or_buffer_storage __res_container = __usm_host_or_buffer_storage<_ExecutionPolicy, _Tp>(__exec, 1);
         // __is_first == true. Reduce over each work_group
         // __is_first == false. Reduce between work groups
         bool __is_first = true;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -129,7 +129,7 @@ struct __parallel_transform_reduce_small_submitter<_Tp, __work_group_size, __ite
                 });
         });
 
-        return __future(__reduce_event, __res_container);
+        return __future(__reduce_event, ::std::move(__res_container));
     }
 }; // struct __parallel_transform_reduce_small_submitter
 
@@ -247,7 +247,7 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<_Tp, __work_group
                 });
         });
 
-        return __future(__reduce_event, __res_container);
+        return __future(__reduce_event, ::std::move(__res_container));
     }
 }; // struct __parallel_transform_reduce_work_group_kernel_submitter
 
@@ -389,7 +389,7 @@ struct __parallel_transform_reduce_impl
             __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __size_per_work_group);
         } while (__n > 1);
 
-        return __future(__reduce_event, __res_container);
+        return __future(__reduce_event, ::std::move(__res_container));
     }
 }; // struct __parallel_transform_reduce_impl
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -113,7 +113,7 @@ struct __parallel_transform_reduce_small_submitter<_Tp, __work_group_size, __ite
 
         const _Size __n_items = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __iters_per_work_item);
 
-        __usm_host_or_buffer_storage __res_container = __usm_host_or_buffer_storage<_ExecutionPolicy, _Tp>(__exec, 1);
+        __usm_host_or_buffer_storage<_ExecutionPolicy, _Tp> __res_container(__exec, 1);
 
         sycl::event __reduce_event = __exec.queue().submit([&, __n, __n_items](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...); // get an access to data under SYCL buffer
@@ -227,7 +227,7 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<_Tp, __work_group
         }
         const _Size __n_items = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __iters_per_work_item);
 
-        __usm_host_or_buffer_storage __res_container = __usm_host_or_buffer_storage<_ExecutionPolicy, _Tp>(__exec, 1);
+        __usm_host_or_buffer_storage<_ExecutionPolicy, _Tp> __res_container(__exec, 1);
 
         __reduce_event = __exec.queue().submit([&, __n, __n_items](sycl::handler& __cgh) {
             __cgh.depends_on(__reduce_event);
@@ -322,7 +322,7 @@ struct __parallel_transform_reduce_impl
 
         // Create temporary global buffers to store temporary values
         sycl::buffer<_Tp> __temp(sycl::range<1>(2 * __n_groups));
-        __usm_host_or_buffer_storage __res_container = __usm_host_or_buffer_storage<_ExecutionPolicy, _Tp>(__exec, 1);
+        __usm_host_or_buffer_storage<_ExecutionPolicy, _Tp> __res_container(__exec, 1);
         // __is_first == true. Reduce over each work_group
         // __is_first == false. Reduce between work groups
         bool __is_first = true;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -381,8 +381,7 @@ struct __parallel_transform_reduce_impl
                         }
                     });
             });
-            if (__is_first)
-                __is_first = false;
+            __is_first = false;
             ::std::swap(__offset_1, __offset_2);
             __n = __n_groups;
             __n_items = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __iters_per_work_item);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -553,7 +553,7 @@ struct __usm_host_or_buffer_storage
     }
 
     _T
-    __get_value(size_t idx = 0)
+    __get_value(size_t idx = 0) const
     {
         return __usm ? *(__usm_buf.get() + idx) : __sycl_buf->get_host_access(sycl::read_only)[idx];
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -516,21 +516,20 @@ struct __storage
 {
   private:
     using __sycl_buffer_t = sycl::buffer<_T, 1>;
+    bool __usm;
     ::std::shared_ptr<__sycl_buffer_t> __sycl_buf;
     ::std::shared_ptr<_T> __usm_buf;
-    bool __usm;
 
   public:
-    __storage(_ExecutionPolicy& __exec, bool __u, ::std::size_t __n) : __usm(__u)
+    __storage(_ExecutionPolicy& __exec, bool __u, ::std::size_t __n)
+        : __usm(__u),
+          __usm_buf(__u ? std::shared_ptr<_T>(
+                               __internal::__sycl_usm_alloc<_ExecutionPolicy, _T, sycl::usm::alloc::host>{__exec}(__n),
+                              __internal::__sycl_usm_free<_ExecutionPolicy, _T>{__exec})
+                        : decltype(__usm_buf){}),
+          __sycl_buf(__u ? decltype(__sycl_buf){}
+                         : ::std::make_shared<__sycl_buffer_t>(__sycl_buffer_t(__n)))
     {
-        if (__usm)
-        {
-            __usm_buf = std::shared_ptr<_T>(
-                __internal::__sycl_usm_alloc<_ExecutionPolicy, _T, sycl::usm::alloc::host>{__exec}(__n),
-                __internal::__sycl_usm_free<_ExecutionPolicy, _T>{__exec});
-        }
-        else
-            __sycl_buf = ::std::make_shared<__sycl_buffer_t>(__sycl_buffer_t(__n));
     }
 
     auto

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -451,7 +451,7 @@ struct __accessor_impl
 #if _ONEDPL_SYCL_USM_HOST_PRESENT
     __accessor_impl(sycl::handler& __cgh, bool __u, sycl::buffer<_T, 1>* __sycl_buf, _T* __usm_buf)
         : __usm(__u), __ptr(__u ? __usm_buf : nullptr),
-          __acc(__u ? decltype(__acc) : sycl::accessor(*__sycl_buf, __cgh, sycl::read_write, __dpl_sycl::__no_init{}))
+          __acc(__u ? decltype(__acc){} : sycl::accessor(*__sycl_buf, __cgh, sycl::read_write, __dpl_sycl::__no_init{}))
     {
     }
 #else

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -489,16 +489,15 @@ struct __accessor
 // A buffer is used by default. Supporting compilers use the unified future on top of USM host memory or a buffer.
 #if _ONEDPL_SYCL_USM_HOST_PRESENT
     __accessor(sycl::handler& __cgh, bool __u, sycl::buffer<_T, 1>* __sycl_buf, _T* __usm_buf)
-        : __usm(__u)
+        : __usm(__u),
+          __ptr(__u ? __usm_buf : nullptr),
+          __acc(__u ? decltype(__acc) 
+                    : sycl::accessor(*__sycl_buf, __cgh, sycl::read_write, __dpl_sycl::__no_init{}))
     {
-        if (__usm)
-            __ptr = __usm_buf;
-        else
-            __acc = sycl::accessor(*__sycl_buf, __cgh, sycl::read_write, __dpl_sycl::__no_init{});
     }
 #else
     __accessor(sycl::handler& __cgh, bool, sycl::buffer<_T, 1>* __sycl_buf, _T* __usm_buf)
-        : __usm(false), __acc(sycl::accessor(*__sycl_buf, __cgh, sycl::read_write, __dpl_sycl::__no_init{}))
+        : __acc(sycl::accessor(*__sycl_buf, __cgh, sycl::read_write, __dpl_sycl::__no_init{}))
     {
     }
 #endif

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -480,25 +480,24 @@ struct __accessor
   private:
     using __accessor_t = sycl::accessor<_T, 1, sycl::access::mode::read_write, __dpl_sycl::__target_device,
                                         sycl::access::placeholder::false_t>;
-    __accessor_t __acc;
-    _T* __ptr = nullptr;
+
     bool __usm = false;
+    _T* __ptr = nullptr;
+    __accessor_t __acc;
 
   public:
 // A buffer is used by default. Supporting compilers use the unified future on top of USM host memory or a buffer.
 #if _ONEDPL_SYCL_USM_HOST_PRESENT
-    __accessor(sycl::handler& __cgh, bool __u, ::std::shared_ptr<sycl::buffer<_T, 1>> __sycl_buf,
-               ::std::shared_ptr<_T> __usm_buf)
+    __accessor(sycl::handler& __cgh, bool __u, sycl::buffer<_T, 1>* __sycl_buf, _T* __usm_buf)
         : __usm(__u)
     {
         if (__usm)
-            __ptr = __usm_buf.get();
+            __ptr = __usm_buf;
         else
             __acc = sycl::accessor(*__sycl_buf, __cgh, sycl::read_write, __dpl_sycl::__no_init{});
     }
 #else
-    __accessor(sycl::handler& __cgh, bool, ::std::shared_ptr<sycl::buffer<_T, 1>> __sycl_buf,
-               ::std::shared_ptr<_T> __usm_buf)
+    __accessor(sycl::handler& __cgh, bool, sycl::buffer<_T, 1>* __sycl_buf, _T* __usm_buf)
         : __usm(false), __acc(sycl::accessor(*__sycl_buf, __cgh, sycl::read_write, __dpl_sycl::__no_init{}))
     {
     }
@@ -535,7 +534,7 @@ struct __storage
     auto
     __get_acc(sycl::handler& __cgh)
     {
-        return __accessor<_T>(__cgh, __usm, __sycl_buf, __usm_buf);
+        return __accessor<_T>(__cgh, __usm, __sycl_buf.get(), __usm_buf.get());
     }
 
     auto

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -516,8 +516,8 @@ struct __storage
   private:
     using __sycl_buffer_t = sycl::buffer<_T, 1>;
     bool __usm;
-    ::std::shared_ptr<__sycl_buffer_t> __sycl_buf;
     ::std::shared_ptr<_T> __usm_buf;
+    ::std::shared_ptr<__sycl_buffer_t> __sycl_buf;
 
   public:
     __storage(_ExecutionPolicy& __exec, bool __u, ::std::size_t __n)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -435,78 +435,6 @@ struct __sycl_usm_alloc
     }
 };
 
-template <typename _T>
-struct __accessor
-{
-  private:
-    using __accessor_t = sycl::accessor<_T, 1, sycl::access::mode::read_write, __dpl_sycl::__target_device,
-                                        sycl::access::placeholder::false_t>;
-
-    bool __usm = false;
-    _T* __ptr = nullptr;
-    __accessor_t __acc;
-
-  public:
-// A buffer is used by default. Supporting compilers use the unified future on top of USM host memory or a buffer.
-#if _ONEDPL_SYCL_USM_HOST_PRESENT
-    __accessor(sycl::handler& __cgh, bool __u, sycl::buffer<_T, 1>* __sycl_buf, _T* __usm_buf)
-        : __usm(__u), __ptr(__u ? __usm_buf : nullptr),
-          __acc(__u ? decltype(__acc){} : sycl::accessor(*__sycl_buf, __cgh, sycl::read_write, __dpl_sycl::__no_init{}))
-    {
-    }
-#else
-    __accessor(sycl::handler& __cgh, bool, sycl::buffer<_T, 1>* __sycl_buf, _T* __usm_buf)
-        : __acc(sycl::accessor(*__sycl_buf, __cgh, sycl::read_write, __dpl_sycl::__no_init{}))
-    {
-    }
-#endif
-
-    auto
-    __get_pointer() const // should be cached within a kernel
-    {
-        return __usm ? __ptr : &__acc[0];
-    }
-};
-
-template <typename _ExecutionPolicy, typename _T>
-class __storage_impl
-{
-  private:
-    using __sycl_buffer_t = sycl::buffer<_T, 1>;
-    bool __usm;
-    ::std::shared_ptr<_T> __usm_buf;
-    ::std::shared_ptr<__sycl_buffer_t> __sycl_buf;
-
-  public:
-    __storage_impl(_ExecutionPolicy& __exec, bool __u, ::std::size_t __n)
-        : __usm(__u),
-          __usm_buf(__u ? std::shared_ptr<_T>(
-                              __internal::__sycl_usm_alloc<_ExecutionPolicy, _T, sycl::usm::alloc::host>{__exec}(__n),
-                              __internal::__sycl_usm_free<_ExecutionPolicy, _T>{__exec})
-                        : decltype(__usm_buf){}),
-          __sycl_buf(__u ? decltype(__sycl_buf){} : ::std::make_shared<__sycl_buffer_t>(__sycl_buffer_t(__n)))
-    {
-    }
-
-    auto
-    __get_acc(sycl::handler& __cgh)
-    {
-        return __accessor<_T>(__cgh, __usm, __sycl_buf.get(), __usm_buf.get());
-    }
-
-    auto
-    __get_value(size_t idx = 0)
-    {
-        return __usm ? *(__usm_buf.get() + idx) : __sycl_buf->get_host_access(sycl::read_only)[idx];
-    }
-
-    bool
-    __get_usm() const
-    {
-        return __usm;
-    }
-};
-
 //-----------------------------------------------------------------------
 // type traits for objects granting access to some value objects
 //-----------------------------------------------------------------------
@@ -546,8 +474,76 @@ using __repacked_tuple_t = typename __repacked_tuple<T>::type;
 template <typename _ContainerOrIterable>
 using __value_t = typename __internal::__memobj_traits<_ContainerOrIterable>::value_type;
 
+template <typename _T>
+struct __accessor
+{
+  private:
+    using __accessor_t = sycl::accessor<_T, 1, sycl::access::mode::read_write, __dpl_sycl::__target_device,
+                                        sycl::access::placeholder::false_t>;
+
+    bool __usm = false;
+    _T* __ptr = nullptr;
+    __accessor_t __acc;
+
+  public:
+    // Buffer accessor
+    __accessor(sycl::handler& __cgh, sycl::buffer<_T, 1>* __sycl_buf)
+        : __usm(false), __acc(sycl::accessor(*__sycl_buf, __cgh, sycl::read_write, __dpl_sycl::__no_init{}))
+    {
+    }
+
+    // USM pointer
+    __accessor(sycl::handler& __cgh, _T* __usm_buf) : __usm(true), __ptr(__usm_buf) {}
+
+    auto
+    __get_pointer() const // should be cached within a kernel
+    {
+        return __usm ? __ptr : &__acc[0];
+    }
+};
+
 template <typename _ExecutionPolicy, typename _T>
-using __storage = __internal::__storage_impl<::std::decay_t<_ExecutionPolicy>, _T>;
+struct __storage
+{
+  private:
+    using __sycl_buffer_t = sycl::buffer<_T, 1>;
+    bool __usm;
+    ::std::shared_ptr<_T> __usm_buf;
+    ::std::shared_ptr<__sycl_buffer_t> __sycl_buf;
+
+  public:
+    __storage(_ExecutionPolicy& __exec, bool __u, ::std::size_t __n) : __usm(__u)
+    {
+        if (__usm)
+        {
+            __usm_buf = std::shared_ptr<_T>(
+                __internal::__sycl_usm_alloc<_ExecutionPolicy, _T, sycl::usm::alloc::host>{__exec}(__n),
+                __internal::__sycl_usm_free<_ExecutionPolicy, _T>{__exec});
+        }
+        else
+        {
+            __sycl_buf = ::std::make_shared<__sycl_buffer_t>(__sycl_buffer_t(__n));
+        }
+    }
+
+    auto
+    __get_acc(sycl::handler& __cgh)
+    {
+        return __usm ? __accessor<_T>(__cgh, __usm_buf.get()) : __accessor<_T>(__cgh, __sycl_buf.get());
+    }
+
+    auto
+    __get_value(size_t idx = 0)
+    {
+        return __usm ? *(__usm_buf.get() + idx) : __sycl_buf->get_host_access(sycl::read_only)[idx];
+    }
+
+    bool
+    __get_usm() const
+    {
+        return __usm;
+    }
+};
 
 //A contract for future class: <sycl::event or other event, a value, sycl::buffers..., or __storage (USM or buffer)>
 //Impl details: inheritance (private) instead of aggregation for enabling the empty base optimization.
@@ -566,7 +562,7 @@ class __future : private std::tuple<_Args...>
 
     template <typename _ExecutionPolicy, typename _T>
     constexpr auto
-    __wait_and_get_value(__internal::__storage_impl<_ExecutionPolicy, _T>& __buf)
+    __wait_and_get_value(__storage<_ExecutionPolicy, _T>& __buf)
     {
         // Explicit wait in case of USM memory. Buffer accessors are synchronous.
         if (__buf.__get_usm())

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -436,7 +436,7 @@ struct __sycl_usm_alloc
 };
 
 template <typename _T>
-struct __accessor_impl
+struct __accessor
 {
   private:
     using __accessor_t = sycl::accessor<_T, 1, sycl::access::mode::read_write, __dpl_sycl::__target_device,
@@ -449,13 +449,13 @@ struct __accessor_impl
   public:
 // A buffer is used by default. Supporting compilers use the unified future on top of USM host memory or a buffer.
 #if _ONEDPL_SYCL_USM_HOST_PRESENT
-    __accessor_impl(sycl::handler& __cgh, bool __u, sycl::buffer<_T, 1>* __sycl_buf, _T* __usm_buf)
+    __accessor(sycl::handler& __cgh, bool __u, sycl::buffer<_T, 1>* __sycl_buf, _T* __usm_buf)
         : __usm(__u), __ptr(__u ? __usm_buf : nullptr),
           __acc(__u ? decltype(__acc){} : sycl::accessor(*__sycl_buf, __cgh, sycl::read_write, __dpl_sycl::__no_init{}))
     {
     }
 #else
-    __accessor_impl(sycl::handler& __cgh, bool, sycl::buffer<_T, 1>* __sycl_buf, _T* __usm_buf)
+    __accessor(sycl::handler& __cgh, bool, sycl::buffer<_T, 1>* __sycl_buf, _T* __usm_buf)
         : __acc(sycl::accessor(*__sycl_buf, __cgh, sycl::read_write, __dpl_sycl::__no_init{}))
     {
     }
@@ -491,7 +491,7 @@ class __storage_impl
     auto
     __get_acc(sycl::handler& __cgh)
     {
-        return __accessor_impl<_T>(__cgh, __usm, __sycl_buf.get(), __usm_buf.get());
+        return __accessor<_T>(__cgh, __usm, __sycl_buf.get(), __usm_buf.get());
     }
 
     auto


### PR DESCRIPTION
This PR targets to refactor the USM host or buffer storage used as a return type for the reduction. This was introduced in #874. This simplifies the `__storage` and `__accessor` classes and moves them in the `__internal` namespace to align with other helpers. These changes are based on input and discussions with @SergeyKopienko.