### PR TITLE
Fix tests from `test/xpu_api` with removed in C++20 functional

### DIFF
--- a/test/xpu_api/utilities/function.objects/negators/binary_negate.pass.cpp
+++ b/test/xpu_api/utilities/function.objects/negators/binary_negate.pass.cpp
@@ -50,8 +50,7 @@ kernel_test()
     auto ret_access_host = buffer1.get_host_access(sycl::read_only);
     EXPECT_TRUE(ret_access_host[0], "Error in work with dpl::binary_negate");
 }
-#    endif // TEST_STD_VER
-#endif // TEST_DPCPP_BACKEND_PRESENT
+#endif // TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER
 
 int
 main()

--- a/test/xpu_api/utilities/function.objects/negators/binary_negate.pass.cpp
+++ b/test/xpu_api/utilities/function.objects/negators/binary_negate.pass.cpp
@@ -18,9 +18,11 @@
 #include <oneapi/dpl/functional>
 #include <oneapi/dpl/type_traits>
 
+#include "support/test_macros.h"
 #include "support/utils.h"
 
 #if TEST_DPCPP_BACKEND_PRESENT
+#    if TEST_STD_VER == 17
 class KernelBinaryNegTest;
 
 void
@@ -48,14 +50,17 @@ kernel_test()
     auto ret_access_host = buffer1.get_host_access(sycl::read_only);
     EXPECT_TRUE(ret_access_host[0], "Error in work with dpl::binary_negate");
 }
+#    endif // TEST_STD_VER
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
 int
 main()
 {
 #if TEST_DPCPP_BACKEND_PRESENT
+#    if TEST_STD_VER == 17
     kernel_test();
+#    endif // TEST_STD_VER
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-    return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT);
+    return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER == 17);
 }

--- a/test/xpu_api/utilities/function.objects/negators/binary_negate.pass.cpp
+++ b/test/xpu_api/utilities/function.objects/negators/binary_negate.pass.cpp
@@ -21,8 +21,8 @@
 #include "support/test_macros.h"
 #include "support/utils.h"
 
-#if TEST_DPCPP_BACKEND_PRESENT
-#    if TEST_STD_VER == 17
+// dpl::binary_negate is removed since C++20
+#if TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER == 17
 class KernelBinaryNegTest;
 
 void

--- a/test/xpu_api/utilities/function.objects/negators/binary_negate.pass.cpp
+++ b/test/xpu_api/utilities/function.objects/negators/binary_negate.pass.cpp
@@ -56,11 +56,9 @@ kernel_test()
 int
 main()
 {
-#if TEST_DPCPP_BACKEND_PRESENT
-#    if TEST_STD_VER == 17
+#if TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER == 17
     kernel_test();
-#    endif // TEST_STD_VER
-#endif // TEST_DPCPP_BACKEND_PRESENT
+#endif // TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER
 
     return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER == 17);
 }

--- a/test/xpu_api/utilities/function.objects/negators/not1.pass.cpp
+++ b/test/xpu_api/utilities/function.objects/negators/not1.pass.cpp
@@ -49,11 +49,9 @@ kernel_test()
 int
 main()
 {
-#if TEST_DPCPP_BACKEND_PRESENT
-#    if TEST_STD_VER == 17
+#if TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER == 17
     kernel_test();
-#    endif // TEST_STD_VER
-#endif // TEST_DPCPP_BACKEND_PRESENT
+#endif // TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER
 
     return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER == 17);
 }

--- a/test/xpu_api/utilities/function.objects/negators/not1.pass.cpp
+++ b/test/xpu_api/utilities/function.objects/negators/not1.pass.cpp
@@ -18,9 +18,11 @@
 #include <oneapi/dpl/functional>
 #include <oneapi/dpl/type_traits>
 
+#include "support/test_macros.h"
 #include "support/utils.h"
 
 #if TEST_DPCPP_BACKEND_PRESENT
+#    if TEST_STD_VER == 17
 class KernelNot1Test;
 
 void
@@ -42,14 +44,17 @@ kernel_test()
     auto ret_access_host = buffer1.get_host_access(sycl::read_only);
     EXPECT_TRUE(ret_access_host[0], "Error in work with dpl::logical_not");
 }
