### PR TITLE
[KT] Revert test change

### DIFF
--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -156,8 +156,7 @@ expect_equal(Iterator1 expected_first, Iterator2 actual_first, Size n, const cha
         if (!(*expected_first == *actual_first))
         {
             ::std::stringstream outstr;
-            outstr << "error at " << file << ":" << line << " - " << message << ", at index " << k << " expected "
-                   << *expected_first << " got " << *actual_first;
+            outstr << "error at " << file << ":" << line << " - " << message << ", at index " << k;
             issue_error_message(outstr);
             ++error_count;
         }


### PR DESCRIPTION
Not every type is printable. This reverts the change done in `esimd_radix_sort`.