### PR TITLE
[Dynamic Selection] Use sycl profiling for auto tune policy

### DIFF
--- a/include/oneapi/dpl/internal/dynamic_selection_impl/sycl_backend.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/sycl_backend.h
@@ -132,7 +132,6 @@ class sycl_backend
                         }
                         else
                         {
-                            auto x = std::chrono::steady_clock::now();
                             s.report(execution_info::task_time, (std::chrono::steady_clock::now() - t0).count());
                         }
                     }

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/sycl_backend.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/sycl_backend.h
@@ -126,12 +126,13 @@ class sycl_backend
                     {
                         if (use_event_profiling)
                         {
-                            cl_ulong time_start = e1.template get_profiling_info<sycl::info::event_profiling::command_start>();
+                            cl_ulong time_start = e1.template get_profiling_info<sycl::info::event_profiling::command_submit>();
                             cl_ulong time_end = e1.template get_profiling_info<sycl::info::event_profiling::command_end>();
                             s.report(execution_info::task_time, time_end - time_start);
                         }
-                        else 
+                        else
                         {
+                            auto x = std::chrono::steady_clock::now();
                             s.report(execution_info::task_time, (std::chrono::steady_clock::now() - t0).count());
                         }
                     }

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/sycl_backend.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/sycl_backend.h
@@ -126,7 +126,7 @@ class sycl_backend
                     {
                         if (use_event_profiling)
                         {
-                            cl_ulong time_start = e1.template get_profiling_info<sycl::info::event_profiling::command_submit>();
+                            cl_ulong time_start = e1.template get_profiling_info<sycl::info::event_profiling::command_start>();
                             cl_ulong time_end = e1.template get_profiling_info<sycl::info::event_profiling::command_end>();
                             s.report(execution_info::task_time, time_end - time_start);
                         }

--- a/test/parallel_api/dynamic_selection/sycl/test_auto_tune_policy_sycl_profile.pass.cpp
+++ b/test/parallel_api/dynamic_selection/sycl/test_auto_tune_policy_sycl_profile.pass.cpp
@@ -452,15 +452,15 @@ test_auto_submit_and_wait(UniverseContainer u, int best_resource)
 }
 
 static inline void
-build_auto_tune_universe_all(std::vector<sycl::queue>& u)
+build_auto_tune_universe1(std::vector<sycl::queue>& u)
 {
     auto prop_list = sycl::property_list{sycl::property::queue::enable_profiling()};
     try
     {
-        auto device_cpu1 = sycl::device(sycl::cpu_selector_v);
-        sycl::queue cpu1_queue{device_cpu1, prop_list};
-        run_sycl_sanity_test(cpu1_queue);
-        u.push_back(cpu1_queue);
+        auto device_cpu = sycl::device(sycl::cpu_selector_v);
+        sycl::queue cpu_queue{device_cpu, prop_list};
+        run_sycl_sanity_test(cpu_queue);
+        u.push_back(cpu_queue);
     }
     catch (const sycl::exception&)
     {
@@ -468,38 +468,38 @@ build_auto_tune_universe_all(std::vector<sycl::queue>& u)
     }
     try
     {
-        auto device_cpu2 = sycl::device(sycl::cpu_selector_v);
-        sycl::queue cpu2_queue{device_cpu2, prop_list};
-        run_sycl_sanity_test(cpu2_queue);
-        u.push_back(cpu2_queue);
+        auto device_gpu = sycl::device(sycl::gpu_selector_v);
+        sycl::queue gpu_queue{device_gpu, prop_list};
+        run_sycl_sanity_test(gpu_queue);
+        u.push_back(gpu_queue);
     }
     catch (const sycl::exception&)
     {
-        std::cout << "SKIPPED: Unable to run with cpu_selector\n";
+        std::cout << "SKIPPED: Unable to run with gpu_selector\n";
     }
 }
 
 static inline void
