### PR TITLE
Cancel existing workflows for PR when new commit is pushed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ env:
   TEST_TIMEOUT: 360
   MACOS_ONEAPI_DOWNLOAD_LINK: https://registrationcenter-download.intel.com/akdlm/irc_nas/18358/m_cpp-compiler-classic_p_2022.0.0.62_offline.dmg
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   clang-format:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ env:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   clang-format:

--- a/include/oneapi/dpl/pstl/glue_algorithm_defs.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_defs.h
@@ -297,7 +297,7 @@ oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy,
 partition_copy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last,
                _ForwardIterator1 __out_true, _ForwardIterator2 __out_false, _UnaryPredicate __pred);
 
-// [alg.sort]
+// [alg.sort]  
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>

--- a/include/oneapi/dpl/pstl/glue_algorithm_defs.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_defs.h
@@ -297,7 +297,7 @@ oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy,
 partition_copy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last,
                _ForwardIterator1 __out_true, _ForwardIterator2 __out_false, _UnaryPredicate __pred);
 
-// [alg.sort]  
+// [alg.sort]
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>


### PR DESCRIPTION
This change cancels all existing workflows queued or actively running for the same PR, in favor of only testing the most recent commit.

People need to be aware that this is being changed.  As it stands there is no way to turn this off via a commit message.  
