### PR TITLE
Adding read-only permission to all jobs in the CI flow to ensure minimum required access

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,8 @@ on:
       - main
       - 'release/**'
 
+permissions: read-all
+
 env:
   BUILD_CONCURRENCY: 2
   MACOS_BUILD_CONCURRENCY: 3


### PR DESCRIPTION
The change is being made to bring the repo into compliance with the recommended best practice of enforcing the policy of least privilege.  See https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions for the details.