### PR TITLE
[KT] Force inlining of ESIMD kernel callables 

### DIFF
--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_kernels.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_kernels.h
@@ -27,7 +27,7 @@ namespace oneapi::dpl::experimental::kt::esimd::__impl
 
 template <bool __is_ascending, ::std::uint8_t __radix_bits, ::std::uint16_t __data_per_work_item,
           ::std::uint16_t __work_group_size, typename _KeyT, typename _InputT>
-void
+inline __attribute__((always_inline)) void
 __one_wg_kernel(sycl::nd_item<1> __idx, ::std::uint32_t __n, const _InputT& __input)
 {
     using _BinT = ::std::uint16_t;
@@ -208,7 +208,7 @@ __one_wg_kernel(sycl::nd_item<1> __idx, ::std::uint32_t __n, const _InputT& __in
 
 template <typename _KeyT, typename _InputT, ::std::uint32_t __radix_bits, ::std::uint32_t __stage_count, ::std::uint32_t __hist_work_group_count,
           ::std::uint32_t __hist_work_group_size, bool __is_ascending>
-void
+inline __attribute__((always_inline)) void
 __global_histogram(sycl::nd_item<1> __idx, size_t __n, const _InputT& __input, ::std::uint32_t* __p_global_offset)
 {
     using _BinT = ::std::uint16_t;
@@ -577,8 +577,8 @@ struct __radix_sort_onesweep_slm_reorder_kernel
             __subgroup_offset = __group_incoming;
     }
 
-    void
-    operator()(sycl::nd_item<1> __idx) const SYCL_ESIMD_KERNEL
+    inline __attribute__((always_inline)) void
+    operator()(sycl::nd_item<1> __idx) const
     {
         __dpl_esimd_ns::slm_init<__slm_size_roundedup>();
 
@@ -902,8 +902,8 @@ struct __radix_sort_onesweep_by_key_slm_reorder_kernel
             __subgroup_offset = __group_incoming;
     }
 
-    void
-    operator()(sycl::nd_item<1> __idx) const SYCL_ESIMD_KERNEL
+    inline __attribute__((always_inline)) void
+    operator()(sycl::nd_item<1> __idx) const
     {
         __dpl_esimd_ns::slm_init<__slm_size_roundedup>();
 

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_kernels.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_kernels.h
@@ -27,7 +27,7 @@ namespace oneapi::dpl::experimental::kt::esimd::__impl
 
 template <bool __is_ascending, ::std::uint8_t __radix_bits, ::std::uint16_t __data_per_work_item,
           ::std::uint16_t __work_group_size, typename _KeyT, typename _InputT>
-inline __attribute__((always_inline)) void
+_ONEDPL_ESIMD_INLINE void
 __one_wg_kernel(sycl::nd_item<1> __idx, ::std::uint32_t __n, const _InputT& __input)
 {
     using _BinT = ::std::uint16_t;
@@ -208,7 +208,7 @@ __one_wg_kernel(sycl::nd_item<1> __idx, ::std::uint32_t __n, const _InputT& __in
 
 template <typename _KeyT, typename _InputT, ::std::uint32_t __radix_bits, ::std::uint32_t __stage_count, ::std::uint32_t __hist_work_group_count,
           ::std::uint32_t __hist_work_group_size, bool __is_ascending>
-inline __attribute__((always_inline)) void
+_ONEDPL_ESIMD_INLINE void
 __global_histogram(sycl::nd_item<1> __idx, size_t __n, const _InputT& __input, ::std::uint32_t* __p_global_offset)
 {
     using _BinT = ::std::uint16_t;
@@ -577,7 +577,7 @@ struct __radix_sort_onesweep_slm_reorder_kernel
             __subgroup_offset = __group_incoming;
     }
 
-    inline __attribute__((always_inline)) void
+    _ONEDPL_ESIMD_INLINE void
     operator()(sycl::nd_item<1> __idx) const
     {
         __dpl_esimd_ns::slm_init<__slm_size_roundedup>();
@@ -902,7 +902,7 @@ struct __radix_sort_onesweep_by_key_slm_reorder_kernel
             __subgroup_offset = __group_incoming;
     }
 
-    inline __attribute__((always_inline)) void
+    _ONEDPL_ESIMD_INLINE void
     operator()(sycl::nd_item<1> __idx) const
     {
         __dpl_esimd_ns::slm_init<__slm_size_roundedup>();

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_kernels.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_kernels.h
@@ -578,7 +578,7 @@ struct __radix_sort_onesweep_slm_reorder_kernel
     }
 
     _ONEDPL_ESIMD_INLINE void
-    operator()(sycl::nd_item<1> __idx) const
+    operator()(sycl::nd_item<1> __idx) const SYCL_ESIMD_KERNEL
     {
         __dpl_esimd_ns::slm_init<__slm_size_roundedup>();
 
@@ -903,7 +903,7 @@ struct __radix_sort_onesweep_by_key_slm_reorder_kernel
     }
 
     _ONEDPL_ESIMD_INLINE void
-    operator()(sycl::nd_item<1> __idx) const
+    operator()(sycl::nd_item<1> __idx) const SYCL_ESIMD_KERNEL
     {
         __dpl_esimd_ns::slm_init<__slm_size_roundedup>();
 

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_utils.h
@@ -21,6 +21,10 @@
 #include <type_traits>
 #include <limits>
 
+// The macro is created to guarantee inlining of functions which contain slm_init. See ESIMD spec for more details:
+// https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_intel_esimd/sycl_ext_intel_esimd.md#static-allocation-of-slm-using-slm_init-function
+#define _ONEDPL_ESIMD_INLINE inline __attribute__((always_inline))
+
 namespace oneapi::dpl::experimental::kt::esimd::__impl
 {
 constexpr int __data_per_step = 16;


### PR DESCRIPTION
Inlining must be guaranteed according to [Static allocation of SLM using slm_init function](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_intel_esimd/sycl_ext_intel_esimd.md#static-allocation-of-slm-using-slm_init-function):
> The call of slm_init must be placed in the beginning of the kernel. If slm_init is called in some function 'F' called from kernel, then inlining of 'F' to the kernel must be forced/guaranteed.

This will help to avoid this issue (usually happens with -O0/-O1/-g compile options):
> LLVM ERROR: GenXLowering failed for: <  
call void @llvm.genx.slm.init(i32 %globalOrPrivateLoad)>: SLM init call is supported only in kernels
