### PR TITLE
std::reduce new known limitation

### DIFF
--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -53,8 +53,7 @@ New in This Release
   with ``unseq`` or ``par_unseq`` policy when compiled by Intel® oneAPI DPC++/C++ Compiler
   with ``-fiopenmp``, ``-fiopenmp-simd``, ``-qopenmp``, ``-qopenmp-simd`` options on Linux.
   To avoid the issue, pass ``-fopenmp`` or ``-fopenmp-simd`` option instead.
-- Incorrect results may be produced with group reduce operation through ``reduce``, ``transform_reduce``
-  for 64-bit data types and ``std::multiplies``, ``sycl::multiplies`` operations on GPUs with the Intel® C++ Compiler 2021.3
+- Incorrect results may be produced by ``reduce`` and ``transform_reduce`` with 64-bit types and ``std::multiplies``, ``sycl::multiplies`` operations when compiled on Intel® C++ Compiler 2021.3 and newer and executed on GPU devices. 
 
 Existing Issues
 ^^^^^^^^^^^^^^^

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -96,7 +96,7 @@ New in This Release
 - Incorrect results may be produced with in-place scans using ``unseq`` and ``par_unseq`` policies on
   CPUs with the Intel® C++ Compiler 2021.8.
 - Incorrect results may be produced with group reduce operation through ``std::reduce``
-  for 64-bit data types and `std::multiplies`` operation on GPUs with the Intel® C++ Compiler 2023.2
+  for 64-bit data types and `std::multiplies`` operation on GPUs with the Intel® C++ Compiler 2021.3
 
 Existing Issues
 ^^^^^^^^^^^^^^^

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -54,7 +54,7 @@ New in This Release
   with ``-fiopenmp``, ``-fiopenmp-simd``, ``-qopenmp``, ``-qopenmp-simd`` options on Linux.
   To avoid the issue, pass ``-fopenmp`` or ``-fopenmp-simd`` option instead.
 - Incorrect results may be produced with group reduce operation through ``reduce``, ``transform_reduce``
-  for 64-bit data types and ``std::multiplies`` operation on GPUs with the Intel® C++ Compiler 2021.3
+  for 64-bit data types and ``std::multiplies``, ``sycl::multiplies`` operation on GPUs with the Intel® C++ Compiler 2021.3
 
 Existing Issues
 ^^^^^^^^^^^^^^^

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -53,7 +53,7 @@ New in This Release
   with ``unseq`` or ``par_unseq`` policy when compiled by Intel® oneAPI DPC++/C++ Compiler
   with ``-fiopenmp``, ``-fiopenmp-simd``, ``-qopenmp``, ``-qopenmp-simd`` options on Linux.
   To avoid the issue, pass ``-fopenmp`` or ``-fopenmp-simd`` option instead.
-- Incorrect results may be produced with group reduce operation through ``std::reduce``
+- Incorrect results may be produced with group reduce operation through ``reduce``
   for 64-bit data types and ``std::multiplies`` operation on GPUs with the Intel® C++ Compiler 2021.3
 
 Existing Issues

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -54,7 +54,7 @@ New in This Release
   with ``-fiopenmp``, ``-fiopenmp-simd``, ``-qopenmp``, ``-qopenmp-simd`` options on Linux.
   To avoid the issue, pass ``-fopenmp`` or ``-fopenmp-simd`` option instead.
 - Incorrect results may be produced with group reduce operation through ``std::reduce``
