### PR TITLE
[KT] Merge key and key-value onesweep kernels

### DIFF
--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_dispatchers.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_dispatchers.h
@@ -112,7 +112,7 @@ class __onesweep_memory_holder
 
     void __appoint_aligned_memory_regions()
     {
-        // It assumes that the raw pointer is already alligned for _HistT
+        // It assumes that the raw pointer is already aligned for _HistT
         __m_global_hist_ptr = reinterpret_cast<_HistT*>(__m_raw_mem_ptr);
         __m_group_hist_ptr = reinterpret_cast<_HistT*>(__m_raw_mem_ptr + __m_global_hist_bytes);
 

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_kernels.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_kernels.h
@@ -20,6 +20,7 @@
 #endif
 
 #include <cstdint>
+#include <type_traits>
 
 #include "esimd_radix_sort_utils.h"
 #include "../../../pstl/utils.h"

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_kernels.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_kernels.h
@@ -507,7 +507,7 @@ struct __radix_sort_onesweep_kernel
         constexpr ::std::uint32_t __global_offset_mask = 0x3fffffff;
 
         _GlobOffsetT* __p_this_group_hist = __p_group_hists + __bin_count * __wg_id;
-        // First group contains global hist to propagate it to other groups during synchronization
+        // First group contains global histogram to propagate it to other groups during synchronization
         _GlobOffsetT* __p_prev_group_hist = (0 == __wg_id)? __p_global_hist : __p_this_group_hist - __bin_count;
 
         {

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_kernels.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_kernels.h
@@ -324,8 +324,8 @@ struct __radix_sort_onesweep_kernel
     using _LocOffsetT = ::std::uint16_t;
     using _GlobOffsetT = ::std::uint32_t;
 
-    using _KeyT = typename _InValuesPack::__key_t;
-    using _ValT = typename _InValuesPack::__val_t;
+    using _KeyT = typename _InValuesPack::_KeyT;
+    using _ValT = typename _InValuesPack::_ValT;
     static constexpr bool __has_values = !::std::is_void_v<_ValT>;
 
     static constexpr ::std::uint32_t __bin_count = 1 << __radix_bits;

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_submitters.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_submitters.h
@@ -140,13 +140,14 @@ struct __radix_sort_onesweep_submitter<__is_ascending, __radix_bits, __data_per_
             [&](sycl::handler& __cgh)
             {
                 oneapi::dpl::__ranges::__require_access(__cgh, __in_keys_rng, __out_keys_rng);
-                auto __in_data = __in_keys_rng.data();
-                auto __out_data = __out_keys_rng.data();
+                auto __in_pack = __make_pack(__in_keys_rng);
+                auto __out_pack = __make_pack(__out_keys_rng);
                 __cgh.depends_on(__e);
-                __radix_sort_onesweep_slm_reorder_kernel<__is_ascending, __radix_bits, __data_per_work_item, __work_group_size,
-                                                       _KeyT, decltype(__in_data), decltype(__out_data)>
-                    __sweep_kernel(__n, __stage, __in_data, __out_data, __p_global_hist, __p_group_hists);
-                __cgh.parallel_for<_Name...>(__nd_range, __sweep_kernel);
+                __radix_sort_onesweep_kernel<
+                    __is_ascending, __radix_bits, __data_per_work_item, __work_group_size,
+                        decltype(__in_pack), decltype(__out_pack)> __kernel(__n, __stage, __p_global_hist,
+                                                                            __p_group_hists, __in_pack, __out_pack);
+                __cgh.parallel_for<_Name...>(__nd_range, __kernel);
             });
     }
 };
