### PR TITLE
Fix compile error in C++17 : only enumeration types have underlying types

### DIFF
--- a/test/xpu_api/utilities/meta/meta.trans/meta.trans.other/underlying_type.pass.cpp
+++ b/test/xpu_api/utilities/meta/meta.trans/meta.trans.other/underlying_type.pass.cpp
@@ -97,6 +97,8 @@ kernel_test1(sycl::queue& deviceQueue)
             static_assert(has_underlying_type_member<E>::value);
             static_assert(has_underlying_type_member<G>::value);
 
+            // Until C++20 the behaviour of std::underlying_type<T> is undefined when T is not enum
+#if TEST_STD_VER >= 20
             static_assert(!has_underlying_type_member<void>::value);
             static_assert(!has_underlying_type_member<int>::value);
             static_assert(!has_underlying_type_member<int[]>::value);
@@ -110,6 +112,7 @@ kernel_test1(sycl::queue& deviceQueue)
             static_assert(!has_underlying_type_member<int&&>::value);
             static_assert(!has_underlying_type_member<int*>::value);
             static_assert(!has_underlying_type_member<dpl::nullptr_t>::value);
+#endif
         });
     });
 }


### PR DESCRIPTION
Error was found in the test `test/xpu_api/utilities/meta/meta.trans/meta.trans.other/underlying_type.pass.cpp`
on configuration
``test_os=rhel8_compiler=icpxrelease_backend=dpcpp_device_type=CPU_std=c++17_cfg=release_unnamed_lambda=ON_compile_kernel=ON`

```C++
In file included from /test/xpu_api/utilities/meta/meta.trans/meta.trans.other/underlying_type.pass.cpp:18:
In file included from /include/oneapi/dpl/type_traits:20:
/../../../../include/c++/8/type_traits:2002:15: error: only enumeration types have underlying types
 2002 |       typedef __underlying_type(_Tp) type;
      |               ^
test/xpu_api/utilities/meta/meta.trans/meta.trans.other/has_type_member.h:27:48: note: in instantiation of template class 'std::underlying_type<void>' requested here
   27 | struct has_type_member<T, dpl::void_t<typename T::type>> : dpl::true_type
      |                                                ^
test/xpu_api/utilities/meta/meta.trans/meta.trans.other/underlying_type.pass.cpp:100:28: note: during template argument deduction for class template partial specialization 'has_type_member<T, dpl::void_t<typename T::type>>' [with T = std::underlying_type<void>]
  100 |             static_assert(!has_underlying_type_member<void>::value);
      |                            ^
```