### PR TITLE
Fix C++20 compilation issues in tests

### DIFF
--- a/test/pstl_offload/headers/headers.standard/requires_header_presence/numbers.pass.cpp
+++ b/test/pstl_offload/headers/headers.standard/requires_header_presence/numbers.pass.cpp
@@ -12,7 +12,7 @@
 
 int main() {
 #if __cpp_lib_math_constants >= 201907L
-    [[maybe_unused]] auto phi = std::numbers::phi_v;
+    [[maybe_unused]] auto phi = std::numbers::phi;
 #endif
     return TestUtils::done();
 }

--- a/test/xpu_api/iterators/predef.iterators/move.iterators/move.iter.ops/move.iter.op.incr/post_incr.pass.cpp
+++ b/test/xpu_api/iterators/predef.iterators/move.iterators/move.iter.ops/move.iter.op.incr/post_incr.pass.cpp
@@ -21,6 +21,7 @@
 
 #include "support/test_iterators.h"
 #include "support/utils.h"
+#include "support/test_macros.h"
 
 #if TEST_DPCPP_BACKEND_PRESENT
 
@@ -29,9 +30,23 @@ bool
 test(It i, It x)
 {
     dpl::move_iterator<It> r(i);
+#if TEST_STD_VER >= 20
+    // dpl::move_iterator post increment operation does not return value if It
+    // is not forward iterator
+    dpl::move_iterator<It> rr;
+    if constexpr (std::forward_iterator<It>) {
+        rr = r++;
+    } else {
+        r++;
+    }
+#else
     dpl::move_iterator<It> rr = r++;
+#endif
     auto ret = (r.base() == x);
-    ret &= (rr.base() == i);
+#if TEST_STD_VER >= 20
+    if constexpr (std::forward_iterator<It>)
+#endif
+        ret &= (rr.base() == i);
     return ret;
 }
 

--- a/test/xpu_api/iterators/predef.iterators/move.iterators/move.iterator/types2.pass.cpp
+++ b/test/xpu_api/iterators/predef.iterators/move.iterators/move.iterator/types2.pass.cpp
@@ -49,6 +49,11 @@ struct DummyIt
     typedef dpl::ptrdiff_t difference_type;
     typedef ValueType* pointer;
     typedef Reference reference;
+
+    // Definition of operator* is not required, only the return type is needed
+    // This operator would only be used by std::iter_rvalue_reference to determine
+    // move_iterator::reference type starting from C++20
+    reference operator*();
 };
 
 template <class It>


### PR DESCRIPTION
Fix minor C++20 compilation issues in newly added `dpl::move_iterator` tests and one PSTL offload test:

* Rename `phi_v` to `phi` in `numbers.pass.cpp` because `phi_v` requires a template argument. Move the test into `requires_header_presence` directory to enable CMake check for C++20 header file before compiling.
* Change `post_incr.pass.cpp` because starting from C++20, post increment operator in `std::move_iterator` returns `void` for an iterator that is not forward iterator.
* Add definition of dereference operator for `DummyIt` in types test - since C++20 to satisfy constraints for `std::iter_rvalue_reference_t` that is used to determine `std::move_iterator::reference` type.