### PR TITLE
Redefine transform_reduce's scratch & result mem

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -183,9 +183,9 @@ struct __parallel_transform_reduce_device_kernel_submitter<_Tp, __work_group_siz
               oneapi::dpl::__internal::__enable_if_device_execution_policy<_ExecutionPolicy, int> = 0,
               typename... _Ranges>
     auto
-    operator()(_ExecutionPolicy&& __exec, _Size __n, _ReduceOp __reduce_op, _TransformOp __transform_op,
-               _InitType __init, __result_and_scratch_storage<_ExecutionPolicy2, _Tp> __scratch_container,
-               _Ranges&&... __rngs) const
+    operator()(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Size __n,
+               _ReduceOp __reduce_op, _TransformOp __transform_op, _InitType __init,
+               __result_and_scratch_storage<_ExecutionPolicy2, _Tp> __scratch_container, _Ranges&&... __rngs) const
     {
         auto __transform_pattern =
             unseq_backend::transform_reduce<_ExecutionPolicy, __iters_per_work_item, _ReduceOp, _TransformOp, _Tp,
@@ -228,8 +228,8 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<
               typename _ExecutionPolicy2,
               oneapi::dpl::__internal::__enable_if_device_execution_policy<_ExecutionPolicy, int> = 0>
     auto
-    operator()(_ExecutionPolicy&& __exec, sycl::event& __reduce_event, _Size __n, _ReduceOp __reduce_op,
-               _TransformOp __transform_op, _InitType __init,
+    operator()(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, sycl::event& __reduce_event,
+               _Size __n, _ReduceOp __reduce_op, _TransformOp __transform_op, _InitType __init,
                __result_and_scratch_storage<_ExecutionPolicy2, _Tp> __scratch_container) const
     {
         using _NoOpFunctor = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -223,11 +223,11 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<
     _Tp, __work_group_size, __iters_per_work_item, _Commutative, __internal::__optional_kernel_name<_KernelName...>>
 {
     template <typename _ExecutionPolicy, typename _Size, typename _ReduceOp, typename _TransformOp, typename _InitType,
-              typename _ExecutionPolicy2,
-              auto operator()(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec,
-                              sycl::event& __reduce_event, _Size __n, _ReduceOp __reduce_op,
-                              _TransformOp __transform_op, _InitType __init,
-                              __result_and_scratch_storage<_ExecutionPolicy2, _Tp> __scratch_container) const
+              typename _ExecutionPolicy2>
+    auto
+    operator()(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, sycl::event& __reduce_event,
+               _Size __n, _ReduceOp __reduce_op, _TransformOp __transform_op, _InitType __init,
+               __result_and_scratch_storage<_ExecutionPolicy2, _Tp> __scratch_container) const
     {
         using _NoOpFunctor = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;
         auto __transform_pattern =

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -179,9 +179,7 @@ struct __parallel_transform_reduce_device_kernel_submitter<_Tp, __work_group_siz
                                                            __internal::__optional_kernel_name<_KernelName...>>
 {
     template <typename _ExecutionPolicy, typename _Size, typename _ReduceOp, typename _TransformOp, typename _InitType,
-              typename _ExecutionPolicy2,
-              oneapi::dpl::__internal::__enable_if_device_execution_policy<_ExecutionPolicy, int> = 0,
-              typename... _Ranges>
+              typename _ExecutionPolicy2, typename... _Ranges>
     auto
     operator()(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Size __n,
                _ReduceOp __reduce_op, _TransformOp __transform_op, _InitType __init,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -132,15 +132,13 @@ struct __parallel_transform_reduce_small_submitter<_Tp, __work_group_size, __ite
 
         sycl::event __reduce_event = __exec.queue().submit([&, __n](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...); // get an access to data under SYCL buffer
-            auto __res_ptr = __scratch_container.__get_result_ptr();
+            auto __res_acc = __scratch_container.__get_result_acc(__cgh);
             ::std::size_t __local_mem_size = __reduce_pattern.local_mem_req(__work_group_size);
             __dpl_sycl::__local_accessor<_Tp> __temp_local(sycl::range<1>(__local_mem_size), __cgh);
             __cgh.parallel_for<_Name...>(
                 sycl::nd_range<1>(sycl::range<1>(__work_group_size), sycl::range<1>(__work_group_size)),
                 [=](sycl::nd_item<1> __item_id) {
-                    auto __res_ptr =
-                        __usm_host_or_buffer_storage<_ExecutionPolicy, _Tp>::__get_usm_host_or_buffer_accessor_ptr(
-                            __res_acc);
+                    auto __res_ptr = __res_acc.__get_pointer();
                     __work_group_reduce_kernel<_Tp>(__item_id, __n, __transform_pattern, __reduce_pattern, __init,
                                                     __temp_local, __res_ptr, __rngs...);
                 });
@@ -184,7 +182,7 @@ struct __parallel_transform_reduce_device_kernel_submitter<_Tp, __work_group_siz
               typename... _Ranges>
     auto
     operator()(_ExecutionPolicy&& __exec, _Size __n, _ReduceOp __reduce_op, _TransformOp __transform_op,
-               _InitType __init, _Tp* __temp_ptr, _Ranges&&... __rngs) const
+               _InitType __init, __usm_host_or_unified_storage<_ExecutionPolicy, _Tp> __scratch_container, _Ranges&&... __rngs) const
     {
         auto __transform_pattern =
             unseq_backend::transform_reduce<_ExecutionPolicy, __iters_per_work_item, _ReduceOp, _TransformOp, _Tp,
@@ -199,9 +197,11 @@ struct __parallel_transform_reduce_device_kernel_submitter<_Tp, __work_group_siz
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...); // get an access to data under SYCL buffer
             ::std::size_t __local_mem_size = __reduce_pattern.local_mem_req(__work_group_size);
             __dpl_sycl::__local_accessor<_Tp> __temp_local(sycl::range<1>(__local_mem_size), __cgh);
+            auto __temp_acc = __scratch_container.__get_scratch_acc(__cgh);
             __cgh.parallel_for<_KernelName...>(
                 sycl::nd_range<1>(sycl::range<1>(__n_groups * __work_group_size), sycl::range<1>(__work_group_size)),
                 [=](sycl::nd_item<1> __item_id) {
+                    auto __temp_ptr = __temp_acc.__get_pointer();
                     __device_reduce_kernel<_Tp>(__item_id, __n, __transform_pattern, __reduce_pattern, __temp_local,
                                                 __temp_ptr, __rngs...);
                 });
@@ -233,9 +233,6 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<
                                             _Commutative>{__reduce_op, _NoOpFunctor{}};
         auto __reduce_pattern = unseq_backend::reduce_over_group<_ExecutionPolicy, _ReduceOp, _Tp>{__reduce_op};
 
-        _Tp* __temp_ptr = __scratch_container.__get_scratch_ptr();
-        _Tp* __res_ptr = __scratch_container.__get_result_ptr();
-
         // Lower the work group size of the second kernel to the next power of 2 if __n < __work_group_size.
         auto __work_group_size2 = __work_group_size;
         if constexpr (__iters_per_work_item == 1)
@@ -251,15 +248,16 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<
         __reduce_event = __exec.queue().submit([&, __n](sycl::handler& __cgh) {
             __cgh.depends_on(__reduce_event);
 
+            auto __temp_acc = __scratch_container.__get_scratch_acc(__cgh);
+            auto __res_acc = __scratch_container.__get_result_acc(__cgh);
             ::std::size_t __local_mem_size = __reduce_pattern.local_mem_req(__work_group_size2);
             __dpl_sycl::__local_accessor<_Tp> __temp_local(sycl::range<1>(__local_mem_size), __cgh);
 
             __cgh.parallel_for<_KernelName...>(
                 sycl::nd_range<1>(sycl::range<1>(__work_group_size2), sycl::range<1>(__work_group_size2)),
                 [=](sycl::nd_item<1> __item_id) {
-                    auto __res_ptr =
-                        __usm_host_or_buffer_storage<_ExecutionPolicy, _Tp>::__get_usm_host_or_buffer_accessor_ptr(
-                            __res_acc);
+                    auto __temp_ptr = __temp_acc.__get_pointer();
+                    auto __res_ptr = __res_acc.__get_pointer();
                     __work_group_reduce_kernel<_Tp>(__item_id, __n, __transform_pattern, __reduce_pattern, __init,
                                                     __temp_local, __res_ptr, __temp_ptr);
                 });
@@ -295,7 +293,7 @@ __parallel_transform_reduce_mid_impl(oneapi::dpl::__internal::__device_backend_t
     sycl::event __reduce_event =
         __parallel_transform_reduce_device_kernel_submitter<_Tp, __work_group_size, __iters_per_work_item_device_kernel,
                                                             _Commutative, _ReduceDeviceKernel>()(
-            __backend_tag, __exec, __n, __reduce_op, __transform_op, __init, __scratch_container.__get_scratch_ptr(),
+            __backend_tag, __exec, __n, __reduce_op, __transform_op, __init, __scratch_container,
             ::std::forward<_Ranges>(__rngs)...);
 
     __n = __n_groups; // Number of preliminary results from the device kernel.
@@ -341,8 +339,6 @@ struct __parallel_transform_reduce_impl
 
         // Create temporary global buffers to store temporary values
         __usm_host_or_unified_storage<_ExecutionPolicy, _Tp> __scratch_container(__exec, 2 * __n_groups);
-        _Tp* __temp_ptr = __scratch_container.__get_scratch_ptr();
-        _Tp* __res_ptr = __scratch_container.__get_result_ptr();
 
         // __is_first == true. Reduce over each work_group
         // __is_first == false. Reduce between work groups
@@ -359,6 +355,8 @@ struct __parallel_transform_reduce_impl
             __reduce_event = __exec.queue().submit([&, __is_first, __offset_1, __offset_2, __n,
                                                     __n_groups](sycl::handler& __cgh) {
                 __cgh.depends_on(__reduce_event);
+                auto __temp_acc = __scratch_container.__get_scratch_acc(__cgh);
+                auto __res_acc = __scratch_container.__get_result_acc(__cgh);
 
                 // get an access to data under SYCL buffer
                 oneapi::dpl::__ranges::__require_access(__cgh, __rngs...);
@@ -374,9 +372,8 @@ struct __parallel_transform_reduce_impl
                     sycl::nd_range<1>(sycl::range<1>(__n_groups * __work_group_size),
                                       sycl::range<1>(__work_group_size)),
                     [=](sycl::nd_item<1> __item_id) {
-                        auto __res_ptr =
-                            __usm_host_or_buffer_storage<_ExecutionPolicy, _Tp>::__get_usm_host_or_buffer_accessor_ptr(
-                                __res_acc);
+                        auto __temp_ptr = __temp_acc.__get_pointer();
+                        auto __res_ptr = __res_acc.__get_pointer();
                         auto __local_idx = __item_id.get_local_id(0);
                         auto __group_idx = __item_id.get_group(0);
                         // 1. Initialization (transform part). Fill local memory

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -224,11 +224,10 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<
 {
     template <typename _ExecutionPolicy, typename _Size, typename _ReduceOp, typename _TransformOp, typename _InitType,
               typename _ExecutionPolicy2,
-              oneapi::dpl::__internal::__enable_if_device_execution_policy<_ExecutionPolicy, int> = 0>
-    auto
-    operator()(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, sycl::event& __reduce_event,
-               _Size __n, _ReduceOp __reduce_op, _TransformOp __transform_op, _InitType __init,
-               __result_and_scratch_storage<_ExecutionPolicy2, _Tp> __scratch_container) const
+              auto operator()(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec,
+                              sycl::event& __reduce_event, _Size __n, _ReduceOp __reduce_op,
+                              _TransformOp __transform_op, _InitType __init,
+                              __result_and_scratch_storage<_ExecutionPolicy2, _Tp> __scratch_container) const
     {
         using _NoOpFunctor = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;
         auto __transform_pattern =

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -564,17 +564,17 @@ struct __result_and_scratch_storage
         if (__use_USM_host && __supports_USM_device)
         {
             // Separate scratch (device) and result (host) allocations on performant backends (i.e. L0)
-            __scratch_buf = std::shared_ptr<_T>(
+            __scratch_buf = ::std::shared_ptr<_T>(
                 __internal::__sycl_usm_alloc<_ExecutionPolicy, _T, sycl::usm::alloc::device>{__exec}(__scratch_n),
                 __internal::__sycl_usm_free<_ExecutionPolicy, _T>{__exec});
-            __result_buf = std::shared_ptr<_T>(
+            __result_buf = ::std::shared_ptr<_T>(
                 __internal::__sycl_usm_alloc<_ExecutionPolicy, _T, sycl::usm::alloc::host>{__exec}(1),
                 __internal::__sycl_usm_free<_ExecutionPolicy, _T>{__exec});
         }
         else if (__supports_USM_device)
         {
             // If we don't use host memory, malloc only a single unified device allocation
-            __scratch_buf = std::shared_ptr<_T>(
+            __scratch_buf = ::std::shared_ptr<_T>(
                 __internal::__sycl_usm_alloc<_ExecutionPolicy, _T, sycl::usm::alloc::device>{__exec}(__scratch_n + 1),
                 __internal::__sycl_usm_free<_ExecutionPolicy, _T>{__exec});
         }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -528,7 +528,6 @@ struct __result_and_scratch_storage
     inline bool
     __use_USM_host_allocations(sycl::queue __queue)
     {
-// USM device memory is used by default. Supporting compilers use the unified future on top of USM host or device memory.
 #if _ONEDPL_SYCL_UNIFIED_USM_BUFFER_PRESENT
         auto __device = __queue.get_device();
         if (!__device.is_gpu())

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -585,7 +585,6 @@ struct __result_and_scratch_storage
         }
     }
 
-<<<<<<< HEAD
     template <typename _Acc>
     static auto
     __get_usm_host_or_buffer_accessor_ptr(const _Acc& __acc)
@@ -597,15 +596,6 @@ struct __result_and_scratch_storage
 #endif
     }
 
-    auto
-    __get_acc(sycl::handler& __cgh)
-    {
-#if _ONEDPL_SYCL_UNIFIED_USM_BUFFER_PRESENT
-        return __usm ? __usm_host_or_buffer_accessor<_T>(__cgh, __usm_buf.get())
-                     : __usm_host_or_buffer_accessor<_T>(__cgh, __sycl_buf.get());
-#else
-        return sycl::accessor(*__sycl_buf.get(), __cgh, sycl::read_write, __dpl_sycl::__no_init{});
-#endif
     auto
     __get_result_acc(sycl::handler& __cgh)
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -544,10 +544,7 @@ struct __result_and_scratch_storage
     __use_USM_allocations(sycl::queue __queue)
     {
 #if _ONEDPL_SYCL_USM_HOST_PRESENT
-        auto __device = __queue.get_device();
-        if (!__device.has(sycl::aspect::usm_device_allocations))
-            return false;
-        return true;
+        return __queue.get_device().has(sycl::aspect::usm_device_allocations);
 #else
         return false;
 #endif

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -641,7 +641,8 @@ struct __result_and_scratch_storage
             __exec.queue().memcpy(&__tmp, __scratch_buf.get() + __scratch_n + idx, 1 * sizeof(_T)).wait();
             return __tmp;
         }
-        else {
+        else
+        {
             return __sycl_buf->get_host_access(sycl::read_only)[__scratch_n];
         }
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -480,23 +480,21 @@ struct __usm_or_buffer_accessor
     __accessor_t __acc;
     _T* __ptr = nullptr;
     bool __usm = false;
-    size_t __offset;
+    size_t __offset = 0;
 
   public:
     // Buffer accessor
     __usm_or_buffer_accessor(sycl::handler& __cgh, sycl::buffer<_T, 1>* __sycl_buf)
-        : __acc(sycl::accessor(*__sycl_buf, __cgh, sycl::read_write, __dpl_sycl::__no_init{})), __usm(false),
-          __offset(0)
+        : __acc(sycl::accessor(*__sycl_buf, __cgh, sycl::read_write, __dpl_sycl::__no_init{}))
     {
     }
     __usm_or_buffer_accessor(sycl::handler& __cgh, sycl::buffer<_T, 1>* __sycl_buf, size_t __acc_offset)
-        : __acc(sycl::accessor(*__sycl_buf, __cgh, sycl::read_write, __dpl_sycl::__no_init{})), __usm(false),
-          __offset(__acc_offset)
+        : __acc(sycl::accessor(*__sycl_buf, __cgh, sycl::read_write, __dpl_sycl::__no_init{})), __offset(__acc_offset)
     {
     }
 
     // USM pointer
-    __usm_or_buffer_accessor(sycl::handler& __cgh, _T* __usm_buf) : __ptr(__usm_buf), __usm(true), __offset(0) {}
+    __usm_or_buffer_accessor(sycl::handler& __cgh, _T* __usm_buf) : __ptr(__usm_buf), __usm(true) {}
     __usm_or_buffer_accessor(sycl::handler& __cgh, _T* __usm_buf, size_t __ptr_offset)
         : __ptr(__usm_buf), __usm(true), __offset(__ptr_offset)
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -599,7 +599,7 @@ struct __result_and_scratch_storage
     auto
     __get_result_acc(sycl::handler& __cgh)
     {
-        if (__use_USM_host)
+        if (__use_USM_host && __supports_USM_device)
             return __usm_or_buffer_accessor<_T>(__cgh, __result_buf.get());
         else if (__supports_USM_device)
             return __usm_or_buffer_accessor<_T>(__cgh, __scratch_buf.get(), __scratch_n);
@@ -625,7 +625,7 @@ struct __result_and_scratch_storage
     _T
     __get_value(size_t idx = 0) const
     {
-        if (__use_USM_host)
+        if (__use_USM_host && __supports_USM_device)
         {
             return *(__result_buf.get() + idx);
         }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -546,10 +546,14 @@ struct __result_and_scratch_storage
     inline bool
     __use_USM_allocations(sycl::queue __queue)
     {
+#if _ONEDPL_SYCL_USM_HOST_PRESENT
         auto __device = __queue.get_device();
         if (!__device.has(sycl::aspect::usm_device_allocations))
             return false;
         return true;
+#else
+        return false;
+#endif
     }
 
   public:

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -643,7 +643,6 @@ struct __result_and_scratch_storage
 };
 
 //A contract for future class: <sycl::event or other event, a value, sycl::buffers..., or __usm_host_or_buffer_storage>
-
 //Impl details: inheritance (private) instead of aggregation for enabling the empty base optimization.
 template <typename _Event, typename... _Args>
 class __future : private std::tuple<_Args...>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -471,47 +471,21 @@ using __repacked_tuple_t = typename __repacked_tuple<T>::type;
 template <typename _ContainerOrIterable>
 using __value_t = typename __internal::__memobj_traits<_ContainerOrIterable>::value_type;
 
-template <typename _T>
-struct __usm_host_or_buffer_accessor
-{
-  private:
-    using __accessor_t = sycl::accessor<_T, 1, sycl::access::mode::read_write, __dpl_sycl::__target_device,
-                                        sycl::access::placeholder::false_t>;
-    __accessor_t __acc;
-    _T* __ptr = nullptr;
-    bool __usm = false;
-
-  public:
-    // Buffer accessor
-    __usm_host_or_buffer_accessor(sycl::handler& __cgh, sycl::buffer<_T, 1>* __sycl_buf)
-        : __acc(sycl::accessor(*__sycl_buf, __cgh, sycl::read_write, __dpl_sycl::__no_init{})), __usm(false)
-    {
-    }
-
-    // USM pointer
-    __usm_host_or_buffer_accessor(sycl::handler& __cgh, _T* __usm_buf) : __ptr(__usm_buf), __usm(true) {}
-
-    auto
-    __get_pointer() const // should be cached within a kernel
-    {
-        return __usm ? __ptr : &__acc[0];
-    }
-};
-
 template <typename _ExecutionPolicy, typename _T>
-struct __usm_host_or_buffer_storage
+struct __usm_host_or_unified_storage
 {
   private:
-    using __sycl_buffer_t = sycl::buffer<_T, 1>;
-    ::std::shared_ptr<__sycl_buffer_t> __sycl_buf;
-    ::std::shared_ptr<_T> __usm_buf;
-    bool __usm;
+    _ExecutionPolicy __exec;
+    ::std::shared_ptr<_T> __scratch_buf;
+    ::std::shared_ptr<_T> __result_buf;
+    ::std::size_t __scratch_n;
+    bool __host;
 
-    // Only use USM host allocations on L0 GPUs. Other devices show significant slowdowns and will use a buffer instead.
+    // Only use USM host allocations on L0 GPUs. Other devices show significant slowdowns and will use a device allocation instead.
     inline bool
     __use_USM_host_allocations(sycl::queue __queue)
     {
-// A buffer is used by default. Supporting compilers use the unified future on top of USM host memory or a buffer.
+// USM device memory is used by default. Supporting compilers use the unified future on top of USM host or device memory.
 #if _ONEDPL_SYCL_UNIFIED_USM_BUFFER_PRESENT
         auto __device = __queue.get_device();
         if (!__device.is_gpu())
@@ -527,18 +501,25 @@ struct __usm_host_or_buffer_storage
     }
 
   public:
-    __usm_host_or_buffer_storage(_ExecutionPolicy& __exec, ::std::size_t __n)
+    __usm_host_or_unified_storage(_ExecutionPolicy& __exec, ::std::size_t __scratch_n)
+        : __exec{__exec}, __scratch_n{__scratch_n}, __host{__use_USM_host_allocations(__exec.queue())}
     {
-        __usm = __use_USM_host_allocations(__exec.queue());
-        if (__usm)
+        if (__host)
         {
-            __usm_buf = std::shared_ptr<_T>(
-                __internal::__sycl_usm_alloc<_ExecutionPolicy, _T, sycl::usm::alloc::host>{__exec}(__n),
+            // Separate scratch (device) and result (host) allocations on performant backends (i.e. L0)
+            __scratch_buf = std::shared_ptr<_T>(
+                __internal::__sycl_usm_alloc<_ExecutionPolicy, _T, sycl::usm::alloc::device>{__exec}(__scratch_n),
+                __internal::__sycl_usm_free<_ExecutionPolicy, _T>{__exec});
+            __result_buf = std::shared_ptr<_T>(
+                __internal::__sycl_usm_alloc<_ExecutionPolicy, _T, sycl::usm::alloc::host>{__exec}(1),
                 __internal::__sycl_usm_free<_ExecutionPolicy, _T>{__exec});
         }
         else
         {
-            __sycl_buf = ::std::make_shared<__sycl_buffer_t>(__sycl_buffer_t(__n));
+            // If we don't use host memory, malloc only a single unified device allocation
+            __scratch_buf = std::shared_ptr<_T>(
+                __internal::__sycl_usm_alloc<_ExecutionPolicy, _T, sycl::usm::alloc::device>{__exec}(__scratch_n + 1),
+                __internal::__sycl_usm_free<_ExecutionPolicy, _T>{__exec});
         }
     }
 
@@ -562,18 +543,34 @@ struct __usm_host_or_buffer_storage
 #else
         return sycl::accessor(*__sycl_buf.get(), __cgh, sycl::read_write, __dpl_sycl::__no_init{});
 #endif
+    _T*
+    __get_scratch_ptr()
+    {
+        assert(__scratch_n > 0);
+        return __scratch_buf.get();
     }
 
+    _T*
+    __get_result_ptr()
+    {
+        return __host ? __result_buf.get() : __scratch_buf.get() + __scratch_n;
+    }
+
+    // Note: this member function assumes the result is *ready*, since the __future has already
+    // waited on the relevant event.
     _T
     __get_value(size_t idx = 0) const
     {
-        return __usm ? *(__usm_buf.get() + idx) : __sycl_buf->get_host_access(sycl::read_only)[idx];
-    }
-
-    bool
-    __get_usm() const
-    {
-        return __usm;
+        if (__host)
+        {
+            return *(__result_buf.get() + idx);
+        }
+        else
+        {
+            _T __tmp;
+            __exec.queue().memcpy(&__tmp, __scratch_buf.get() + __scratch_n + idx, 1 * sizeof(_T)).wait();
+            return __tmp;
+        }
     }
 };
 
@@ -594,11 +591,9 @@ class __future : private std::tuple<_Args...>
 
     template <typename _ExecutionPolicy, typename _T>
     constexpr auto
-    __wait_and_get_value(__usm_host_or_buffer_storage<_ExecutionPolicy, _T>& __buf)
+    __wait_and_get_value(__usm_host_or_unified_storage<_ExecutionPolicy, _T>& __buf)
     {
-        // Explicit wait in case of USM memory. Buffer accessors are synchronous.
-        if (__buf.__get_usm())
-            wait();
+        wait();
         return __buf.__get_value();
     }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -620,6 +620,12 @@ struct __result_and_scratch_storage
         return __usm_or_buffer_accessor<_T>(__cgh, __sycl_buf.get());
     }
 
+    bool
+    is_USM() const
+    {
+        return __supports_USM_device;
+    }
+
     // Note: this member function assumes the result is *ready*, since the __future has already
     // waited on the relevant event.
     _T
@@ -659,10 +665,11 @@ class __future : private std::tuple<_Args...>
 
     template <typename _ExecutionPolicy, typename _T>
     constexpr auto
-    __wait_and_get_value(__result_and_scratch_storage<_ExecutionPolicy, _T>& __buf)
+    __wait_and_get_value(__result_and_scratch_storage<_ExecutionPolicy, _T>& __storage)
     {
-        wait();
-        return __buf.__get_value();
+        if (__storage.is_USM())
+            wait();
+        return __storage.__get_value();
     }
 
     template <typename _T>


### PR DESCRIPTION
## Rationale

Algorithms using `transform_reduce` (`std::reduce`, `std::max_element`, etc) return a single value result. They also, except for the smallest cases, require intermediate scratch memory on the device to hold partial results.

For L0 backend, it's faster to have a 1-element USM host allocation and to write the final reduction result directly to that.

For Nvidia, host USM is expensive, and it's faster instead to have a single USM device allocation for both the **result** and the **intermediate scratch**.

## Approach

This PR combines the two approaches into a struct `__usm_host_or_unified_storage`, based on the previous `__usm_host_or_buffer_storage`. When host USM is supported and the backend is L0, this struct holds two memory allocations (device USM for intermediate scratch, and host USM for final result). In all other cases, this struct holds a single device USM allocation, large enough for both intermediate scratch and final result. In this latter case, a `memcpy` from device to host is needed to return the final result.