-  for 64-bit data types and `std::multiplies`` operation on GPUs with the Intel® C++ Compiler 2021.3
+  for 64-bit data types and ``std::multiplies`` operation on GPUs with the Intel® C++ Compiler 2021.3
 
 Existing Issues
 ^^^^^^^^^^^^^^^

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -53,7 +53,8 @@ New in This Release
   with ``unseq`` or ``par_unseq`` policy when compiled by Intel® oneAPI DPC++/C++ Compiler
   with ``-fiopenmp``, ``-fiopenmp-simd``, ``-qopenmp``, ``-qopenmp-simd`` options on Linux.
   To avoid the issue, pass ``-fopenmp`` or ``-fopenmp-simd`` option instead.
-- Incorrect results may be produced by ``reduce`` and ``transform_reduce`` with 64-bit types and ``std::multiplies``, ``sycl::multiplies`` operations when compiled on Intel® C++ Compiler 2021.3 and newer and executed on GPU devices. 
+- Incorrect results may be produced by ``reduce`` and ``transform_reduce`` with 64-bit types and ``std::multiplies``,
+  ``sycl::multiplies`` operations when compiled by Intel® C++ Compiler 2021.3 and newer and executed on GPU devices. 
 
 Existing Issues
 ^^^^^^^^^^^^^^^

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -95,6 +95,8 @@ New in This Release
 ^^^^^^^^^^^^^^^^^^^
 - Incorrect results may be produced with in-place scans using ``unseq`` and ``par_unseq`` policies on
   CPUs with the Intel® C++ Compiler 2021.8.
+- Incorrect results may be produced with group reduce operation through ``std::reduce``
+  for 64-bit data types and `std::multiplies`` operation on GPUs with the Intel® C++ Compiler 2023.2
 
 Existing Issues
 ^^^^^^^^^^^^^^^

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -53,7 +53,7 @@ New in This Release
   with ``unseq`` or ``par_unseq`` policy when compiled by Intel® oneAPI DPC++/C++ Compiler
   with ``-fiopenmp``, ``-fiopenmp-simd``, ``-qopenmp``, ``-qopenmp-simd`` options on Linux.
   To avoid the issue, pass ``-fopenmp`` or ``-fopenmp-simd`` option instead.
-- Incorrect results may be produced with group reduce operation through ``reduce``
+- Incorrect results may be produced with group reduce operation through ``reduce``, ``transform_reduce``
   for 64-bit data types and ``std::multiplies`` operation on GPUs with the Intel® C++ Compiler 2021.3
 
 Existing Issues

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -54,7 +54,7 @@ New in This Release
   with ``-fiopenmp``, ``-fiopenmp-simd``, ``-qopenmp``, ``-qopenmp-simd`` options on Linux.
   To avoid the issue, pass ``-fopenmp`` or ``-fopenmp-simd`` option instead.
 - Incorrect results may be produced with group reduce operation through ``reduce``, ``transform_reduce``
-  for 64-bit data types and ``std::multiplies``, ``sycl::multiplies`` operation on GPUs with the Intel® C++ Compiler 2021.3
+  for 64-bit data types and ``std::multiplies``, ``sycl::multiplies`` operations on GPUs with the Intel® C++ Compiler 2021.3
 
 Existing Issues
 ^^^^^^^^^^^^^^^

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -53,6 +53,8 @@ New in This Release
   with ``unseq`` or ``par_unseq`` policy when compiled by Intel® oneAPI DPC++/C++ Compiler
   with ``-fiopenmp``, ``-fiopenmp-simd``, ``-qopenmp``, ``-qopenmp-simd`` options on Linux.
   To avoid the issue, pass ``-fopenmp`` or ``-fopenmp-simd`` option instead.
+- Incorrect results may be produced with group reduce operation through ``std::reduce``
+  for 64-bit data types and `std::multiplies`` operation on GPUs with the Intel® C++ Compiler 2021.3
 
 Existing Issues
 ^^^^^^^^^^^^^^^
@@ -95,8 +97,6 @@ New in This Release
 ^^^^^^^^^^^^^^^^^^^
 - Incorrect results may be produced with in-place scans using ``unseq`` and ``par_unseq`` policies on
   CPUs with the Intel® C++ Compiler 2021.8.
-- Incorrect results may be produced with group reduce operation through ``std::reduce``
-  for 64-bit data types and `std::multiplies`` operation on GPUs with the Intel® C++ Compiler 2021.3
 
 Existing Issues
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
Add new known issue about std::reduce on GPU for 64-bit data types with std::multiplies operation