### PR TITLE
Fix tests from `test/xpu_api`

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -171,7 +171,7 @@ macro(onedpl_add_test test_source_file switch_off_checked_iterators)
 endmacro()
 
 set(_regexp_dpcpp_backend_required "(xpu_api/algorithms|xpu_api/functional|xpu_api/numerics|parallel_api/dynamic_selection/sycl)")
-set(_regexp_switch_off_checked_it  "(test/general/header_order_ranges|test/parallel_api/algorithm/alg.sorting/alg.min.max|test/parallel_api/ranges|test/parallel_api/dynamic_selection|test/xpu_api/random/device_tests|test/xpu_api/random/interface_tests|test/xpu_api/random/statistics_tests|test/parallel_api/numeric/numeric.ops/transform_scan)")
+set(_regexp_switch_off_checked_it  "(test/general/header_order_ranges|test/parallel_api/algorithm/alg.sorting/alg.min.max|test/parallel_api/ranges|test/parallel_api/dynamic_selection|test/xpu_api/iterators/iterator.primitives|test/xpu_api/random/device_tests|test/xpu_api/random/interface_tests|test/xpu_api/random/statistics_tests|test/parallel_api/numeric/numeric.ops/transform_scan)")
 
 set(_regexp_pstl_offload_only "(test/pstl_offload)")
 set(_regexp_pstl_offload_parallel_api "(test/xpu_api|test/parallel_api/algorithm|test/parallel_api/memory|test/parallel_api/numeric)")

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -54,6 +54,12 @@
 #define _PSTL_STD_UNINITIALIZED_FILL_BROKEN (_MSC_VER == 1900)
 // GCC10 produces wrong answer calling exclusive_scan using vectorized polices
 #define TEST_GCC10_EXCLUSIVE_SCAN_BROKEN (_GLIBCXX_RELEASE == 10)
+// Array swap broken on Windows
+#ifdef _MSC_VER
+#   define TEST_ARRAY_SWAP_BROKEN 1
+#else
+#   define TEST_ARRAY_SWAP_BROKEN 0
+#endif
 
 #define _PSTL_SYCL_TEST_USM 1
 

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -55,11 +55,19 @@
 // GCC10 produces wrong answer calling exclusive_scan using vectorized polices
 #define TEST_GCC10_EXCLUSIVE_SCAN_BROKEN (_GLIBCXX_RELEASE == 10)
 // Array swap broken on Windows because Microsoft implementation of std::swap function for std::array
-// call some function which is not declared as SYCL external and we have compile error
-#define TEST_XPU_ARRAY_SWAP_BROKEN (_MSC_VER <= 1937)
+// call some internal function which is not declared as SYCL external and we have compile error
+#if defined(_MSC_VER)
+#   define TEST_XPU_ARRAY_SWAP_BROKEN (_MSC_VER <= 1937)
+#else
+#   define TEST_XPU_ARRAY_SWAP_BROKEN 0
+#endif
 
 // The usage of class Final final {}; as Kernel name is broken on Intel(С) C++ Compiler before 2024.0
-#define TEST_CLASS_FINAL_BROKEN (__INTEL_LLVM_COMPILER && __INTEL_LLVM_COMPILER < 20240000)
+#if (defined(__INTEL_LLVM_COMPILER))
+#   define TEST_CLASS_FINAL_BROKEN (__INTEL_LLVM_COMPILER < 20240000)
+#else
+#   define TEST_CLASS_FINAL_BROKEN 0
+#endif
 
 #define _PSTL_SYCL_TEST_USM 1
 

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -61,13 +61,8 @@
 #else
 #   define TEST_XPU_ARRAY_SWAP_BROKEN 0
 #endif
-
 // The usage of class Final final {}; as Kernel name is broken on Intel(С) C++ Compiler before 2024.0
-#if (defined(__INTEL_LLVM_COMPILER))
-#   define TEST_CLASS_FINAL_BROKEN (__INTEL_LLVM_COMPILER < 20240000)
-#else
-#   define TEST_CLASS_FINAL_BROKEN 0
-#endif
+#define TEST_CLASS_FINAL_BROKEN (__INTEL_LLVM_COMPILER && __INTEL_LLVM_COMPILER < 20240000)
 
 #define _PSTL_SYCL_TEST_USM 1
 

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -61,8 +61,6 @@
 #else
 #   define TEST_XPU_ARRAY_SWAP_BROKEN 0
 #endif
