### PR TITLE
Code improvements in tag dispatch prototype for current code base

### DIFF
--- a/include/oneapi/dpl/pstl/execution_impl.h
+++ b/include/oneapi/dpl/pstl/execution_impl.h
@@ -161,10 +161,10 @@ struct __parallel_forward_tag
 };
 
 template <class _IsVector, class... _IteratorTypes>
-using __tag_type = typename ::std::conditional<
-    __internal::__is_random_access_iterator<_IteratorTypes...>::value, __parallel_tag<_IsVector>,
-    typename ::std::conditional<__is_forward_iterator<_IteratorTypes...>::value, __parallel_forward_tag,
-                                __serial_tag<_IsVector>>::type>::type;
+using __tag_type =
+    ::std::conditional_t<__internal::__is_random_access_iterator<_IteratorTypes...>::value, __parallel_tag<_IsVector>,
+                         ::std::conditional_t<__is_forward_iterator<_IteratorTypes...>::value, __parallel_forward_tag,
+                                              __serial_tag<_IsVector>>>;
 
 template <class... _IteratorTypes>
 __serial_tag<std::false_type>

--- a/include/oneapi/dpl/pstl/execution_impl.h
+++ b/include/oneapi/dpl/pstl/execution_impl.h
@@ -161,10 +161,9 @@ struct __parallel_forward_tag
 };
 
 template <class _IsVector, class... _IteratorTypes>
-using __tag_type =
-    ::std::conditional_t<__internal::__is_random_access_iterator<_IteratorTypes...>::value, __parallel_tag<_IsVector>,
-                         ::std::conditional_t<__is_forward_iterator<_IteratorTypes...>::value, __parallel_forward_tag,
-                                              __serial_tag<_IsVector>>>;
+using __tag_type = ::std::conditional_t<
+    __internal::__is_random_access_iterator_v<_IteratorTypes...>, __parallel_tag<_IsVector>,
+    ::std::conditional_t<__is_forward_iterator_v<_IteratorTypes...>, __parallel_forward_tag, __serial_tag<_IsVector>>>;
 
 template <class... _IteratorTypes>
 __serial_tag<std::false_type>

--- a/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
@@ -65,7 +65,7 @@ struct __difference<_Ip, ::std::enable_if_t<::std::is_integral_v<_Ip>>>
 template <typename _Ip>
 struct __difference<_Ip, ::std::enable_if_t<!::std::is_integral_v<_Ip>>>
 {
-    using __type = typename oneapi::dpl::__internal::__iterator_traits<_Ip>::difference_type;
+    using __type = typename ::std::iterator_traits<_Ip>::difference_type;
 };
 
 // This type is used as a stride value when it's known that stride == 1 at compile time(the case of for_loop and for_loop_n).
@@ -232,9 +232,9 @@ __pattern_for_loop(_ExecutionPolicy&& __exec, _Ip __first, _Ip __last, _Function
 }
 
 template <typename _Ip, typename _Function, typename _Sp, typename _Pack, typename _IndexType>
