### PR TITLE
Bugfix for permutation_iterator operator[]

### DIFF
--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -477,7 +477,7 @@ struct permutation_view_simple<_Source, _M, ::std::enable_if_t<oneapi::dpl::__in
 
     //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range
     template <typename Idx>
-    auto
+    value_type&
     operator[](Idx __i) const
     {
         return __src[__map_fn(__i)];
@@ -516,7 +516,7 @@ struct permutation_view_simple<_Source, _M, ::std::enable_if_t<is_map_view<_M>::
 
     //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range
     template <typename Idx>
-    auto
+    value_type&
     operator[](Idx __i) const
     {
         return __src[__map[__i]];

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -477,8 +477,7 @@ struct permutation_view_simple<_Source, _M, ::std::enable_if_t<oneapi::dpl::__in
 
     //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range
     template <typename Idx>
-    auto
-    operator[](Idx __i) const -> decltype(__src[__map_fn(__i)])
+    decltype(auto) operator[](Idx __i) const
     {
         return __src[__map_fn(__i)];
     }
@@ -516,8 +515,7 @@ struct permutation_view_simple<_Source, _M, ::std::enable_if_t<is_map_view<_M>::
 
     //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range
     template <typename Idx>
-    auto
-    operator[](Idx __i) const -> decltype(__src[__map[__i]])
+    decltype(auto) operator[](Idx __i) const
     {
         return __src[__map[__i]];
     }

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -477,7 +477,8 @@ struct permutation_view_simple<_Source, _M, ::std::enable_if_t<oneapi::dpl::__in
 
     //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range
     template <typename Idx>
-    decltype(auto) operator[](Idx __i) const
+    decltype(auto)
+    operator[](Idx __i) const
     {
         return __src[__map_fn(__i)];
     }
@@ -515,7 +516,8 @@ struct permutation_view_simple<_Source, _M, ::std::enable_if_t<is_map_view<_M>::
 
     //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range
     template <typename Idx>
-    decltype(auto) operator[](Idx __i) const
+    decltype(auto)
+    operator[](Idx __i) const
     {
         return __src[__map[__i]];
     }

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -477,8 +477,8 @@ struct permutation_view_simple<_Source, _M, ::std::enable_if_t<oneapi::dpl::__in
 
     //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range
     template <typename Idx>
-    value_type&
-    operator[](Idx __i) const
+    auto
+    operator[](Idx __i) const -> decltype(__src[__map_fn(__i)])
     {
         return __src[__map_fn(__i)];
     }
@@ -516,8 +516,8 @@ struct permutation_view_simple<_Source, _M, ::std::enable_if_t<is_map_view<_M>::
 
     //TODO: to be consistent with C++ standard, this Idx should be changed to diff_type of underlying range
     template <typename Idx>
-    value_type&
-    operator[](Idx __i) const
+    auto
+    operator[](Idx __i) const -> decltype(__src[__map[__i]])
     {
         return __src[__map[__i]];
     }

--- a/test/parallel_api/iterator/permutation_iterator.h
+++ b/test/parallel_api/iterator/permutation_iterator.h
@@ -204,8 +204,6 @@ struct test_through_permutation_iterator<TSourceIterator, TSourceDataSize, perm_
     void
     operator()(Operand op)
     {
-
-        auto indexes_begin = dpl::counting_iterator<TSourceDataSize>(0);
         using ValueType = typename ::std::iterator_traits<TSourceIterator>::value_type;
 
         // Using callable object instead of lambda here to ensure transform iterator would be
@@ -218,6 +216,7 @@ struct test_through_permutation_iterator<TSourceIterator, TSourceDataSize, perm_
             }
         };
 
+        auto indexes_begin = dpl::counting_iterator<TSourceDataSize>(0);
         auto itTransformBegin = dpl::make_transform_iterator(indexes_begin, NoTransform{});
         auto permItBegin = dpl::make_permutation_iterator(data.itSource, itTransformBegin);
         auto permItEnd = permItBegin + data.src_data_size;

--- a/test/parallel_api/iterator/permutation_iterator.h
+++ b/test/parallel_api/iterator/permutation_iterator.h
@@ -204,6 +204,8 @@ struct test_through_permutation_iterator<TSourceIterator, TSourceDataSize, perm_
     void
     operator()(Operand op)
     {
+
+        auto indexes_begin = dpl::counting_iterator<TSourceDataSize>(0);
         using ValueType = typename ::std::iterator_traits<TSourceIterator>::value_type;
 
         // Using callable object instead of lambda here to ensure transform iterator would be
@@ -216,10 +218,11 @@ struct test_through_permutation_iterator<TSourceIterator, TSourceDataSize, perm_
             }
         };
 
