### PR TITLE
Tests for `dpl::transform`  and `dpl::transform_async` algorithms with `zip_iterator`

### DIFF
--- a/include/oneapi/dpl/internal/async_impl/glue_async_impl.h
+++ b/include/oneapi/dpl/internal/async_impl/glue_async_impl.h
@@ -46,7 +46,7 @@ transform_async(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIt
     wait_for_all(::std::forward<_Events>(__dependencies)...);
     auto ret_val = oneapi::dpl::__internal::__pattern_walk2_async(
         ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
-        oneapi::dpl::__internal::__invoke_unary_op<_UnaryOperation>{::std::move(__op)});
+        oneapi::dpl::__internal::__transform_functor<_UnaryOperation>{::std::move(__op)});
     return ret_val;
 }
 

--- a/include/oneapi/dpl/internal/async_impl/glue_async_impl.h
+++ b/include/oneapi/dpl/internal/async_impl/glue_async_impl.h
@@ -62,7 +62,7 @@ transform_async(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardI
     wait_for_all(::std::forward<_Events>(__dependencies)...);
     auto ret_val = oneapi::dpl::__internal::__pattern_walk3_async(
         ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __result,
-        oneapi::dpl::__internal::__transform_functor<_BinaryOperation>>(std::move(__op)));
+        oneapi::dpl::__internal::__transform_functor<_BinaryOperation>>(::std::move(__op)));
     return ret_val;
 }
 

--- a/include/oneapi/dpl/internal/async_impl/glue_async_impl.h
+++ b/include/oneapi/dpl/internal/async_impl/glue_async_impl.h
@@ -62,7 +62,7 @@ transform_async(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardI
     wait_for_all(::std::forward<_Events>(__dependencies)...);
     auto ret_val = oneapi::dpl::__internal::__pattern_walk3_async(
         ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __result,
-        oneapi::dpl::__internal::__transform_functor<_BinaryOperation>>(::std::move(__op)));
+        oneapi::dpl::__internal::__transform_functor<_BinaryOperation>(::std::move(__op)));
     return ret_val;
 }
 

--- a/include/oneapi/dpl/internal/async_impl/glue_async_impl.h
+++ b/include/oneapi/dpl/internal/async_impl/glue_async_impl.h
@@ -62,8 +62,7 @@ transform_async(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardI
     wait_for_all(::std::forward<_Events>(__dependencies)...);
     auto ret_val = oneapi::dpl::__internal::__pattern_walk3_async(
         ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __result,
-        oneapi::dpl::__internal::__transform_functor<
-            oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, _BinaryOperation>>(__op));
+        oneapi::dpl::__internal::__transform_functor<_BinaryOperation>>(std::move(__op)));
     return ret_val;
 }
 

