### PR TITLE
Remove `__collector_t` as unused

### DIFF
--- a/include/oneapi/dpl/pstl/execution_impl.h
+++ b/include/oneapi/dpl/pstl/execution_impl.h
@@ -96,9 +96,6 @@ struct __policy_traits<oneapi::dpl::execution::parallel_unsequenced_policy>
 };
 
 template <typename _ExecutionPolicy>
-using __collector_t = typename __internal::__policy_traits<::std::decay_t<_ExecutionPolicy>>::__collector_type;
-
-template <typename _ExecutionPolicy>
 using __allow_vector = typename __internal::__policy_traits<::std::decay_t<_ExecutionPolicy>>::__allow_vector;
 
 template <typename _ExecutionPolicy>


### PR DESCRIPTION
In this PR we remove `oneapi::dpl::__internal::__collector_t` as unused.

Previous definition of `__collector_t` were:
```C++
template <typename _ExecutionPolicy>
using __collector_t = typename __internal::__policy_traits<::std::decay_t<_ExecutionPolicy>>::__collector_type;
``` 

but `__collector_type` type is already absent in onDPL code too: [search results](https://github.com/search?q=repo%3Aoneapi-src%2FoneDPL%20__collector_type%20&type=code)

The type alias `__collector_t` is never used in oneDPL code: [search results](https://github.com/search?q=repo%3Aoneapi-src%2FoneDPL%20__collector_t%20&type=code)