+#    endif // TEST_STD_VER
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
 int
 main()
 {
 #if TEST_DPCPP_BACKEND_PRESENT
+#    if TEST_STD_VER == 17
     kernel_test();
+#    endif // TEST_STD_VER
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-    return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT);
+    return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER == 17);
 }

--- a/test/xpu_api/utilities/function.objects/negators/not1.pass.cpp
+++ b/test/xpu_api/utilities/function.objects/negators/not1.pass.cpp
@@ -21,8 +21,8 @@
 #include "support/test_macros.h"
 #include "support/utils.h"
 
-#if TEST_DPCPP_BACKEND_PRESENT
-#    if TEST_STD_VER == 17
+// dpl::not1 is removed since C++20
+#if TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER == 17
 class KernelNot1Test;
 
 void

--- a/test/xpu_api/utilities/function.objects/negators/not1.pass.cpp
+++ b/test/xpu_api/utilities/function.objects/negators/not1.pass.cpp
@@ -44,8 +44,7 @@ kernel_test()
     auto ret_access_host = buffer1.get_host_access(sycl::read_only);
     EXPECT_TRUE(ret_access_host[0], "Error in work with dpl::logical_not");
 }
-#    endif // TEST_STD_VER
-#endif // TEST_DPCPP_BACKEND_PRESENT
+#endif // TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER
 
 int
 main()

--- a/test/xpu_api/utilities/function.objects/negators/not2.pass.cpp
+++ b/test/xpu_api/utilities/function.objects/negators/not2.pass.cpp
@@ -21,8 +21,8 @@
 #include "support/test_macros.h"
 #include "support/utils.h"
 
-#if TEST_DPCPP_BACKEND_PRESENT
-#    if TEST_STD_VER == 17
+// dpl::not2 is removed since C++20
+#if TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER == 17
 class KernelNot2Test;
 
 void

--- a/test/xpu_api/utilities/function.objects/negators/not2.pass.cpp
+++ b/test/xpu_api/utilities/function.objects/negators/not2.pass.cpp
@@ -46,8 +46,7 @@ kernel_test()
     auto ret_access_host = buffer1.get_host_access(sycl::read_only);
     EXPECT_TRUE(ret_access_host[0], "Error in work with dpl::not2");
 }
-#    endif // TEST_STD_VER
-#endif // TEST_DPCPP_BACKEND_PRESENT
+#endif // TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER
 
 int
 main()

--- a/test/xpu_api/utilities/function.objects/negators/not2.pass.cpp
+++ b/test/xpu_api/utilities/function.objects/negators/not2.pass.cpp
@@ -51,11 +51,9 @@ kernel_test()
 int
 main()
 {
-#if TEST_DPCPP_BACKEND_PRESENT
-#    if TEST_STD_VER == 17
+#if TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER == 17
     kernel_test();
-#   endif // TEST_STD_VER
-#endif // TEST_DPCPP_BACKEND_PRESENT
+#endif // TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER
 
     return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER == 17);
 }

--- a/test/xpu_api/utilities/function.objects/negators/not2.pass.cpp
+++ b/test/xpu_api/utilities/function.objects/negators/not2.pass.cpp
@@ -18,9 +18,11 @@
 #include <oneapi/dpl/functional>
 #include <oneapi/dpl/type_traits>
 
+#include "support/test_macros.h"
 #include "support/utils.h"
 
 #if TEST_DPCPP_BACKEND_PRESENT
+#    if TEST_STD_VER == 17
 class KernelNot2Test;
 
 void
@@ -44,14 +46,17 @@ kernel_test()
     auto ret_access_host = buffer1.get_host_access(sycl::read_only);
     EXPECT_TRUE(ret_access_host[0], "Error in work with dpl::not2");
 }
+#    endif // TEST_STD_VER
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
 int
 main()
 {
 #if TEST_DPCPP_BACKEND_PRESENT
+#    if TEST_STD_VER == 17
     kernel_test();
+#   endif // TEST_STD_VER
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-    return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT);
+    return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER == 17);
 }

--- a/test/xpu_api/utilities/function.objects/negators/unary_negate.pass.cpp
+++ b/test/xpu_api/utilities/function.objects/negators/unary_negate.pass.cpp
@@ -52,11 +52,9 @@ kernel_test()
 int
 main()
 {
-#if TEST_DPCPP_BACKEND_PRESENT
-#    if TEST_STD_VER == 17
+#if TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER == 17
     kernel_test();
-#    endif // TEST_STD_VER
-#endif // TEST_DPCPP_BACKEND_PRESENT
+#endif // TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER
 
     return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER == 17);
 }

