### PR TITLE
[CI] Fix environment for FPGA emulator testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,11 @@ jobs:
           export PATH=$CONDA/lib:$PATH
           export CPATH=$CONDA/include:$CPATH
           export OCL_ICD_FILENAMES=$CONDA/lib/libintelocl.so
+          
+          # Workaround for partially absent FPGA emulator runtime in https://anaconda.org/intel/intel-opencl-rt 2024.0.0 package (part of dpcpp_linux-64)
+          find ${CONDA_PREFIX} -name "libintelocl_emu.so*" > ${CONDA_PREFIX}/etc/OpenCL/vendors/intel-fpga_emu.icd
+          cp ${CONDA_PREFIX}/lib/cl.cfg ${CONDA_PREFIX}/lib/cl.fpga_emu.cfg
+
           echo "::warning::Compiler: $(cmake --version)"
           if [[ "${{ matrix.cxx_compiler }}" == "icpx" ]] || [[ "${{ matrix.cxx_compiler }}" == "icx" ]] || [[ "${{ matrix.cxx_compiler }}" == "icx-cl" ]] || [[ "${{ matrix.cxx_compiler }}" == "dpcpp" ]] || [[ "${{ matrix.cxx_compiler }}" == "dpcpp-cl" ]]; then
             echo "::warning::Compiler: $(${{ matrix.cxx_compiler }} --version)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,7 +181,7 @@ jobs:
           export CPATH=$CONDA/include:$CPATH
           export OCL_ICD_FILENAMES=$CONDA/lib/libintelocl.so
           
-          # Workaround for partially absent FPGA emulator runtime in https://anaconda.org/intel/intel-opencl-rt 2024.0.0 package (part of dpcpp_linux-64)
+          # Workaround for absent FPGA emulator runtime config files in https://anaconda.org/intel/intel-opencl-rt 2024.0.0 package (part of dpcpp_linux-64)
           find ${CONDA_PREFIX} -name "libintelocl_emu.so*" > ${CONDA_PREFIX}/etc/OpenCL/vendors/intel-fpga_emu.icd
           cp ${CONDA_PREFIX}/lib/cl.cfg ${CONDA_PREFIX}/lib/cl.fpga_emu.cfg
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,12 +184,16 @@ jobs:
           echo "::warning::Compiler: $(cmake --version)"
           if [[ "${{ matrix.cxx_compiler }}" == "icpx" ]] || [[ "${{ matrix.cxx_compiler }}" == "icx" ]] || [[ "${{ matrix.cxx_compiler }}" == "icx-cl" ]] || [[ "${{ matrix.cxx_compiler }}" == "dpcpp" ]] || [[ "${{ matrix.cxx_compiler }}" == "dpcpp-cl" ]]; then
             echo "::warning::Compiler: $(${{ matrix.cxx_compiler }} --version)"
-            # Workaround for absent FPGA emulator runtime config files in https://anaconda.org/intel/intel-opencl-rt 2024.0.0 package (part of dpcpp_linux-64)
-            find $CONDA -name "libintelocl_emu.so*" > $CONDA/etc/OpenCL/vendors/intel-fpga_emu.icd
 
+            # Workaround for absent FPGA emulator runtime config files in https://anaconda.org/intel/intel-opencl-rt 2024.0.0 package (part of dpcpp_linux-64)
+            FPGA_RUNTIME_PATH=$(find $CONDA -name "libintelocl_emu.so*") 
+            echo $FPGA_RUNTIME_PATH > $CONDA/etc/OpenCL/vendors/intel-fpga_emu.icd
+            export OCL_ICD_FILENAMES=OCL_ICD_FILENAMES:$FPGA_RUNTIME_PATH
             cp $CONDA/lib/cl.cfg $CONDA/lib/cl.fpga_emu.cfg
+            sed -i "s/cpu/fpga-emu/g" $CONDA/lib/cl.fpga_emu.cfg
             # TODO: remove, CI debugging
             cat $CONDA/etc/OpenCL/vendors/intel-fpga_emu.icd
