### PR TITLE
Basic structure for kt::gpu::radix_sort

### DIFF
--- a/include/oneapi/dpl/experimental/kernel_templates
+++ b/include/oneapi/dpl/experimental/kernel_templates
@@ -14,5 +14,6 @@
 
 #include "kt/kernel_param.h"
 #include "kt/esimd_radix_sort.h"
+#include "kt/gpu_radix_sort.h"
 
 #endif // _ONEDPL_KERNEL_TEMPLATES

--- a/include/oneapi/dpl/experimental/kt/gpu_radix_sort.h
+++ b/include/oneapi/dpl/experimental/kt/gpu_radix_sort.h
@@ -1,0 +1,33 @@
+// -*- C++ -*-
+//===-- gpu_radix_sort.h --------------------------------===//
+//
+// Copyright (C) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===------------------------------------------------------===//
+
+#ifndef _ONEDPL_KT_GPU_RADIX_SORT_H
+#define _ONEDPL_KT_GPU_RADIX_SORT_H
+
+#include "kernel_param.h"
+#include "../../pstl/utils_ranges.h"
+#include "../../pstl/hetero/dpcpp/utils_ranges_sycl.h"
+#include "../../pstl/hetero/dpcpp/parallel_backend_sycl_utils.h"
+
+#include <cstdint>
+
+namespace oneapi::dpl::experimental::kt::gpu
+{
+
+template <bool __is_ascending = true, ::std::uint8_t __radix_bits = 8, typename _KernelParam, typename _Range>
+sycl::event
+radix_sort(sycl::queue __q, _Range&& __rng, _KernelParam __param = {});
+
+template <bool __is_ascending = true, ::std::uint8_t __radix_bits = 8, typename _KernelParam, typename _Iterator>
+sycl::event
+radix_sort(sycl::queue __q, _Iterator __first, _Iterator __last, _KernelParam __param = {});
+
+} // namespace oneapi::dpl::experimental::kt::gpu
+
+#endif // _ONEDPL_KT_GPU_RADIX_SORT_H


### PR DESCRIPTION
This is the first PR for the pure SYCL onesweep radix_sort implementation.

I am adopting a similar PR strategy as `esimd-radix-sort`: incremental PRs into the feature branch `gpu-radix-sort`, followed by eventual merging into `main`.

This PR simply declares the `oneapi::dpl::experimental::kt::gpu::radix_sort` function signatures. It copies the equivalent declarations for `oneapi::dpl::experimental::kt::esimd::radix_sort`, though we omit `radix_sort_by_key` since this is not yet implemented.