### PR TITLE
[Doc] Fix doc generation: pin sphinxcontrib_applehelp version

### DIFF
--- a/documentation/library_guide/requirements.txt
+++ b/documentation/library_guide/requirements.txt
@@ -3,6 +3,8 @@ sphinx==3.4.0
 jinja2<3.1
 # https://github.com/sphinx-doc/sphinx/issues/9923
 docutils==0.15
+# sphinxcontrib_applehelp==1.0.8 (docutils dependency): "The sphinxcontrib.applehelp extension used by this project needs at least Sphinx v5.0"
+sphinxcontrib_applehelp<1.0.8
 sphinx_book_theme
 sphinx-intl==2.0.0
 sphinx-tabs


### PR DESCRIPTION
`sphinxcontrib_applehelp`, which `docutils` depends on, recently updated its version. This version is not compatible with `sphinx` versions older than `5`, while we use `3`. See **https://github.com/sphinx-doc/sphinxcontrib-applehelp/pull/15#issuecomment-1890824244** for more details. 