-build_auto_tune_universe_single(std::vector<sycl::queue>& u)
+build_auto_tune_universe2(std::vector<sycl::queue>& u)
 {
     auto prop_list = sycl::property_list{sycl::property::queue::enable_profiling()};
     try
     {
-        auto device_cpu1 = sycl::device(sycl::cpu_selector_v);
-        sycl::queue cpu1_queue{device_cpu1, prop_list};
-        run_sycl_sanity_test(cpu1_queue);
-        u.push_back(cpu1_queue);
+        auto device_gpu = sycl::device(sycl::gpu_selector_v);
+        sycl::queue gpu_queue{device_gpu, prop_list};
+        run_sycl_sanity_test(gpu_queue);
+        u.push_back(gpu_queue);
     }
     catch (const sycl::exception&)
     {
-        std::cout << "SKIPPED: Unable to run with cpu_selector\n";
+        std::cout << "SKIPPED: Unable to run with gpu_selector\n";
     }
     try
     {
-        auto device_cpu2 = sycl::device(sycl::cpu_selector_v);
-        sycl::queue cpu2_queue{device_cpu2};
-        run_sycl_sanity_test(cpu2_queue);
-        u.push_back(cpu2_queue);
+        auto device_cpu = sycl::device(sycl::cpu_selector_v);
+        sycl::queue cpu_queue{device_cpu, prop_list};
+        run_sycl_sanity_test(cpu_queue);
+        u.push_back(cpu_queue);
     }
     catch (const sycl::exception&)
     {
@@ -514,8 +514,8 @@ main()
 #if TEST_DYNAMIC_SELECTION_AVAILABLE
     using policy_t = oneapi::dpl::experimental::auto_tune_policy<oneapi::dpl::experimental::sycl_backend>;
     std::vector<sycl::queue> u1, u2;
-    build_auto_tune_universe_all(u1);
-    build_auto_tune_universe_single(u2);
+    build_auto_tune_universe1(u1);
+    build_auto_tune_universe2(u2);
 
     //If building the universe is not a success, return
     if (u1.size() == 0 || u2.size()==0)
@@ -524,7 +524,7 @@ main()
     constexpr bool just_call_submit = false;
     constexpr bool call_select_before_submit = true;
 
-    if (test_auto_submit_wait_on_event<just_call_submit, policy_t>(u1, 0) ||
+    if (test_auto_submit_wait_on_event<just_call_submit, policy_t>(u1, 0) /*||
         test_auto_submit_wait_on_event<just_call_submit, policy_t>(u1, 1) ||
         test_auto_submit_wait_on_event<just_call_submit, policy_t>(u2, 0) ||
         test_auto_submit_wait_on_event<just_call_submit, policy_t>(u2, 1) ||
@@ -548,7 +548,7 @@ main()
         test_auto_submit_and_wait<call_select_before_submit, policy_t>(u1, 0) ||
         test_auto_submit_and_wait<call_select_before_submit, policy_t>(u1, 1) ||
         test_auto_submit_and_wait<call_select_before_submit, policy_t>(u2, 0) ||
-        test_auto_submit_and_wait<call_select_before_submit, policy_t>(u2, 1))
+        test_auto_submit_and_wait<call_select_before_submit, policy_t>(u2, 1)*/)
     {
         std::cout << "FAIL\n";
         return 1;

--- a/test/parallel_api/dynamic_selection/sycl/test_auto_tune_policy_sycl_profile.pass.cpp
+++ b/test/parallel_api/dynamic_selection/sycl/test_auto_tune_policy_sycl_profile.pass.cpp
@@ -41,11 +41,6 @@ test_auto_submit_wait_on_event(UniverseContainer u, int best_resource)
         {
             j = 0;
         }
-        // we can capture all by reference
-        // the inline_scheduler reports timings in submit
-        // We wait but it should return immediately, since inline
-        // scheduler does the work "inline".
-        // The unwrapped wait type should be equal to the resource
         const size_t bytes = 1000000 * sizeof(double);
         if constexpr (call_select_before_submit)
         {
@@ -192,11 +187,6 @@ test_auto_submit_wait_on_group(UniverseContainer u, int best_resource)
         {
             j = 0;
         }
-        // we can capture all by reference
-        // the inline_scheduler reports timings in submit
-        // We wait but it should return immediately, since inline
-        // scheduler does the work "inline".
-        // The unwrapped wait type should be equal to the resource
         const size_t bytes = 1000000 * sizeof(double);
         if constexpr (call_select_before_submit)
         {
@@ -343,11 +333,6 @@ test_auto_submit_and_wait(UniverseContainer u, int best_resource)
         {
             j = 0;
         }
-        // we can capture all by reference
-        // the inline_scheduler reports timings in submit
-        // We wait but it should return immediately, since inline
-        // scheduler does the work "inline".
-        // The unwrapped wait type should be equal to the resource
         const size_t bytes = 1000000 * sizeof(double);
         if constexpr (call_select_before_submit)
         {

--- a/test/parallel_api/dynamic_selection/sycl/test_auto_tune_policy_sycl_profile.pass.cpp
+++ b/test/parallel_api/dynamic_selection/sycl/test_auto_tune_policy_sycl_profile.pass.cpp
@@ -21,9 +21,8 @@ test_auto_submit_wait_on_event(UniverseContainer u, int best_resource)
 {
     using my_policy_t = Policy;
 
-    // they are cpus so this is ok
-    double* v = sycl::malloc_shared<double>(1000000, u[0]);
-    int* j = sycl::malloc_shared<int>(1, u[0]);
+    int j;
+    std::vector<double> v(1000000, 0.0);
 
     my_policy_t p{u};
     auto n_samples = u.size();
@@ -36,17 +35,18 @@ test_auto_submit_wait_on_event(UniverseContainer u, int best_resource)
     {
         if (i <= 2 * n_samples && (i - 1) % n_samples != best_resource)
         {
-            *j = 100;
+            j = 100;
         }
         else
         {
-            *j = 0;
+            j = 0;
         }
         // we can capture all by reference
         // the inline_scheduler reports timings in submit
         // We wait but it should return immediately, since inline
         // scheduler does the work "inline".
         // The unwrapped wait type should be equal to the resource
+        const size_t bytes = 1000000 * sizeof(double);
         if constexpr (call_select_before_submit)
         {
             auto f = [&](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type q) {
@@ -68,23 +68,26 @@ test_auto_submit_wait_on_event(UniverseContainer u, int best_resource)
                     }
                 }
                 ecount += i;
-                if (*j == 0)
+                if (j == 0)
                 {
-                     return q.submit([=](sycl::handler& h){
+                     return q.submit([&](sycl::handler& h)
+                     {
                              h.single_task([=](){});
                          });
                 }
                 else
                 {
-                    return q.submit([=](sycl::handler& h) {
-                        h.parallel_for<TestUtils::unique_kernel_name<
-                            class tune1, TestUtils::uniq_kernel_index<sycl::usm::alloc::shared>()>>(
+                    return q.submit([&](sycl::handler& h) {
+                        double *d_v = sycl::malloc_device<double>(1000000, q);
+                        q.memcpy(d_v, v.data(), bytes).wait();
+                        q.parallel_for(
                             1000000, [=](sycl::id<1> idx) {
-                                for (int j0 = 0; j0 < *j; ++j0)
+                                for (int j0 = 0; j0 < j; ++j0)
                                 {
-                                    v[idx] += idx;
+                                    d_v[idx] += idx;
                                 }
                             });
+                        q.memcpy(v.data(), d_v, bytes).wait();
                     });
                 }
             };
@@ -115,23 +118,25 @@ test_auto_submit_wait_on_event(UniverseContainer u, int best_resource)
                         }
                     }
                     ecount += i;
-                    if (*j == 0)
+                    if (j == 0)
                     {
-                     return q.submit([=](sycl::handler& h){
+                     return q.submit([&](sycl::handler& h){
                              h.single_task([=](){});
                          });
                     }
                     else
                     {
-                        return q.submit([=](sycl::handler& h) {
-                            h.parallel_for<TestUtils::unique_kernel_name<
-                                class tune2, TestUtils::uniq_kernel_index<sycl::usm::alloc::shared>()>>(
+                        return q.submit([&](sycl::handler& h) {
+                            double *d_v = sycl::malloc_device<double>(1000000, q);
+                            q.memcpy(d_v, v.data(), bytes).wait();
+                            q.parallel_for(
                                 1000000, [=](sycl::id<1> idx) {
-                                    for (int j0 = 0; j0 < *j; ++j0)
+                                    for (int j0 = 0; j0 < j; ++j0)
                                     {
-                                        v[idx] += idx;
+                                        d_v[idx] += idx;
                                     }
                                 });
+                            q.memcpy(v.data(), d_v, bytes).wait();
                         });
                     }
                 });
@@ -167,9 +172,8 @@ test_auto_submit_wait_on_group(UniverseContainer u, int best_resource)
 {
     using my_policy_t = Policy;
 
-    // they are cpus so this is ok
-    double* v = sycl::malloc_shared<double>(1000000, u[0]);
-    int* j = sycl::malloc_shared<int>(1, u[0]);
+    int j;
+    std::vector<double> v(1000000, 0.0);
 
     my_policy_t p{u};
     auto n_samples = u.size();
@@ -182,17 +186,18 @@ test_auto_submit_wait_on_group(UniverseContainer u, int best_resource)
     {
         if (i <= 2 * n_samples && (i - 1) % n_samples != best_resource)
         {
-            *j = 100;
+            j = 100;
         }
         else
         {
-            *j = 0;
+            j = 0;
         }
         // we can capture all by reference
         // the inline_scheduler reports timings in submit
         // We wait but it should return immediately, since inline
         // scheduler does the work "inline".
         // The unwrapped wait type should be equal to the resource
+        const size_t bytes = 1000000 * sizeof(double);
         if constexpr (call_select_before_submit)
         {
             auto f = [&](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type q) {
@@ -214,23 +219,25 @@ test_auto_submit_wait_on_group(UniverseContainer u, int best_resource)
                     }
                 }
                 ecount += i;
-                if (*j == 0)
+                if (j == 0)
                 {
                      return q.submit([=](sycl::handler& h){
-                             h.single_task([=](){});
+                            h.single_task([=](){});
                          });
                 }
                 else
                 {
-                    return q.submit([=](sycl::handler& h) {
-                        h.parallel_for<TestUtils::unique_kernel_name<
-                            class tune3, TestUtils::uniq_kernel_index<sycl::usm::alloc::shared>()>>(
+                    return q.submit([&](sycl::handler& h) {
+                            double *d_v = sycl::malloc_device<double>(1000000, q);
+                            q.memcpy(d_v, v.data(), bytes).wait();
+                            h.parallel_for(
                             1000000, [=](sycl::id<1> idx) {
-                                for (int j0 = 0; j0 < *j; ++j0)
+                                for (int j0 = 0; j0 < j; ++j0)
                                 {
-                                    v[idx] += idx;
+                                    d_v[idx] += idx;
                                 }
                             });
+                            q.memcpy(v.data(), d_v, bytes).wait();
                     });
                 }
             };
@@ -261,7 +268,7 @@ test_auto_submit_wait_on_group(UniverseContainer u, int best_resource)
                         }
                     }
                     ecount += i;
-                    if (*j == 0)
+                    if (j == 0)
                     {
                      return q.submit([=](sycl::handler& h){
                              h.single_task([=](){});
@@ -269,15 +276,17 @@ test_auto_submit_wait_on_group(UniverseContainer u, int best_resource)
                     }
                     else
                     {
-                        return q.submit([=](sycl::handler& h) {
-                            h.parallel_for<TestUtils::unique_kernel_name<
-                                class tune4, TestUtils::uniq_kernel_index<sycl::usm::alloc::shared>()>>(
+                        return q.submit([&](sycl::handler& h) {
+                            double *d_v = sycl::malloc_device<double>(1000000, q);
+                            q.memcpy(d_v, v.data(), bytes).wait();
+                            h.parallel_for(
                                 1000000, [=](sycl::id<1> idx) {
-                                    for (int j0 = 0; j0 < *j; ++j0)
+                                    for (int j0 = 0; j0 < j; ++j0)
                                     {
-                                        v[idx] += idx;
+                                        d_v[idx] += idx;
                                     }
                                 });
+                            q.memcpy(v.data(), d_v, bytes).wait();
                         });
                     }
                 });
@@ -314,8 +323,8 @@ test_auto_submit_and_wait(UniverseContainer u, int best_resource)
     using my_policy_t = Policy;
 
     // they are cpus so this is ok
-    double* v = sycl::malloc_shared<double>(1000000, u[0]);
-    int* j = sycl::malloc_shared<int>(1, u[0]);
+    int j;
+    std::vector<double> v(1000000, 0.0);
 
     my_policy_t p{u};
     auto n_samples = u.size();
@@ -328,17 +337,18 @@ test_auto_submit_and_wait(UniverseContainer u, int best_resource)
     {
         if (i <= 2 * n_samples && (i - 1) % n_samples != best_resource)
         {
-            *j = 100;
+            j = 100;
         }
         else
         {
-            *j = 0;
+            j = 0;
         }
         // we can capture all by reference
         // the inline_scheduler reports timings in submit
         // We wait but it should return immediately, since inline
         // scheduler does the work "inline".
         // The unwrapped wait type should be equal to the resource
+        const size_t bytes = 1000000 * sizeof(double);
         if constexpr (call_select_before_submit)
         {
             auto f = [&](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type q) {
@@ -360,7 +370,7 @@ test_auto_submit_and_wait(UniverseContainer u, int best_resource)
                     }
                 }
                 ecount += i;
-                if (*j == 0)
+                if (j == 0)
                 {
                      return q.submit([=](sycl::handler& h){
                              h.single_task([=](){});
@@ -368,15 +378,17 @@ test_auto_submit_and_wait(UniverseContainer u, int best_resource)
                 }
                 else
                 {
-                    return q.submit([=](sycl::handler& h) {
-                        h.parallel_for<TestUtils::unique_kernel_name<
-                            class tune5, TestUtils::uniq_kernel_index<sycl::usm::alloc::shared>()>>(
+                    return q.submit([&](sycl::handler& h) {
+                        double *d_v = sycl::malloc_device<double>(1000000, q);
+                        q.memcpy(d_v, v.data(), bytes).wait();
+                        h.parallel_for(
                             1000000, [=](sycl::id<1> idx) {
-                                for (int j0 = 0; j0 < *j; ++j0)
+                                for (int j0 = 0; j0 < j; ++j0)
                                 {
-                                    v[idx] += idx;
+                                    d_v[idx] += idx;
                                 }
                             });
+                            q.memcpy(v.data(), d_v, bytes).wait();
                     });
                 }
             };
@@ -406,7 +418,7 @@ test_auto_submit_and_wait(UniverseContainer u, int best_resource)
                         }
                     }
                     ecount += i;
-                    if (*j == 0)
+                    if (j == 0)
                     {
                      return q.submit([=](sycl::handler& h){
                              h.single_task([=](){});
@@ -414,15 +426,17 @@ test_auto_submit_and_wait(UniverseContainer u, int best_resource)
                     }
                     else
                     {
-                        return q.submit([=](sycl::handler& h) {
-                            h.parallel_for<TestUtils::unique_kernel_name<
-                                class tune6, TestUtils::uniq_kernel_index<sycl::usm::alloc::shared>()>>(
+                        return q.submit([&](sycl::handler& h) {
+                            double *d_v = sycl::malloc_device<double>(1000000, q);
+                            q.memcpy(d_v, v.data(), bytes).wait();
+                            h.parallel_for(
                                 1000000, [=](sycl::id<1> idx) {
-                                    for (int j0 = 0; j0 < *j; ++j0)
+                                    for (int j0 = 0; j0 < j; ++j0)
                                     {
-                                        v[idx] += idx;
+                                        d_v[idx] += idx;
                                     }
                                 });
+                            q.memcpy(v.data(), d_v, bytes).wait();
                         });
                     }
                 });
@@ -458,7 +472,7 @@ build_auto_tune_universe1(std::vector<sycl::queue>& u)
     try
     {
         auto device_cpu = sycl::device(sycl::cpu_selector_v);
-        sycl::queue cpu_queue{device_cpu, prop_list};
+        sycl::queue cpu_queue{device_cpu};
         run_sycl_sanity_test(cpu_queue);
         u.push_back(cpu_queue);
     }
@@ -469,7 +483,7 @@ build_auto_tune_universe1(std::vector<sycl::queue>& u)
     try
     {
         auto device_gpu = sycl::device(sycl::gpu_selector_v);
-        sycl::queue gpu_queue{device_gpu, prop_list};
+        sycl::queue gpu_queue{device_gpu};
         run_sycl_sanity_test(gpu_queue);
         u.push_back(gpu_queue);
     }
@@ -479,33 +493,6 @@ build_auto_tune_universe1(std::vector<sycl::queue>& u)
     }
 }
 
-static inline void
-build_auto_tune_universe2(std::vector<sycl::queue>& u)
-{
-    auto prop_list = sycl::property_list{sycl::property::queue::enable_profiling()};
-    try
-    {
-        auto device_gpu = sycl::device(sycl::gpu_selector_v);
-        sycl::queue gpu_queue{device_gpu, prop_list};
-        run_sycl_sanity_test(gpu_queue);
-        u.push_back(gpu_queue);
-    }
-    catch (const sycl::exception&)
-    {
-        std::cout << "SKIPPED: Unable to run with gpu_selector\n";
-    }
-    try
-    {
-        auto device_cpu = sycl::device(sycl::cpu_selector_v);
-        sycl::queue cpu_queue{device_cpu, prop_list};
-        run_sycl_sanity_test(cpu_queue);
-        u.push_back(cpu_queue);
-    }
-    catch (const sycl::exception&)
-    {
-        std::cout << "SKIPPED: Unable to run with cpu_selector\n";
-    }
-}
 #endif
 
 int
@@ -513,42 +500,41 @@ main()
 {
 #if TEST_DYNAMIC_SELECTION_AVAILABLE
     using policy_t = oneapi::dpl::experimental::auto_tune_policy<oneapi::dpl::experimental::sycl_backend>;
-    std::vector<sycl::queue> u1, u2;
-    build_auto_tune_universe1(u1);
-    build_auto_tune_universe2(u2);
+    std::vector<sycl::queue> u;
+    build_auto_tune_universe1(u);
 
     //If building the universe is not a success, return
-    if (u1.size() == 0 || u2.size()==0)
+    if (u.size() == 0 || u.size()==0)
         return 0;
 
     constexpr bool just_call_submit = false;
     constexpr bool call_select_before_submit = true;
 
-    if (test_auto_submit_wait_on_event<just_call_submit, policy_t>(u1, 0) /*||
-        test_auto_submit_wait_on_event<just_call_submit, policy_t>(u1, 1) ||
-        test_auto_submit_wait_on_event<just_call_submit, policy_t>(u2, 0) ||
-        test_auto_submit_wait_on_event<just_call_submit, policy_t>(u2, 1) ||
-        test_auto_submit_wait_on_group<just_call_submit, policy_t>(u1, 0) ||
-        test_auto_submit_wait_on_group<just_call_submit, policy_t>(u1, 1) ||
-        test_auto_submit_wait_on_group<just_call_submit, policy_t>(u2, 0) ||
-        test_auto_submit_wait_on_group<just_call_submit, policy_t>(u2, 1) ||
-        test_auto_submit_and_wait<just_call_submit, policy_t>(u1, 0) ||
-        test_auto_submit_and_wait<just_call_submit, policy_t>(u1, 1)||
-        test_auto_submit_and_wait<just_call_submit, policy_t>(u2, 0) ||
-        test_auto_submit_and_wait<just_call_submit, policy_t>(u2, 1)||
+    if (test_auto_submit_wait_on_event<just_call_submit, policy_t>(u, 0) ||
+        test_auto_submit_wait_on_event<just_call_submit, policy_t>(u, 1) ||
+        test_auto_submit_wait_on_event<just_call_submit, policy_t>(u, 0) ||
+        test_auto_submit_wait_on_event<just_call_submit, policy_t>(u, 1) ||
+        test_auto_submit_wait_on_group<just_call_submit, policy_t>(u, 0) ||
+        test_auto_submit_wait_on_group<just_call_submit, policy_t>(u, 1) ||
+        test_auto_submit_wait_on_group<just_call_submit, policy_t>(u, 0) ||
+        test_auto_submit_wait_on_group<just_call_submit, policy_t>(u, 1) ||
+        test_auto_submit_and_wait<just_call_submit, policy_t>(u, 0) ||
+        test_auto_submit_and_wait<just_call_submit, policy_t>(u, 1)||
+        test_auto_submit_and_wait<just_call_submit, policy_t>(u, 0) ||
+        test_auto_submit_and_wait<just_call_submit, policy_t>(u, 1) ||
         // now select then submits
-        test_auto_submit_wait_on_event<call_select_before_submit, policy_t>(u1, 0) ||
-        test_auto_submit_wait_on_event<call_select_before_submit, policy_t>(u1, 1) ||
-        test_auto_submit_wait_on_event<call_select_before_submit, policy_t>(u2, 0) ||
-        test_auto_submit_wait_on_event<call_select_before_submit, policy_t>(u2, 1) ||
-        test_auto_submit_wait_on_group<call_select_before_submit, policy_t>(u1, 0) ||
-        test_auto_submit_wait_on_group<call_select_before_submit, policy_t>(u2, 1) ||
-        test_auto_submit_wait_on_group<call_select_before_submit, policy_t>(u1, 0) ||
-        test_auto_submit_wait_on_group<call_select_before_submit, policy_t>(u2, 1) ||
-        test_auto_submit_and_wait<call_select_before_submit, policy_t>(u1, 0) ||
-        test_auto_submit_and_wait<call_select_before_submit, policy_t>(u1, 1) ||
-        test_auto_submit_and_wait<call_select_before_submit, policy_t>(u2, 0) ||
-        test_auto_submit_and_wait<call_select_before_submit, policy_t>(u2, 1)*/)
+        test_auto_submit_wait_on_event<call_select_before_submit, policy_t>(u, 0) ||
+        test_auto_submit_wait_on_event<call_select_before_submit, policy_t>(u, 1) ||
+        test_auto_submit_wait_on_event<call_select_before_submit, policy_t>(u, 0) ||
+        test_auto_submit_wait_on_event<call_select_before_submit, policy_t>(u, 1) ||
+        test_auto_submit_wait_on_group<call_select_before_submit, policy_t>(u, 0) ||
+        test_auto_submit_wait_on_group<call_select_before_submit, policy_t>(u, 1) ||
+        test_auto_submit_wait_on_group<call_select_before_submit, policy_t>(u, 0) ||
+        test_auto_submit_wait_on_group<call_select_before_submit, policy_t>(u, 1) ||
+        test_auto_submit_and_wait<call_select_before_submit, policy_t>(u, 0) ||
+        test_auto_submit_and_wait<call_select_before_submit, policy_t>(u, 1) ||
+        test_auto_submit_and_wait<call_select_before_submit, policy_t>(u, 0) ||
+        test_auto_submit_and_wait<call_select_before_submit, policy_t>(u, 1))
     {
         std::cout << "FAIL\n";
         return 1;

--- a/test/parallel_api/dynamic_selection/sycl/test_auto_tune_policy_sycl_profile.pass.cpp
+++ b/test/parallel_api/dynamic_selection/sycl/test_auto_tune_policy_sycl_profile.pass.cpp
@@ -1,0 +1,565 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <iostream>
+#include <thread>
+#include "oneapi/dpl/dynamic_selection"
+#include "support/test_dynamic_selection_utils.h"
+#include "support/test_config.h"
+#if TEST_DYNAMIC_SELECTION_AVAILABLE
+#    include "support/sycl_sanity.h"
+
+template <bool call_select_before_submit, typename Policy, typename UniverseContainer>
+int
+test_auto_submit_wait_on_event(UniverseContainer u, int best_resource)
+{
+    using my_policy_t = Policy;
+
+    // they are cpus so this is ok
+    double* v = sycl::malloc_shared<double>(1000000, u[0]);
+    int* j = sycl::malloc_shared<int>(1, u[0]);
+
+    my_policy_t p{u};
+    auto n_samples = u.size();
+
+    const int N = 10;
+    std::atomic<int> ecount = 0;
+    bool pass = true;
+
+    for (int i = 1; i <= N; ++i)
+    {
+        if (i <= 2 * n_samples && (i - 1) % n_samples != best_resource)
+        {
+            *j = 100;
+        }
+        else
+        {
+            *j = 0;
+        }
+        // we can capture all by reference
+        // the inline_scheduler reports timings in submit
+        // We wait but it should return immediately, since inline
+        // scheduler does the work "inline".
+        // The unwrapped wait type should be equal to the resource
+        if constexpr (call_select_before_submit)
+        {
+            auto f = [&](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type q) {
+                if (i <= 2 * n_samples)
+                {
+                    // we should be round-robining through the resources
+                    if (q != u[(i - 1) % n_samples])
+                    {
+                        std::cout << i << ": mismatch during rr phase\n" << std::flush;
+                        pass = false;
+                    }
+                }
+                else
+                {
+                    if (q != u[best_resource])
+                    {
+                        std::cout << i << ": mismatch during prod phase " << best_resource << "\n" << std::flush;
+                        pass = false;
+                    }
+                }
+                ecount += i;
+                if (*j == 0)
+                {
+                     return q.submit([=](sycl::handler& h){
+                             h.single_task([=](){});
+                         });
+                }
+                else
+                {
+                    return q.submit([=](sycl::handler& h) {
+                        h.parallel_for<TestUtils::unique_kernel_name<
+                            class tune1, TestUtils::uniq_kernel_index<sycl::usm::alloc::shared>()>>(
+                            1000000, [=](sycl::id<1> idx) {
+                                for (int j0 = 0; j0 < *j; ++j0)
+                                {
+                                    v[idx] += idx;
+                                }
+                            });
+                    });
+                }
+            };
+            auto s = oneapi::dpl::experimental::select(p, f);
+            auto e = oneapi::dpl::experimental::submit(s, f);
+            oneapi::dpl::experimental::wait(e);
+        }
+        else
+        {
+            // it's ok to capture by reference since we are waiting on each call
+            auto s = oneapi::dpl::experimental::submit(
+                p, [&](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type q) {
+                    if (i <= 2 * n_samples)
+                    {
+                        // we should be round-robining through the resources
+                        if (q != u[(i - 1) % n_samples])
+                        {
+                            std::cout << i << ": mismatch during rr phase\n" << std::flush;
+                            pass = false;
+                        }
+                    }
+                    else
+                    {
+                        if (q != u[best_resource])
+                        {
+                            std::cout << i << ": mismatch during prod phase " << best_resource << "\n" << std::flush;
+                            pass = false;
+                        }
+                    }
+                    ecount += i;
+                    if (*j == 0)
+                    {
+                     return q.submit([=](sycl::handler& h){
+                             h.single_task([=](){});
+                         });
+                    }
+                    else
+                    {
+                        return q.submit([=](sycl::handler& h) {
+                            h.parallel_for<TestUtils::unique_kernel_name<
+                                class tune2, TestUtils::uniq_kernel_index<sycl::usm::alloc::shared>()>>(
+                                1000000, [=](sycl::id<1> idx) {
+                                    for (int j0 = 0; j0 < *j; ++j0)
+                                    {
+                                        v[idx] += idx;
+                                    }
+                                });
+                        });
+                    }
+                });
+            oneapi::dpl::experimental::wait(s);
+        }
+
+        int count = ecount.load();
+        if (count != i * (i + 1) / 2)
+        {
+            std::cout << "ERROR: scheduler did not execute all tasks exactly once\n";
+            return 1;
+        }
+    }
+    if (!pass)
+    {
+        std::cout << "ERROR: did not select expected resources\n";
+        return 1;
+    }
+    if constexpr (call_select_before_submit)
+    {
+        std::cout << "select then submit and wait on event: OK\n";
+    }
+    else
+    {
+        std::cout << "submit and wait on event: OK\n";
+    }
+    return 0;
+}
+
+template <bool call_select_before_submit, typename Policy, typename UniverseContainer>
+int
+test_auto_submit_wait_on_group(UniverseContainer u, int best_resource)
+{
+    using my_policy_t = Policy;
+
+    // they are cpus so this is ok
+    double* v = sycl::malloc_shared<double>(1000000, u[0]);
+    int* j = sycl::malloc_shared<int>(1, u[0]);
+
+    my_policy_t p{u};
+    auto n_samples = u.size();
+
+    const int N = 10;
+    std::atomic<int> ecount = 0;
+    bool pass = true;
+
+    for (int i = 1; i <= N; ++i)
+    {
+        if (i <= 2 * n_samples && (i - 1) % n_samples != best_resource)
+        {
+            *j = 100;
+        }
+        else
+        {
+            *j = 0;
+        }
+        // we can capture all by reference
+        // the inline_scheduler reports timings in submit
+        // We wait but it should return immediately, since inline
+        // scheduler does the work "inline".
+        // The unwrapped wait type should be equal to the resource
+        if constexpr (call_select_before_submit)
+        {
+            auto f = [&](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type q) {
+                if (i <= 2 * n_samples)
+                {
+                    // we should be round-robining through the resources
+                    if (q != u[(i - 1) % n_samples])
+                    {
+                        std::cout << i << ": mismatch during rr phase\n" << std::flush;
+                        pass = false;
+                    }
+                }
+                else
+                {
+                    if (q != u[best_resource])
+                    {
+                        std::cout << i << ": mismatch during prod phase " << best_resource << "\n" << std::flush;
+                        pass = false;
+                    }
+                }
+                ecount += i;
+                if (*j == 0)
+                {
+                     return q.submit([=](sycl::handler& h){
+                             h.single_task([=](){});
+                         });
+                }
+                else
+                {
+                    return q.submit([=](sycl::handler& h) {
+                        h.parallel_for<TestUtils::unique_kernel_name<
+                            class tune3, TestUtils::uniq_kernel_index<sycl::usm::alloc::shared>()>>(
+                            1000000, [=](sycl::id<1> idx) {
+                                for (int j0 = 0; j0 < *j; ++j0)
+                                {
+                                    v[idx] += idx;
+                                }
+                            });
+                    });
+                }
+            };
+            auto s = oneapi::dpl::experimental::select(p, f);
+            auto e = oneapi::dpl::experimental::submit(s, f);
+            oneapi::dpl::experimental::wait(p.get_submission_group());
+        }
+        else
+        {
+            // it's ok to capture by reference since we are waiting on each call
+            auto s = oneapi::dpl::experimental::submit(
+                p, [&](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type q) {
+                    if (i <= 2 * n_samples)
+                    {
+                        // we should be round-robining through the resources
+                        if (q != u[(i - 1) % n_samples])
+                        {
+                            std::cout << i << ": mismatch during rr phase\n" << std::flush;
+                            pass = false;
+                        }
+                    }
+                    else
+                    {
+                        if (q != u[best_resource])
+                        {
+                            std::cout << i << ": mismatch during prod phase " << best_resource << "\n" << std::flush;
+                            pass = false;
+                        }
+                    }
+                    ecount += i;
+                    if (*j == 0)
+                    {
+                     return q.submit([=](sycl::handler& h){
+                             h.single_task([=](){});
+                         });
+                    }
+                    else
+                    {
+                        return q.submit([=](sycl::handler& h) {
+                            h.parallel_for<TestUtils::unique_kernel_name<
+                                class tune4, TestUtils::uniq_kernel_index<sycl::usm::alloc::shared>()>>(
+                                1000000, [=](sycl::id<1> idx) {
+                                    for (int j0 = 0; j0 < *j; ++j0)
+                                    {
+                                        v[idx] += idx;
+                                    }
+                                });
+                        });
+                    }
+                });
+            oneapi::dpl::experimental::wait(p.get_submission_group());
+        }
+
+        int count = ecount.load();
+        if (count != i * (i + 1) / 2)
+        {
+            std::cout << "ERROR: scheduler did not execute all tasks exactly once\n";
+            return 1;
+        }
+    }
+    if (!pass)
+    {
+        std::cout << "ERROR: did not select expected resources\n";
+        return 1;
+    }
+    if constexpr (call_select_before_submit)
+    {
+        std::cout << "select then submit and wait on group: OK\n";
+    }
+    else
+    {
+        std::cout << "submit and wait on group: OK\n";
+    }
+    return 0;
+}
+
+template <bool call_select_before_submit, typename Policy, typename UniverseContainer>
+int
+test_auto_submit_and_wait(UniverseContainer u, int best_resource)
+{
+    using my_policy_t = Policy;
+
+    // they are cpus so this is ok
+    double* v = sycl::malloc_shared<double>(1000000, u[0]);
+    int* j = sycl::malloc_shared<int>(1, u[0]);
+
+    my_policy_t p{u};
+    auto n_samples = u.size();
+
+    const int N = 10;
+    std::atomic<int> ecount = 0;
+    bool pass = true;
+
+    for (int i = 1; i <= N; ++i)
+    {
+        if (i <= 2 * n_samples && (i - 1) % n_samples != best_resource)
+        {
+            *j = 100;
+        }
+        else
+        {
+            *j = 0;
+        }
+        // we can capture all by reference
+        // the inline_scheduler reports timings in submit
+        // We wait but it should return immediately, since inline
+        // scheduler does the work "inline".
+        // The unwrapped wait type should be equal to the resource
+        if constexpr (call_select_before_submit)
+        {
+            auto f = [&](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type q) {
+                if (i <= 2 * n_samples)
+                {
+                    // we should be round-robining through the resources
+                    if (q != u[(i - 1) % n_samples])
+                    {
+                        std::cout << i << ": mismatch during rr phase\n" << std::flush;
+                        pass = false;
+                    }
+                }
+                else
+                {
+                    if (q != u[best_resource])
+                    {
+                        std::cout << i << ": mismatch during prod phase " << best_resource << "\n" << std::flush;
+                        pass = false;
+                    }
+                }
+                ecount += i;
+                if (*j == 0)
+                {
+                     return q.submit([=](sycl::handler& h){
+                             h.single_task([=](){});
+                         });
+                }
+                else
+                {
+                    return q.submit([=](sycl::handler& h) {
+                        h.parallel_for<TestUtils::unique_kernel_name<
+                            class tune5, TestUtils::uniq_kernel_index<sycl::usm::alloc::shared>()>>(
+                            1000000, [=](sycl::id<1> idx) {
+                                for (int j0 = 0; j0 < *j; ++j0)
+                                {
+                                    v[idx] += idx;
+                                }
+                            });
+                    });
+                }
+            };
+            auto s = oneapi::dpl::experimental::select(p, f);
+            oneapi::dpl::experimental::submit_and_wait(s, f);
+        }
+        else
+        {
+            // it's ok to capture by reference since we are waiting on each call
+            oneapi::dpl::experimental::submit_and_wait(
+                p, [&](typename oneapi::dpl::experimental::policy_traits<Policy>::resource_type q) {
+                    if (i <= 2 * n_samples)
+                    {
+                        // we should be round-robining through the resources
+                        if (q != u[(i - 1) % n_samples])
+                        {
+                            std::cout << i << ": mismatch during rr phase\n" << std::flush;
+                            pass = false;
+                        }
+                    }
+                    else
+                    {
+                        if (q != u[best_resource])
+                        {
+                            std::cout << i << ": mismatch during prod phase " << best_resource << "\n" << std::flush;
+                            pass = false;
+                        }
+                    }
+                    ecount += i;
+                    if (*j == 0)
+                    {
+                     return q.submit([=](sycl::handler& h){
+                             h.single_task([=](){});
+                         });
+                    }
+                    else
+                    {
+                        return q.submit([=](sycl::handler& h) {
+                            h.parallel_for<TestUtils::unique_kernel_name<
+                                class tune6, TestUtils::uniq_kernel_index<sycl::usm::alloc::shared>()>>(
+                                1000000, [=](sycl::id<1> idx) {
+                                    for (int j0 = 0; j0 < *j; ++j0)
+                                    {
+                                        v[idx] += idx;
+                                    }
+                                });
+                        });
+                    }
+                });
+        }
+
+        int count = ecount.load();
+        if (count != i * (i + 1) / 2)
+        {
+            std::cout << "ERROR: scheduler did not execute all tasks exactly once\n";
+            return 1;
+        }
+    }
+    if (!pass)
+    {
+        std::cout << "ERROR: did not select expected resources\n";
+        return 1;
+    }
+    if constexpr (call_select_before_submit)
+    {
+        std::cout << "select then submit_and_wait: OK\n";
+    }
+    else
+    {
+        std::cout << "submit_and_wait: OK\n";
+    }
+    return 0;
+}
+
+static inline void
+build_auto_tune_universe_all(std::vector<sycl::queue>& u)
+{
+    auto prop_list = sycl::property_list{sycl::property::queue::enable_profiling()};
+    try
+    {
+        auto device_cpu1 = sycl::device(sycl::cpu_selector_v);
+        sycl::queue cpu1_queue{device_cpu1, prop_list};
+        run_sycl_sanity_test(cpu1_queue);
+        u.push_back(cpu1_queue);
+    }
+    catch (const sycl::exception&)
+    {
+        std::cout << "SKIPPED: Unable to run with cpu_selector\n";
+    }
+    try
+    {
+        auto device_cpu2 = sycl::device(sycl::cpu_selector_v);
+        sycl::queue cpu2_queue{device_cpu2, prop_list};
+        run_sycl_sanity_test(cpu2_queue);
+        u.push_back(cpu2_queue);
+    }
+    catch (const sycl::exception&)
+    {
+        std::cout << "SKIPPED: Unable to run with cpu_selector\n";
+    }
+}
+
+static inline void
+build_auto_tune_universe_single(std::vector<sycl::queue>& u)
+{
+    auto prop_list = sycl::property_list{sycl::property::queue::enable_profiling()};
+    try
+    {
+        auto device_cpu1 = sycl::device(sycl::cpu_selector_v);
+        sycl::queue cpu1_queue{device_cpu1, prop_list};
+        run_sycl_sanity_test(cpu1_queue);
+        u.push_back(cpu1_queue);
+    }
+    catch (const sycl::exception&)
+    {
+        std::cout << "SKIPPED: Unable to run with cpu_selector\n";
+    }
+    try
+    {
+        auto device_cpu2 = sycl::device(sycl::cpu_selector_v);
+        sycl::queue cpu2_queue{device_cpu2};
+        run_sycl_sanity_test(cpu2_queue);
+        u.push_back(cpu2_queue);
+    }
+    catch (const sycl::exception&)
+    {
+        std::cout << "SKIPPED: Unable to run with cpu_selector\n";
+    }
+}
+#endif
+
+int
+main()
+{
+#if TEST_DYNAMIC_SELECTION_AVAILABLE
+    using policy_t = oneapi::dpl::experimental::auto_tune_policy<oneapi::dpl::experimental::sycl_backend>;
+    std::vector<sycl::queue> u1, u2;
+    build_auto_tune_universe_all(u1);
+    build_auto_tune_universe_single(u2);
+
+    //If building the universe is not a success, return
+    if (u1.size() == 0 || u2.size()==0)
+        return 0;
+
+    constexpr bool just_call_submit = false;
+    constexpr bool call_select_before_submit = true;
+
+    if (test_auto_submit_wait_on_event<just_call_submit, policy_t>(u1, 0) ||
+        test_auto_submit_wait_on_event<just_call_submit, policy_t>(u1, 1) ||
+        test_auto_submit_wait_on_event<just_call_submit, policy_t>(u2, 0) ||
+        test_auto_submit_wait_on_event<just_call_submit, policy_t>(u2, 1) ||
+        test_auto_submit_wait_on_group<just_call_submit, policy_t>(u1, 0) ||
+        test_auto_submit_wait_on_group<just_call_submit, policy_t>(u1, 1) ||
+        test_auto_submit_wait_on_group<just_call_submit, policy_t>(u2, 0) ||
+        test_auto_submit_wait_on_group<just_call_submit, policy_t>(u2, 1) ||
+        test_auto_submit_and_wait<just_call_submit, policy_t>(u1, 0) ||
+        test_auto_submit_and_wait<just_call_submit, policy_t>(u1, 1)||
+        test_auto_submit_and_wait<just_call_submit, policy_t>(u2, 0) ||
+        test_auto_submit_and_wait<just_call_submit, policy_t>(u2, 1)||
+        // now select then submits
+        test_auto_submit_wait_on_event<call_select_before_submit, policy_t>(u1, 0) ||
+        test_auto_submit_wait_on_event<call_select_before_submit, policy_t>(u1, 1) ||
+        test_auto_submit_wait_on_event<call_select_before_submit, policy_t>(u2, 0) ||
+        test_auto_submit_wait_on_event<call_select_before_submit, policy_t>(u2, 1) ||
+        test_auto_submit_wait_on_group<call_select_before_submit, policy_t>(u1, 0) ||
+        test_auto_submit_wait_on_group<call_select_before_submit, policy_t>(u2, 1) ||
+        test_auto_submit_wait_on_group<call_select_before_submit, policy_t>(u1, 0) ||
+        test_auto_submit_wait_on_group<call_select_before_submit, policy_t>(u2, 1) ||
+        test_auto_submit_and_wait<call_select_before_submit, policy_t>(u1, 0) ||
+        test_auto_submit_and_wait<call_select_before_submit, policy_t>(u1, 1) ||
+        test_auto_submit_and_wait<call_select_before_submit, policy_t>(u2, 0) ||
+        test_auto_submit_and_wait<call_select_before_submit, policy_t>(u2, 1))
+    {
+        std::cout << "FAIL\n";
+        return 1;
+    }
+    else
+    {
+        std::cout << "PASS\n";
+        return 0;
+    }
+#else
+    std::cout << "SKIPPED\n";
+    return 0;
+#endif // TEST_DYNAMIC_SELECTION_AVAILABLE
+}

--- a/test/parallel_api/dynamic_selection/sycl/test_auto_tune_policy_sycl_profile.pass.cpp
+++ b/test/parallel_api/dynamic_selection/sycl/test_auto_tune_policy_sycl_profile.pass.cpp
@@ -457,7 +457,7 @@ build_auto_tune_universe1(std::vector<sycl::queue>& u)
     try
     {
         auto device_cpu = sycl::device(sycl::cpu_selector_v);
-        sycl::queue cpu_queue{device_cpu};
+        sycl::queue cpu_queue{device_cpu, prop_list};
         run_sycl_sanity_test(cpu_queue);
         u.push_back(cpu_queue);
     }
@@ -468,7 +468,7 @@ build_auto_tune_universe1(std::vector<sycl::queue>& u)
     try
     {
         auto device_gpu = sycl::device(sycl::gpu_selector_v);
-        sycl::queue gpu_queue{device_gpu};
+        sycl::queue gpu_queue{device_gpu, prop_list};
         run_sycl_sanity_test(gpu_queue);
         u.push_back(gpu_queue);
     }


### PR DESCRIPTION
Using an option for sycl profiling to calculate timings in auto_tune policy with a sycl backend. In case a sycl queue does not have sycl profiling enabled, fall back to the method used previously.
Developed tests 