### PR TITLE
[pstl-offload] Remove returning function pointer from __get_original_ functions

### DIFF
--- a/include/pstl_offload/internal/usm_memory_replacement.h
+++ b/include/pstl_offload/internal/usm_memory_replacement.h
@@ -105,14 +105,14 @@ class __offload_policy_holder_type
 static __offload_policy_holder_type __offload_policy_holder{__get_offload_device_selector(), __set_active_device};
 
 #if __linux__
-inline auto
-__get_original_aligned_alloc()
+inline void*
+__original_aligned_alloc(std::size_t __alignment, std::size_t __size)
 {
     using __aligned_alloc_func_type = void* (*)(std::size_t, std::size_t);
 
     static __aligned_alloc_func_type __orig_aligned_alloc =
         __aligned_alloc_func_type(dlsym(RTLD_NEXT, "aligned_alloc"));
-    return __orig_aligned_alloc;
+    return __orig_aligned_alloc(__alignment, __size);
 }
 #endif // __linux__
 
@@ -128,7 +128,7 @@ __internal_aligned_alloc(std::size_t __size, std::size_t __alignment)
     }
     else
     {
-        __res = __get_original_aligned_alloc()(__alignment, __size);
+        __res = __original_aligned_alloc(__alignment, __size);
     }
 
     assert((std::uintptr_t(__res) & (__alignment - 1)) == 0);

--- a/include/pstl_offload/internal/usm_memory_replacement_common.h
+++ b/include/pstl_offload/internal/usm_memory_replacement_common.h
@@ -100,13 +100,13 @@ __allocate_shared_for_device(sycl::device* __device, std::size_t __size, std::si
     return __ptr;
 }
 
-inline auto
-__get_original_realloc()
+inline void*
+__original_realloc(void* __user_ptr, std::size_t __new_size)
 {
     using __realloc_func_type = void* (*)(void*, std::size_t);
 
     static __realloc_func_type __orig_realloc = __realloc_func_type(dlsym(RTLD_NEXT, "realloc"));
-    return __orig_realloc;
+    return __orig_realloc(__user_ptr, __new_size);
 }
 
 inline void
@@ -156,7 +156,7 @@ __realloc_real_pointer(void* __user_ptr, std::size_t __new_size)
     else
     {
         // __user_ptr is not a USM pointer, use original realloc function
-        __result = __get_original_realloc()(__user_ptr, __new_size);
+        __result = __original_realloc(__user_ptr, __new_size);
     }
     return __result;
 }

--- a/src/pstl_offload.cpp
+++ b/src/pstl_offload.cpp
@@ -86,14 +86,14 @@ __original_free(void* __ptr_to_free)
     __orig_free(__ptr_to_free);
 }
 
-static auto
-__get_original_msize()
+static std::size_t
+__original_msize(void* __user_ptr)
 {
     using __msize_func_type = std::size_t (*)(void*);
 
     static __msize_func_type __orig_msize =
         __msize_func_type(dlsym(RTLD_NEXT, "malloc_usable_size"));
-    return __orig_msize;
+    return __orig_msize(__user_ptr);
 }
 
 static void
@@ -145,7 +145,7 @@ __internal_msize(void* __user_ptr)
         }
         else
         {
-            __res = __get_original_msize()(__user_ptr);
+            __res = __original_msize(__user_ptr);
         }
     }
     return __res;


### PR DESCRIPTION
Change `__get_original_msize`, `__get_original_aligned_alloc` and `__get_original_realloc` to do action instead of returning the function pointer. Changes are aligned with `__get_original_free` removal made previously. 