### PR TITLE
[oneDPL][hetero] Simplifying of temporary sycl::buffer support

### DIFF
--- a/include/oneapi/dpl/pstl/execution_defs.h
+++ b/include/oneapi/dpl/pstl/execution_defs.h
@@ -208,7 +208,7 @@ __check_size(long) -> decltype(::std::declval<_R&>().get_count());
 
 template <typename _It>
 auto
-__check_size(long long) -> typename ::std::iterator_traits<_It>::difference_type;
+__check_size(...) -> typename ::std::iterator_traits<_It>::difference_type;
 
 template <typename _R>
 using __difference_t = ::std::make_signed_t<decltype(__check_size<_R>(0))>;

--- a/include/oneapi/dpl/pstl/execution_defs.h
+++ b/include/oneapi/dpl/pstl/execution_defs.h
@@ -204,7 +204,11 @@ __check_size(int) -> decltype(::std::declval<_R&>().size());
 
 template <typename _R>
 auto
-__check_size(...) -> decltype(::std::declval<_R&>().get_count());
+__check_size(long) -> decltype(::std::declval<_R&>().get_count());
+
+template <typename _It>
+auto
+__check_size(long long) -> typename ::std::iterator_traits<_It>::difference_type;
 
 template <typename _R>
 using __difference_t = ::std::make_signed_t<decltype(__check_size<_R>(0))>;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1632,7 +1632,7 @@ struct __parallel_sort_submitter<_IdType, __internal::__optional_kernel_name<_Le
             });
         }
 
-        return __future(__event1, __temp);
+        return __future(__event1);
     }
 };
 
@@ -1739,7 +1739,7 @@ struct __parallel_partial_sort_submitter<__internal::__optional_kernel_name<_Glo
             });
         }
         // return future and extend lifetime of temporary buffer
-        return __future(__event1, __temp);
+        return __future(__event1);
     }
 };
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -809,7 +809,7 @@ __parallel_radix_sort(_ExecutionPolicy&& __exec, _Range&& __in_rng, _Proj __proj
         // 'No operation' flag specifies whether to skip re-order phase if the all keys are the same (lie in one bin)
         const ::std::size_t __tmp_buf_size = __segments * __radix_states + __radix_states + 1 /*no_op flag*/;
         // memory for storing count and offset values
-        auto __tmp_buf = sycl::buffer<::std::uint32_t, 1>(sycl::range<1>(__tmp_buf_size));
+        sycl::buffer<::std::uint32_t, 1> __tmp_buf{sycl::range<1>(__tmp_buf_size)};
 
         // memory for storing values sorted for an iteration
         oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueT> __out_buffer_holder{__exec, __n};

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -835,7 +835,7 @@ __parallel_radix_sort(_ExecutionPolicy&& __exec, _Range&& __in_rng, _Proj __proj
         }
     }
 
