### PR TITLE
Replace `struct __conjunction` to `std::conjunction` as supported since C++17

### DIFF
--- a/include/oneapi/dpl/pstl/tuple_impl.h
+++ b/include/oneapi/dpl/pstl/tuple_impl.h
@@ -341,8 +341,8 @@ struct tuple<T1, T...>
     template <typename _U1, typename... _U,
               typename = ::std::enable_if_t<
                   (sizeof...(_U) == sizeof...(T) &&
-                   oneapi::dpl::__internal::__conjunction<::std::is_constructible<T1, _U1&&>,
-                                                          ::std::is_constructible<T, _U&&>...>::value)>>
+                   std::conjunction<::std::is_constructible<T1, _U1&&>,
+                                    ::std::is_constructible<T, _U&&>...>::value)>>
     tuple(_U1&& _value, _U&&... _next) : holder(::std::forward<_U1>(_value)), next(::std::forward<_U>(_next)...)
     {
     }

--- a/include/oneapi/dpl/pstl/tuple_impl.h
+++ b/include/oneapi/dpl/pstl/tuple_impl.h
@@ -341,7 +341,7 @@ struct tuple<T1, T...>
     template <typename _U1, typename... _U,
               typename = ::std::enable_if_t<
                   (sizeof...(_U) == sizeof...(T) &&
-                   std::conjunction_v<::std::is_constructible<T1, _U1&&>, ::std::is_constructible<T, _U&&>...>)>>
+                   ::std::conjunction_v<::std::is_constructible<T1, _U1&&>, ::std::is_constructible<T, _U&&>...>)>>
     tuple(_U1&& _value, _U&&... _next) : holder(::std::forward<_U1>(_value)), next(::std::forward<_U>(_next)...)
     {
     }

--- a/include/oneapi/dpl/pstl/tuple_impl.h
+++ b/include/oneapi/dpl/pstl/tuple_impl.h
@@ -341,8 +341,7 @@ struct tuple<T1, T...>
     template <typename _U1, typename... _U,
               typename = ::std::enable_if_t<
                   (sizeof...(_U) == sizeof...(T) &&
-                   std::conjunction<::std::is_constructible<T1, _U1&&>,
-                                    ::std::is_constructible<T, _U&&>...>::value)>>
+                   std::conjunction<::std::is_constructible<T1, _U1&&>, ::std::is_constructible<T, _U&&>...>::value)>>
     tuple(_U1&& _value, _U&&... _next) : holder(::std::forward<_U1>(_value)), next(::std::forward<_U>(_next)...)
     {
     }

--- a/include/oneapi/dpl/pstl/tuple_impl.h
+++ b/include/oneapi/dpl/pstl/tuple_impl.h
@@ -341,7 +341,7 @@ struct tuple<T1, T...>
     template <typename _U1, typename... _U,
               typename = ::std::enable_if_t<
                   (sizeof...(_U) == sizeof...(T) &&
-                   std::conjunction<::std::is_constructible<T1, _U1&&>, ::std::is_constructible<T, _U&&>...>::value)>>
+                   std::conjunction_v<::std::is_constructible<T1, _U1&&>, ::std::is_constructible<T, _U&&>...>)>>
     tuple(_U1&& _value, _U&&... _next) : holder(::std::forward<_U1>(_value)), next(::std::forward<_U>(_next)...)
     {
     }

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -542,21 +542,6 @@ struct __next_to_last
 template <typename _T, class _Enable = void>
 class __future;
 
-template <typename... _Bs>
-struct __conjunction : ::std::true_type
-{
-};
-
-template <typename _B1>
-struct __conjunction<_B1> : _B1
-{
-};
-
-template <typename _B1, typename... _Bs>
-struct __conjunction<_B1, _Bs...> : ::std::conditional_t<!bool(_B1::value), _B1, __conjunction<_Bs...>>
-{
-};
-
 // empty base class for type erasure
 struct __lifetime_keeper_base
 {


### PR DESCRIPTION
In this PR we remove implementations of `struct __conjunction` from oneDPL code
and replace it' usage to [std::conjunction](https://en.cppreference.com/w/cpp/types/conjunction) (since C++17)

Looks like ourself implementation of `struct __conjunction` have required in oneDPL code when we supported C++11 and C++14 standards. But now our minimal supported standard is C++17.