### PR TITLE
Fix run-time errors in xpu_api tests

### DIFF
--- a/test/xpu_api/utilities/function.objects/arithmetic.operations/minus_arithm_op.pass.cpp
+++ b/test/xpu_api/utilities/function.objects/arithmetic.operations/minus_arithm_op.pass.cpp
@@ -35,7 +35,7 @@ kernel_test()
             ret_access[0] = (f1(3, 7) == -4);
 
             const dpl::minus<float> f2;
-            ret_access[0] &= (f2(3, 2.5) == 0.5);
+            ret_access[0] &= (f2(3.f, 2.5f) == 0.5f);
         });
     });
 

--- a/test/xpu_api/utilities/utility/utility.swap/swap_utility.pass.cpp
+++ b/test/xpu_api/utilities/utility/utility.swap/swap_utility.pass.cpp
@@ -66,8 +66,8 @@ kernel_test()
                     ret_access[0] &= (c1.real() == 1.5f && c1.imag() == 2.5f);
                     ret_access[0] &= (c2.real() == 1.f && c2.imag() == 5.5f);
                     dpl::swap(c1, c2);
-                    ret_access[0] &= (c2.real() == 1.5 && c2.imag() == 2.5);
-                    ret_access[0] &= (c1.real() == 1 && c1.imag() == 5.5);
+                    ret_access[0] &= (c2.real() == 1.5f && c2.imag() == 2.5f);
+                    ret_access[0] &= (c1.real() == 1.f && c1.imag() == 5.5f);
                 }
 
                 {


### PR DESCRIPTION
In this PR we fix run-time errors in xpu_api tests: `Required aspect fp64 is not supported on the device`