--- a/include/oneapi/dpl/pstl/glue_algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_impl.h
@@ -335,7 +335,7 @@ transform(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator
 {
     return oneapi::dpl::__internal::__pattern_walk2(
         ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result,
-        oneapi::dpl::__internal::__invoke_unary_op<_UnaryOperation>{::std::move(__op)},
+        oneapi::dpl::__internal::__transform_functor<_UnaryOperation>{::std::move(__op)},
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(
             __exec),
         __exec.__allow_parallel());
@@ -351,7 +351,7 @@ transform(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterato
     return oneapi::dpl::__internal::__pattern_walk3(
         ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __result,
         oneapi::dpl::__internal::__transform_functor<
-            oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, _BinaryOperation>>(__op),
+            oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, _BinaryOperation>>(std::move(__op)),
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2,
                                                               _ForwardIterator>(__exec),
         __exec.__allow_parallel());

--- a/include/oneapi/dpl/pstl/glue_algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_impl.h
@@ -350,8 +350,7 @@ transform(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterato
 {
     return oneapi::dpl::__internal::__pattern_walk3(
         ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __result,
-        oneapi::dpl::__internal::__transform_functor<
-            oneapi::dpl::__internal::__ref_or_copy<_ExecutionPolicy, _BinaryOperation>>(std::move(__op)),
+        oneapi::dpl::__internal::__transform_functor<_BinaryOperation>(std::move(__op)),
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2,
                                                               _ForwardIterator>(__exec),
         __exec.__allow_parallel());

--- a/include/oneapi/dpl/pstl/glue_algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_impl.h
@@ -350,7 +350,7 @@ transform(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterato
 {
     return oneapi::dpl::__internal::__pattern_walk3(
         ::std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __result,
-        oneapi::dpl::__internal::__transform_functor<_BinaryOperation>(std::move(__op)),
+        oneapi::dpl::__internal::__transform_functor<_BinaryOperation>(::std::move(__op)),
         oneapi::dpl::__internal::__is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2,
                                                               _ForwardIterator>(__exec),
         __exec.__allow_parallel());

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -277,18 +277,18 @@ class __transform_functor
 
     template <typename _Input1Type, typename _OutputType>
     void
-    operator()(const _Input1Type& x, _OutputType&& output) const
+    operator()(_Input1Type&& x, _OutputType&& output) const
     {
         __transform_impl(::std::forward<_OutputType>(output), x);
     }
 
 private:
     template <typename _OutputType, typename... _Args>
-    void __transform_impl(_OutputType&& output, const _Args&... args) const
+    void __transform_impl(_OutputType&& output, _Args&&... args) const
     {
         static_assert(sizeof...(_Args) < 3, "A predicate supports either unary or binary transformation");
         static_assert(::std::is_invocable_v<_Pred, _Args...>, "A predicate cannot be called with the passed arguments");
-        ::std::forward<_OutputType>(output) = _M_pred(args...);
+        ::std::forward<_OutputType>(output) = _M_pred(std::forward<_Args>(args)...);
     }
 };
 

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -263,7 +263,7 @@ class __not_equal_value
 template <typename _Pred>
 class __transform_functor
 {
-    _Pred _M_pred;
+    mutable _Pred _M_pred;
 
   public:
     explicit __transform_functor(_Pred __pred) : _M_pred(std::move(__pred)) {}

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -275,11 +275,11 @@ class __transform_functor
         __transform_impl(::std::forward<_OutputType>(output), x, y);
     }
 
-    template <typename _Input1Type, typename _OutputType>
+    template <typename _InputType, typename _OutputType>
     void
-    operator()(_Input1Type&& x, _OutputType&& output) const
+    operator()(_InputType&& x, _OutputType&& output) const
     {
-        __transform_impl(::std::forward<_OutputType>(output), x);
+        __transform_impl(::std::forward<_OutputType>(output), std::forward<_InputType>(x));
     }
 
 private:

--- a/test/parallel_api/algorithm/alg.modifying.operations/transform_binary_zip.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/transform_binary_zip.pass.cpp
@@ -22,24 +22,20 @@
 
 using namespace TestUtils;
 
-template <typename... Types>
-using typle_t = oneapi::dpl::__internal::tuple<Types...>;
-//using typle_t = ::std::tuple<Types...>;
-
-template <typename Out>
+template <typename TInput1, typename TInput2, typename TOutput>
 class TheOperation
 {
-    Out val;
+    TOutput val;
 
-  public:
+public:
 
-    TheOperation(Out v) : val(v) {}
+    TheOperation(TOutput v) : val(v) {}
 
-    template <typename T1A, typename T1B, typename T2A, typename T2B>
-    Out
-    operator()(const typle_t<T1A, T1B>& x, const typle_t<T2A, T2B>& y) const
+    TOutput
+    operator()(const ::std::tuple<const TInput1&, const TInput1&>& x,
+               const ::std::tuple<const TInput2&, const TInput2&>& y) const
     {
-        return Out(val + (std::get<0>(x) + std::get<1>(x)) - (std::get<0>(y) + std::get<1>(y)));
+        return TOutput(val + (::std::get<0>(x) + ::std::get<1>(x)) - (::std::get<0>(y) + ::std::get<1>(y)));
     }
 };
 
@@ -52,7 +48,7 @@ check_and_reset(InputIterator1 first1, InputIterator1 last1, InputIterator2 firs
     for (; first1 != last1; ++first1, ++first2, ++out_first, ++k)
     {
         // check
-        Out expected = Out(1.5) + (std::get<0>(*first1) + std::get<1>(*first1)) - (std::get<0>(*first2) + std::get<1>(*first2));
+        Out expected = Out(1.5) + (::std::get<0>(*first1) + ::std::get<1>(*first1)) - (::std::get<0>(*first2) + ::std::get<1>(*first2));
         Out actual = *out_first;
         if (::std::is_floating_point_v<Out>)
         {
@@ -82,25 +78,25 @@ struct test_one_policy
     }
 };
 
-template <typename In1, typename In2, typename Out, typename Predicate>
+template <typename TInput1, typename TInput2, typename TOutput, typename Predicate>
 void
 test(Predicate pred)
 {
     for (size_t n = 0; n <= 100000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
-        Sequence<In1> in1_a(n, [](size_t k) { return k % 5 != 1 ? In1(3 * k + 7) : 0; });
-        Sequence<In1> in1_b(n, [](size_t k) { return 0; });
+        Sequence<TInput1> in1_a(n, [](size_t k) { return k % 5 != 1 ? TInput1(3 * k + 7) : 0; });
+        Sequence<TInput1> in1_b(n, [](size_t k) { return 0; });
         auto in1_zip_begin = dpl::make_zip_iterator(in1_a.begin(), in1_b.begin());
         auto in1_zip_end   = dpl::make_zip_iterator(in1_a.end(),   in1_b.end());
 
-        Sequence<In2> in2_a(n, [](size_t k) { return k % 7 != 2 ? In2(5 * k + 5) : 0; });
-        Sequence<In2> in2_b(n, [](size_t k) { return 0; });
+        Sequence<TInput2> in2_a(n, [](size_t k) { return k % 7 != 2 ? TInput2(5 * k + 5) : 0; });
+        Sequence<TInput2> in2_b(n, [](size_t k) { return 0; });
         auto in2_zip_begin = dpl::make_zip_iterator(in2_a.begin(), in1_b.begin());
         auto in2_zip_end   = dpl::make_zip_iterator(in2_a.end(),   in2_b.end());
 
-        Sequence<Out> out(n, [](size_t) { return -1; });
+        Sequence<TOutput> out(n, [](size_t) { return -1; });
 
-        invoke_on_all_policies<0>()(test_one_policy<In1, In2, Out>(),
+        invoke_on_all_policies<0>()(test_one_policy<TInput1, TInput2, TOutput>(),
                                     in1_zip_begin, in1_zip_end,
                                     in2_zip_begin, in2_zip_end,
                                     out.begin(), out.end(),
@@ -114,7 +110,7 @@ test(Predicate pred)
             auto in2_zip_cbegin = dpl::make_zip_iterator(in2_a.cbegin(), in1_b.cbegin());
             auto in2_zip_cend   = dpl::make_zip_iterator(in2_a.cend(),   in2_b.cend());
 
-            invoke_on_all_policies<1>()(test_one_policy<In1, In2, Out>(),
+            invoke_on_all_policies<1>()(test_one_policy<TInput1, TInput2, TOutput>(),
                                         in1_zip_cbegin, in1_zip_cend,
                                         in2_zip_cbegin, in2_zip_cend,
                                         out.begin(), out.end(),
@@ -124,29 +120,49 @@ test(Predicate pred)
     }
 }
 
+template <typename TInput1, typename TInput2, typename TOutput>
+void test_with_pred(TOutput initial_value)
+{
+    TheOperation<TInput1, TInput2, TOutput> pred(initial_value);
+
+    test<TInput1, TInput2, TOutput>(pred);
+}
+
+template <typename TInput1, typename TInput2, typename TOutput>
+void
+test_with_pred_non_const(TOutput initial_value)
+{
+    TheOperation<TInput1, TInput2, TOutput> pred(initial_value);
+
+    test<TInput1, TInput2, TOutput>(non_const(pred));
+}
+
+template <typename TInput1, typename TInput2, typename TOutput>
+void
+test_with_lambda(TOutput initial_value)
+{
+    test<TInput1, TInput2, TOutput>(
+        [initial_value](const ::std::tuple<const TInput1&, const TInput1&>& x,
+                        const ::std::tuple<const TInput2&, const TInput2&>& y)
+        {
+            return TOutput(initial_value + (::std::get<0>(x) + ::std::get<1>(x)) - (::std::get<0>(y) + ::std::get<1>(y)));
+        });
+}
+
 int
 main()
 {
     //const operator()
-    test<std::int32_t, std::int32_t, std::int32_t>(TheOperation<std::int32_t>(1));
-    test<float32_t, float32_t, float32_t>(TheOperation<float32_t>(1.5));
+    test_with_pred<std::int32_t, std::int32_t, std::int32_t>(1);
+    test_with_pred<float32_t, float32_t, float32_t>(1.5);
 
     //non-const operator()
-    test<std::int32_t, std::int32_t, std::int32_t>(non_const(TheOperation<std::int32_t>(1)));
-    test<float32_t, float32_t, float32_t>(non_const(TheOperation<float32_t>(1.5)));
+    test_with_pred_non_const<std::int32_t, std::int32_t, std::int32_t>(1);
+    test_with_pred_non_const<float32_t, float32_t, float32_t>(1.5);
 
     // lambda
-    test<std::int32_t, std::int32_t, std::int32_t>(
-        [](const typle_t<const std::int32_t&, const std::int32_t&>& x, const typle_t<const std::int32_t&, const std::int32_t&>& y)
-        {
-            return std::int32_t(1 + (std::get<0>(x) + std::get<1>(x)) - (std::get<0>(y) + std::get<1>(y)));
-        });
-
-    test<float32_t, float32_t, float32_t>(
-        [](const typle_t<const float32_t&, const float32_t&>& x, const typle_t<const float32_t&, const float32_t&>& y)
-        {
-            return float32_t(1 + (std::get<0>(x) + std::get<1>(x)) - (std::get<0>(y) + std::get<1>(y)));
-        });
+    test_with_lambda<std::int32_t, std::int32_t, std::int32_t>(1);
+    test_with_lambda<float32_t, float32_t, float32_t>(1.5);
 
     return TestUtils::done();
 }

--- a/test/parallel_api/algorithm/alg.modifying.operations/transform_binary_zip.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/transform_binary_zip.pass.cpp
@@ -1,0 +1,152 @@
+// -*- C++ -*-
+//===-- transform_binary.pass.cpp -----------------------------------------===//
+//
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#include "support/test_config.h"
+
+#include _PSTL_TEST_HEADER(execution)
+#include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
+
+using namespace TestUtils;
+
+template <typename... Types>
+using typle_t = oneapi::dpl::__internal::tuple<Types...>;
+//using typle_t = ::std::tuple<Types...>;
+
+template <typename Out>
+class TheOperation
+{
+    Out val;
+
+  public:
+
+    TheOperation(Out v) : val(v) {}
+
+    template <typename T1A, typename T1B, typename T2A, typename T2B>
+    Out
+    operator()(const typle_t<T1A, T1B>& x, const typle_t<T2A, T2B>& y) const
+    {
+        return Out(val + (std::get<0>(x) + std::get<1>(x)) - (std::get<0>(y) + std::get<1>(y)));
+    }
+};
+
+template <typename InputIterator1, typename InputIterator2, typename OutputIterator>
+void
+check_and_reset(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, OutputIterator out_first)
+{
+    typedef typename ::std::iterator_traits<OutputIterator>::value_type Out;
+    typename ::std::iterator_traits<OutputIterator>::difference_type k = 0;
+    for (; first1 != last1; ++first1, ++first2, ++out_first, ++k)
+    {
+        // check
+        Out expected = Out(1.5) + (std::get<0>(*first1) + std::get<1>(*first1)) - (std::get<0>(*first2) + std::get<1>(*first2));
+        Out actual = *out_first;
+        if (::std::is_floating_point_v<Out>)
+        {
+            EXPECT_TRUE((expected > actual ? expected - actual : actual - expected) < Out(1e-7),
+                        "wrong value in output sequence");
+        }
+        else
+        {
+            EXPECT_EQ(expected, actual, "wrong value in output sequence");
+        }
+        // reset
+        *out_first = k % 7 != 4 ? 7 * k + 5 : 0;
+    }
+}
+
+template <typename T1, typename T2, typename T3>
+struct test_one_policy
+{
+    template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
+              typename BinaryOp>
+    void
+    operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 /* last2 */,
+               OutputIterator out_first, OutputIterator /* out_last */, BinaryOp op)
+    {
+        ::std::transform(exec, first1, last1, first2, out_first, op);
+        check_and_reset(first1, last1, first2, out_first);
+    }
+};
+
+template <typename In1, typename In2, typename Out, typename Predicate>
+void
+test(Predicate pred)
+{
+    for (size_t n = 0; n <= 100000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
+    {
+        Sequence<In1> in1_a(n, [](size_t k) { return k % 5 != 1 ? In1(3 * k + 7) : 0; });
+        Sequence<In1> in1_b(n, [](size_t k) { return 0; });
+        auto in1_zip_begin = dpl::make_zip_iterator(in1_a.begin(), in1_b.begin());
+        auto in1_zip_end   = dpl::make_zip_iterator(in1_a.end(),   in1_b.end());
+
+        Sequence<In2> in2_a(n, [](size_t k) { return k % 7 != 2 ? In2(5 * k + 5) : 0; });
+        Sequence<In2> in2_b(n, [](size_t k) { return 0; });
+        auto in2_zip_begin = dpl::make_zip_iterator(in2_a.begin(), in1_b.begin());
+        auto in2_zip_end   = dpl::make_zip_iterator(in2_a.end(),   in2_b.end());
+
+        Sequence<Out> out(n, [](size_t) { return -1; });
+
+        invoke_on_all_policies<0>()(test_one_policy<In1, In2, Out>(),
+                                    in1_zip_begin, in1_zip_end,
+                                    in2_zip_begin, in2_zip_end,
+                                    out.begin(), out.end(),
+                                    pred);
+
+#if !ONEDPL_FPGA_DEVICE
+        {
+            auto in1_zip_cbegin = dpl::make_zip_iterator(in1_a.cbegin(), in1_b.cbegin());
+            auto in1_zip_cend   = dpl::make_zip_iterator(in1_a.cend(),   in1_b.cend());
+
+            auto in2_zip_cbegin = dpl::make_zip_iterator(in2_a.cbegin(), in1_b.cbegin());
+            auto in2_zip_cend   = dpl::make_zip_iterator(in2_a.cend(),   in2_b.cend());
+
+            invoke_on_all_policies<1>()(test_one_policy<In1, In2, Out>(),
+                                        in1_zip_cbegin, in1_zip_cend,
+                                        in2_zip_cbegin, in2_zip_cend,
+                                        out.begin(), out.end(),
+                                        pred);
+        }
+#endif // ONEDPL_FPGA_DEVICE
+    }
+}
+
+int
+main()
+{
+    //const operator()
+    test<std::int32_t, std::int32_t, std::int32_t>(TheOperation<std::int32_t>(1));
+    test<float32_t, float32_t, float32_t>(TheOperation<float32_t>(1.5));
+
+    //non-const operator()
+    test<std::int32_t, std::int32_t, std::int32_t>(non_const(TheOperation<std::int32_t>(1)));
+    test<float32_t, float32_t, float32_t>(non_const(TheOperation<float32_t>(1.5)));
+
+    // lambda
+    test<std::int32_t, std::int32_t, std::int32_t>(
+        [](const typle_t<const std::int32_t&, const std::int32_t&>& x, const typle_t<const std::int32_t&, const std::int32_t&>& y)
+        {
+            return std::int32_t(1 + (std::get<0>(x) + std::get<1>(x)) - (std::get<0>(y) + std::get<1>(y)));
+        });
+
+    test<float32_t, float32_t, float32_t>(
+        [](const typle_t<const float32_t&, const float32_t&>& x, const typle_t<const float32_t&, const float32_t&>& y)
+        {
+            return float32_t(1 + (std::get<0>(x) + std::get<1>(x)) - (std::get<0>(y) + std::get<1>(y)));
+        });
+
+    return TestUtils::done();
+}

--- a/test/parallel_api/algorithm/alg.modifying.operations/transform_unary_zip.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/transform_unary_zip.pass.cpp
@@ -24,10 +24,6 @@
 
 using namespace TestUtils;
 
-template <typename... Types>
-using typle_t = oneapi::dpl::__internal::tuple<Types...>;
-//using typle_t = ::std::tuple<Types...>;
-
 template <typename InputIterator, typename OutputIterator>
 void
 check_and_reset(InputIterator first, InputIterator last, OutputIterator out_first)
@@ -59,7 +55,7 @@ struct test_one_policy
     }
 };
 
-template <typename U>
+template <typename TInput, typename TOutput>
 class ZipComplement
 {
     std::int32_t val;
@@ -68,10 +64,9 @@ public:
 
     ZipComplement(std::size_t v) : val(v) {}
 
-    template <typename T1, typename T2>
-    U operator()(const typle_t<T1, T2>& x) const
+    TOutput operator()(const ::std::tuple<const TInput&, const TInput&>& x) const
     {
-        return U(val - std::get<0>(x) - std::get<1>(x));
+        return TOutput(val - std::get<0>(x) - std::get<1>(x));
     }
 };
 
@@ -88,7 +83,7 @@ test()
         auto in_zip_end = dpl::make_zip_iterator(in_a.end(), in_b.end());
 
         Sequence<Tout> out(n);
-        const ZipComplement<Tout> flip(1);
+        const ZipComplement<Tin, Tout> flip(1);
 
         invoke_on_all_policies<0>()(test_one_policy<Tin, Tout>(), in_zip_begin, in_zip_end, out.begin(), out.end(), flip);
 #if !ONEDPL_FPGA_DEVICE

--- a/test/parallel_api/algorithm/alg.modifying.operations/transform_unary_zip.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/transform_unary_zip.pass.cpp
@@ -102,20 +102,6 @@ test()
     }
 }
 
-template <typename T>
-struct test_non_const
-{
-    template <typename Policy, typename InputIterator, typename OutputInterator>
-    void
-    operator()(Policy&& exec, InputIterator input_iter, OutputInterator out_iter)
-    {
-        invoke_if(exec, [&]()
-            {
-                transform(exec, input_iter, input_iter, out_iter, non_const(::std::negate<T>()));
-            });
-    }
-};
-
 int
 main()
 {
@@ -125,7 +111,5 @@ main()
     test<float32_t, float64_t>();
     test<float64_t, float64_t>();
     
-    test_algo_basic_double<std::int64_t>(run_for_rnd_fw<test_non_const<std::int32_t>>());
-
     return TestUtils::done();
 }

--- a/test/parallel_api/algorithm/alg.modifying.operations/transform_unary_zip.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/transform_unary_zip.pass.cpp
@@ -1,0 +1,131 @@
+// -*- C++ -*-
+//===-- transform_unary.pass.cpp ------------------------------------------===//
+//
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+// Tests for transform
+
+#include "support/test_config.h"
+
+#include _PSTL_TEST_HEADER(execution)
+#include _PSTL_TEST_HEADER(algorithm)
+
+#include "support/utils.h"
+
+using namespace TestUtils;
+
+template <typename... Types>
+using typle_t = oneapi::dpl::__internal::tuple<Types...>;
+//using typle_t = ::std::tuple<Types...>;
+
+template <typename InputIterator, typename OutputIterator>
+void
+check_and_reset(InputIterator first, InputIterator last, OutputIterator out_first)
+{
+    typedef typename ::std::iterator_traits<OutputIterator>::value_type Out;
+    typename ::std::iterator_traits<OutputIterator>::difference_type k = 0;
+    for (; first != last; ++first, ++out_first, ++k)
+    {
+        // check
+        Out expected = 1 - std::get<0>(*first) - std::get<1>(*first);
+        Out actual = *out_first;
+        EXPECT_EQ(expected, actual, "wrong value in output sequence");
+        // reset
+        *out_first = k % 7 != 4 ? 7 * k - 5 : 0;
+    }
+}
+
+template <typename T1, typename T2>
+struct test_one_policy
+{
+    template <typename Policy, typename InputIterator, typename OutputIterator, typename UnaryOp>
+    void
+    operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
+               OutputIterator out_last, UnaryOp op)
+    {
+        auto orr = ::std::transform(exec, first, last, out_first, op);
+        EXPECT_TRUE(out_last == orr, "transform returned wrong iterator");
+        check_and_reset(first, last, out_first);
+    }
+};
+
+template <typename U>
+class ZipComplement
+{
+    std::int32_t val;
+
+public:
+
+    ZipComplement(std::size_t v) : val(v) {}
+
+    template <typename T1, typename T2>
+    U operator()(const typle_t<T1, T2>& x) const
+    {
+        return U(val - std::get<0>(x) - std::get<1>(x));
+    }
+};
+
+template <typename Tin, typename Tout>
+void
+test()
+{
+    for (size_t n = 0; n <= 100000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
+    {
+        Sequence<Tin> in_a(n, [](std::int32_t k) { return k % 5 != 1 ? 3 * k - 7 : 0; });
+        Sequence<Tin> in_b(n, [](std::int32_t k) { return 0; });
+
+        auto in_zip_begin = dpl::make_zip_iterator(in_a.begin(), in_b.begin());
+        auto in_zip_end = dpl::make_zip_iterator(in_a.end(), in_b.end());
+
+        Sequence<Tout> out(n);
+        const ZipComplement<Tout> flip(1);
+
+        invoke_on_all_policies<0>()(test_one_policy<Tin, Tout>(), in_zip_begin, in_zip_end, out.begin(), out.end(), flip);
+#if !ONEDPL_FPGA_DEVICE
+        {
+            auto in_zip_cbegin = dpl::make_zip_iterator(in_a.cbegin(), in_b.cbegin());
+            auto in_zip_cend = dpl::make_zip_iterator(in_a.cend(), in_b.cend());
+
+            invoke_on_all_policies<1>()(test_one_policy<Tin, Tout>(), in_zip_cbegin, in_zip_cend, out.begin(), out.end(), flip);
+        }
+#endif // ONEDPL_FPGA_DEVICE
+    }
+}
+
+template <typename T>
+struct test_non_const
+{
+    template <typename Policy, typename InputIterator, typename OutputInterator>
+    void
+    operator()(Policy&& exec, InputIterator input_iter, OutputInterator out_iter)
+    {
+        invoke_if(exec, [&]()
+            {
+                transform(exec, input_iter, input_iter, out_iter, non_const(::std::negate<T>()));
+            });
+    }
+};
+
+int
+main()
+{
+    test<std::int32_t, std::int32_t>();
+    test<std::int32_t, float32_t>();
+    test<std::uint16_t, float32_t>();
+    test<float32_t, float64_t>();
+    test<float64_t, float64_t>();
+    
+    test_algo_basic_double<std::int64_t>(run_for_rnd_fw<test_non_const<std::int32_t>>());
+
+    return TestUtils::done();
+}

--- a/test/parallel_api/experimental/transform_async_binary_zip.pass.cpp
+++ b/test/parallel_api/experimental/transform_async_binary_zip.pass.cpp
@@ -1,0 +1,188 @@
+// -*- C++ -*-
+//===-- transform_binary.pass.cpp -----------------------------------------===//
+//
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#include "support/test_config.h"
+
+#include _PSTL_TEST_HEADER(execution)
+#include _PSTL_TEST_HEADER(algorithm)
+
+#if TEST_DPCPP_BACKEND_PRESENT
+#    include "oneapi/dpl/async"
+#endif // TEST_DPCPP_BACKEND_PRESENT
+
+#include "support/utils.h"
+
+using namespace TestUtils;
+
+#if TEST_DPCPP_BACKEND_PRESENT
+template <typename TInput1, typename TInput2, typename TOutput>
+class TheOperation
+{
+    TOutput val;
+
+public:
+
+    TheOperation(TOutput v) : val(v) {}
+
+    TOutput
+    operator()(const ::std::tuple<const TInput1&, const TInput1&>& x,
+               const ::std::tuple<const TInput2&, const TInput2&>& y) const
+    {
+        return TOutput(val + (::std::get<0>(x) + ::std::get<1>(x)) - (::std::get<0>(y) + ::std::get<1>(y)));
+    }
+};
+
+template <typename InputIterator1, typename InputIterator2, typename OutputIterator>
+void
+check_and_reset(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, OutputIterator out_first)
+{
+    typedef typename ::std::iterator_traits<OutputIterator>::value_type Out;
+    typename ::std::iterator_traits<OutputIterator>::difference_type k = 0;
+    for (; first1 != last1; ++first1, ++first2, ++out_first, ++k)
+    {
+        // check
+        Out expected = Out(1.5) + (::std::get<0>(*first1) + ::std::get<1>(*first1)) - (::std::get<0>(*first2) + ::std::get<1>(*first2));
+        Out actual = *out_first;
+        if (::std::is_floating_point_v<Out>)
+        {
+            EXPECT_TRUE((expected > actual ? expected - actual : actual - expected) < Out(1e-7),
+                        "wrong value in output sequence");
+        }
+        else
+        {
+            EXPECT_EQ(expected, actual, "wrong value in output sequence");
+        }
+        // reset
+        *out_first = k % 7 != 4 ? 7 * k + 5 : 0;
+    }
+}
+
+template <typename T1, typename T2, typename T3>
+struct test_one_policy
+{
+    template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
+              typename BinaryOp>
+    oneapi::dpl::__internal::__enable_if_hetero_execution_policy<Policy>
+    operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 /* last2 */,
+               OutputIterator out_first, OutputIterator /* out_last */, BinaryOp op)
+    {
+        auto result = oneapi::dpl::experimental::transform_async(exec, first1, last1, first2, out_first, op);
+        result.wait();
+
+        check_and_reset(first1, last1, first2, out_first);
+    }
+
+    template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
+              typename BinaryOp>
+    ::std::enable_if_t<!oneapi::dpl::__internal::__is_hetero_execution_policy_v<::std::decay_t<Policy>>, void>
+    operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
+               InputIterator2 /* last2 */, OutputIterator out_first, OutputIterator /* out_last */, BinaryOp op)
+    {
+        // transform_async implemented now only for hetero policy
+    }
+};
+
+template <typename TInput1, typename TInput2, typename TOutput, typename Predicate>
+void
+test(Predicate pred)
+{
+    // TODO required to start from 0 when it will be implemented in __pattern_walk3_async and all other patterns
+    for (size_t n = 1; n <= 100000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
+    {
+        Sequence<TInput1> in1_a(n, [](size_t k) { return k % 5 != 1 ? TInput1(3 * k + 7) : 0; });
+        Sequence<TInput1> in1_b(n, [](size_t k) { return 0; });
+        auto in1_zip_begin = dpl::make_zip_iterator(in1_a.begin(), in1_b.begin());
+        auto in1_zip_end   = dpl::make_zip_iterator(in1_a.end(),   in1_b.end());
+
+        Sequence<TInput2> in2_a(n, [](size_t k) { return k % 7 != 2 ? TInput2(5 * k + 5) : 0; });
+        Sequence<TInput2> in2_b(n, [](size_t k) { return 0; });
+        auto in2_zip_begin = dpl::make_zip_iterator(in2_a.begin(), in1_b.begin());
+        auto in2_zip_end   = dpl::make_zip_iterator(in2_a.end(),   in2_b.end());
+
+        Sequence<TOutput> out(n, [](size_t) { return -1; });
+
+        invoke_on_all_policies<0>()(test_one_policy<TInput1, TInput2, TOutput>(),
+                                    in1_zip_begin, in1_zip_end,
+                                    in2_zip_begin, in2_zip_end,
+                                    out.begin(), out.end(),
+                                    pred);
+
+#if !ONEDPL_FPGA_DEVICE
+        {
+            auto in1_zip_cbegin = dpl::make_zip_iterator(in1_a.cbegin(), in1_b.cbegin());
+            auto in1_zip_cend   = dpl::make_zip_iterator(in1_a.cend(),   in1_b.cend());
+
+            auto in2_zip_cbegin = dpl::make_zip_iterator(in2_a.cbegin(), in1_b.cbegin());
+            auto in2_zip_cend   = dpl::make_zip_iterator(in2_a.cend(),   in2_b.cend());
+
+            invoke_on_all_policies<1>()(test_one_policy<TInput1, TInput2, TOutput>(),
+                                        in1_zip_cbegin, in1_zip_cend,
+                                        in2_zip_cbegin, in2_zip_cend,
+                                        out.begin(), out.end(),
+                                        pred);
+        }
+#endif // ONEDPL_FPGA_DEVICE
+    }
+}
+
+template <typename TInput1, typename TInput2, typename TOutput>
+void test_with_pred(TOutput initial_value)
+{
+    TheOperation<TInput1, TInput2, TOutput> pred(initial_value);
+
+    test<TInput1, TInput2, TOutput>(pred);
+}
+
+template <typename TInput1, typename TInput2, typename TOutput>
+void
+test_with_pred_non_const(TOutput initial_value)
+{
+    TheOperation<TInput1, TInput2, TOutput> pred(initial_value);
+
+    test<TInput1, TInput2, TOutput>(non_const(pred));
+}
+
+template <typename TInput1, typename TInput2, typename TOutput>
+void
+test_with_lambda(TOutput initial_value)
+{
+    test<TInput1, TInput2, TOutput>(
+        [initial_value](const ::std::tuple<const TInput1&, const TInput1&>& x,
+                        const ::std::tuple<const TInput2&, const TInput2&>& y)
+        {
+            return TOutput(initial_value + (::std::get<0>(x) + ::std::get<1>(x)) - (::std::get<0>(y) + ::std::get<1>(y)));
+        });
+}
+#endif // TEST_DPCPP_BACKEND_PRESENT
+
+int
+main()
+{
+#if TEST_DPCPP_BACKEND_PRESENT
+    //const operator()
+    test_with_pred<std::int32_t, std::int32_t, std::int32_t>(1);
+    test_with_pred<float32_t, float32_t, float32_t>(1.5);
+
+    //non-const operator()
+    test_with_pred_non_const<std::int32_t, std::int32_t, std::int32_t>(1);
+    test_with_pred_non_const<float32_t, float32_t, float32_t>(1.5);
+
+    // lambda
+    test_with_lambda<std::int32_t, std::int32_t, std::int32_t>(1);
+    test_with_lambda<float32_t, float32_t, float32_t>(1.5);
+#endif // TEST_DPCPP_BACKEND_PRESENT
+
+    return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT);
+}

--- a/test/parallel_api/experimental/transform_async_binary_zip.pass.cpp
+++ b/test/parallel_api/experimental/transform_async_binary_zip.pass.cpp
@@ -74,7 +74,7 @@ struct test_one_policy
 {
     template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
               typename BinaryOp>
-    oneapi::dpl::__internal::__enable_if_hetero_execution_policy<Policy>
+    void
     operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 /* last2 */,
                OutputIterator out_first, OutputIterator /* out_last */, BinaryOp op)
     {
@@ -82,15 +82,6 @@ struct test_one_policy
         result.wait();
 
         check_and_reset(first1, last1, first2, out_first);
-    }
-
-    template <typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
-              typename BinaryOp>
-    ::std::enable_if_t<!oneapi::dpl::__internal::__is_hetero_execution_policy_v<::std::decay_t<Policy>>, void>
-    operator()(Policy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
-               InputIterator2 /* last2 */, OutputIterator out_first, OutputIterator /* out_last */, BinaryOp op)
-    {
-        // transform_async implemented now only for hetero policy
     }
 };
 
@@ -113,11 +104,12 @@ test(Predicate pred)
 
         Sequence<TOutput> out(n, [](size_t) { return -1; });
 
-        invoke_on_all_policies<0>()(test_one_policy<TInput1, TInput2, TOutput>(),
-                                    in1_zip_begin, in1_zip_end,
-                                    in2_zip_begin, in2_zip_end,
-                                    out.begin(), out.end(),
-                                    pred);
+        // transform_async implemented now only for hetero policy
+        invoke_on_all_hetero_policies<0>()(test_one_policy<TInput1, TInput2, TOutput>(),
+                                           in1_zip_begin, in1_zip_end,
+                                           in2_zip_begin, in2_zip_end,
+                                           out.begin(), out.end(),
+                                           pred);
 
 #if !ONEDPL_FPGA_DEVICE
         {
@@ -127,11 +119,12 @@ test(Predicate pred)
             auto in2_zip_cbegin = dpl::make_zip_iterator(in2_a.cbegin(), in1_b.cbegin());
             auto in2_zip_cend   = dpl::make_zip_iterator(in2_a.cend(),   in2_b.cend());
 
-            invoke_on_all_policies<1>()(test_one_policy<TInput1, TInput2, TOutput>(),
-                                        in1_zip_cbegin, in1_zip_cend,
-                                        in2_zip_cbegin, in2_zip_cend,
-                                        out.begin(), out.end(),
-                                        pred);
+            // transform_async implemented now only for hetero policy
+            invoke_on_all_hetero_policies<1>()(test_one_policy<TInput1, TInput2, TOutput>(),
+                                               in1_zip_cbegin, in1_zip_cend,
+                                               in2_zip_cbegin, in2_zip_cend,
+                                               out.begin(), out.end(),
+                                               pred);
         }
 #endif // ONEDPL_FPGA_DEVICE
     }

--- a/test/parallel_api/experimental/transform_async_unary_zip.pass.cpp
+++ b/test/parallel_api/experimental/transform_async_unary_zip.pass.cpp
@@ -50,7 +50,7 @@ template <typename T1, typename T2>
 struct test_one_policy
 {
     template <typename Policy, typename InputIterator, typename OutputIterator, typename UnaryOp>
-    oneapi::dpl::__internal::__enable_if_hetero_execution_policy<Policy>
+    void
     operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
                OutputIterator out_last, UnaryOp op)
     {
@@ -58,14 +58,6 @@ struct test_one_policy
         result.wait();
 
         check_and_reset(first, last, out_first);
-    }
-
-    template <typename Policy, typename InputIterator, typename OutputIterator, typename UnaryOp>
-    ::std::enable_if_t<!oneapi::dpl::__internal::__is_hetero_execution_policy_v<::std::decay_t<Policy>>, void>
-    operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
-               OutputIterator out_last, UnaryOp op)
-    {
-        // transform_async implemented now only for hetero policy
     }
 };
 
@@ -100,13 +92,17 @@ test()
         Sequence<Tout> out(n);
         const ZipComplement<Tin, Tout> flip(1);
 
-        invoke_on_all_policies<0>()(test_one_policy<Tin, Tout>(), in_zip_begin, in_zip_end, out.begin(), out.end(), flip);
+        // transform_async implemented now only for hetero policy
+        invoke_on_all_hetero_policies<0>()(test_one_policy<Tin, Tout>(), in_zip_begin, in_zip_end, out.begin(),
+                                           out.end(), flip);
 #if !ONEDPL_FPGA_DEVICE
         {
             auto in_zip_cbegin = dpl::make_zip_iterator(in_a.cbegin(), in_b.cbegin());
             auto in_zip_cend = dpl::make_zip_iterator(in_a.cend(), in_b.cend());
 
-            invoke_on_all_policies<1>()(test_one_policy<Tin, Tout>(), in_zip_cbegin, in_zip_cend, out.begin(), out.end(), flip);
+            // transform_async implemented now only for hetero policy
+            invoke_on_all_hetero_policies<1>()(test_one_policy<Tin, Tout>(), in_zip_cbegin, in_zip_cend, out.begin(),
+                                               out.end(), flip);
         }
 #endif // ONEDPL_FPGA_DEVICE
     }

