### PR TITLE
GCC7 std::get not returning const rvalue reference from const rvalue reference of tuple - additional fix

### DIFF
--- a/test/xpu_api/tuple/tuple.tuple/tuple.elem/tuple_get_const_rvalue.pass.cpp
+++ b/test/xpu_api/tuple/tuple.tuple/tuple.elem/tuple_get_const_rvalue.pass.cpp
@@ -24,6 +24,7 @@
 
 class KernelGetConstRvTest;
 
+#if !_PSTL_TEST_GCC7_RVALUE_TUPLE_GET_BROKEN
 void
 kernel_test()
 {
@@ -47,6 +48,7 @@ kernel_test()
     auto ret_access_host = buffer1.get_host_access(sycl::read_only);
     EXPECT_TRUE(ret_access_host[0], "Wrong result of dpl::get(dpl::tuple&&) check");
 }
+#endif // !_PSTL_TEST_GCC7_RVALUE_TUPLE_GET_BROKEN
 
 int
 main()


### PR DESCRIPTION
Additional fix for https://github.com/oneapi-src/oneDPL/pull/1333