### PR TITLE
[oneDPL][test][perm_it] Some test cases were disabled, because it is not supported by oneDPL

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -521,11 +521,18 @@ struct __get_sycl_range
 
     template <typename _Iter, typename _Map,
               ::std::enable_if_t<!is_sycl_iterator_v<_Iter> && !is_passed_directly_v<_Iter>, int> = 0>
-    void
+    auto
     operator()(oneapi::dpl::permutation_iterator<_Iter, _Map>, oneapi::dpl::permutation_iterator<_Iter, _Map>)
     {
         static_assert(std::is_same_v<oneapi::dpl::permutation_iterator<_Iter, _Map>, void>,
                       "error: the iterator type is not supported with a device policy");
+
+        //To make the dummy return data of a proper type for diagnostic reasons:
+        //To avoid "error: variable has incomplete type 'void'" message;
+        //static_assert mentined above should be shown as first compile time error.
+        using _T = val_t<_Iter>;
+        return __range_holder<oneapi::dpl::__ranges::all_view<_T, AccMode>>{
+            oneapi::dpl::__ranges::all_view<_T, AccMode>(sycl::buffer<_T, 1>{})};
     }
 
     //specialization for permutation discard iterator

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment_perm_it.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment_perm_it.pass.cpp
@@ -139,6 +139,8 @@ test_exclusive_scan(sycl::queue q, std::vector<size_t>& perms, std::vector<TestV
     EXPECT_EQ_RANGES(expectedResults, results, "wrong effect from exclusive_scan_by_segment #2");
 }
 
+#define _ONEDPL_PERM_BASE_ITERATOR_HOST_DEVICE_POL_SUPPORT 0
+
 template <typename... Args>
 void
 test_exclusive_scan(sycl::queue q)
@@ -173,6 +175,17 @@ test_exclusive_scan(sycl::queue q)
     // Res:  0, 1, 2, 3, 4, 0, 1, 2, 3, 4
     test_exclusive_scan<N, TestValueType, Args...>(q, keys1, vals1, res1);
 
+    // Keys: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9
+    // Vals: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+    // Res:  0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+    test_exclusive_scan<N, TestValueType, Args...>(q, keys2, vals2, res2);
+
+    // Keys: 0, 0, 0, 0, 0, 1, 1, 1, 1, 1
+    // Vals: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
+    // Res:  0, 1, 2, 3, 4, 0, 1, 2, 3, 4
+    test_exclusive_scan<N, TestValueType, Args...>(q, keys1, vals1, res1);
+
+#if _ONEDPL_PERM_BASE_ITERATOR_HOST_DEVICE_POL_SUPPORT
     // Perm: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9
     // Keys: 0, 0, 0, 0, 0, 1, 1, 1, 1, 1
     // Vals: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
@@ -184,11 +197,6 @@ test_exclusive_scan(sycl::queue q)
     // Vals: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
     // Res:  0, 1, 2, 3, 4, 5, 6, 7, 8, 9
     test_exclusive_scan<N, TestValueType, Args...>(q, permutations2, keys1, vals1, res3);
-
-    // Keys: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9
-    // Vals: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
-    // Res:  0, 0, 0, 0, 0, 0, 0, 0, 0, 0
-    test_exclusive_scan<N, TestValueType, Args...>(q, keys2, vals2, res2);
 
     // Perm: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9
     // Keys: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9
@@ -202,11 +210,6 @@ test_exclusive_scan(sycl::queue q)
     // Res:  0, 1, 2, 3, 4, 0, 1, 2, 3, 4
     test_exclusive_scan<N, TestValueType, Args...>(q, permutations2, keys2, vals2, res1);
 
-    // Keys: 0, 0, 0, 0, 0, 1, 1, 1, 1, 1
-    // Vals: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
-    // Res:  0, 1, 2, 3, 4, 0, 1, 2, 3, 4
-    test_exclusive_scan<N, TestValueType, Args...>(q, keys1, vals1, res1);
-
     // Perm: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9
     // Keys: 0, 0, 0, 0, 0, 1, 1, 1, 1, 1
     // Vals: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
@@ -218,6 +221,7 @@ test_exclusive_scan(sycl::queue q)
     // Vals: 1, 1, 1, 1, 1, 1, 1, 1, 1, 1
     // Res:  0, 1, 2, 3, 4, 5, 6, 7, 8, 9
     test_exclusive_scan<N, TestValueType, Args...>(q, permutations2, keys1, vals1, res3);
+#endif
 }
 #endif // TEST_DPCPP_BACKEND_PRESENT
 


### PR DESCRIPTION
1. The test coverages for a case with permutation_iterator(host_iterator, valid_iterator) was disabled, because it is not supported by oneDPL. Before it was UB, now - compile time error.
2. Compile time diagnostic improved for the mentioned case.