### PR TITLE
Implement `__is_callable_object` as `std::is_invocable` as supported since C++17

### DIFF
--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -515,14 +515,7 @@ using __first_semantic = ::std::false_type;
 
 // is_callable_object
 template <typename _Tp, typename = void>
-struct __is_callable_object : ::std::false_type
-{
-};
-
-template <typename _Tp>
-struct __is_callable_object<_Tp, ::std::void_t<decltype(&_Tp::operator())>> : ::std::true_type
-{
-};
+using __is_callable_object = ::std::is_invocable<_Tp>;
 
 // is_pointer_to_const_member
 template <typename _Tp>


### PR DESCRIPTION
In this PR we reimplement `struct __is_callable_object` as [std::is_invocable](https://en.cppreference.com/w/cpp/types/is_invocable) :
Before:
```C++
// is_callable_object
template <typename _Tp, typename = void>
struct __is_callable_object : ::std::false_type
{
};

template <typename _Tp>
struct __is_callable_object<_Tp, __void_type<decltype(&_Tp::operator())>> : ::std::true_type
{
};
```

After:
```C++
// is_callable_object
template <typename _Tp, typename = void>
using __is_callable_object = ::std::is_invocable<_Tp>;
```

Please see an example at [godbolt.org](https://godbolt.org/z/WbjeY7xhr) to demonstrate how it's work.
Another example: https://godbolt.org/z/6Pvdffr8j