### PR TITLE
Adding sourcing of vars.sh to linux testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,6 +177,7 @@ jobs:
         run: |
           set -x
           source $CONDA/bin/activate
+          source /usr/share/miniconda/env/setvars.sh
           export PATH=$CONDA/lib:$PATH
           export CPATH=$CONDA/include:$CPATH
           export OCL_ICD_FILENAMES=$CONDA/lib/libintelocl.so
@@ -222,6 +223,7 @@ jobs:
         run: |
           set -x
           source $CONDA/bin/activate
+          source /usr/share/miniconda/env/setvars.sh
           export PATH=$CONDA/lib:$PATH
           export CPATH=$CONDA/include:$CPATH
           export OCL_ICD_FILENAMES=$CONDA/lib/libintelocl.so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
         run: |
           set -x
           source $CONDA/bin/activate
-          source /usr/share/miniconda/env/setvars.sh
+          source /opt/intel/oneapi/setvars.sh
           export PATH=$CONDA/lib:$PATH
           export CPATH=$CONDA/include:$CPATH
           export OCL_ICD_FILENAMES=$CONDA/lib/libintelocl.so
@@ -223,7 +223,7 @@ jobs:
         run: |
           set -x
           source $CONDA/bin/activate
-          source /usr/share/miniconda/env/setvars.sh
+          source /opt/intel/oneapi/setvars.sh
           export PATH=$CONDA/lib:$PATH
           export CPATH=$CONDA/include:$CPATH
           export OCL_ICD_FILENAMES=$CONDA/lib/libintelocl.so


### PR DESCRIPTION
When installing from conda, we did not source vars.sh previously.  This adds that to the script(s).