--- a/test/xpu_api/utilities/function.objects/negators/unary_negate.pass.cpp
+++ b/test/xpu_api/utilities/function.objects/negators/unary_negate.pass.cpp
@@ -21,8 +21,8 @@
 #include "support/test_macros.h"
 #include "support/utils.h"
 
-#if TEST_DPCPP_BACKEND_PRESENT
-#    if TEST_STD_VER == 17
+// dpl::unary_negate is removed since C++20
+#if TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER == 17
 class KernelUnaryNegTest;
 
 void

--- a/test/xpu_api/utilities/function.objects/negators/unary_negate.pass.cpp
+++ b/test/xpu_api/utilities/function.objects/negators/unary_negate.pass.cpp
@@ -18,9 +18,11 @@
 #include <oneapi/dpl/functional>
 #include <oneapi/dpl/type_traits>
 
+#include "support/test_macros.h"
 #include "support/utils.h"
 
 #if TEST_DPCPP_BACKEND_PRESENT
+#    if TEST_STD_VER == 17
 class KernelUnaryNegTest;
 
 void
@@ -45,14 +47,17 @@ kernel_test()
     auto ret_access_host = buffer1.get_host_access(sycl::read_only);
     EXPECT_TRUE(ret_access_host[0], "Error in work with dpl::unary_negate");
 }
+#    endif // TEST_STD_VER
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
 int
 main()
 {
 #if TEST_DPCPP_BACKEND_PRESENT
+#    if TEST_STD_VER == 17
     kernel_test();
+#    endif // TEST_STD_VER
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-    return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT);
+    return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER == 17);
 }

--- a/test/xpu_api/utilities/function.objects/negators/unary_negate.pass.cpp
+++ b/test/xpu_api/utilities/function.objects/negators/unary_negate.pass.cpp
@@ -47,8 +47,7 @@ kernel_test()
     auto ret_access_host = buffer1.get_host_access(sycl::read_only);
     EXPECT_TRUE(ret_access_host[0], "Error in work with dpl::unary_negate");
 }
-#    endif // TEST_STD_VER
-#endif // TEST_DPCPP_BACKEND_PRESENT
+#endif // TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER
 
 int
 main()

--- a/test/xpu_api/utilities/function.objects/refwrap/weak_result.pass.cpp
+++ b/test/xpu_api/utilities/function.objects/refwrap/weak_result.pass.cpp
@@ -18,9 +18,11 @@
 #include <oneapi/dpl/functional>
 #include <oneapi/dpl/type_traits>
 
+#include "support/test_macros.h"
 #include "support/utils.h"
 
 #if TEST_DPCPP_BACKEND_PRESENT
+#    if TEST_STD_VER == 17
 class KernelWeakResultTest;
 
 template <class Arg, class Result>
@@ -125,14 +127,17 @@ kernel_test()
     auto ret_access_host = buffer1.get_host_access(sycl::read_only);
     EXPECT_TRUE(ret_access_host[0], "Error in work with weak results");
 }
+#    endif // TEST_STD_VER
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
 int
 main()
 {
 #if TEST_DPCPP_BACKEND_PRESENT
+#    if TEST_STD_VER == 17
     kernel_test();
+#    endif // TEST_STD_VER
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-    return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT);
+    return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER == 17);
 }

--- a/test/xpu_api/utilities/function.objects/refwrap/weak_result.pass.cpp
+++ b/test/xpu_api/utilities/function.objects/refwrap/weak_result.pass.cpp
@@ -132,11 +132,9 @@ kernel_test()
 int
 main()
 {
-#if TEST_DPCPP_BACKEND_PRESENT
-#    if TEST_STD_VER == 17
+#if TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER == 17
     kernel_test();
-#    endif // TEST_STD_VER
-#endif // TEST_DPCPP_BACKEND_PRESENT
+#endif // TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER
 
     return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER == 17);
 }

--- a/test/xpu_api/utilities/function.objects/refwrap/weak_result.pass.cpp
+++ b/test/xpu_api/utilities/function.objects/refwrap/weak_result.pass.cpp
@@ -21,8 +21,8 @@
 #include "support/test_macros.h"
 #include "support/utils.h"
 