--- a/test/parallel_api/experimental/transform_async_unary_zip.pass.cpp
+++ b/test/parallel_api/experimental/transform_async_unary_zip.pass.cpp
@@ -1,0 +1,128 @@
+// -*- C++ -*-
+//===-- transform_unary.pass.cpp ------------------------------------------===//
+//
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+// Tests for transform
+
+#include "support/test_config.h"
+
+#include _PSTL_TEST_HEADER(execution)
+#include _PSTL_TEST_HEADER(algorithm)
+
+#if TEST_DPCPP_BACKEND_PRESENT
+#    include "oneapi/dpl/async"
+#endif // TEST_DPCPP_BACKEND_PRESENT
+
+#include "support/utils.h"
+
+using namespace TestUtils;
+
+#if TEST_DPCPP_BACKEND_PRESENT
+template <typename InputIterator, typename OutputIterator>
+void
+check_and_reset(InputIterator first, InputIterator last, OutputIterator out_first)
+{
+    typedef typename ::std::iterator_traits<OutputIterator>::value_type Out;
+    typename ::std::iterator_traits<OutputIterator>::difference_type k = 0;
+    for (; first != last; ++first, ++out_first, ++k)
+    {
+        // check
+        Out expected = 1 - std::get<0>(*first) - std::get<1>(*first);
+        Out actual = *out_first;
+        EXPECT_EQ(expected, actual, "wrong value in output sequence");
+        // reset
+        *out_first = k % 7 != 4 ? 7 * k - 5 : 0;
+    }
+}
+
+template <typename T1, typename T2>
+struct test_one_policy
+{
+    template <typename Policy, typename InputIterator, typename OutputIterator, typename UnaryOp>
+    oneapi::dpl::__internal::__enable_if_hetero_execution_policy<Policy>
+    operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
+               OutputIterator out_last, UnaryOp op)
+    {
+        auto result = oneapi::dpl::experimental::transform_async(exec, first, last, out_first, op);
+        result.wait();
+
+        check_and_reset(first, last, out_first);
+    }
+
+    template <typename Policy, typename InputIterator, typename OutputIterator, typename UnaryOp>
+    ::std::enable_if_t<!oneapi::dpl::__internal::__is_hetero_execution_policy_v<::std::decay_t<Policy>>, void>
+    operator()(Policy&& exec, InputIterator first, InputIterator last, OutputIterator out_first,
+               OutputIterator out_last, UnaryOp op)
+    {
+        // transform_async implemented now only for hetero policy
+    }
+};
+
+template <typename TInput, typename TOutput>
+class ZipComplement
+{
+    std::int32_t val;
+
+public:
+
+    ZipComplement(std::size_t v) : val(v) {}
+
+    TOutput operator()(const ::std::tuple<const TInput&, const TInput&>& x) const
+    {
+        return TOutput(val - std::get<0>(x) - std::get<1>(x));
+    }
+};
+
+template <typename Tin, typename Tout>
+void
+test()
+{
+    // TODO required to start from 0 when it will be implemented in __pattern_walk3_async and all other patterns
+    for (size_t n = 1; n <= 100000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
+    {
+        Sequence<Tin> in_a(n, [](std::int32_t k) { return k % 5 != 1 ? 3 * k - 7 : 0; });
+        Sequence<Tin> in_b(n, [](std::int32_t k) { return 0; });
+
+        auto in_zip_begin = dpl::make_zip_iterator(in_a.begin(), in_b.begin());
+        auto in_zip_end = dpl::make_zip_iterator(in_a.end(), in_b.end());
+
+        Sequence<Tout> out(n);
+        const ZipComplement<Tin, Tout> flip(1);
+
+        invoke_on_all_policies<0>()(test_one_policy<Tin, Tout>(), in_zip_begin, in_zip_end, out.begin(), out.end(), flip);
+#if !ONEDPL_FPGA_DEVICE
+        {
+            auto in_zip_cbegin = dpl::make_zip_iterator(in_a.cbegin(), in_b.cbegin());
+            auto in_zip_cend = dpl::make_zip_iterator(in_a.cend(), in_b.cend());
+
+            invoke_on_all_policies<1>()(test_one_policy<Tin, Tout>(), in_zip_cbegin, in_zip_cend, out.begin(), out.end(), flip);
+        }
+#endif // ONEDPL_FPGA_DEVICE
+    }
+}
+#endif // TEST_DPCPP_BACKEND_PRESENT
+
+int
+main()
+{
+#if TEST_DPCPP_BACKEND_PRESENT
+    test<std::int32_t, std::int32_t>();
+    test<std::int32_t, float32_t>();
+    test<std::uint16_t, float32_t>();
+    test<float32_t, float64_t>();
+    test<float64_t, float64_t>();
+#endif // TEST_DPCPP_BACKEND_PRESENT
+    
+    return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT);
+}


### PR DESCRIPTION
Source implementation received from @rarutyun and PR https://github.com/oneapi-src/oneDPL/pull/1233
This separate PR has been created to rebase source commits from https://github.com/oneapi-src/oneDPL/pull/1233 based on current `main` branch state.

In this PR we simple create tests for check works with [`zip_iterator`](https://github.com/oneapi-src/oneDPL/blob/5fe797ff97db04e7446448d0177ce376380d7b59/include/oneapi/dpl/pstl/iterator_impl.h#L265) and:
- for `dpl::transform` algorithm;
- for `dpl::transform_async` algorithm;
- for `unary` predicate case;
- for `binary` predicate case.