### PR TITLE
Replace `__void_type` to `std::void_t` as supported since C++17

### DIFF
--- a/include/oneapi/dpl/pstl/iterator_defs.h
+++ b/include/oneapi/dpl/pstl/iterator_defs.h
@@ -38,8 +38,8 @@ struct __iterator_traits
 
 template <typename _Ip>
 struct __iterator_traits<_Ip,
-                         __void_type<typename _Ip::iterator_category, typename _Ip::value_type,
-                                     typename _Ip::difference_type, typename _Ip::pointer, typename _Ip::reference>>
+                         ::std::void_t<typename _Ip::iterator_category, typename _Ip::value_type,
+                                       typename _Ip::difference_type, typename _Ip::pointer, typename _Ip::reference>>
     : ::std::iterator_traits<_Ip>
 {
 };
@@ -59,7 +59,7 @@ struct __is_random_access_iterator_impl : ::std::false_type
 
 template <typename _IteratorType>
 struct __is_random_access_iterator_impl<_IteratorType,
-                                        __void_type<typename __iterator_traits<_IteratorType>::iterator_category>>
+                                        ::std::void_t<typename __iterator_traits<_IteratorType>::iterator_category>>
     : ::std::is_same<typename __iterator_traits<_IteratorType>::iterator_category, ::std::random_access_iterator_tag>
 {
 };

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -471,14 +471,6 @@ __pstl_left_bound(_Buffer& __a, _Index __first, _Index __last, const _Value& __v
 using __or_semantic = ::std::true_type;
 using __first_semantic = ::std::false_type;
 
-// Define __void_type via this structure to handle redefinition issue.
-// See CWG 1558 for information about it.
-template <typename... _Ts>
-struct __make_void_type
-{
-    using __type = void;
-};
-
 // is_callable_object
 template <typename _Tp, typename = void>
 struct __is_callable_object : ::std::false_type

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -489,7 +489,7 @@ struct __is_callable_object : ::std::false_type
 };
 
 template <typename _Tp>
-struct __is_callable_object<_Tp, __void_type<decltype(&_Tp::operator())>> : ::std::true_type
+struct __is_callable_object<_Tp, ::std::void_t<decltype(&_Tp::operator())>> : ::std::true_type
 {
 };
 

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -479,9 +479,6 @@ struct __make_void_type
     using __type = void;
 };
 
-template <typename... _Ts>
-using __void_type = typename __make_void_type<_Ts...>::__type;
-
 // is_callable_object
 template <typename _Tp, typename = void>
 struct __is_callable_object : ::std::false_type


### PR DESCRIPTION
In this PR we remove implementations of `struct __make_void_type` and `__void_type` from oneDPL code
and replace it' usage to [std::void_t](https://en.cppreference.com/w/cpp/types/void_t) (since C++17)