-// The usage of class Final final {}; as Kernel name is broken on Intel(С) C++ Compiler before 2024.0
-#define TEST_CLASS_FINAL_BROKEN (__INTEL_LLVM_COMPILER && __INTEL_LLVM_COMPILER < 20240000)
 
 #define _PSTL_SYCL_TEST_USM 1
 

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -54,10 +54,11 @@
 #define _PSTL_STD_UNINITIALIZED_FILL_BROKEN (_MSC_VER == 1900)
 // GCC10 produces wrong answer calling exclusive_scan using vectorized polices
 #define TEST_GCC10_EXCLUSIVE_SCAN_BROKEN (_GLIBCXX_RELEASE == 10)
-// Array swap broken on Windows
-#define TEST_ARRAY_SWAP_BROKEN _MSC_VER
+// Array swap broken on Windows because Microsoft implementation of std::swap function for std::array
+// call some function which is not declared as SYCL external and we have compile error
+#define TEST_XPU_ARRAY_SWAP_BROKEN (_MSC_VER <= 1937)
 
-// The usage of class Final final {}; as Kernel name is broken on Intel� C++ Compiler before 2024.0
+// The usage of class Final final {}; as Kernel name is broken on Intel(С) C++ Compiler before 2024.0
 #define TEST_CLASS_FINAL_BROKEN (__INTEL_LLVM_COMPILER && __INTEL_LLVM_COMPILER < 20240000)
 
 #define _PSTL_SYCL_TEST_USM 1

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -55,17 +55,10 @@
 // GCC10 produces wrong answer calling exclusive_scan using vectorized polices
 #define TEST_GCC10_EXCLUSIVE_SCAN_BROKEN (_GLIBCXX_RELEASE == 10)
 // Array swap broken on Windows
-#ifdef _MSC_VER
-#   define TEST_ARRAY_SWAP_BROKEN 1
-#else
-#   define TEST_ARRAY_SWAP_BROKEN 0
-#endif
-// The usage of class Final final {}; as Kernel name is broken on Intel® C++ Compiler before 2024.0
-#if defined(__INTEL_LLVM_COMPILER)
-#   define TEST_CLASS_FINAL_BROKEN (__INTEL_LLVM_COMPILER < 20240000)
-#else
-#   define TEST_CLASS_FINAL_BROKEN 0
-#endif
+#define TEST_ARRAY_SWAP_BROKEN _MSC_VER
+
+// The usage of class Final final {}; as Kernel name is broken on Intelï¿½ C++ Compiler before 2024.0
+#define TEST_CLASS_FINAL_BROKEN (__INTEL_LLVM_COMPILER && __INTEL_LLVM_COMPILER < 20240000)
 
 #define _PSTL_SYCL_TEST_USM 1
 

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -60,6 +60,12 @@
 #else
 #   define TEST_ARRAY_SWAP_BROKEN 0
 #endif
+// The usage of class Final final {}; as Kernel name is broken on ICPX before 2024.0
+#if defined(__INTEL_LLVM_COMPILER)
+#   define TEST_CLASS_FINAL_BROKEN (__INTEL_LLVM_COMPILER < 20240000)
+#else
+#   define TEST_CLASS_FINAL_BROKEN 0
+#endif
 
 #define _PSTL_SYCL_TEST_USM 1
 

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -60,7 +60,7 @@
 #else
 #   define TEST_ARRAY_SWAP_BROKEN 0
 #endif
-// The usage of class Final final {}; as Kernel name is broken on ICPX before 2024.0
+// The usage of class Final final {}; as Kernel name is broken on Intel® C++ Compiler before 2024.0
 #if defined(__INTEL_LLVM_COMPILER)
 #   define TEST_CLASS_FINAL_BROKEN (__INTEL_LLVM_COMPILER < 20240000)
 #else

--- a/test/xpu_api/containers/sequences/array/array.special/swap1.pass.cpp
+++ b/test/xpu_api/containers/sequences/array/array.special/swap1.pass.cpp
@@ -25,7 +25,7 @@
 int
 main()
 {
-#if TEST_DPCPP_BACKEND_PRESENT
+#if TEST_DPCPP_BACKEND_PRESENT && !TEST_ARRAY_SWAP_BROKEN
     bool ret = true;
     {
         sycl::buffer<bool, 1> buf(&ret, sycl::range<1>{1});
@@ -62,7 +62,7 @@ main()
     }
 
     EXPECT_TRUE(ret, "Wrong result of work with dpl::swap(dpl::array, dpl::array)");
-#endif // TEST_DPCPP_BACKEND_PRESENT
+#endif // TEST_DPCPP_BACKEND_PRESENT &&  && !TEST_ARRAY_SWAP_BROKEN
 
-    return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT);
+    return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT && !TEST_ARRAY_SWAP_BROKEN);
 }