-    return __future(__event, __tmp_buf, __val_buf);
+    return __future(__event);
 }
 
 } // namespace __par_backend_hetero

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -813,8 +813,7 @@ __parallel_radix_sort(_ExecutionPolicy&& __exec, _Range&& __in_rng, _Proj __proj
 
         // memory for storing values sorted for an iteration
         oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueT> __out_buffer_holder{__exec, __n};
-        auto __out_rng =
-            oneapi::dpl::__ranges::all_view<_ValueT, __par_backend_hetero::access_mode::read_write>(
+        auto __out_rng = oneapi::dpl::__ranges::all_view<_ValueT, __par_backend_hetero::access_mode::read_write>(
             __out_buffer_holder.get_buffer());
 
         // iterations per each bucket

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -755,9 +755,6 @@ __parallel_radix_sort(_ExecutionPolicy&& __exec, _Range&& __in_rng, _Proj __proj
     // radix bits represent number of processed bits in each value during one iteration
     constexpr ::std::uint32_t __radix_bits = 4;
 
-    //sycl::buffer doesn't have a default constructor; so, we have to pass zero-range to create an empty buffer
-    sycl::buffer<::std::uint32_t, 1> __tmp_buf(sycl::range<1>(0));
-    sycl::buffer<_ValueT, 1> __val_buf(sycl::range<1>(0));
     sycl::event __event{};
 
     const auto __max_wg_size = oneapi::dpl::__internal::__max_work_group_size(__exec);
@@ -812,13 +809,13 @@ __parallel_radix_sort(_ExecutionPolicy&& __exec, _Range&& __in_rng, _Proj __proj
         // 'No operation' flag specifies whether to skip re-order phase if the all keys are the same (lie in one bin)
         const ::std::size_t __tmp_buf_size = __segments * __radix_states + __radix_states + 1 /*no_op flag*/;
         // memory for storing count and offset values
-        __tmp_buf = sycl::buffer<::std::uint32_t, 1>(sycl::range<1>(__tmp_buf_size));
+        auto __tmp_buf = sycl::buffer<::std::uint32_t, 1>(sycl::range<1>(__tmp_buf_size));
 
         // memory for storing values sorted for an iteration
         oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueT> __out_buffer_holder{__exec, __n};
-        __val_buf = __out_buffer_holder.get_buffer();
         auto __out_rng =
-            oneapi::dpl::__ranges::all_view<_ValueT, __par_backend_hetero::access_mode::read_write>(__val_buf);
+            oneapi::dpl::__ranges::all_view<_ValueT, __par_backend_hetero::access_mode::read_write>(
+            __out_buffer_holder.get_buffer());
 
         // iterations per each bucket
         assert("Number of iterations must be even" && __radix_iters % 2 == 0);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -46,7 +46,6 @@ struct sycl_iterator
     using pointer = T*;
     using reference = T&;
     using iterator_category = ::std::random_access_iterator_tag;
-    using is_hetero = ::std::true_type;
     static constexpr access_mode mode = Mode;
 
     // required for make_sycl_iterator

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -232,7 +232,7 @@ struct is_passed_directly<zip_iterator<Iters...>>: ::std::conjunction<is_passed_
 };
 
 template<typename Iter>
-inline constexpr bool is_passed_directly_v = is_passed_directly<Iter>::value;
+inline constexpr bool is_passed_directly_v = is_passed_directly<::std::remove_const_t<Iter>>::value;
 
 // A trait for checking if iterator is heterogeneous or not
 
@@ -247,7 +247,7 @@ struct is_hetero<oneapi::dpl::__internal::sycl_iterator<Mode, Types...>> : ::std
 };
 
 template<typename Iter>
-inline constexpr bool is_hetero_v = is_hetero<Iter>::value;
+inline constexpr bool is_hetero_v = is_hetero<::std::remove_const_t<Iter>>::value;
 
 //A trait for checking if it needs to create a temporary SYCL buffer or not
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -232,22 +232,22 @@ struct is_passed_directly<zip_iterator<Iters...>>: ::std::conjunction<is_passed_
 };
 
 template<typename Iter>
-inline constexpr bool is_passed_directly_v = is_passed_directly<::std::remove_const_t<Iter>>::value;
+inline constexpr bool is_passed_directly_v = is_passed_directly<Iter>::value;
 
 // A trait for checking if iterator is heterogeneous or not
 
 template <typename Iter>
-struct is_hetero : ::std::false_type
+struct is_sycl_iterator : ::std::false_type
 {
 };
 
 template <oneapi::dpl::access_mode Mode, typename... Types>
-struct is_hetero<oneapi::dpl::__internal::sycl_iterator<Mode, Types...>> : ::std::true_type
+struct is_sycl_iterator<oneapi::dpl::__internal::sycl_iterator<Mode, Types...>> : ::std::true_type
 {
 };
 
 template<typename Iter>
-inline constexpr bool is_hetero_v = is_hetero<::std::remove_const_t<Iter>>::value;
+inline constexpr bool is_sycl_iterator_v = is_sycl_iterator<Iter>::value;
 
 //A trait for checking if it needs to create a temporary SYCL buffer or not
 
@@ -258,7 +258,7 @@ struct is_temp_buff : ::std::false_type
 
 template <typename _Iter>
 struct is_temp_buff<
-    _Iter, ::std::enable_if_t<!is_hetero_v<_Iter> && !::std::is_pointer_v<_Iter> && !is_passed_directly_v<_Iter>>>
+    _Iter, ::std::enable_if_t<!is_sycl_iterator_v<_Iter> && !::std::is_pointer_v<_Iter> && !is_passed_directly_v<_Iter>>>
     : ::std::true_type
 {
 };
@@ -485,7 +485,7 @@ struct __get_sycl_range
 
   public:
     //specialization for permutation_iterator using sycl_iterator as source
-    template <typename _It, typename _Map, ::std::enable_if_t<is_hetero_v<_It>, int> = 0>
+    template <typename _It, typename _Map, ::std::enable_if_t<is_sycl_iterator_v<_It>, int> = 0>
     auto
     operator()(oneapi::dpl::permutation_iterator<_It, _Map> __first,
                oneapi::dpl::permutation_iterator<_It, _Map> __last)
@@ -502,7 +502,7 @@ struct __get_sycl_range
     }
 
     //specialization for permutation_iterator using USM pointer or direct pass object as source
