### PR TITLE
[Tests] Update broken macro for reduce_by_segment test

### DIFF
--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -144,7 +144,7 @@
 // oneAPI DPC++ compiler in 2023.2 release build crashes during optimization of reduce_by_segment.pass.cpp
 // with TBB backend.
 #if !PSTL_USE_DEBUG && TEST_TBB_BACKEND_PRESENT && defined(__INTEL_LLVM_COMPILER)
-#   define _PSTL_ICPX_TEST_RED_BY_SEG_OPTIMIZER_CRASH ((__INTEL_LLVM_COMPILER == 20230200) || (__INTEL_LLVM_COMPILER == 20240000))
+#   define _PSTL_ICPX_TEST_RED_BY_SEG_OPTIMIZER_CRASH ((__INTEL_LLVM_COMPILER >= 20230200) && (__INTEL_LLVM_COMPILER <= 20240001))
 #else
 #   define _PSTL_ICPX_TEST_RED_BY_SEG_OPTIMIZER_CRASH 0
 #endif


### PR DESCRIPTION
Let's extend the macro for Intel(R) oneAPI DPC++/C++ Compiler 2024.0.1 (2024.0.1.20231122). This compiler is still not able to compile this test entirely. 