--- a/test/xpu_api/containers/sequences/array/array.special/swap1.pass.cpp
+++ b/test/xpu_api/containers/sequences/array/array.special/swap1.pass.cpp
@@ -25,7 +25,7 @@
 int
 main()
 {
-#if TEST_DPCPP_BACKEND_PRESENT && !TEST_ARRAY_SWAP_BROKEN
+#if TEST_DPCPP_BACKEND_PRESENT && !TEST_XPU_ARRAY_SWAP_BROKEN
     bool ret = true;
     {
         sycl::buffer<bool, 1> buf(&ret, sycl::range<1>{1});
@@ -62,7 +62,7 @@ main()
     }
 
     EXPECT_TRUE(ret, "Wrong result of work with dpl::swap(dpl::array, dpl::array)");
-#endif // TEST_DPCPP_BACKEND_PRESENT &&  && !TEST_ARRAY_SWAP_BROKEN
+#endif // TEST_DPCPP_BACKEND_PRESENT &&  && !TEST_XPU_ARRAY_SWAP_BROKEN
 
-    return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT && !TEST_ARRAY_SWAP_BROKEN);
+    return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT && !TEST_XPU_ARRAY_SWAP_BROKEN);
 }

--- a/test/xpu_api/containers/sequences/array/array.swap/swap.pass.cpp
+++ b/test/xpu_api/containers/sequences/array/array.swap/swap.pass.cpp
@@ -24,7 +24,7 @@
 
 #include "support/utils.h"
 
-#if TEST_DPCPP_BACKEND_PRESENT
+#if TEST_DPCPP_BACKEND_PRESENT && !TEST_ARRAY_SWAP_BROKEN
 class KernelTest1;
 
 bool
@@ -91,15 +91,15 @@ kernel_test()
     }
     return ret;
 }
-#endif // TEST_DPCPP_BACKEND_PRESENT
+#endif // TEST_DPCPP_BACKEND_PRESENT && !TEST_ARRAY_SWAP_BROKEN
 
 int
 main()
 {
-#if TEST_DPCPP_BACKEND_PRESENT
+#if TEST_DPCPP_BACKEND_PRESENT && !TEST_ARRAY_SWAP_BROKEN
     auto ret = kernel_test();
     EXPECT_TRUE(ret, "Wrong result of work with dpl::swap");
-#endif // TEST_DPCPP_BACKEND_PRESENT
+#endif // TEST_DPCPP_BACKEND_PRESENT && !TEST_ARRAY_SWAP_BROKEN
 
-    return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT);
+    return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT && !TEST_ARRAY_SWAP_BROKEN);
 }

--- a/test/xpu_api/containers/sequences/array/array.swap/swap.pass.cpp
+++ b/test/xpu_api/containers/sequences/array/array.swap/swap.pass.cpp
@@ -24,7 +24,7 @@
 
 #include "support/utils.h"
 
-#if TEST_DPCPP_BACKEND_PRESENT && !TEST_ARRAY_SWAP_BROKEN
+#if TEST_DPCPP_BACKEND_PRESENT && !TEST_XPU_ARRAY_SWAP_BROKEN
 class KernelTest1;
 
 bool
@@ -91,15 +91,15 @@ kernel_test()
     }
     return ret;
 }
-#endif // TEST_DPCPP_BACKEND_PRESENT && !TEST_ARRAY_SWAP_BROKEN
+#endif // TEST_DPCPP_BACKEND_PRESENT && !TEST_XPU_ARRAY_SWAP_BROKEN
 
 int
 main()
 {
-#if TEST_DPCPP_BACKEND_PRESENT && !TEST_ARRAY_SWAP_BROKEN
+#if TEST_DPCPP_BACKEND_PRESENT && !TEST_XPU_ARRAY_SWAP_BROKEN
     auto ret = kernel_test();
     EXPECT_TRUE(ret, "Wrong result of work with dpl::swap");
-#endif // TEST_DPCPP_BACKEND_PRESENT && !TEST_ARRAY_SWAP_BROKEN
+#endif // TEST_DPCPP_BACKEND_PRESENT && !TEST_XPU_ARRAY_SWAP_BROKEN
 
-    return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT && !TEST_ARRAY_SWAP_BROKEN);
+    return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT && !TEST_XPU_ARRAY_SWAP_BROKEN);
 }