-    template <typename _Iter, typename _Map, ::std::enable_if_t<!is_hetero_v<_Iter>
+    template <typename _Iter, typename _Map, ::std::enable_if_t<!is_sycl_iterator_v<_Iter>
               && is_passed_directly_v<_Iter>, int> = 0>
     auto
     operator()(oneapi::dpl::permutation_iterator<_Iter, _Map> __first,
@@ -518,7 +518,7 @@ struct __get_sycl_range
         return __range_holder<decltype(rng)>{rng};
     }
 
-    template <typename _Iter, typename _Map, ::std::enable_if_t<!is_hetero_v<_Iter>
+    template <typename _Iter, typename _Map, ::std::enable_if_t<!is_sycl_iterator_v<_Iter>
               && !is_passed_directly_v<_Iter>, int> = 0>
     void
     operator()(oneapi::dpl::permutation_iterator<_Iter, _Map>, oneapi::dpl::permutation_iterator<_Iter, _Map>)
@@ -555,7 +555,7 @@ struct __get_sycl_range
     template <typename _Iter>
     auto
     operator()(_Iter __first, _Iter __last)
-        -> ::std::enable_if_t<is_hetero_v<_Iter>,
+        -> ::std::enable_if_t<is_sycl_iterator_v<_Iter>,
                               __range_holder<oneapi::dpl::__ranges::all_view<val_t<_Iter>, AccMode>>>
     {
         assert(__first < __last);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -344,9 +344,10 @@ struct __get_sycl_range
     ::std::vector<::std::unique_ptr<oneapi::dpl::__internal::__lifetime_keeper_base>> m_buffers;
 
     //SFINAE iterator type checks
-    template<typename _It, typename _T = decltype(::std::addressof(*_It{}))>
-    constexpr ::std::true_type __test_addressof(_It) { return {};}
-    constexpr ::std::false_type __test_addressof(...) { return {};}
+    template<typename It, typename T = decltype(std::addressof(*It{}))>
+    static constexpr std::true_type __test_addressof(int) { return {};}
+    template<typename It>
+    static constexpr std::false_type __test_addressof(...) { return {};}
 
     template <typename _F, typename _It, typename _DiffType>
     static auto
@@ -535,7 +536,7 @@ struct __get_sycl_range
         {
             if constexpr(__is_copy_direct)
             {
-                if constexpr(__test_addressof(_Iter{}))
+                if constexpr(__test_addressof<_Iter>(0))
                 {
                     //buffer will wait and copying on destructor; an exclusive access buffer, good performance
                     return sycl::buffer<_T, 1>(::std::addressof(*__first), __last - __first);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -323,6 +323,15 @@ __require_access_range(sycl::handler& __cgh, zip_view<_Ranges...>& zip_rng)
     __require_access_zip(__cgh, zip_rng);
 }
 
+template <typename... _Ranges>
+void
+__require_access_range(sycl::handler& __cgh, oneapi::dpl::__internal::tuple<_Ranges...>& __tuple)
+{
+    const ::std::size_t __num_ranges = sizeof...(_Ranges);
+    oneapi::dpl::__ranges::invoke(__tuple, _require_access_args<decltype(__cgh)>{__cgh},
+                                  ::std::make_index_sequence<__num_ranges>());
+}
+
 template <typename _BaseRange>
 void
 __require_access_range(sycl::handler&, _BaseRange&)
@@ -333,8 +342,6 @@ template <typename _Range, typename... _Ranges>
 void
 __require_access(sycl::handler& __cgh, _Range&& __rng, _Ranges&&... __rest)
 {
-    assert(!__rng.empty());
-
     //getting an access for the all_view based range
     auto base_rng = oneapi::dpl::__ranges::pipeline_base_range<_Range>(::std::forward<_Range>(__rng)).base_range();
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -400,12 +400,12 @@ struct __get_sycl_range
             AccMode == sycl::access::mode::read_write || AccMode == sycl::access::mode::write;
 
     //SFINAE iterator type checks
-    template<typename It, typename T = decltype(std::addressof(*::std::declval<It&>()))>
-    static constexpr std::true_type __is_addressable (int);
     template<typename It>
-    static constexpr std::false_type __is_addressable (...);
+    static constexpr auto __is_addressable(int) -> decltype(std::addressof(*::std::declval<It&>()), std::true_type{});
     template<typename It>
-    static constexpr bool __is_addressable_v = decltype(__is_addressable <It>(0))::value;
+    static constexpr std::false_type __is_addressable(...);
+    template<typename It>
+    static constexpr bool __is_addressable_v = decltype(__is_addressable<It>(0))::value;
 
     template <typename _F, typename _It, typename _DiffType>
     static auto
@@ -578,8 +578,6 @@ struct __get_sycl_range
         -> ::std::enable_if_t<is_temp_buff<_Iter>::value && __is_addressable_v<_Iter> && !is_zip<_Iter>::value &&
         !is_permutation<_Iter>::value, __range_holder<oneapi::dpl::__ranges::all_view<val_t<_Iter>, AccMode>>>
     {
-        static_assert(__is_addressable_v<_Iter>);
-
         using _T = val_t<_Iter>;
 
         return __process_host_iter_impl(__first, __last, [&]()

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -508,17 +508,20 @@ struct __get_sycl_range
 
         using _T = val_t<_Iter>;
 
-        constexpr bool __is_copy_direct = AccMode == sycl::access::mode::read_write || AccMode == sycl::access::mode::read;
-        constexpr bool __is_copy_back = AccMode == sycl::access::mode::read_write || AccMode == sycl::access::mode::write;
+        constexpr bool __is_copy_direct =
+            AccMode == sycl::access::mode::read_write || AccMode == sycl::access::mode::read;
+        constexpr bool __is_copy_back =
+            AccMode == sycl::access::mode::read_write || AccMode == sycl::access::mode::write;
 
         auto __get_buf = [&]()
         {
             if constexpr(__is_copy_direct)
-                return sycl::buffer<_T, 1>(std::addressof(*__first), __last - __first); //buffer will wait and copying on destrcutor
+                //buffer will wait and copying on destructor
+                return sycl::buffer<_T, 1>(std::addressof(*__first), __last - __first);
             else
             {
                 sycl::buffer<_T, 1> __buf(__last - __first);
-                __buf.set_final_data(__first); //buffer wait and copying on destrcutor
+                __buf.set_final_data(__first); //buffer wait and copying on destructor
                 return __buf;
             }
         };

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -552,7 +552,10 @@ struct __get_sycl_range
             else
             {
                 sycl::buffer<_T, 1> __buf(__last - __first);
-                __buf.set_final_data(__first); //wait and copy on a buffer destructor
+                if constexpr (__test_addressof<_Iter>(0))
+                    __buf.set_final_data(::std::addressof(*__first)); //wait and fast copy on a buffer destructor
+                else
+                    __buf.set_final_data(__first); //wait and copy on a buffer destructor
                 return __buf;
             }
         };

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -376,9 +376,6 @@ struct __get_sycl_range
     template <typename... Iters>
     auto
     operator()(oneapi::dpl::zip_iterator<Iters...> __first, oneapi::dpl::zip_iterator<Iters...> __last)
-        -> decltype(__range_holder<decltype(gen_zip_view(__first.base(), __last - __first,
-                                                         ::std::make_index_sequence<sizeof...(Iters)>()))>{
-            gen_zip_view(__first.base(), __last - __first, ::std::make_index_sequence<sizeof...(Iters)>())})
     {
         assert(__first < __last);
 
@@ -469,12 +466,12 @@ struct __get_sycl_range
         return __range_holder<decltype(rng)>{rng};
     }
 
-    //specialization for permutation_iterator based on the host iterator
-    template <typename _Iter, typename _Map, ::std::enable_if_t<is_temp_buff<_Iter>::value &&
-              !__test_addressof<_Iter>(0), int> = 0>
+    //An overload  for another iterator types based on the host iterator
+    template <typename _Iter, ::std::enable_if_t<is_temp_buff<_Iter>::value && !is_zip<_Iter>::value, int> = 0>
     auto
     operator()(_Iter __first, _Iter __last)
     {
+        static_assert(false, "OneDPL doesn't support such iterator type.");
         using _T = val_t<_Iter>;
 
         return __process_host_iter_impl(__first, __last, [&]()

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -534,25 +534,25 @@ struct __get_sycl_range
 
         auto __get_buf = [&]()
         {
-            if constexpr(__is_copy_direct)
+            if constexpr (__is_copy_direct)
             {
-                if constexpr(__test_addressof<_Iter>(0))
+                if constexpr (__test_addressof<_Iter>(0))
                 {
-                    //buffer will wait and copying on destructor; an exclusive access buffer, good performance
+                    //wait and copy on a buffer destructor; an exclusive access buffer, good performance
                     return sycl::buffer<_T, 1>(::std::addressof(*__first), __last - __first);
                 }
                 else
                 {
                     sycl::buffer<_T, 1> __buf(__first, __last); //a non-exclusive access buffer, poor performance
-                    if(__is_copy_back)
-                        __buf.set_final_data(__first); //buffer wait and copying on destructor
+                    if (__is_copy_back)
+                        __buf.set_final_data(__first); //wait and copy on a buffer destructor
                     return __buf;
                 }
             }
             else
             {
                 sycl::buffer<_T, 1> __buf(__last - __first);
-                __buf.set_final_data(__first); //buffer wait and copying on destructor
+                __buf.set_final_data(__first); //wait and copy on a buffer destructor
                 return __buf;
             }
         };

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -341,7 +341,7 @@ struct __get_sycl_range
 
   private:
     //We have to keep sycl buffer(s) instance here by sync reasons;
-    ::std::vector<::std::shared_ptr<oneapi::dpl::__internal::__lifetime_keeper_base>> m_buffers;
+    ::std::vector<::std::unique_ptr<oneapi::dpl::__internal::__lifetime_keeper_base>> m_buffers;
 
     template <typename _F, typename _It, typename _DiffType>
     static auto

--- a/include/oneapi/dpl/pstl/iterator_defs.h
+++ b/include/oneapi/dpl/pstl/iterator_defs.h
@@ -83,45 +83,6 @@ using __is_random_access_iterator_t = typename __is_random_access_iterator<_Iter
 template <typename... _IteratorTypes>
 inline constexpr bool __is_random_access_iterator_v = __is_random_access_iterator<_IteratorTypes...>::value;
 
-// struct for checking if iterator is heterogeneous or not
-template <typename Iter, typename Void = void> // for non-heterogeneous iterators
-struct is_hetero_iterator : ::std::false_type
-{
-};
-
-template <typename Iter> // for heterogeneous iterators
-struct is_hetero_iterator<Iter, ::std::enable_if_t<Iter::is_hetero::value>> : ::std::true_type
-{
-};
-
-template <typename Iter> // recursive check for hetero iterator
-struct is_hetero_iterator<Iter, ::std::enable_if_t<is_hetero_iterator<
-                          decltype(::std::declval<Iter&>().base())>::value>> : ::std::true_type
-{
-};
-
-// struct for checking if iterator should be passed directly to device or not
-template <typename Iter, typename Void = void> // for iterators that should not be passed directly
-struct is_passed_directly : ::std::false_type
-{
-};
-
-template <typename Iter> // for iterators defined as direct pass
-struct is_passed_directly<Iter, ::std::enable_if_t<Iter::is_passed_directly::value>> : ::std::true_type
-{
-};
-
-template <typename Iter> // recursive check for directly passed iterator
-struct is_passed_directly<Iter, ::std::enable_if_t<is_passed_directly<
-                          decltype(::std::declval<Iter&>().base())>::value>> : ::std::true_type
-{
-};
-
-template <typename Iter> // for pointers to objects on device
-struct is_passed_directly<Iter, ::std::enable_if_t<::std::is_pointer_v<Iter>>> : ::std::true_type
-{
-};
-
 } // namespace __internal
 } // namespace dpl
 } // namespace oneapi

--- a/include/oneapi/dpl/pstl/iterator_defs.h
+++ b/include/oneapi/dpl/pstl/iterator_defs.h
@@ -93,6 +93,13 @@ template <typename Iter> // for heterogeneous iterators
 struct is_hetero_iterator<Iter, ::std::enable_if_t<Iter::is_hetero::value>> : ::std::true_type
 {
 };
+
+template <typename Iter> // recursive check for hetero iterator
+struct is_hetero_iterator<Iter, ::std::enable_if_t<is_hetero_iterator<
+                          decltype(::std::declval<Iter&>().base())>::value>> : ::std::true_type
+{
+};
+
 // struct for checking if iterator should be passed directly to device or not
 template <typename Iter, typename Void = void> // for iterators that should not be passed directly
 struct is_passed_directly : ::std::false_type
@@ -101,6 +108,12 @@ struct is_passed_directly : ::std::false_type
 
 template <typename Iter> // for iterators defined as direct pass
 struct is_passed_directly<Iter, ::std::enable_if_t<Iter::is_passed_directly::value>> : ::std::true_type
+{
+};
+
+template <typename Iter> // recursive check for directly passed iterator
+struct is_passed_directly<Iter, ::std::enable_if_t<is_passed_directly<
+                          decltype(::std::declval<Iter&>().base())>::value>> : ::std::true_type
 {
 };
 

--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -159,7 +159,6 @@ class counting_iterator
     // There is no storage behind the iterator, so we return a value instead of reference.
     typedef _Ip reference;
     typedef ::std::random_access_iterator_tag iterator_category;
-    using is_passed_directly = ::std::true_type;
 
     counting_iterator() : __my_counter_() {}
     explicit counting_iterator(_Ip __init) : __my_counter_(__init) {}
@@ -776,7 +775,6 @@ class discard_iterator
     typedef void* pointer;
     typedef value_type reference;
     typedef ::std::random_access_iterator_tag iterator_category;
-    using is_passed_directly = ::std::true_type;
     using is_discard = ::std::true_type;
 
     discard_iterator() : __my_position_() {}

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -537,7 +537,7 @@ struct permutation_view_simple<_Source, _M, ::std::enable_if_t<is_map_view<_M>::
     auto
     base() const
     {
-        return __src;
+        return oneapi::dpl::__internal::make_tuple(__src, __map);
     }
 };
 

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -503,14 +503,14 @@ struct permutation_view_simple<_Source, _M, ::std::enable_if_t<oneapi::dpl::__in
 };
 
 //permutation view: specialization for a map view (a viewable range concept)
-//size of such view  is specified by size of the map view (permiutation range)
+//size of such view  is specified by size of the map view (permutation range)
 template <typename _Source, typename _M>
 struct permutation_view_simple<_Source, _M, ::std::enable_if_t<is_map_view<_M>::value>>
 {
     using value_type = oneapi::dpl::__internal::__value_t<_Source>;
 
     _Source __src; //Iterator (pointer) or unreachable range
-    _M __map;      //permiutation range
+    _M __map;      //permutation range
 
     permutation_view_simple(_Source __data, _M __m) : __src(__data), __map(__m) {}
 

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -40,6 +40,10 @@ auto
 get_value_type(long) ->
     typename ::std::iterator_traits<::std::decay_t<decltype(::std::declval<_R&>().begin())>>::value_type;
 
+template <typename _It>
+auto
+get_value_type(long long) -> typename ::std::iterator_traits<_It>::value_type;
+
 template <typename _R>
 auto
 get_value_type(...)
@@ -454,31 +458,33 @@ struct is_map_view : decltype(test_map_view<_Map>(0))
 };
 
 //It is kind of pseudo-view for permutation_iterator support.
-template <typename _R, typename _M, typename = void>
+template <typename _Source, typename _M, typename = void>
 struct permutation_view_simple;
 
 //permutation view: specialization for an index map functor
-template <typename _R, typename _M>
-struct permutation_view_simple<_R, _M, ::std::enable_if_t<oneapi::dpl::__internal::__is_functor<_M>>>
+//size of such view  is specified by a caller
+template <typename _Source, typename _M>
+struct permutation_view_simple<_Source, _M, ::std::enable_if_t<oneapi::dpl::__internal::__is_functor<_M>>>
 {
-    using value_type = oneapi::dpl::__internal::__value_t<_R>;
-    using _Size = oneapi::dpl::__internal::__difference_t<_R>;
+    using value_type = oneapi::dpl::__internal::__value_t<_Source>;
+    using _Size = oneapi::dpl::__internal::__difference_t<_Source>;
 
-    _R __r;
+    _Source __src; //Iterator (pointer) or unreachable range
     _M __map_fn;
     _Size __size;
 
-    permutation_view_simple(_R __rng, _M __m, _Size __s) : __r(__rng), __map_fn(__m), __size(__s) {}
+    permutation_view_simple(_Source __data, _M __m, _Size __s) : __src(__data), __map_fn(__m), __size(__s) {}
 
     //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range
     template <typename Idx>
-    auto operator[](Idx __i) const -> decltype(__r[__map_fn(__i)])
+    auto
+    operator[](Idx __i) const
     {
-        return __r[__map_fn(__i)];
+        return __src[__map_fn(__i)];
     }
 
     auto
-    size() const -> decltype(__size)
+    size() const
     {
         return __size;
     }
@@ -490,33 +496,36 @@ struct permutation_view_simple<_R, _M, ::std::enable_if_t<oneapi::dpl::__interna
     }
 
     auto
-    base() const -> decltype(__r)
+    base() const
     {
-        return __r;
+        return __src;
     }
 };
 
 //permutation view: specialization for a map view (a viewable range concept)
-template <typename _R, typename _M>
-struct permutation_view_simple<_R, _M, ::std::enable_if_t<is_map_view<_M>::value>>
+//size of such view  is specified by size of the map view (permiutation range)
+template <typename _Source, typename _M>
+struct permutation_view_simple<_Source, _M, ::std::enable_if_t<is_map_view<_M>::value>>
 {
-    using value_type = oneapi::dpl::__internal::__value_t<_R>;
+    using value_type = oneapi::dpl::__internal::__value_t<_Source>;
 
-    zip_view<_R, _M> __data;
+    _Source __src; //Iterator (pointer) or unreachable range
+    _M __map;      //permiutation range
 
-    permutation_view_simple(_R __r, _M __m) : __data(__r, __m) {}
+    permutation_view_simple(_Source __data, _M __m) : __src(__data), __map(__m) {}
 
     //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range
     template <typename Idx>
-    auto operator[](Idx __i) const -> decltype(::std::get<0>(__data.tuple())[::std::get<1>(__data.tuple())[__i]])
+    auto
+    operator[](Idx __i) const
     {
-        return ::std::get<0>(__data.tuple())[::std::get<1>(__data.tuple())[__i]];
+        return __src[__map[__i]];
     }
 
     auto
-    size() const -> decltype(::std::get<1>(__data.tuple()).size())
+    size() const
     {
-        return ::std::get<1>(__data.tuple()).size();
+        return __map.size();
     }
 
     bool
@@ -526,9 +535,9 @@ struct permutation_view_simple<_R, _M, ::std::enable_if_t<is_map_view<_M>::value
     }
 
     auto
-    base() const -> decltype(__data)
+    base() const
     {
-        return __data;
+        return __src;
     }
 };
 


### PR DESCRIPTION
1. Simplified temporary sycl::buffer support in case of host iterators (when it needs to copy data to a temp buffer and back). 
2. Removed lifetime extension for temporary  sycl::buffer, which used within some SYCL backend patterns. According to the SYCL spec, SYCL runtime manages lifetime of such buffer itself.
3. Permutation_iterator support fixes.
4. A mention about a limitation in the doc: https://github.com/oneapi-src/oneDPL/pull/1295/files
5. Compiler time error for some non-supported iterator types (according to the documentation)
6.  is_passed_directly and is_hetero traits refactoring
7. Usage of exclusive access sycl::buffer with pointer to host data and data size for better performance. (Instead of sycl::buffer with iterators constructor - slow perf because of element-wise copy) 
