### PR TITLE
[Dynamic Selection] Addressing comments to sycl_backend.h

### DIFF
--- a/include/oneapi/dpl/internal/dynamic_selection_impl/sycl_backend.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/sycl_backend.h
@@ -41,7 +41,7 @@ class sycl_backend
         sycl::event e_;
 
       public:
-        async_waiter(sycl::event e) : e_(e) {}
+        async_waiter(const sycl::event& e) : e_(e) {}
         sycl::event
         unwrap()
         {
@@ -114,12 +114,12 @@ class sycl_backend
             auto e2 = q.submit([=](sycl::handler& h) {
                 h.depends_on(e1);
                 h.host_task([=]() {
+                    if constexpr (report_value_v<SelectionHandle, execution_info::task_time_t>)
+                        s.report(execution_info::task_time, (std::chrono::steady_clock::now() - t0).count());
                     if constexpr (report_info_v<SelectionHandle, execution_info::task_completion_t>)
                     {
                         s.report(execution_info::task_completion);
                     }
-                    if constexpr (report_value_v<SelectionHandle, execution_info::task_time_t>)
-                        s.report(execution_info::task_time, (std::chrono::steady_clock::now() - t0).count());
                 });
             });
             return async_waiter{e2};

--- a/test/parallel_api/dynamic_selection/sycl/test_internal_sycl_scheduler.pass.cpp
+++ b/test/parallel_api/dynamic_selection/sycl/test_internal_sycl_scheduler.pass.cpp
@@ -218,7 +218,7 @@ test_properties()
         sycl::queue cpu_queue{sycl::cpu_selector_v};
         v.push_back(cpu_queue);
     }
-    catch (sycl::exception)
+    catch (const sycl::exception&)
     {
         std::cout << "SKIPPED: Unable to use cpu selector\n";
     }
@@ -227,7 +227,7 @@ test_properties()
         sycl::queue gpu_queue{sycl::gpu_selector_v};
         v.push_back(gpu_queue);
     }
-    catch (sycl::exception)
+    catch (const sycl::exception&)
     {
         std::cout << "SKIPPED: Unable to use gpu selector\n";
     }
@@ -262,7 +262,7 @@ main()
     {
         sycl::queue q;
     }
-    catch (sycl::exception)
+    catch (const sycl::exception&)
     {
         std::cout << "SKIPPED: Unable to use sycl at all\n";
         return 0;

--- a/test/parallel_api/dynamic_selection/sycl/test_sycl_sanity.pass.cpp
+++ b/test/parallel_api/dynamic_selection/sycl/test_sycl_sanity.pass.cpp
@@ -68,7 +68,7 @@ run_test(sycl::queue q)
 }
 
 int
-test_runner()
+test_runner_default()
 {
     int r = 0;
     try
@@ -77,29 +77,43 @@ test_runner()
         default_queue = sycl::queue{sycl::default_selector_v};
         r += run_test(default_queue);
     }
-    catch (sycl::exception)
+    catch (const sycl::exception&)
     {
         std::cout << "SKIPPED: Unable to run with default_selector\n";
     }
 
+    return r;
+}
+
+int
+test_runner_gpu()
+{
+    int r = 0;
     try
     {
         sycl::queue gpu_queue;
         gpu_queue = sycl::queue{sycl::gpu_selector_v};
         r += run_test(gpu_queue);
     }
-    catch (sycl::exception)
+    catch (const sycl::exception&)
     {
         std::cout << "SKIPPED: Unable to run with gpu_selector\n";
     }
 
+    return r;
+}
+
+int
+test_runner_cpu()
+{
+    int r = 0;
     try
     {
         sycl::queue cpu_queue;
         cpu_queue = sycl::queue{sycl::cpu_selector_v};
         r += run_test(cpu_queue);
     }
-    catch (sycl::exception)
+    catch (const sycl::exception&)
     {
         std::cout << "SKIPPED: Unable to run with cpu_selector\n";
     }
@@ -112,7 +126,7 @@ int
 main()
 {
 #if TEST_DYNAMIC_SELECTION_AVAILABLE
-    return test_runner();
+    return test_runner_default() ||  test_runner_gpu() || test_runner_cpu();
 #else
     std::cout << "SKIPPED\n";
     return 0;

--- a/test/support/sycl_sanity.h
+++ b/test/support/sycl_sanity.h
@@ -29,9 +29,6 @@ namespace TestUtils
 
   template <typename Op, ::std::size_t CallNumber>
   struct unique_kernel_name;
-
-  template <typename Policy, int idx>
-  using new_kernel_name = unique_kernel_name<typename ::std::decay_t<Policy>, idx>;
 }
 
 


### PR DESCRIPTION
Addressed comments in https://github.com/oneapi-src/oneDPL/pull/1085 directed for sycl_backend.h
1. Change order of execution_info::task_completion_t and execution_info::task_time_t
2. for construction async_waiter - const sycl::event& e or e_(std::move(e))