-::std::enable_if_t<::std::is_same_v<typename oneapi::dpl::__internal::__iterator_traits<_Ip>::iterator_category,
-                                    ::std::bidirectional_iterator_tag>,
-                   _IndexType>
+::std::enable_if_t<
+    ::std::is_same_v<typename ::std::iterator_traits<_Ip>::iterator_category, ::std::bidirectional_iterator_tag>,
+    _IndexType>
 __execute_loop_strided(_Ip __first, _Ip __last, _Function __f, _Sp __stride, _Pack& __pack, _IndexType) noexcept
 {
     _IndexType __ordinal_position = 0;
@@ -269,11 +269,10 @@ __execute_loop_strided(_Ip __first, _Ip __last, _Function __f, _Sp __stride, _Pa
 }
 
 template <typename _Ip, typename _Function, typename _Sp, typename _Pack, typename _IndexType>
-::std::enable_if_t<::std::is_same_v<typename oneapi::dpl::__internal::__iterator_traits<_Ip>::iterator_category,
-                                    ::std::forward_iterator_tag> ||
-                       ::std::is_same_v<typename oneapi::dpl::__internal::__iterator_traits<_Ip>::iterator_category,
-                                        ::std::input_iterator_tag>,
-                   _IndexType>
+::std::enable_if_t<
+    ::std::is_same_v<typename ::std::iterator_traits<_Ip>::iterator_category, ::std::forward_iterator_tag> ||
+        ::std::is_same_v<typename ::std::iterator_traits<_Ip>::iterator_category, ::std::input_iterator_tag>,
+    _IndexType>
 __execute_loop_strided(_Ip __first, _Ip __last, _Function __f, _Sp __stride, _Pack& __pack, _IndexType) noexcept
 {
     _IndexType __ordinal_position = 0;

--- a/include/oneapi/dpl/pstl/iterator_defs.h
+++ b/include/oneapi/dpl/pstl/iterator_defs.h
@@ -31,9 +31,9 @@ namespace __internal
 //SFINAE with a non-iterator type by providing a default value.
 template <typename _IteratorTag, typename... _IteratorTypes>
 auto
-__is_iterator_of(int)
-    -> decltype(std::conjunction<::std::is_base_of<_IteratorTag, typename ::std::iterator_traits<typename ::std::decay<
-                                                                     _IteratorTypes>::type>::iterator_category>...>{});
+__is_iterator_of(int) -> decltype(
+    std::conjunction<::std::is_base_of<
+        _IteratorTag, typename ::std::iterator_traits<::std::decay_t<_IteratorTypes>>::iterator_category>...>{});
 
 template <typename... _IteratorTypes>
 auto

--- a/include/oneapi/dpl/pstl/iterator_defs.h
+++ b/include/oneapi/dpl/pstl/iterator_defs.h
@@ -28,7 +28,7 @@ namespace __internal
 {
 
 // Make is_random_access_iterator and is_forward_iterator not to fail with a 'hard' error when it's used in
-//SFINAE with a non-iterator type by providing a default value.
+// SFINAE with a non-iterator type by providing a default value.
 template <typename _IteratorTag, typename... _IteratorTypes>
 auto
 __is_iterator_of(int) -> decltype(
@@ -59,27 +59,32 @@ template <typename... _IteratorTypes>
 inline constexpr bool __is_forward_iterator_v = __is_forward_iterator<_IteratorTypes...>::value;
 
 // struct for checking if iterator is heterogeneous or not
-template <typename Iter, typename Void = void> // for non-heterogeneous iterators
+// for non-heterogeneous iterators
+template <typename Iter, typename Void = void>
 struct is_hetero_iterator : ::std::false_type
 {
 };
 
-template <typename Iter> // for heterogeneous iterators
+// for heterogeneous iterators
+template <typename Iter>
 struct is_hetero_iterator<Iter, ::std::enable_if_t<Iter::is_hetero::value>> : ::std::true_type
 {
 };
 // struct for checking if iterator should be passed directly to device or not
-template <typename Iter, typename Void = void> // for iterators that should not be passed directly
+// for iterators that should not be passed directly
+template <typename Iter, typename Void = void>
 struct is_passed_directly : ::std::false_type
 {
 };
 
-template <typename Iter> // for iterators defined as direct pass
+// for iterators defined as direct pass
+template <typename Iter>
 struct is_passed_directly<Iter, ::std::enable_if_t<Iter::is_passed_directly::value>> : ::std::true_type
 {
 };
 
-template <typename Iter> // for pointers to objects on device
+// for pointers to objects on device
+template <typename Iter>
 struct is_passed_directly<Iter, ::std::enable_if_t<::std::is_pointer_v<Iter>>> : ::std::true_type
 {
 };

--- a/include/oneapi/dpl/pstl/iterator_defs.h
+++ b/include/oneapi/dpl/pstl/iterator_defs.h
@@ -55,6 +55,9 @@ using __is_random_access_iterator_t = typename __is_random_access_iterator<_Iter
 template <typename... _IteratorTypes>
 inline constexpr bool __is_random_access_iterator_v = __is_random_access_iterator<_IteratorTypes...>::value;
 
+template <typename... _IteratorTypes>
+inline constexpr bool __is_forward_iterator_v = __is_forward_iterator<_IteratorTypes...>::value;
+
 // struct for checking if iterator is heterogeneous or not
 template <typename Iter, typename Void = void> // for non-heterogeneous iterators
 struct is_hetero_iterator : ::std::false_type

--- a/include/oneapi/dpl/pstl/iterator_defs.h
+++ b/include/oneapi/dpl/pstl/iterator_defs.h
@@ -27,35 +27,12 @@ namespace dpl
 namespace __internal
 {
 
-// Internal wrapper around ::std::iterator_traits as it is required to be
-// SFINAE-friendly(not produce "hard" error when _Ip is not an iterator)
-// only starting with C++17. Although many standard library implementations
-// provide it for older versions, we cannot rely on that.
-template <typename _Ip, typename = void>
-struct __iterator_traits
-{
-};
-
-template <typename _Ip>
-struct __iterator_traits<_Ip,
-                         __void_type<typename _Ip::iterator_category, typename _Ip::value_type,
-                                     typename _Ip::difference_type, typename _Ip::pointer, typename _Ip::reference>>
-    : ::std::iterator_traits<_Ip>
-{
-};
-
-// Handles _Tp* and const _Tp* specializations
-template <typename _Tp>
-struct __iterator_traits<_Tp*, void> : ::std::iterator_traits<_Tp*>
-{
-};
-
 // Make is_random_access_iterator and is_forward_iterator not to fail with a 'hard' error when it's used in
 //SFINAE with a non-iterator type by providing a default value.
 template <typename _IteratorTag, typename... _IteratorTypes>
 auto
 __is_iterator_of(int)
-    -> decltype(std::conjunction<::std::is_base_of<_IteratorTag, typename __iterator_traits<typename ::std::decay<
+    -> decltype(std::conjunction<::std::is_base_of<_IteratorTag, typename ::std::iterator_traits<typename ::std::decay<
                                                                      _IteratorTypes>::type>::iterator_category>...>{});
 
 template <typename... _IteratorTypes>


### PR DESCRIPTION
- using `std::conditional_t` instead of `typename std::conditional<...>::type`;
- using `__is_random_access_iterator_v` instead of `__is_random_access_iterator<>::value`;
- using `::std::iterator_traits` instead of `oneapi::dpl::__internal::__iterator_traits`;
- remove `oneapi::dpl::__internal::__iterator_traits` as unused anymore;
- define and using `__is_forward_iterator_v` :
```C++
template <typename... _IteratorTypes>
inline constexpr bool __is_forward_iterator_v = __is_forward_iterator<_IteratorTypes...>::value;
```