-        auto itTransformBegin = dpl::make_transform_iterator(data.itSource, NoTransform{});
-        auto itTransformEnd = itTransformBegin + data.src_data_size;
+        auto itTransformBegin = dpl::make_transform_iterator(indexes_begin, NoTransform{});
+        auto permItBegin = dpl::make_permutation_iterator(data.itSource, itTransformBegin);
+        auto permItEnd = permItBegin + data.src_data_size;
 
-        op(itTransformBegin, itTransformEnd);
+        op(permItBegin, permItEnd);
     }
 };
 

--- a/test/parallel_api/iterator/permutation_iterator.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator.pass.cpp
@@ -68,21 +68,21 @@ struct is_able_to_modify_src_data_in_test<ExecutionPolicy, perm_it_index_tags::h
 
 template <typename ExecutionPolicy>
 struct is_able_to_modify_src_data_in_test<ExecutionPolicy, perm_it_index_tags::usm_shared>
-    : std::true_type
+    : ::std::true_type
 {
 };
 
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
 template <typename ExecutionPolicy>
-struct is_able_to_modify_src_data_in_test<ExecutionPolicy, perm_it_index_tags::usm_device>
-    : oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<ExecutionPolicy>>
+struct is_able_to_modify_src_data_in_test<ExecutionPolicy, perm_it_index_tags::transform_iterator>
+    : ::std::true_type
 {
 };
 
 template <typename ExecutionPolicy>
 struct is_able_to_modify_src_data_in_test<ExecutionPolicy, perm_it_index_tags::callable_object>
-    : ::std::false_type
+    : ::std::true_type
 {
 };
 };

--- a/test/parallel_api/iterator/permutation_iterator.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator.pass.cpp
@@ -54,6 +54,7 @@ template <typename ExecutionPolicy, typename PermItIndexTag>
 struct is_able_to_modify_src_data_in_test : ::std::true_type { };
 
 #if TEST_DPCPP_BACKEND_PRESENT
+// TODO: fix bug for host_iterator as permutation_iterator index and re-enable this case
 template <typename ExecutionPolicy>
 struct is_able_to_modify_src_data_in_test<ExecutionPolicy, perm_it_index_tags::host>
     : ::std::negation<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<ExecutionPolicy>>>

--- a/test/parallel_api/iterator/permutation_iterator.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator.pass.cpp
@@ -35,9 +35,9 @@ using namespace TestUtils;
 // 
 // Table: Current test state
 // 
-// +------------------------+-----------------------+-----------+--------------------------------------+---------------------------------------------+---------------+
-// +       Test name        |     Algorithm         + Is modify +         Pattern                      + Host policy + Hetero policy +
-// +------------------------+-----------------------+-----------+--------------------------------------+---------------------------------------------+---------------+
+// +------------------------+-----------------------+-----------+--------------------------------------+-------------+-------------------------------+
+// +       Test name        |     Algorithm         + Is modify +         Pattern                      + Host policy +        Hetero policy          +
+// +------------------------+-----------------------+-----------+--------------------------------------+-------------+-------------------------------+
 // | test_transform         | dpl::transform        |     N     | __parallel_for                       |     +       |              +                |
 // | test_transform_reduce  | dpl::transform_reduce |     N     | __parallel_transform_reduce          |     +       |              +                |
 // | test_find              | dpl::find             |     N     | __parallel_find -> _parallel_find_or |     +       |              +                |
@@ -46,7 +46,7 @@ using namespace TestUtils;
 // | test_sort              | dpl::sort             |     Y     | __parallel_stable_sort               |     +       | exc. perm_it_index_tags::host |
 // | test_partial_sort      | dpl::partial_sort     |     Y     | __parallel_partial_sort              |     +       | exc. perm_it_index_tags::host |
 // | test_remove_if         | dpl::remove_if        |     Y     | __parallel_transform_scan            |     +       | exc. perm_it_index_tags::host |
