### PR TITLE
Limit _PSTL_ICPX_OMP_SIMD_DESTROY_WINDOWS_BROKEN

### DIFF
--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -303,9 +303,7 @@
 #    define _ONEDPL_SYCL_INTEL_COMPILER 1
 #endif
 
-// This 'broken' macro should be defined to 1 till the compiler processes 'omp simd' code correctly
-// TODO: limit the macro with a specific version once the issue is fixed
-#if defined(_MSC_VER) && __INTEL_LLVM_COMPILER
+#if defined(_MSC_VER) && __INTEL_LLVM_COMPILER < 20240100
 #    define _ONEDPL_ICPX_OMP_SIMD_DESTROY_WINDOWS_BROKEN 1
 #else
 #    define _ONEDPL_ICPX_OMP_SIMD_DESTROY_WINDOWS_BROKEN 0

--- a/include/oneapi/dpl/pstl/pstl_config.h
+++ b/include/oneapi/dpl/pstl/pstl_config.h
@@ -176,9 +176,7 @@
 // broken macros
 #define _PSTL_ICC_18_OMP_SIMD_BROKEN (__INTEL_COMPILER == 1800)
 
-// This 'broken' macro should be defined to 1 till the compiler processes 'omp simd' code correctly
-// TODO: limit the macro with a specific version once the issue is fixed
-#if defined(_MSC_VER) && __INTEL_LLVM_COMPILER
+#if defined(_MSC_VER) && __INTEL_LLVM_COMPILER < 20240100
 #    define _PSTL_ICPX_OMP_SIMD_DESTROY_WINDOWS_BROKEN 1
 #else
 #    define _PSTL_ICPX_OMP_SIMD_DESTROY_WINDOWS_BROKEN 0


### PR DESCRIPTION
It's been verified that the issue (`icx: error: clang frontend command failed...`) does not reproduce with the most recent internal build for the upcoming release of Intel(R) oneAPI DPC++/C++ Compiler.