### PR TITLE
Dispatcher decls for kt::gpu::radix_sort

### DIFF
--- a/include/oneapi/dpl/experimental/kernel_templates
+++ b/include/oneapi/dpl/experimental/kernel_templates
@@ -14,5 +14,6 @@
 
 #include "kt/kernel_param.h"
 #include "kt/esimd_radix_sort.h"
+#include "kt/gpu_radix_sort.h"
 
 #endif // _ONEDPL_KERNEL_TEMPLATES

--- a/include/oneapi/dpl/experimental/kt/gpu_radix_sort.h
+++ b/include/oneapi/dpl/experimental/kt/gpu_radix_sort.h
@@ -17,16 +17,33 @@
 
 #include <cstdint>
 
+#include "internal/gpu_radix_sort_dispatchers.h"
+
 namespace oneapi::dpl::experimental::kt::gpu
 {
 
 template <bool __is_ascending = true, ::std::uint8_t __radix_bits = 8, typename _KernelParam, typename _Range>
 sycl::event
-radix_sort(sycl::queue __q, _Range&& __rng, _KernelParam __param = {});
+radix_sort(sycl::queue __q, _Range&& __rng, _KernelParam __param = {})
+{
+    if (__rng.size() < 2)
+        return {};
+
+    return __impl::__radix_sort<__is_ascending, __radix_bits>(__q, ::std::forward<_Range>(__rng), __param);
+}
 
 template <bool __is_ascending = true, ::std::uint8_t __radix_bits = 8, typename _KernelParam, typename _Iterator>
 sycl::event
-radix_sort(sycl::queue __q, _Iterator __first, _Iterator __last, _KernelParam __param = {});
+radix_sort(sycl::queue __q, _Iterator __first, _Iterator __last, _KernelParam __param = {})
+{
+    if (__last - __first < 2)
+        return {};
+
+    auto __keep = oneapi::dpl::__ranges::__get_sycl_range<oneapi::dpl::__par_backend_hetero::access_mode::read_write,
+                                                          _Iterator>();
+    auto __rng = __keep(__first, __last);
+    return __impl::__radix_sort<__is_ascending, __radix_bits>(__q, __rng.all_view(), __param);
+}
 
 } // namespace oneapi::dpl::experimental::kt::gpu
 

--- a/include/oneapi/dpl/experimental/kt/gpu_radix_sort.h
+++ b/include/oneapi/dpl/experimental/kt/gpu_radix_sort.h
@@ -1,0 +1,33 @@
+// -*- C++ -*-
+//===-- gpu_radix_sort.h --------------------------------===//
+//
+// Copyright (C) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===------------------------------------------------------===//
+
+#ifndef _ONEDPL_KT_GPU_RADIX_SORT_H
+#define _ONEDPL_KT_GPU_RADIX_SORT_H
+
+#include "kernel_param.h"
+#include "../../pstl/utils_ranges.h"
+#include "../../pstl/hetero/dpcpp/utils_ranges_sycl.h"
+#include "../../pstl/hetero/dpcpp/parallel_backend_sycl_utils.h"
+
+#include <cstdint>
+
+namespace oneapi::dpl::experimental::kt::gpu
+{
+
+template <bool __is_ascending = true, ::std::uint8_t __radix_bits = 8, typename _KernelParam, typename _Range>
+sycl::event
+radix_sort(sycl::queue __q, _Range&& __rng, _KernelParam __param = {});
+
+template <bool __is_ascending = true, ::std::uint8_t __radix_bits = 8, typename _KernelParam, typename _Iterator>
+sycl::event
+radix_sort(sycl::queue __q, _Iterator __first, _Iterator __last, _KernelParam __param = {});
+
+} // namespace oneapi::dpl::experimental::kt::gpu
+
+#endif // _ONEDPL_KT_GPU_RADIX_SORT_H

--- a/include/oneapi/dpl/experimental/kt/internal/gpu_radix_sort_dispatchers.h
+++ b/include/oneapi/dpl/experimental/kt/internal/gpu_radix_sort_dispatchers.h
@@ -1,0 +1,36 @@
+// -*- C++ -*-
+//===-- gpu_radix_sort_dispatchers.h --------------------------------===//
+//
+// Copyright (C) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===------------------------------------------------------===//
+
+#ifndef _ONEDPL_KT_GPU_RADIX_SORT_DISPATCHERS_H
+#define _ONEDPL_KT_GPU_RADIX_SORT_DISPATCHERS_H
+
+#if __has_include(<sycl/sycl.hpp>)
+#    include <sycl/sycl.hpp>
+#else
+#    include <CL/sycl.hpp>
+#endif
+
+#include <cstdint>
+#include <cassert>
+
+#include "../kernel_param.h"
+
+#include "../../../pstl/hetero/dpcpp/parallel_backend_sycl_utils.h"
+#include "../../../pstl/hetero/dpcpp/utils_ranges_sycl.h"
+
+namespace oneapi::dpl::experimental::kt::gpu::__impl
+{
+
+template <bool __is_ascending, ::std::uint8_t __radix_bits, typename _KernelParam, typename _Range>
+sycl::event
+__radix_sort(sycl::queue __q, _Range&& __rng, _KernelParam __param);
+
+} // namespace oneapi::dpl::experimental::kt::gpu::__impl
+
+#endif // _ONEDPL_KT_GPU_RADIX_SORT_DISPATCHERS_H


### PR DESCRIPTION
This is the 2nd PR for the pure SYCL onesweep radix_sort implementation.

This PR builds on top of (and depends on) #1241, adding dispatcher declarations and `radix_sort` implementations.