-#if TEST_DPCPP_BACKEND_PRESENT
-#    if TEST_STD_VER == 17
+// dpl::reference_wrapper::result_type is removed since C++20
+#if TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER == 17
 class KernelWeakResultTest;
 
 template <class Arg, class Result>

--- a/test/xpu_api/utilities/function.objects/refwrap/weak_result.pass.cpp
+++ b/test/xpu_api/utilities/function.objects/refwrap/weak_result.pass.cpp
@@ -127,8 +127,7 @@ kernel_test()
     auto ret_access_host = buffer1.get_host_access(sycl::read_only);
     EXPECT_TRUE(ret_access_host[0], "Error in work with weak results");
 }
-#    endif // TEST_STD_VER
-#endif // TEST_DPCPP_BACKEND_PRESENT
+#endif // TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER
 
 int
 main()

--- a/test/xpu_api/utilities/meta/meta.trans/meta.trans.other/common_type.pass.cpp
+++ b/test/xpu_api/utilities/meta/meta.trans/meta.trans.other/common_type.pass.cpp
@@ -170,9 +170,6 @@ typedef void (S::*PMF)(long) const;
 typedef char S::*PMD;
 
 using dpl::is_same;
-#    if TEST_STD_VER == 17
-using dpl::result_of;
-#    endif // TEST_STD_VER
 } // namespace note_b_example
 
 void

--- a/test/xpu_api/utilities/meta/meta.trans/meta.trans.other/common_type.pass.cpp
+++ b/test/xpu_api/utilities/meta/meta.trans/meta.trans.other/common_type.pass.cpp
@@ -170,7 +170,9 @@ typedef void (S::*PMF)(long) const;
 typedef char S::*PMD;
 
 using dpl::is_same;
+#    if TEST_STD_VER == 17
 using dpl::result_of;
+#    endif // TEST_STD_VER
 } // namespace note_b_example
 
 void

--- a/test/xpu_api/utilities/meta/meta.trans/meta.trans.other/invoke_result.pass.cpp
+++ b/test/xpu_api/utilities/meta/meta.trans/meta.trans.other/invoke_result.pass.cpp
@@ -25,7 +25,6 @@
 #include "has_type_member.h"
 
 #if TEST_DPCPP_BACKEND_PRESENT
-#    if TEST_STD_VER == 17
 struct S
 {
     typedef short (*FreeFunc)(long);
@@ -163,17 +162,15 @@ kernel_test()
         test_no_result<KernelTest21, PMD(NotDerived&)>(deviceQueue);
     }
 }
-#    endif // TEST_STD_VER
+
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
 int
 main()
 {
 #if TEST_DPCPP_BACKEND_PRESENT
-#    if TEST_STD_VER == 17
     kernel_test();
-#    endif // TEST_STD_VER
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-    return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER == 17);
+    return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT);
 }

--- a/test/xpu_api/utilities/meta/meta.trans/meta.trans.other/invoke_result.pass.cpp
+++ b/test/xpu_api/utilities/meta/meta.trans/meta.trans.other/invoke_result.pass.cpp
@@ -72,7 +72,10 @@ test_result_of(sycl::queue& deviceQueue)
 {
     deviceQueue.submit([&](sycl::handler& cgh) {
         cgh.single_task<KernelTest>([=]() {
+// dpl::result_of is removed since C++20
+#    if TEST_STD_VER == 17
             ASSERT_SAME_TYPE(U, typename dpl::result_of<T>::type);
+#    endif // TEST_STD_VER
             test_invoke_result<T, U>::call();
         });
     });
@@ -98,7 +101,10 @@ test_no_result(sycl::queue& deviceQueue)
 {
     deviceQueue.submit([&](sycl::handler& cgh) {
         cgh.single_task<KernelTest>([=]() {
+// dpl::result_of is removed since C++20
+#    if TEST_STD_VER == 17
             static_assert(!HasType<dpl::result_of<T>>::value);
+#endif // TEST_STD_VER
             test_invoke_no_result<T>::call();
         });
     });

--- a/test/xpu_api/utilities/meta/meta.trans/meta.trans.other/invoke_result.pass.cpp
+++ b/test/xpu_api/utilities/meta/meta.trans/meta.trans.other/invoke_result.pass.cpp
@@ -25,6 +25,7 @@
 #include "has_type_member.h"
 
 #if TEST_DPCPP_BACKEND_PRESENT
+#    if TEST_STD_VER == 17
 struct S
 {
     typedef short (*FreeFunc)(long);
@@ -162,15 +163,17 @@ kernel_test()
         test_no_result<KernelTest21, PMD(NotDerived&)>(deviceQueue);
     }
 }
-
+#    endif // TEST_STD_VER
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
 int
 main()
 {
 #if TEST_DPCPP_BACKEND_PRESENT
+#    if TEST_STD_VER == 17
     kernel_test();
+#    endif // TEST_STD_VER
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-    return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT);
+    return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER == 17);
 }

