### PR TITLE
Fix common config for including STL headers before oneDPL on GCC9 and GCC10

### DIFF
--- a/include/oneapi/dpl/internal/common_config.h
+++ b/include/oneapi/dpl/internal/common_config.h
@@ -49,6 +49,9 @@
 #        endif
 #        ifndef _GLIBCXX_USE_TBB_PAR_BACKEND
 #            define _GLIBCXX_USE_TBB_PAR_BACKEND (_GLIBCXX_RELEASE > 10)
+#        elif defined(_GLIBCXX_RELEASE) && (_GLIBCXX_RELEASE == 10) && defined(_PSTL_PAR_BACKEND_TBB)
+#            undef _PSTL_PAR_BACKEND_TBB
+#            define _PSTL_PAR_BACKEND_SERIAL
 #        endif
 #    endif // __has_include(<tbb/version.h>)
 // - TBB is not found (libstdc++ v9)

--- a/include/oneapi/dpl/internal/common_config.h
+++ b/include/oneapi/dpl/internal/common_config.h
@@ -31,7 +31,11 @@
 // - New TBB version with incompatible APIs is found (libstdc++ v9/v10)
 #    if __has_include(<tbb/version.h>)
 #        ifndef PSTL_USE_PARALLEL_POLICIES
+//           _GLIBCXX_RELEASE can be undefined if oneDPL is included before any STL headers
+//           It is not an issue if PSTL_USE_PARALLEL_POLICIES would be used after _GLIBCXX_RELEASE definition
 #            define PSTL_USE_PARALLEL_POLICIES (_GLIBCXX_RELEASE != 9)
+//           If STL headers are included before oneDPL, __PSTL_USE_PAR_POLICIES and
+//           __PSTL_PAR_BACKEND_TBB would be included before this config file
 #            if defined (_GLIBCXX_RELEASE) && (_GLIBCXX_RELEASE == 9)
 #                ifdef __PSTL_USE_PAR_POLICIES
 #                     undef __PSTL_USE_PAR_POLICIES

--- a/include/oneapi/dpl/internal/common_config.h
+++ b/include/oneapi/dpl/internal/common_config.h
@@ -30,28 +30,28 @@
 #if __cplusplus >= 201703L
 // - New TBB version with incompatible APIs is found (libstdc++ v9/v10)
 #    if __has_include(<tbb/version.h>)
-#        ifndef PSTL_USE_PARALLEL_POLICIES
-//           _GLIBCXX_RELEASE can be undefined if oneDPL is included before any STL headers
-//           It is not an issue if PSTL_USE_PARALLEL_POLICIES would be used after _GLIBCXX_RELEASE definition
-#            define PSTL_USE_PARALLEL_POLICIES (_GLIBCXX_RELEASE != 9)
-//           If STL headers are included before oneDPL, __PSTL_USE_PAR_POLICIES and
-//           __PSTL_PAR_BACKEND_TBB would be included before this config file
-#            if defined(_GLIBCXX_RELEASE) && (_GLIBCXX_RELEASE == 9)
-#                ifdef __PSTL_USE_PAR_POLICIES
-#                    undef __PSTL_USE_PAR_POLICIES
-#                    define __PSTL_USE_PAR_POLICIES 0
-#                endif
-#                ifdef __PSTL_PAR_BACKEND_TBB
-#                    undef __PSTL_PAR_BACKEND_TBB
-#                    define __PSTL_PAR_BACKEND_TBB 0
-#                endif
+#        if defined(_GLIBCXX_RELEASE) && (_GLIBCXX_RELEASE == 9 || _GLIBCXX_RELEASE == 10)
+//           If STL headers are included before oneDPL, __PSTL_USE_PAR_POLICIES,
+//           __PSTL_PAR_BACKEND_TBB and _PSTL_PAR_BACKEND_TBB macros can be defined
+//           before this config file
+#            ifdef __PSTL_USE_PAR_POLICIES
+#                undef __PSTL_USE_PAR_POLICIES
+#                define __PSTL_USE_PAR_POLICIES 0
 #            endif