@@ -201,15 +202,14 @@ struct __radix_sort_onesweep_by_key_submitter<__is_ascending, __radix_bits, __da
             [&](sycl::handler& __cgh)
             {
                 oneapi::dpl::__ranges::__require_access(__cgh, __in_keys_rng, __out_keys_rng, __in_vals_rng, __out_vals_rng);
-                auto __in_keys_data = __in_keys_rng.data();
-                auto __out_keys_data = __out_keys_rng.data();
-                auto __in_vals_data = __in_vals_rng.data();
-                auto __out_vals_data = __out_vals_rng.data();
+                auto __in_pack = __make_pack(__in_keys_rng, __in_vals_rng);
+                auto __out_pack = __make_pack(__out_keys_rng, __out_vals_rng);
                 __cgh.depends_on(__e);
-                __radix_sort_onesweep_by_key_slm_reorder_kernel<__is_ascending, __radix_bits, __data_per_work_item, __work_group_size,
-                                                       _KeyT, _ValT, decltype(__in_keys_data), decltype(__out_keys_data), decltype(__in_vals_data), decltype(__out_vals_data)>
-                    __sweep_kernel(__n, __stage, __in_keys_data, __out_keys_data, __in_vals_data, __out_vals_data, __p_global_hist, __p_group_hists);
-                __cgh.parallel_for<_Name...>(__nd_range, __sweep_kernel);
+                __radix_sort_onesweep_kernel<
+                    __is_ascending, __radix_bits, __data_per_work_item, __work_group_size,
+                        decltype(__in_pack), decltype(__out_pack)> __kernel(__n, __stage, __p_global_hist,
+                                                                            __p_group_hists, __in_pack, __out_pack);
+                __cgh.parallel_for<_Name...>(__nd_range, __kernel);
             });
     }
 };

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_submitters.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_submitters.h
@@ -58,11 +58,11 @@ struct __radix_sort_one_wg_submitter<__is_ascending, __radix_bits, __data_per_wo
     }
 };
 
-template <typename _KeyT, ::std::uint32_t __radix_bits, ::std::uint32_t __stage_count, ::std::uint32_t __hist_work_group_count,
+template <typename _KeyT, ::std::uint8_t __radix_bits, ::std::uint32_t __stage_count, ::std::uint32_t __hist_work_group_count,
           ::std::uint32_t __hist_work_group_size, bool __is_ascending, typename _KernelName>
 struct __radix_sort_onesweep_histogram_submitter;
 
-template <typename _KeyT, ::std::uint32_t __radix_bits, ::std::uint32_t __stage_count, ::std::uint32_t __hist_work_group_count,
+template <typename _KeyT, ::std::uint8_t __radix_bits, ::std::uint32_t __stage_count, ::std::uint32_t __hist_work_group_count,
           ::std::uint32_t __hist_work_group_size, bool __is_ascending, typename... _Name>
 struct __radix_sort_onesweep_histogram_submitter<
     _KeyT, __radix_bits, __stage_count, __hist_work_group_count, __hist_work_group_size, __is_ascending,
@@ -89,7 +89,7 @@ struct __radix_sort_onesweep_histogram_submitter<
     }
 };
 
-template <::std::uint32_t __stage_count, ::std::uint32_t __bin_count, typename _KernelName>
+template <::std::uint32_t __stage_count, ::std::uint16_t __bin_count, typename _KernelName>
 struct __radix_sort_onesweep_scan_submitter;
 
 template <::std::uint32_t __stage_count, ::std::uint32_t __bin_count, typename... _Name>
@@ -140,13 +140,12 @@ struct __radix_sort_onesweep_submitter<__is_ascending, __radix_bits, __data_per_
             [&](sycl::handler& __cgh)
             {
                 oneapi::dpl::__ranges::__require_access(__cgh, __in_keys_rng, __out_keys_rng);
-                auto __in_pack = __make_pack(__in_keys_rng);
-                auto __out_pack = __make_pack(__out_keys_rng);
+                auto __in_pack = __utils::__make_pack(__in_keys_rng);
+                auto __out_pack = __utils::__make_pack(__out_keys_rng);
                 __cgh.depends_on(__e);
-                __radix_sort_onesweep_kernel<
-                    __is_ascending, __radix_bits, __data_per_work_item, __work_group_size,
-                        decltype(__in_pack), decltype(__out_pack)> __kernel(__n, __stage, __p_global_hist,
-                                                                            __p_group_hists, __in_pack, __out_pack);
+                __radix_sort_onesweep_kernel<__is_ascending, __radix_bits, __data_per_work_item, __work_group_size,
+                                            decltype(__in_pack), decltype(__out_pack)>
+                    __kernel(__n, __stage, __p_global_hist, __p_group_hists, __in_pack, __out_pack);
                 __cgh.parallel_for<_Name...>(__nd_range, __kernel);
             });
     }