--- a/test/xpu_api/utilities/meta/meta.trans/meta.trans.other/result_of11.pass.cpp
+++ b/test/xpu_api/utilities/meta/meta.trans/meta.trans.other/result_of11.pass.cpp
@@ -57,8 +57,10 @@ template <class T, class U>
 void
 test_result_of_imp()
 {
+#    if TEST_STD_VER == 17
     ASSERT_SAME_TYPE(U, typename dpl::result_of<T>::type);
     ASSERT_SAME_TYPE(U, dpl::result_of_t<T>);
+#    endif // TEST_STD_VER
     test_invoke_result<T, U>::call();
 }
 

--- a/test/xpu_api/utilities/meta/meta.unary/meta.unary.prop/is_literal_type.pass.cpp
+++ b/test/xpu_api/utilities/meta/meta.unary/meta.unary.prop/is_literal_type.pass.cpp
@@ -124,11 +124,9 @@ kernel_test()
 int
 main()
 {
-#if TEST_DPCPP_BACKEND_PRESENT
-#    if TEST_STD_VER == 17
+#if TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER == 17
     kernel_test();
-#    endif // TEST_STD_VER
-#endif // TEST_DPCPP_BACKEND_PRESENT
+#endif // TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER
 
     return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER == 17);
 }

--- a/test/xpu_api/utilities/meta/meta.unary/meta.unary.prop/is_literal_type.pass.cpp
+++ b/test/xpu_api/utilities/meta/meta.unary/meta.unary.prop/is_literal_type.pass.cpp
@@ -21,8 +21,8 @@
 #include "support/utils.h"
 #include "support/utils_invoke.h"
 
-#if TEST_DPCPP_BACKEND_PRESENT
-#    if TEST_STD_VER == 17
+// dpl::is_literal_type is removed since C++20
+#if TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER == 17
 template <class KernelTest, class T>
 void
 test_is_literal_type(sycl::queue& deviceQueue)

--- a/test/xpu_api/utilities/meta/meta.unary/meta.unary.prop/is_literal_type.pass.cpp
+++ b/test/xpu_api/utilities/meta/meta.unary/meta.unary.prop/is_literal_type.pass.cpp
@@ -22,6 +22,7 @@
 #include "support/utils_invoke.h"
 
 #if TEST_DPCPP_BACKEND_PRESENT
+#    if TEST_STD_VER == 17
 template <class KernelTest, class T>
 void
 test_is_literal_type(sycl::queue& deviceQueue)
@@ -118,14 +119,17 @@ kernel_test()
         test_is_literal_type<KernelTest16, double>(deviceQueue);
     }
 }
+#endif // TEST_STD_VER
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
 int
 main()
 {
 #if TEST_DPCPP_BACKEND_PRESENT
+#    if TEST_STD_VER == 17
     kernel_test();
+#    endif // TEST_STD_VER
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-    return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT);
+    return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER == 17);
 }

--- a/test/xpu_api/utilities/meta/meta.unary/meta.unary.prop/is_literal_type.pass.cpp
+++ b/test/xpu_api/utilities/meta/meta.unary/meta.unary.prop/is_literal_type.pass.cpp
@@ -119,8 +119,7 @@ kernel_test()
         test_is_literal_type<KernelTest16, double>(deviceQueue);
     }
 }
-#endif // TEST_STD_VER
-#endif // TEST_DPCPP_BACKEND_PRESENT
+#endif // TEST_DPCPP_BACKEND_PRESENT && TEST_STD_VER
 
 int
 main()


### PR DESCRIPTION
In this PR we fix tests from `test/xpu_api` with removed in C++20 functional: simple run these tests only for C++17.
All errors fixed in this PR were introduces into oneDPL tests during import new tests in last month.