-// +------------------------+-----------------------+-----------+--------------------------------------+---------------------------------------------+---------------+
+// +------------------------+-----------------------+-----------+--------------------------------------+-------------+-------------------------------+
 
 namespace
 {

--- a/test/parallel_api/iterator/permutation_iterator.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator.pass.cpp
@@ -36,16 +36,16 @@ using namespace TestUtils;
 // Table: Current test state
 // 
 // +------------------------+-----------------------+-----------+--------------------------------------+---------------------------------------------+---------------+
-// +       Test name        |     Algorithm         + Is modify +         Pattern                      +                Host policy                  + Hetero policy +
+// +       Test name        |     Algorithm         + Is modify +         Pattern                      + Host policy + Hetero policy +
 // +------------------------+-----------------------+-----------+--------------------------------------+---------------------------------------------+---------------+
-// | test_transform         | dpl::transform        |     N     | __parallel_for                       |                     +                       |       +       |
-// | test_transform_reduce  | dpl::transform_reduce |     N     | __parallel_transform_reduce          |                     +                       |       +       |
-// | test_find              | dpl::find             |     N     | __parallel_find -> _parallel_find_or |                     +                       |       +       |
-// | test_is_heap           | dpl::is_heap          |     N     | __parallel_or -> _parallel_find_or   |                     +                       |       +       |
-// | test_merge             | dpl::merge            |     N     | __parallel_merge                     | exc. perm_it_index_tags::transform_iterator |       +       |
-// | test_sort              | dpl::sort             |     Y     | __parallel_stable_sort               | exc. perm_it_index_tags::transform_iterator |       -       |
-// | test_partial_sort      | dpl::partial_sort     |     Y     | __parallel_partial_sort              | exc. perm_it_index_tags::transform_iterator |       -       |
-// | test_remove_if         | dpl::remove_if        |     Y     | __parallel_transform_scan            | exc. perm_it_index_tags::transform_iterator |       -       |
+// | test_transform         | dpl::transform        |     N     | __parallel_for                       |     +       |              +                |
+// | test_transform_reduce  | dpl::transform_reduce |     N     | __parallel_transform_reduce          |     +       |              +                |
+// | test_find              | dpl::find             |     N     | __parallel_find -> _parallel_find_or |     +       |              +                |
+// | test_is_heap           | dpl::is_heap          |     N     | __parallel_or -> _parallel_find_or   |     +       |              +                |
+// | test_merge             | dpl::merge            |     N     | __parallel_merge                     |     +       |              +                |
+// | test_sort              | dpl::sort             |     Y     | __parallel_stable_sort               |     +       | exc. perm_it_index_tags::host |
+// | test_partial_sort      | dpl::partial_sort     |     Y     | __parallel_partial_sort              |     +       | exc. perm_it_index_tags::host |
+// | test_remove_if         | dpl::remove_if        |     Y     | __parallel_transform_scan            |     +       | exc. perm_it_index_tags::host |
 // +------------------------+-----------------------+-----------+--------------------------------------+---------------------------------------------+---------------+
 
 namespace
@@ -55,36 +55,12 @@ struct is_able_to_modify_src_data_in_test : ::std::true_type { };
 
 #if TEST_DPCPP_BACKEND_PRESENT
 template <typename ExecutionPolicy>
-struct is_able_to_modify_src_data_in_test<ExecutionPolicy, perm_it_index_tags::counting>
-    : ::std::true_type
-{
-};
-
-template <typename ExecutionPolicy>
 struct is_able_to_modify_src_data_in_test<ExecutionPolicy, perm_it_index_tags::host>
     : ::std::negation<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<ExecutionPolicy>>>
 {
 };
 
-template <typename ExecutionPolicy>
-struct is_able_to_modify_src_data_in_test<ExecutionPolicy, perm_it_index_tags::usm_shared>
-    : ::std::true_type
-{
-};
-
 #endif // TEST_DPCPP_BACKEND_PRESENT
-
-template <typename ExecutionPolicy>
-struct is_able_to_modify_src_data_in_test<ExecutionPolicy, perm_it_index_tags::transform_iterator>
-    : ::std::true_type
-{
-};
-
-template <typename ExecutionPolicy>
-struct is_able_to_modify_src_data_in_test<ExecutionPolicy, perm_it_index_tags::callable_object>
-    : ::std::true_type
-{
-};
 };
 
 // Check ability to run non-modifying source data test

