### PR TITLE
[KT] Test API with sycl::buffer

### DIFF
--- a/test/kt/esimd_radix_sort.cpp
+++ b/test/kt/esimd_radix_sort.cpp
@@ -136,10 +136,10 @@ test_sycl_iterators(sycl::queue q, std::size_t size, KernelParam param)
 
 template <typename T, bool IsAscending, std::uint8_t RadixBits, typename KernelParam>
 void
-test_buffer(sycl::queue q, std::size_t size, KernelParam param)
+test_sycl_buffer(sycl::queue q, std::size_t size, KernelParam param)
 {
 #if LOG_TEST_INFO
-    std::cout << "\t\ttest_buffer<" << TypeInfo().name<T>() << ">(" << size << ");" << std::endl;
+    std::cout << "\t\ttest_sycl_buffer<" << TypeInfo().name<T>() << ">(" << size << ");" << std::endl;
 #endif
     std::vector<T> input(size);
     generate_data(input.data(), size, 42);
@@ -181,7 +181,7 @@ test_general_cases(sycl::queue q, std::size_t size, KernelParam param)
     test_usm<T, IsAscending, RadixBits, sycl::usm::alloc::shared>(q, size, param);
     test_usm<T, IsAscending, RadixBits, sycl::usm::alloc::device>(q, size, param);
     test_sycl_iterators<T, IsAscending, RadixBits>(q, size, param);
-    test_buffer<T, IsAscending, RadixBits>(q, size, param);
+    test_sycl_buffer<T, IsAscending, RadixBits>(q, size, param);
 #if _ENABLE_RANGES_TESTING
     test_all_view<T, IsAscending, RadixBits>(q, size, param);
     test_subrange_view<T, IsAscending, RadixBits>(q, size, param);

--- a/test/kt/esimd_radix_sort_by_key.cpp
+++ b/test/kt/esimd_radix_sort_by_key.cpp
@@ -29,7 +29,7 @@
 #include "../support/sycl_alloc_utils.h"
 
 template<typename KeyT, typename ValueT, bool isAscending, std::uint32_t RadixBits, typename KernelParam>
-void test_buffer(sycl::queue q, std::size_t size, KernelParam param)
+void test_sycl_buffer(sycl::queue q, std::size_t size, KernelParam param)
 {
     std::vector<KeyT> expected_keys(size);
     std::vector<ValueT> expected_values(size);
@@ -107,8 +107,8 @@ int main()
                     q, size, params);
                 test_usm<TEST_KEY_TYPE, TEST_VALUE_TYPE, Descending, TestRadixBits, sycl::usm::alloc::shared>(
                     q, size, params);
-                test_buffer<TEST_KEY_TYPE, TEST_VALUE_TYPE, Ascending, TestRadixBits>(q, size, params);
-                test_buffer<TEST_KEY_TYPE, TEST_VALUE_TYPE, Descending, TestRadixBits>(q, size, params);
+                test_sycl_buffer<TEST_KEY_TYPE, TEST_VALUE_TYPE, Ascending, TestRadixBits>(q, size, params);
+                test_sycl_buffer<TEST_KEY_TYPE, TEST_VALUE_TYPE, Descending, TestRadixBits>(q, size, params);
             }
         }
         catch (const ::std::exception& exc)


### PR DESCRIPTION
`test_sycl_iterators` was replaced by `test_buffer` in `esimd_radix_sort_by_key` to tests both APIs: ranges and iterators (not only iterators).