@@ -202,13 +201,12 @@ struct __radix_sort_onesweep_by_key_submitter<__is_ascending, __radix_bits, __da
             [&](sycl::handler& __cgh)
             {
                 oneapi::dpl::__ranges::__require_access(__cgh, __in_keys_rng, __out_keys_rng, __in_vals_rng, __out_vals_rng);
-                auto __in_pack = __make_pack(__in_keys_rng, __in_vals_rng);
-                auto __out_pack = __make_pack(__out_keys_rng, __out_vals_rng);
+                auto __in_pack = __utils::__make_pack(__in_keys_rng, __in_vals_rng);
+                auto __out_pack = __utils::__make_pack(__out_keys_rng, __out_vals_rng);
                 __cgh.depends_on(__e);
-                __radix_sort_onesweep_kernel<
-                    __is_ascending, __radix_bits, __data_per_work_item, __work_group_size,
-                        decltype(__in_pack), decltype(__out_pack)> __kernel(__n, __stage, __p_global_hist,
-                                                                            __p_group_hists, __in_pack, __out_pack);
+                __radix_sort_onesweep_kernel<__is_ascending, __radix_bits, __data_per_work_item, __work_group_size,
+                                             decltype(__in_pack), decltype(__out_pack)>
+                    __kernel(__n, __stage, __p_global_hist, __p_group_hists, __in_pack, __out_pack);
                 __cgh.parallel_for<_Name...>(__nd_range, __kernel);
             });
     }

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_utils.h
@@ -791,23 +791,23 @@ struct _slm_lookup_t
     }
 };
 
-template<typename _KeyT, typename _KeysData>
+template<typename _T, typename _Acc>
 struct _keys_pack
 {
-    using __key_t = _KeyT;
-    using __val_t = void;
-    _KeysData __keys;
-    _keys_pack(const _KeysData& __keys): __keys(__keys) {}
+    using _KeyT = _T;
+    using _ValT = void;
+    _Acc __keys;
+    _keys_pack(const _Acc& __keys): __keys(__keys) {}
 };
 
-template<typename _KeyT, typename _ValT, typename _KeysData, typename _ValsData>
+template<typename _T1, typename _T2, typename _Acc1, typename _Acc2>
 struct _pairs_pack
 {
-    using __key_t = _KeyT;
-    using __val_t = _ValT;
-    _KeysData __keys;
-    _ValsData __vals;
-    _pairs_pack(const _KeysData& __keys, const _ValsData& __vals): __keys(__keys), __vals(__vals) {}
+    using _KeyT = _T1;
+    using _ValT = _T2;
+    _Acc1 __keys;
+    _Acc2 __vals;
+    _pairs_pack(const _Acc1& __keys, const _Acc2& __vals): __keys(__keys), __vals(__vals) {}
 };
 
 template<typename _KeysRng, typename _ValsRng>

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_utils.h
@@ -10,6 +10,8 @@
 #ifndef _ONEDPL_KT_ESIMD_RADIX_SORT_UTILS_H
 #define _ONEDPL_KT_ESIMD_RADIX_SORT_UTILS_H
 
+#include "oneapi/dpl/pstl/onedpl_config.h"
+
 #if __has_include(<sycl/sycl.hpp>)
 #    include <sycl/sycl.hpp>
 #else
@@ -752,12 +754,105 @@ __create_simd(_T initial, _T step)
     __dpl_esimd_ns::simd<_T, _N> ret;
     ret.template select<16, 1>(0) = __dpl_esimd_ns::simd<_T, 16>(0, 1) * step + initial;
     __dpl_esimd_ns::fence<__dpl_esimd_ns::fence_mask::sw_barrier>();
-#pragma unroll
+    _ONEDPL_PRAGMA_UNROLL
     for (int pos = 16; pos < _N; pos += 16)
     {
         ret.template select<16, 1>(pos) = ret.template select<16, 1>(0) + pos * step;
     }
     return ret;
