### PR TITLE
GCC7 std::get not returning const rvalue reference from const rvalue reference of tuple

### DIFF
--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -55,7 +55,7 @@
 // GCC10 produces wrong answer calling exclusive_scan using vectorized polices
 #define TEST_GCC10_EXCLUSIVE_SCAN_BROKEN (_GLIBCXX_RELEASE == 10)
 // GCC7 std::get not returning const rvalue reference from const rvalue reference of tuple
-#define TEST_GCC7_RVALUE_REFERENCE_FROM_TUPLE_BROKEN (_GLIBCXX_RELEASE && _GLIBCXX_RELEASE < 8)
+#define TEST_GCC7_RVALUE_TUPLE_GET_BROKEN (_GLIBCXX_RELEASE && _GLIBCXX_RELEASE < 8)
 // Array swap broken on Windows because Microsoft implementation of std::swap function for std::array
 // call some internal function which is not declared as SYCL external and we have compile error
 #if defined(_MSC_VER)

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -54,6 +54,8 @@
 #define _PSTL_STD_UNINITIALIZED_FILL_BROKEN (_MSC_VER == 1900)
 // GCC10 produces wrong answer calling exclusive_scan using vectorized polices
 #define TEST_GCC10_EXCLUSIVE_SCAN_BROKEN (_GLIBCXX_RELEASE == 10)
+// GCC7 not returning const rvalue reference from const rvalue reference of tuple
+#define TEST_GCC7_RVALUE_REFERENCE_FROM_TUPLE_BROKEN (_GLIBCXX_RELEASE && _GLIBCXX_RELEASE < 8)
 // Array swap broken on Windows because Microsoft implementation of std::swap function for std::array
 // call some internal function which is not declared as SYCL external and we have compile error
 #if defined(_MSC_VER)

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -55,7 +55,7 @@
 // GCC10 produces wrong answer calling exclusive_scan using vectorized polices
 #define TEST_GCC10_EXCLUSIVE_SCAN_BROKEN (_GLIBCXX_RELEASE == 10)
 // GCC7 std::get doesn't return const rvalue reference from const rvalue reference of tuple
-#define TEST_GCC7_RVALUE_TUPLE_GET_BROKEN (_GLIBCXX_RELEASE && _GLIBCXX_RELEASE < 8)
+#define _PSTL_TEST_GCC7_RVALUE_TUPLE_GET_BROKEN (_GLIBCXX_RELEASE && _GLIBCXX_RELEASE < 8)
 // Array swap broken on Windows because Microsoft implementation of std::swap function for std::array
 // call some internal function which is not declared as SYCL external and we have compile error
 #if defined(_MSC_VER)

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -54,7 +54,7 @@
 #define _PSTL_STD_UNINITIALIZED_FILL_BROKEN (_MSC_VER == 1900)
 // GCC10 produces wrong answer calling exclusive_scan using vectorized polices
 #define TEST_GCC10_EXCLUSIVE_SCAN_BROKEN (_GLIBCXX_RELEASE == 10)
-// GCC7 std::get not returning const rvalue reference from const rvalue reference of tuple
+// GCC7 std::get doesn't return const rvalue reference from const rvalue reference of tuple
 #define TEST_GCC7_RVALUE_TUPLE_GET_BROKEN (_GLIBCXX_RELEASE && _GLIBCXX_RELEASE < 8)
 // Array swap broken on Windows because Microsoft implementation of std::swap function for std::array
 // call some internal function which is not declared as SYCL external and we have compile error

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -54,7 +54,7 @@
 #define _PSTL_STD_UNINITIALIZED_FILL_BROKEN (_MSC_VER == 1900)
 // GCC10 produces wrong answer calling exclusive_scan using vectorized polices
 #define TEST_GCC10_EXCLUSIVE_SCAN_BROKEN (_GLIBCXX_RELEASE == 10)
-// GCC7 not returning const rvalue reference from const rvalue reference of tuple
+// GCC7 std::get not returning const rvalue reference from const rvalue reference of tuple
 #define TEST_GCC7_RVALUE_REFERENCE_FROM_TUPLE_BROKEN (_GLIBCXX_RELEASE && _GLIBCXX_RELEASE < 8)
 // Array swap broken on Windows because Microsoft implementation of std::swap function for std::array
 // call some internal function which is not declared as SYCL external and we have compile error

--- a/test/xpu_api/tuple/tuple.tuple/tuple.elem/tuple_get_const_rvalue.pass.cpp
+++ b/test/xpu_api/tuple/tuple.tuple/tuple.elem/tuple_get_const_rvalue.pass.cpp
@@ -51,9 +51,9 @@ kernel_test()
 int
 main()
 {
-#if !TEST_GCC7_RVALUE_TUPLE_GET_BROKEN
+#if !_PSTL_TEST_GCC7_RVALUE_TUPLE_GET_BROKEN
     kernel_test();
-#endif // !TEST_GCC7_RVALUE_TUPLE_GET_BROKEN
+#endif // !_PSTL_TEST_GCC7_RVALUE_TUPLE_GET_BROKEN
 
-    return TestUtils::done(!TEST_GCC7_RVALUE_TUPLE_GET_BROKEN);
+    return TestUtils::done(!_PSTL_TEST_GCC7_RVALUE_TUPLE_GET_BROKEN);
 }

--- a/test/xpu_api/tuple/tuple.tuple/tuple.elem/tuple_get_const_rvalue.pass.cpp
+++ b/test/xpu_api/tuple/tuple.tuple/tuple.elem/tuple_get_const_rvalue.pass.cpp
@@ -51,9 +51,9 @@ kernel_test()
 int
 main()
 {
-#if !TEST_GCC7_RVALUE_REFERENCE_FROM_TUPLE_BROKEN
+#if !TEST_GCC7_RVALUE_TUPLE_GET_BROKEN
     kernel_test();
 #endif
 
-    return TestUtils::done(!TEST_GCC7_RVALUE_REFERENCE_FROM_TUPLE_BROKEN);
+    return TestUtils::done(!TEST_GCC7_RVALUE_TUPLE_GET_BROKEN);
 }

--- a/test/xpu_api/tuple/tuple.tuple/tuple.elem/tuple_get_const_rvalue.pass.cpp
+++ b/test/xpu_api/tuple/tuple.tuple/tuple.elem/tuple_get_const_rvalue.pass.cpp
@@ -53,7 +53,7 @@ main()
 {
 #if !TEST_GCC7_RVALUE_TUPLE_GET_BROKEN
     kernel_test();
-#endif
+#endif // !TEST_GCC7_RVALUE_TUPLE_GET_BROKEN
 
     return TestUtils::done(!TEST_GCC7_RVALUE_TUPLE_GET_BROKEN);
 }

--- a/test/xpu_api/tuple/tuple.tuple/tuple.elem/tuple_get_const_rvalue.pass.cpp
+++ b/test/xpu_api/tuple/tuple.tuple/tuple.elem/tuple_get_const_rvalue.pass.cpp
@@ -51,7 +51,9 @@ kernel_test()
 int
 main()
 {
+#if !TEST_GCC7_RVALUE_REFERENCE_FROM_TUPLE_BROKEN
     kernel_test();
+#endif
 
-    return TestUtils::done();
+    return TestUtils::done(!TEST_GCC7_RVALUE_REFERENCE_FROM_TUPLE_BROKEN);
 }


### PR DESCRIPTION
In this PR we avoid GCC7 compiler error described at https://gcc.gnu.org/pipermail/gcc-help/2018-May/133865.html :
`std::get not returning const rvalue reference from const rvalue reference of tuple`