### PR TITLE
Adding legacy support for is_passed_directly trait

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -231,8 +231,19 @@ struct is_passed_directly<zip_iterator<Iters...>> : ::std::conjunction<is_passed
 {
 };
 
+template <typename Iter, typename Void = void>
+struct is_passed_directly_legacy_support : ::std::false_type
+{
+};
+
+template <typename Iter> // for permutation_iterators
+struct is_passed_directly_legacy_support<Iter, ::std::enable_if_t<Iter::is_passed_directly::value>> : ::std::true_type
+{
+};
+
 template <typename Iter>
-inline constexpr bool is_passed_directly_v = is_passed_directly<Iter>::value;
+inline constexpr bool is_passed_directly_v =
+    is_passed_directly<Iter>::value || is_passed_directly_legacy_support<Iter>::value;
 
 // A trait for checking if iterator is heterogeneous or not
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -232,18 +232,18 @@ struct is_passed_directly<zip_iterator<Iters...>> : ::std::conjunction<is_passed
 };
 
 template <typename Iter, typename Void = void>
-struct is_passed_directly_legacy_support : ::std::false_type
+struct is_passed_directly_legacy_trait : ::std::false_type
 {
 };
 
-template <typename Iter> // for permutation_iterators
-struct is_passed_directly_legacy_support<Iter, ::std::enable_if_t<Iter::is_passed_directly::value>> : ::std::true_type
+template <typename Iter>
+struct is_passed_directly_legacy_trait<Iter, ::std::enable_if_t<Iter::is_passed_directly::value>> : ::std::true_type
 {
 };
 
 template <typename Iter>
 inline constexpr bool is_passed_directly_v =
-    is_passed_directly<Iter>::value || is_passed_directly_legacy_support<Iter>::value;
+    is_passed_directly<Iter>::value || is_passed_directly_legacy_trait<Iter>::value;
 
 // A trait for checking if iterator is heterogeneous or not
 


### PR DESCRIPTION
This PR returns legacy support for types having the `is_passed_directly` trait provided.
#1254 changed the way that this was implemented internally by instead enumerating the types which were passed directly with template specialization of `struct is_passed_directly`.  

While this is an implementation detail, it is a useful one which has been used in the compatibility headers to support `device_iterator` and `device_pointer`, and may be used in some user code. This returns the support for the `is_passed_directly` trait, to augment the new system. 

