### PR TITLE
Exclude reduce_by_segment test case that crashes compiler

### DIFF
--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -137,7 +137,7 @@
 // oneAPI DPC++ compiler in 2023.2 release build crashes during optimization of reduce_by_segment.pass.cpp
 // with TBB backend.
 #if !PSTL_USE_DEBUG && TEST_TBB_BACKEND_PRESENT && defined(__INTEL_LLVM_COMPILER)
-#   define _PSTL_ICPX_TEST_RED_BY_SEG_OPTIMIZER_CRASH (__INTEL_LLVM_COMPILER == 20230200) || (__INTEL_LLVM_COMPILER == 20240000)
+#   define _PSTL_ICPX_TEST_RED_BY_SEG_OPTIMIZER_CRASH ((__INTEL_LLVM_COMPILER == 20230200) || (__INTEL_LLVM_COMPILER == 20240000))
 #else
 #   define _PSTL_ICPX_TEST_RED_BY_SEG_OPTIMIZER_CRASH 0
 #endif

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -137,7 +137,7 @@
 // oneAPI DPC++ compiler in 2023.2 release build crashes during optimization of reduce_by_segment.pass.cpp
 // with TBB backend.
 #if !PSTL_USE_DEBUG && TEST_TBB_BACKEND_PRESENT && defined(__INTEL_LLVM_COMPILER)
-#   define _PSTL_ICPX_TEST_RED_BY_SEG_OPTIMIZER_CRASH (__INTEL_LLVM_COMPILER == 20230200)
+#   define _PSTL_ICPX_TEST_RED_BY_SEG_OPTIMIZER_CRASH (__INTEL_LLVM_COMPILER == 20230200) || (__INTEL_LLVM_COMPILER == 20240000)
 #else
 #   define _PSTL_ICPX_TEST_RED_BY_SEG_OPTIMIZER_CRASH 0
 #endif


### PR DESCRIPTION
This PR updates the test macro that excludes compilation of code that crashes the compiler during optimization in `reduce_by_segment.pass`.