### PR TITLE
test/xpu_api/tuple/tuple.tuple/tuple.creation/tuple_cat1.pass.cpp - f…

### DIFF
--- a/test/xpu_api/tuple/tuple.tuple/tuple.creation/tuple_cat1.pass.cpp
+++ b/test/xpu_api/tuple/tuple.tuple/tuple.creation/tuple_cat1.pass.cpp
@@ -85,7 +85,7 @@ kernel_test1(sycl::queue& deviceQueue)
             }
 
             {
-                constexpr dpl::array<int, 0> empty_array;
+                constexpr dpl::array<int, 0> empty_array = {};
                 constexpr dpl::tuple<> t = dpl::tuple_cat(empty_array);
             }
 


### PR DESCRIPTION
In this PR we fix compile error: `default initialization of an object of const type 'const dpl::array<int, 0>' without a user-provided default constructor`