+            cat $CONDA/lib/cl.fpga_emu.cfg
             sycl-ls
           fi
           if [[ "${{ matrix.backend }}" == "dpcpp" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,11 @@ jobs:
             echo "::warning::Compiler: $(${{ matrix.cxx_compiler }} --version)"
             # Workaround for absent FPGA emulator runtime config files in https://anaconda.org/intel/intel-opencl-rt 2024.0.0 package (part of dpcpp_linux-64)
             find $CONDA -name "libintelocl_emu.so*" > $CONDA/etc/OpenCL/vendors/intel-fpga_emu.icd
+
             cp $CONDA/lib/cl.cfg $CONDA/lib/cl.fpga_emu.cfg
+            # TODO: remove, CI debugging
+            cat $CONDA/etc/OpenCL/vendors/intel-fpga_emu.icd
+            sycl-ls
           fi
           if [[ "${{ matrix.backend }}" == "dpcpp" ]]; then
             make_targets="build-onedpl-sycl_iterator-tests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,14 +180,13 @@ jobs:
           export PATH=$CONDA/lib:$PATH
           export CPATH=$CONDA/include:$CPATH
           export OCL_ICD_FILENAMES=$CONDA/lib/libintelocl.so
-          
-          # Workaround for absent FPGA emulator runtime config files in https://anaconda.org/intel/intel-opencl-rt 2024.0.0 package (part of dpcpp_linux-64)
-          find ${CONDA_PREFIX} -name "libintelocl_emu.so*" > ${CONDA_PREFIX}/etc/OpenCL/vendors/intel-fpga_emu.icd
-          cp ${CONDA_PREFIX}/lib/cl.cfg ${CONDA_PREFIX}/lib/cl.fpga_emu.cfg
 
           echo "::warning::Compiler: $(cmake --version)"
           if [[ "${{ matrix.cxx_compiler }}" == "icpx" ]] || [[ "${{ matrix.cxx_compiler }}" == "icx" ]] || [[ "${{ matrix.cxx_compiler }}" == "icx-cl" ]] || [[ "${{ matrix.cxx_compiler }}" == "dpcpp" ]] || [[ "${{ matrix.cxx_compiler }}" == "dpcpp-cl" ]]; then
             echo "::warning::Compiler: $(${{ matrix.cxx_compiler }} --version)"
+            # Workaround for absent FPGA emulator runtime config files in https://anaconda.org/intel/intel-opencl-rt 2024.0.0 package (part of dpcpp_linux-64)
+            find $CONDA -name "libintelocl_emu.so*" > $CONDA/etc/OpenCL/vendors/intel-fpga_emu.icd
+            cp $CONDA/lib/cl.cfg $CONDA/lib/cl.fpga_emu.cfg
           fi
           if [[ "${{ matrix.backend }}" == "dpcpp" ]]; then
             make_targets="build-onedpl-sycl_iterator-tests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,9 +169,13 @@ jobs:
       - uses: actions/checkout@v3
       - name: Install Intel® oneAPI Threading Building Blocks (oneTBB)
         run: $CONDA/bin/conda install -c intel tbb-devel
-      - name: Install Intel® oneAPI DPC++/C++ Compiler
-        if: matrix.cxx_compiler == 'icpx' || matrix.cxx_compiler == 'icx' || matrix.cxx_compiler == 'icx-cl' || matrix.cxx_compiler == 'dpcpp' || matrix.cxx_compiler == 'dpcpp-cl'
+      - name: Install Intel® oneAPI DPC++/C++ Compiler (latest)
+        if: (matrix.cxx_compiler == 'icpx' || matrix.cxx_compiler == 'icx' || matrix.cxx_compiler == 'icx-cl' || matrix.cxx_compiler == 'dpcpp' || matrix.cxx_compiler == 'dpcpp-cl') && matrix.device_type != 'FPGA_EMU'
         run: $CONDA/bin/conda install -c intel dpcpp_linux-64
+        # FPGA emulator runtime configuration is broken in the 2024.0.0 dpcpp_linux-64 conda package
+      - name: Install Intel® oneAPI DPC++/C++ Compiler (2023.2)
+        if: (matrix.cxx_compiler == 'icpx' || matrix.cxx_compiler == 'icx' || matrix.cxx_compiler == 'icx-cl' || matrix.cxx_compiler == 'dpcpp' || matrix.cxx_compiler == 'dpcpp-cl') && matrix.device_type == 'FPGA_EMU'
+        run: $CONDA/bin/conda install -c intel dpcpp_linux-64=2023.2.0
       - name: Run testing
         shell: bash
         run: |
@@ -180,21 +184,9 @@ jobs:
           export PATH=$CONDA/lib:$PATH
           export CPATH=$CONDA/include:$CPATH
           export OCL_ICD_FILENAMES=$CONDA/lib/libintelocl.so
-
           echo "::warning::Compiler: $(cmake --version)"
           if [[ "${{ matrix.cxx_compiler }}" == "icpx" ]] || [[ "${{ matrix.cxx_compiler }}" == "icx" ]] || [[ "${{ matrix.cxx_compiler }}" == "icx-cl" ]] || [[ "${{ matrix.cxx_compiler }}" == "dpcpp" ]] || [[ "${{ matrix.cxx_compiler }}" == "dpcpp-cl" ]]; then
             echo "::warning::Compiler: $(${{ matrix.cxx_compiler }} --version)"
-
-            # Workaround for absent FPGA emulator runtime config files in https://anaconda.org/intel/intel-opencl-rt 2024.0.0 package (part of dpcpp_linux-64)
-            FPGA_RUNTIME_PATH=$(find $CONDA -name "libintelocl_emu.so*") 
-            echo $FPGA_RUNTIME_PATH > $CONDA/etc/OpenCL/vendors/intel-fpga_emu.icd
-            export OCL_ICD_FILENAMES=$OCL_ICD_FILENAMES:$FPGA_RUNTIME_PATH
-            cp $CONDA/lib/cl.cfg $CONDA/lib/cl.fpga_emu.cfg
-            sed -i "s/cpu/fpga-emu/g" $CONDA/lib/cl.fpga_emu.cfg
-            # TODO: remove, CI debugging
-            cat $CONDA/etc/OpenCL/vendors/intel-fpga_emu.icd
-            cat $CONDA/lib/cl.fpga_emu.cfg
-            sycl-ls
           fi
           if [[ "${{ matrix.backend }}" == "dpcpp" ]]; then
             make_targets="build-onedpl-sycl_iterator-tests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,7 @@ jobs:
             # Workaround for absent FPGA emulator runtime config files in https://anaconda.org/intel/intel-opencl-rt 2024.0.0 package (part of dpcpp_linux-64)
             FPGA_RUNTIME_PATH=$(find $CONDA -name "libintelocl_emu.so*") 
             echo $FPGA_RUNTIME_PATH > $CONDA/etc/OpenCL/vendors/intel-fpga_emu.icd
-            export OCL_ICD_FILENAMES=OCL_ICD_FILENAMES:$FPGA_RUNTIME_PATH
+            export OCL_ICD_FILENAMES=$OCL_ICD_FILENAMES:$FPGA_RUNTIME_PATH
             cp $CONDA/lib/cl.cfg $CONDA/lib/cl.fpga_emu.cfg
             sed -i "s/cpu/fpga-emu/g" $CONDA/lib/cl.fpga_emu.cfg
             # TODO: remove, CI debugging


### PR DESCRIPTION
**Summary**
`dpcpp_linux-64` `2024.0.0`, in contrast to `2023.2.0`, lacks some files which allow discovery of FPGA emulator device.
This PR switches testing of FPGA emulator from the latest compiler version (`2024.0.0`) to the previous (`2023.2.0`) where FPGA emulator is available.

**Notes**
I was able to fix the environment for the emulator on `dpcpp_linux-64` `2024.0.0` locally following these steps:
 - copy `cl.cfg` as `cl.fpga_emu.cfg`
 - set `OCL_ICD_FILENAMES` to point the location of `libintelocl_emu.so*` or write this location into `$CONDA_PREFIX/etc/OpenCL/vendors/intel-fpga_emu.icd`. 

But it does not work with the environment on a github-hosted runner. Let me know if it still requires investigation. Other possible option is to use other, OS specific package managers, e.g. APT.
