### PR TITLE
Redefine of __is_hetero_execution_policy trait through __is_device_execution_policy and __is_fpga_execution_policy

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -258,12 +258,12 @@ struct __ref_or_copy_impl<execution::device_policy<PolicyParams...>, _T>
 };
 
 // Extension: hetero execution policy type trait
-template <typename... PolicyParams>
-using __is_hetero_execution_policy = ::std::disjunction<typename __is_device_execution_policy<PolicyParams...>::type,
-                                                        typename __is_fpga_execution_policy<PolicyParams...>::type>;
+template <typename _T>
+using __is_hetero_execution_policy = ::std::disjunction<typename __is_device_execution_policy<_T>::type,
+                                                        typename __is_fpga_execution_policy<_T>::type>;
 
-template <typename... PolicyParams>
-inline constexpr bool __is_hetero_execution_policy_v = __is_hetero_execution_policy<PolicyParams...>::value;
+template <typename _T>
+inline constexpr bool __is_hetero_execution_policy_v = __is_hetero_execution_policy<_T>::value;
 
 // Extension: check if parameter pack is convertible to events
 template <class... _Ts>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -258,9 +258,9 @@ struct __ref_or_copy_impl<execution::device_policy<PolicyParams...>, _T>
 };
 
 // Extension: hetero execution policy type trait
-template <typename... Args>
-using __is_hetero_execution_policy = ::std::disjunction<typename __is_device_execution_policy<Args...>::type,
-                                                        typename __is_fpga_execution_policy<Args...>::type>;
+template <typename... PolicyParams>
+using __is_hetero_execution_policy = ::std::disjunction<typename __is_device_execution_policy<PolicyParams...>::type,
+                                                        typename __is_fpga_execution_policy<PolicyParams...>::type>;
 
 template <typename... PolicyParams>
 inline constexpr bool __is_hetero_execution_policy_v = __is_hetero_execution_policy<PolicyParams...>::value;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -230,8 +230,8 @@ struct __is_device_execution_policy<execution::device_policy<PolicyParams...>> :
 {
 };
 
-template <typename... PolicyParams>
-inline constexpr bool __is_device_execution_policy_v = __is_device_execution_policy<PolicyParams...>::value;
+template <typename _T>
+inline constexpr bool __is_device_execution_policy_v = __is_device_execution_policy<_T>::value;
 
 template <typename _T>
 struct __is_fpga_execution_policy : ::std::false_type

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -259,7 +259,8 @@ struct __ref_or_copy_impl<execution::device_policy<PolicyParams...>, _T>
 
 // Extension: hetero execution policy type trait
 template <typename... Args>
-using __is_hetero_execution_policy = ::std::disjunction<__is_device_execution_policy<Args...> || __is_fpga_execution_policy<Args...>>;
+using __is_hetero_execution_policy = ::std::disjunction<typename __is_device_execution_policy<Args...>::type,
+                                                        typename __is_fpga_execution_policy<Args...>::type>;
 
 template <typename... PolicyParams>
 inline constexpr bool __is_hetero_execution_policy_v = __is_hetero_execution_policy<PolicyParams...>::value;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -259,8 +259,8 @@ struct __ref_or_copy_impl<execution::device_policy<PolicyParams...>, _T>
 
 // Extension: hetero execution policy type trait
 template <typename _T>
-using __is_hetero_execution_policy = ::std::disjunction<typename __is_device_execution_policy<_T>::type,
-                                                        typename __is_fpga_execution_policy<_T>::type>;
+using __is_hetero_execution_policy =
+    ::std::disjunction<typename __is_device_execution_policy<_T>::type, typename __is_fpga_execution_policy<_T>::type>;
 
 template <typename _T>
 inline constexpr bool __is_hetero_execution_policy_v = __is_hetero_execution_policy<_T>::value;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -220,20 +220,6 @@ struct is_execution_policy<__dpl::fpga_policy<unroll_factor, PolicyParams...>> :
 namespace __internal
 {
 
-// Extension: hetero execution policy type trait
-template <typename _T>
-struct __is_hetero_execution_policy : ::std::false_type
-{
-};
-
-template <typename... PolicyParams>
-struct __is_hetero_execution_policy<execution::device_policy<PolicyParams...>> : ::std::true_type
-{
-};
-
-template <typename... PolicyParams>
-inline constexpr bool __is_hetero_execution_policy_v = __is_hetero_execution_policy<PolicyParams...>::value;
-
 template <typename _T>
 struct __is_device_execution_policy : ::std::false_type
 {
@@ -254,11 +240,6 @@ struct __is_fpga_execution_policy : ::std::false_type
 
 #if _ONEDPL_FPGA_DEVICE
 template <unsigned int unroll_factor, typename... PolicyParams>
-struct __is_hetero_execution_policy<execution::fpga_policy<unroll_factor, PolicyParams...>> : ::std::true_type
-{
-};
-
-template <unsigned int unroll_factor, typename... PolicyParams>
 struct __is_fpga_execution_policy<execution::fpga_policy<unroll_factor, PolicyParams...>> : ::std::true_type
 {
 };
@@ -275,6 +256,13 @@ struct __ref_or_copy_impl<execution::device_policy<PolicyParams...>, _T>
 {
     using type = _T;
 };
+
+// Extension: hetero execution policy type trait
+template <typename... Args>
+using __is_hetero_execution_policy = ::std::disjunction<__is_device_execution_policy<Args...> || __is_fpga_execution_policy<Args...>>;
+
+template <typename... PolicyParams>
+inline constexpr bool __is_hetero_execution_policy_v = __is_hetero_execution_policy<PolicyParams...>::value;
 
 // Extension: check if parameter pack is convertible to events
 template <class... _Ts>


### PR DESCRIPTION
The goal of this PR - to avoid extra code in policy traits implementations and redefine `__is_hetero_execution_policy` trait as [disjunction](https://en.cppreference.com/w/cpp/types/disjunction) of `__is_device_execution_policy` and `__is_device_execution_policy` traits:
```C++
template <typename _T>
using __is_hetero_execution_policy =
    ::std::disjunction<
      typename __is_device_execution_policy<_T>::type,
      typename __is_fpga_execution_policy<_T>::type>;
```

Previously we had more complicated implementation of `__is_hetero_execution_policy` trait:
```C++
template <typename _T>
struct __is_hetero_execution_policy : ::std::false_type
{
};

template <typename... PolicyParams>
struct __is_hetero_execution_policy<execution::device_policy<PolicyParams...>> : ::std::true_type
{
};

template <unsigned int unroll_factor, typename... PolicyParams>
struct __is_hetero_execution_policy<execution::fpga_policy<unroll_factor, PolicyParams...>> : ::std::true_type
{
};
```

But taking a look at the implementation of `__is_device_execution_policy` and `__is_fpga_execution_policy` :
```C++
template <typename _T>
struct __is_device_execution_policy : ::std::false_type
{
};

template <typename... PolicyParams>
struct __is_device_execution_policy<execution::device_policy<PolicyParams...>> : ::std::true_type
{
};
```
```C++
template <typename _T>
struct __is_fpga_execution_policy : ::std::false_type
{
};

template <unsigned int unroll_factor, typename... PolicyParams>
struct __is_fpga_execution_policy<execution::fpga_policy<unroll_factor, PolicyParams...>> : ::std::true_type
{
};
```
we are able to reimplement `__is_hetero_execution_policy` as proposed.