### PR TITLE
[Dynamic Selection] Use ::std::lock guard instead of ::std::unique_lock in auto_tune and dynamic_load policy

### DIFF
--- a/include/oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h
@@ -117,7 +117,7 @@ class auto_tune_policy
         void
         add_new_timing(resource_with_index_t r, timing_t t)
         {
-            std::unique_lock<std::mutex> l(m_);
+            std::lock_guard<std::mutex> l(m_);
             auto index = r.index_;
             timing_t new_value = t;
             if (time_by_index_.count(index) == 0)
@@ -217,7 +217,7 @@ class auto_tune_policy
         static_assert(sizeof...(KeyArgs) == sizeof...(Args));
         if (state_)
         {
-            std::unique_lock<std::mutex> l(state_->m_);
+            std::lock_guard<std::mutex> l(state_->m_);
             auto k = make_task_key(std::forward<Function>(f), std::forward<Args>(args)...);
             auto t = state_->tuner_by_key_[k];
             auto index = t->get_resource_to_profile();

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/dynamic_load_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/dynamic_load_policy.h
@@ -152,7 +152,7 @@ struct dynamic_load_policy
     {
         if (state_)
         {
-            std::unique_lock<std::mutex> l(state_->m_);
+            std::lock_guard<std::mutex> l(state_->m_);
             std::shared_ptr<resource_t> least_loaded;
             int least_load = std::numeric_limits<load_t>::max();
             for (int i = 0; i < state_->resources_.size(); i++)


### PR DESCRIPTION
Addressing issue #1262 