### PR TITLE
test/xpu_api/utilities/meta/meta.trans/meta.trans.other/underlying_ty…

### DIFF
--- a/test/xpu_api/utilities/meta/meta.trans/meta.trans.other/underlying_type.pass.cpp
+++ b/test/xpu_api/utilities/meta/meta.trans/meta.trans.other/underlying_type.pass.cpp
@@ -120,9 +120,12 @@ kernel_test1(sycl::queue& deviceQueue)
 void
 kernel_test2(sycl::queue& deviceQueue)
 {
+    // Until C++20 the behaviour of std::underlying_type<T> is undefined when T is not enum
+#if TEST_STD_VER >= 20
     deviceQueue.submit([&](sycl::handler& cgh) {
         cgh.single_task<class KernelTest2>([=]() { static_assert(!has_underlying_type_member<double>::value); });
     });
+#endif
 }
 
 int


### PR DESCRIPTION
In this PR we fix the compile error in underlying_type.pass.cpp test: `only enumeration types have underlying types`