--- a/test/xpu_api/iterators/predef.iterators/move.iterators/move.iter.ops/move.iter.op.incr/post_incr.pass.cpp
+++ b/test/xpu_api/iterators/predef.iterators/move.iterators/move.iter.ops/move.iter.op.incr/post_incr.pass.cpp
@@ -23,8 +23,6 @@
 #include "support/utils.h"
 #include "support/test_macros.h"
 
-#include <type_traits>
-
 #if TEST_DPCPP_BACKEND_PRESENT
 
 template <typename It>

--- a/test/xpu_api/iterators/predef.iterators/move.iterators/move.iter.ops/move.iter.op.incr/post_incr.pass.cpp
+++ b/test/xpu_api/iterators/predef.iterators/move.iterators/move.iter.ops/move.iter.op.incr/post_incr.pass.cpp
@@ -23,7 +23,13 @@
 #include "support/utils.h"
 #include "support/test_macros.h"
 
+#include <type_traits>
+
 #if TEST_DPCPP_BACKEND_PRESENT
+
+template <typename It>
+constexpr bool __is_forward_iterator =
+    std::is_base_of_v<std::forward_iterator_tag, typename std::iterator_traits<It>::iterator_category>;
 
 template <class It>
 bool
@@ -34,7 +40,7 @@ test(It i, It x)
     // dpl::move_iterator post increment operation does not return value if It
     // is not forward iterator
     dpl::move_iterator<It> rr;