+}
+
+template <typename _T>
+struct _slm_lookup_t
+{
+    ::std::uint32_t __slm;
+    inline _slm_lookup_t(::std::uint32_t __slm) : __slm(__slm) {}
+
+    template <int __table_size>
+    inline void
+    __setup(__dpl_esimd_ns::simd<_T, __table_size> __source) SYCL_ESIMD_FUNCTION
+    {
+        __utils::__block_store_slm<_T, __table_size>(__slm, __source);
+    }
+
+    template <int _N, typename _Idx>
+    inline auto
+    __lookup(_Idx __idx) SYCL_ESIMD_FUNCTION
+    {
+        return __utils::__vector_load<_T, 1, _N>(__slm + __dpl_esimd_ns::simd<::std::uint32_t, _N>(__idx) * sizeof(_T));
+    }
+
+    template <int _N, int __table_size, typename _Idx>
+    inline auto
+    __lookup(__dpl_esimd_ns::simd<_T, __table_size> __source, _Idx __idx) SYCL_ESIMD_FUNCTION
+    {
+        __setup(__source);
+        return __lookup<_N>(__idx);
+    }
+};
+
+template<typename _KeyT, typename _KeysData>
+struct _keys_pack
+{
+    using __key_t = _KeyT;
+    using __val_t = void;
+    _KeysData __keys;
+    _keys_pack(const _KeysData& __keys): __keys(__keys) {}
+};
+
+template<typename _KeyT, typename _ValT, typename _KeysData, typename _ValsData>
+struct _pairs_pack
+{
+    using __key_t = _KeyT;
+    using __val_t = _ValT;
+    _KeysData __keys;
+    _ValsData __vals;
+    _pairs_pack(const _KeysData& __keys, const _ValsData& __vals): __keys(__keys), __vals(__vals) {}
+};
+
+template<typename _KeysRng, typename _ValsRng>
+auto __make_pack(_KeysRng& __keys_rng, _ValsRng& __vals_rng)
+{
+    using _KeyT = oneapi::dpl::__internal::__value_t<_KeysRng>;
+    using _ValT = oneapi::dpl::__internal::__value_t<_ValsRng>;
+    using _KeysData = decltype(__keys_rng.data());
+    using _ValsData = decltype(__vals_rng.data());
+    return _pairs_pack<_KeyT, _ValT, _KeysData, _ValsData> {__keys_rng.data(), __vals_rng.data()};
+}
+
+template<typename _KeysRng>
+auto __make_pack(_KeysRng& __keys_rng)
+{
+    using _KeyT = oneapi::dpl::__internal::__value_t<_KeysRng>;
+    using _KeysData = decltype(__keys_rng.data());
+    return _keys_pack<_KeyT, _KeysData>{__keys_rng.data()};
+}
+
+template<::std::uint16_t _N, typename _KeyT>
+struct _keys_simd_pack
+{
+    __dpl_esimd_ns::simd<_KeyT, _N> __keys;
+};
+
+template< ::std::uint16_t _N, typename _KeyT, typename _ValT>
+struct _pairs_simd_pack
+{
+    __dpl_esimd_ns::simd<_KeyT, _N> __keys;
+    __dpl_esimd_ns::simd<_ValT, _N> __vals;
+};
+
+template<::std::uint16_t _N, typename _T1, typename _T2 = void>
+auto
+__make_simd_pack()
+{
+    if constexpr (::std::is_void_v<_T2>)
+    {
+        return __utils::_keys_simd_pack<_N, _T1>{};
+    }
+    else
+    {
+        return __utils::_pairs_simd_pack<_N, _T1, _T2>{};
+    }
 }
 
 } // namespace __utils

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -34,7 +34,7 @@ namespace __ranges
 namespace __internal
 {
 template<typename _AccessorType, typename _BufferType, typename _DiffType>
-static _AccessorType 
+static _AccessorType
 __create_accessor(_BufferType& __buf, _DiffType __offset, _DiffType __n)
 {
     auto __n_buf = __dpl_sycl::__get_buffer_size(__buf);
@@ -97,7 +97,7 @@ class all_view
         __cgh.require(__m_acc);
     }
 
-    // Unified funciton to get pointer or accessor to use inside ESIMD kernels
+    // Unified function to get pointer or accessor to use inside ESIMD kernels
     __accessor_t data()
     {
         return __m_acc;

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -245,7 +245,7 @@ class guard_view
         return size() == 0;
     }
 
-    // Unified funciton to get pointer or accessor to use inside ESIMD kernels
+    // Unified function to get pointer or accessor to use inside ESIMD kernels
     _Iterator data()
     {
         return m_p;

--- a/test/kt/esimd_radix_sort_by_key.cpp
+++ b/test/kt/esimd_radix_sort_by_key.cpp
@@ -119,5 +119,5 @@ int main()
         }
     }
 
-    return TestUtils::done();
+    return TestUtils::done(run_test);
 }


### PR DESCRIPTION
Also:
- The remaining onesweep kernel has been refactored to highlight steps of the algorithm.
- Unroll pragma has been replaced with the internal macro.
- Some typos have been corrected