+#            ifdef __PSTL_PAR_BACKEND_TBB
+#                undef __PSTL_PAR_BACKEND_TBB
+#                define __PSTL_PAR_BACKEND_TBB 0
+#            endif
+#            ifdef _PSTL_PAR_BACKEND_TBB // For GCC10
+#                undef _PSTL_PAR_BACKEND_TBB
+#                define _PSTL_PAR_BACKEND_SERIAL
+#            endif
+#        endif
+#        ifndef PSTL_USE_PARALLEL_POLICIES
+#            define PSTL_USE_PARALLEL_POLICIES (_GLIBCXX_RELEASE != 9)
 #        endif
 #        ifndef _GLIBCXX_USE_TBB_PAR_BACKEND
 #            define _GLIBCXX_USE_TBB_PAR_BACKEND (_GLIBCXX_RELEASE > 10)
-#        elif defined(_GLIBCXX_RELEASE) && (_GLIBCXX_RELEASE == 10) && defined(_PSTL_PAR_BACKEND_TBB)
-#            undef _PSTL_PAR_BACKEND_TBB
-#            define _PSTL_PAR_BACKEND_SERIAL
 #        endif
 #    endif // __has_include(<tbb/version.h>)
 // - TBB is not found (libstdc++ v9)

--- a/include/oneapi/dpl/internal/common_config.h
+++ b/include/oneapi/dpl/internal/common_config.h
@@ -32,6 +32,16 @@
 #    if __has_include(<tbb/version.h>)
 #        ifndef PSTL_USE_PARALLEL_POLICIES
 #            define PSTL_USE_PARALLEL_POLICIES (_GLIBCXX_RELEASE != 9)
+#            if defined (_GLIBCXX_RELEASE) && (_GLIBCXX_RELEASE == 9)
+#                ifdef __PSTL_USE_PAR_POLICIES
+#                     undef __PSTL_USE_PAR_POLICIES
+#                     define __PSTL_USE_PAR_POLICIES 0
+#                endif
+#                ifdef __PSTL_PAR_BACKEND_TBB
+#                     undef __PSTL_PAR_BACKEND_TBB
+#                     define __PSTL_PAR_BACKEND_TBB 0
+#                endif
+#            endif
 #        endif
 #        ifndef _GLIBCXX_USE_TBB_PAR_BACKEND
 #            define _GLIBCXX_USE_TBB_PAR_BACKEND (_GLIBCXX_RELEASE > 10)

--- a/include/oneapi/dpl/internal/common_config.h
+++ b/include/oneapi/dpl/internal/common_config.h
@@ -36,14 +36,14 @@
 #            define PSTL_USE_PARALLEL_POLICIES (_GLIBCXX_RELEASE != 9)
 //           If STL headers are included before oneDPL, __PSTL_USE_PAR_POLICIES and
 //           __PSTL_PAR_BACKEND_TBB would be included before this config file
-#            if defined (_GLIBCXX_RELEASE) && (_GLIBCXX_RELEASE == 9)
+#            if defined(_GLIBCXX_RELEASE) && (_GLIBCXX_RELEASE == 9)
 #                ifdef __PSTL_USE_PAR_POLICIES
-#                     undef __PSTL_USE_PAR_POLICIES
-#                     define __PSTL_USE_PAR_POLICIES 0
+#                    undef __PSTL_USE_PAR_POLICIES
+#                    define __PSTL_USE_PAR_POLICIES 0
 #                endif
 #                ifdef __PSTL_PAR_BACKEND_TBB
-#                     undef __PSTL_PAR_BACKEND_TBB
-#                     define __PSTL_PAR_BACKEND_TBB 0
+#                    undef __PSTL_PAR_BACKEND_TBB
+#                    define __PSTL_PAR_BACKEND_TBB 0
 #                endif
 #            endif
 #        endif


### PR DESCRIPTION
There is an issue while STL headers before `<oneapi/dpl/execution>` on GCC9 and GCC10 with modern oneTBB versions:

```
#include <cstddef>
#include <oneapi/dpl/execution>

int main() { ... }
```

Any STL header includes the file `bits/c++config.h` that defines macros `__PSTL_USE_PAR_POLICIES` and `__PSTL_PAR_BACKEND_TBB`. Since STL headers goes before `oneDPL/common_config.h`, these macros would be defined to `1` because oneTBB is present but the version is not checked.

If we want to include `<execution>` safely in `<oneapi/dpl/execution>`, these macros should be unset in common config.