-    if constexpr (std::forward_iterator<It>) {
+    if constexpr (__is_forward_iterator<It>) {
         rr = r++;
     } else {
         r++;
@@ -44,7 +50,7 @@ test(It i, It x)
 #endif
     auto ret = (r.base() == x);
 #if TEST_STD_VER >= 20
-    if constexpr (std::forward_iterator<It>)
+    if constexpr (__is_forward_iterator<It>)
 #endif
         ret &= (rr.base() == i);
     return ret;

--- a/test/xpu_api/iterators/predef.iterators/move.iterators/move.iter.ops/move.iter.op.incr/post_incr.pass.cpp
+++ b/test/xpu_api/iterators/predef.iterators/move.iterators/move.iter.ops/move.iter.op.incr/post_incr.pass.cpp
@@ -26,7 +26,7 @@
 #if TEST_DPCPP_BACKEND_PRESENT
 
 template <typename It>
-constexpr bool __is_forward_iterator =
+constexpr bool is_forward_iterator =
     std::is_base_of_v<std::forward_iterator_tag, typename std::iterator_traits<It>::iterator_category>;
 
 template <class It>
@@ -38,7 +38,7 @@ test(It i, It x)
     // dpl::move_iterator post increment operation does not return value if It
     // is not forward iterator
     dpl::move_iterator<It> rr;
-    if constexpr (__is_forward_iterator<It>) {
+    if constexpr (is_forward_iterator<It>) {
         rr = r++;
     } else {
         r++;
@@ -48,7 +48,7 @@ test(It i, It x)
 #endif
     auto ret = (r.base() == x);
 #if TEST_STD_VER >= 20
-    if constexpr (__is_forward_iterator<It>)
+    if constexpr (is_forward_iterator<It>)
 #endif
         ret &= (rr.base() == i);
     return ret;

--- a/test/xpu_api/utilities/meta/meta.unary/meta.unary.prop/is_polymorphic.pass.cpp
+++ b/test/xpu_api/utilities/meta/meta.unary/meta.unary.prop/is_polymorphic.pass.cpp
@@ -71,9 +71,11 @@ struct bit_zero
     int : 0;
 };
 
+#if !TEST_CLASS_FINAL_BROKEN
 class Final final
 {
 };
+#endif // !TEST_CLASS_FINAL_BROKEN
 
 struct Base
 {
@@ -98,7 +100,9 @@ kernel_test()
     test_is_not_polymorphic<Union>(deviceQueue);
     test_is_not_polymorphic<Empty>(deviceQueue);
     test_is_not_polymorphic<bit_zero>(deviceQueue);
+#if !TEST_CLASS_FINAL_BROKEN
     test_is_not_polymorphic<Final>(deviceQueue);
+#endif // !TEST_CLASS_FINAL_BROKEN
 
     if (TestUtils::has_type_support<double>(deviceQueue.get_device()))
     {

--- a/test/xpu_api/utilities/meta/meta.unary/meta.unary.prop/is_polymorphic.pass.cpp
+++ b/test/xpu_api/utilities/meta/meta.unary/meta.unary.prop/is_polymorphic.pass.cpp
@@ -22,12 +22,12 @@
 #include "support/utils_invoke.h"
 
 #if TEST_DPCPP_BACKEND_PRESENT
-template <class T>
+template <class KernelName, class T>
 void
 test_is_not_polymorphic(sycl::queue& deviceQueue)
 {
     deviceQueue.submit([&](sycl::handler& cgh) {
-        cgh.single_task<T>([=]() {
+        cgh.single_task<KernelName>([=]() {
             static_assert(!dpl::is_polymorphic<T>::value);
             static_assert(!dpl::is_polymorphic<const T>::value);
             static_assert(!dpl::is_polymorphic<volatile T>::value);
@@ -40,12 +40,12 @@ test_is_not_polymorphic(sycl::queue& deviceQueue)
     });
 }
 
-template <class T>
+template <class KernelName, class T>
 void
 test_is_polymorphic(sycl::queue& deviceQueue)
 {
     deviceQueue.submit([&](sycl::handler& cgh) {
-        cgh.single_task<T>([=]() {
+        cgh.single_task<KernelName>([=]() {
             static_assert(dpl::is_polymorphic<T>::value);
             static_assert(dpl::is_polymorphic<const T>::value);
             static_assert(dpl::is_polymorphic<volatile T>::value);
@@ -86,31 +86,44 @@ struct Derived : Base
 {
 };
 
+class KernelName1;
+class KernelName2;
+class KernelName3;
+class KernelName4;
+class KernelName5;
+class KernelName6;
+class KernelName7;
+class KernelName8;
+class KernelName9;
+class KernelName10;
+class KernelName11;
+class KernelName12;
+class KernelName13;
+class KernelName14;
+
 void
 kernel_test()
 {
     sycl::queue deviceQueue = TestUtils::get_test_queue();
-    test_is_not_polymorphic<void>(deviceQueue);
-    test_is_not_polymorphic<int&>(deviceQueue);
-    test_is_not_polymorphic<int>(deviceQueue);
-    test_is_not_polymorphic<int*>(deviceQueue);
-    test_is_not_polymorphic<const int*>(deviceQueue);
-    test_is_not_polymorphic<char[3]>(deviceQueue);
-    test_is_not_polymorphic<char[]>(deviceQueue);
-    test_is_not_polymorphic<Union>(deviceQueue);
-    test_is_not_polymorphic<Empty>(deviceQueue);
-    test_is_not_polymorphic<bit_zero>(deviceQueue);
-#if !TEST_CLASS_FINAL_BROKEN
-    test_is_not_polymorphic<Final>(deviceQueue);
-#endif // !TEST_CLASS_FINAL_BROKEN
+    test_is_not_polymorphic<KernelName1, void>(deviceQueue);
+    test_is_not_polymorphic<KernelName2, int&>(deviceQueue);
+    test_is_not_polymorphic<KernelName3, int>(deviceQueue);
+    test_is_not_polymorphic<KernelName4, int*>(deviceQueue);
+    test_is_not_polymorphic<KernelName5, const int*>(deviceQueue);
+    test_is_not_polymorphic<KernelName6, char[3]>(deviceQueue);
+    test_is_not_polymorphic<KernelName7, char[]>(deviceQueue);
+    test_is_not_polymorphic<KernelName8, Union>(deviceQueue);
+    test_is_not_polymorphic<KernelName9, Empty>(deviceQueue);
+    test_is_not_polymorphic<KernelName10, bit_zero>(deviceQueue);
+    test_is_not_polymorphic<KernelName11, Final>(deviceQueue);
 
     if (TestUtils::has_type_support<double>(deviceQueue.get_device()))
     {
-        test_is_not_polymorphic<double>(deviceQueue);
+        test_is_not_polymorphic<KernelName12, double>(deviceQueue);
     }
 
-    test_is_polymorphic<Base>(deviceQueue);
-    test_is_polymorphic<Derived>(deviceQueue);
+    test_is_polymorphic<KernelName13, Base>(deviceQueue);
+    test_is_polymorphic<KernelName14, Derived>(deviceQueue);
 }
 #endif // TEST_DPCPP_BACKEND_PRESENT
 


### PR DESCRIPTION
In this PR we fix some new errors :
- switch off checked iterators under MSVC for folder 'iterators/iterator.primitives|test/xpu_api';
- add broken test macro for array swap in two tests;
- fixed test with 'C++20' concept usage;
- fixed an error with `class Final final {};` usage as Kernel name for all version of Intel® C++ Compiler before `2024.0`