### PR TITLE
[pstl-offload] Support free() call while obtaining system free() address

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,7 +16,8 @@ add_library(pstloffload SHARED ${CMAKE_CURRENT_SOURCE_DIR}/pstl_offload.cpp)
 target_compile_options(pstloffload PRIVATE
             -fsycl
             -Wall -Wextra -Wformat -Wformat-security -Wremarks -Werror
-            -fPIE -mretpoline
+            # have to put -fPIC after -fPIE to support linking when TLS is in use
+            -fPIE -fPIC -mretpoline
             -fstack-protector
             )
 

--- a/src/pstl_offload.cpp
+++ b/src/pstl_offload.cpp
@@ -31,8 +31,13 @@ namespace __pstl_offload
 
 using __free_func_type = void (*)(void*);
 
+// list of objects for delayed releasing
 struct __delayed_free_header {
     __delayed_free_header* _M_next;
+    void*                  _M_to_free;
+
+    __delayed_free_header(__delayed_free_header* __next, void* __to_free)
+        : _M_next(__next), _M_to_free(__to_free) {}
 };
 
 // are we inside dlsym call?
@@ -78,26 +83,29 @@ __internal_free(void* __user_ptr)
         {
             if (__dlsym_called)
             {
-                // delay releasing till exit of dlsym
-                __delayed_free_header* __header = static_cast<__delayed_free_header*>(__user_ptr);
-                __header->_M_next = __delayed_free? __delayed_free : nullptr;
-                __delayed_free = __header;
+                // Delay releasing till exit of dlsym. We do not overload malloc globally,
+                // so can use it safely. Do not use new to able to use free() during
+                // __delayed_free_header releasing.
+                void* __buf = malloc(sizeof(__delayed_free_header));
+                __delayed_free_header* __h = new(__buf) __delayed_free_header(__delayed_free, __user_ptr);
+                __delayed_free = __h;
             }
             else
             {
                 static __free_func_type __orig_free = __get_original_free();
 
-                // release objects from delayed release list
+                // releasing objects from delayed release list
                 while (__delayed_free)
                 {
                     __delayed_free_header* __next = __delayed_free->_M_next;
                     // it's possible that an object to be released during 1st call of __internal_free
-                    // would be released 2nd time from inside dlsym call. To prevent "double free"
+                    // would be released 2nd time from inside nested dlsym call. To prevent "double free"
                     // situation, check for it explicitly.
-                    if (__user_ptr != __delayed_free)
+                    if (__user_ptr != __delayed_free->_M_to_free)
                     {
-                        __orig_free(__delayed_free);
+                        __orig_free(__delayed_free->_M_to_free);
                     }
+                    __orig_free(__delayed_free);
                     __delayed_free = __next;
                 }
                 __orig_free(__user_ptr);

--- a/src/pstl_offload.cpp
+++ b/src/pstl_offload.cpp
@@ -87,6 +87,10 @@ __internal_free(void* __user_ptr)
                 // so can use it safely. Do not use new to able to use free() during
                 // __delayed_free_header releasing.
                 void* __buf = malloc(sizeof(__delayed_free_header));
+                if (!__buf)
+                {
+                    throw std::bad_alloc();
+                }
                 __delayed_free_header* __h = new(__buf) __delayed_free_header(__delayed_free, __user_ptr);
                 __delayed_free = __h;
             }

--- a/src/pstl_offload.cpp
+++ b/src/pstl_offload.cpp
@@ -29,12 +29,27 @@
 namespace __pstl_offload
 {
 
-static auto
-__get_original_free()
-{
-    using __free_func_type = void (*)(void*);
+using __free_func_type = void (*)(void*);
 
-    static __free_func_type __orig_free = __free_func_type(dlsym(RTLD_NEXT, "free"));
+struct __delayed_free_header {
+    __delayed_free_header* _M_next;
+};
+
+// are we inside dlsym call?
+static thread_local bool __dlsym_called = false;
+// objects released inside of dlsym call
+static thread_local __delayed_free_header* __delayed_free = nullptr;
+
+static __free_func_type
+__get_next_free_protected()
+{
+    __dlsym_called = true;
+    __free_func_type __orig_free = __free_func_type(dlsym(RTLD_NEXT, "free"));
+    __dlsym_called = false;
+    if (!__orig_free)
+    {
+        throw std::system_error(std::error_code(), dlerror());
+    }
     return __orig_free;
 }
 
@@ -61,7 +76,32 @@ __internal_free(void* __user_ptr)
         }
         else
         {
-            __get_original_free()(__user_ptr);
+            if (__dlsym_called)
+            {
+                // delay releasing till exit of dlsym
+                __delayed_free_header* __header = static_cast<__delayed_free_header*>(__user_ptr);
+                __header->_M_next = __delayed_free? __delayed_free : nullptr;
+                __delayed_free = __header;
+            }
+            else
+            {
+                static __free_func_type __orig_free = __get_next_free_protected();
+
+                // release objects from delayed release list
+                while (__delayed_free)
+                {
+                    __delayed_free_header* __next = __delayed_free->_M_next;
+                    // it's possible that an object to be released during 1st call of __internal_free
+                    // would be released 2nd time from inside dlsym call. To prevent "double free"
+                    // situation, check for it explicitly.
+                    if (__user_ptr != __delayed_free)
+                    {
+                        __orig_free(__delayed_free);
+                    }
+                    __delayed_free = __next;
+                }
+                __orig_free(__user_ptr);
+            }
         }
     }
 }

--- a/src/pstl_offload.cpp
+++ b/src/pstl_offload.cpp
@@ -34,7 +34,7 @@ using __free_func_type = void (*)(void*);
 // list of objects for delayed releasing
 struct __delayed_free_list {
     __delayed_free_list* _M_next;
-    void*                  _M_to_free;
+    void*                _M_to_free;
 };
 
 // are we inside dlsym call?

--- a/src/pstl_offload.cpp
+++ b/src/pstl_offload.cpp
@@ -41,7 +41,7 @@ static thread_local bool __dlsym_called = false;
 static thread_local __delayed_free_header* __delayed_free = nullptr;
 
 static __free_func_type
-__get_next_free_protected()
+__get_original_free()
 {
     __dlsym_called = true;
     __free_func_type __orig_free = __free_func_type(dlsym(RTLD_NEXT, "free"));
@@ -85,7 +85,7 @@ __internal_free(void* __user_ptr)
             }
             else
             {
-                static __free_func_type __orig_free = __get_next_free_protected();
+                static __free_func_type __orig_free = __get_original_free();
 
                 // release objects from delayed release list
                 while (__delayed_free)


### PR DESCRIPTION
free() call is possible inside dlsym(). Because global free() is overloaded, this may lead to crash. The situation is detected via TLS flag and releasing of object from nested free() calls is delayed till obtaining system free() address.