### PR TITLE
Fix oneDPL header inclusion before any other STL headers on GCC9

### DIFF
--- a/include/oneapi/dpl/internal/common_config.h
+++ b/include/oneapi/dpl/internal/common_config.h
@@ -16,6 +16,10 @@
 #ifndef _ONEDPL_COMMON_CONFIG_H
 #define _ONEDPL_COMMON_CONFIG_H
 
+#if __has_include(<version>)
+#    include <version> // for _GLIBCXX_RELEASE
+#endif
+
 #if __cplusplus >= 201703L
 #    define _ONEDPL___cplusplus __cplusplus
 #elif defined(_MSVC_LANG) && _MSVC_LANG >= 201703L


### PR DESCRIPTION
There is an issue in oneDPL config file that can lead to compilation issues on the user side if some oneDPL public headers is included before any STL header. E.g:

```
#include <oneapi/dpl/execution>

int main() { ... }
```

In the case above, `<oneapi/dpl/execution>` will include `oneapi/dpl/internal/common_config.h` firstly which defines 
`PSTL_USE_PARALLEL_POLICIES` according to the `_GLIBCXX_RELEASE` macro value. 
But the issue is when oneDPL is included before any other STL headers, `_GLIBCXX_RELEASE` is not yet defined so the value of `PSTL_USE_PARALLEL_POLICIES` would be always `true` that can result in known compilation issues in case of compiling by GCC9 with modern oneTBB.

This patch adds an inclusion of `<version>` into the common_config to be sure that `_GLIBCXX_RELEASE` is defined.
From the standard perspective, `<version>` is a C++20 header file but it is present in GCC9 and is not expected to include any other STL headers. I have wrapped it into `__has_include` to make sure that other configurations would not be affected. 