--- a/test/parallel_api/iterator/permutation_iterator.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator.pass.cpp
@@ -56,7 +56,7 @@ struct is_able_to_modify_src_data_in_test : ::std::true_type { };
 #if TEST_DPCPP_BACKEND_PRESENT
 template <typename ExecutionPolicy>
 struct is_able_to_modify_src_data_in_test<ExecutionPolicy, perm_it_index_tags::counting>
-    : ::std::negation<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<ExecutionPolicy>>>
+    : ::std::true_type
 {
 };
 
@@ -68,15 +68,15 @@ struct is_able_to_modify_src_data_in_test<ExecutionPolicy, perm_it_index_tags::h
 
 template <typename ExecutionPolicy>
 struct is_able_to_modify_src_data_in_test<ExecutionPolicy, perm_it_index_tags::usm_shared>
-    : ::std::negation<oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<ExecutionPolicy>>>
+    : std::true_type
 {
 };
 
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
 template <typename ExecutionPolicy>
-struct is_able_to_modify_src_data_in_test<ExecutionPolicy, perm_it_index_tags::transform_iterator>
-    : ::std::false_type
+struct is_able_to_modify_src_data_in_test<ExecutionPolicy, perm_it_index_tags::usm_device>
+    : oneapi::dpl::__internal::__is_hetero_execution_policy<::std::decay_t<ExecutionPolicy>>
 {
 };
 

--- a/test/parallel_api/iterator/permutation_iterator.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator.pass.cpp
@@ -76,7 +76,7 @@ struct is_able_to_modify_src_data_in_test<ExecutionPolicy, perm_it_index_tags::u
 
 template <typename ExecutionPolicy>
 struct is_able_to_modify_src_data_in_test<ExecutionPolicy, perm_it_index_tags::transform_iterator>
-    : ::std::false_type
+    : ::std::true_type
 {
 };
 

--- a/test/parallel_api/iterator/permutation_iterator.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator.pass.cpp
@@ -76,7 +76,7 @@ struct is_able_to_modify_src_data_in_test<ExecutionPolicy, perm_it_index_tags::u
 
 template <typename ExecutionPolicy>
 struct is_able_to_modify_src_data_in_test<ExecutionPolicy, perm_it_index_tags::transform_iterator>
-    : ::std::true_type
+    : ::std::false_type
 {
 };
 

--- a/test/parallel_api/iterator/permutation_iterator.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator.pass.cpp
@@ -76,13 +76,13 @@ struct is_able_to_modify_src_data_in_test<ExecutionPolicy, perm_it_index_tags::u
 
 template <typename ExecutionPolicy>
 struct is_able_to_modify_src_data_in_test<ExecutionPolicy, perm_it_index_tags::transform_iterator>
-    : std::false_type
+    : ::std::false_type
 {
 };
 
 template <typename ExecutionPolicy>
 struct is_able_to_modify_src_data_in_test<ExecutionPolicy, perm_it_index_tags::callable_object>
-    : std::false_type
+    : ::std::false_type
 {
 };
 };
@@ -676,6 +676,8 @@ run_algo_tests_on_buffers()
 }
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
+//These are only invoked on the host side, because permutation iterator is unsupported
+// for host std::vector iterator input source data.
 template <typename ValueType, typename PermItIndexTag>
 void
 run_algo_tests_on_sequence()


### PR DESCRIPTION
Fix for implementation of `permutation_view_simple` to return from `operator[]` by reference rather than by value.

Adding test for fill to cover missed test case.

Fixing some rules for modifying source data in permutation iterator tests, **this was resulting in a number of skipped tests.**

Following with other tests in this permutation_iterator.pass, checking of result is skipped.  Another PR should provide the checks for permutation iterator to properly evaluate if the result is achieved appropriately, and should apply the same permutation safely on the host to check the result.

The bug we experience and are fixing in this PR is at compile time and it is resolved.