### PR TITLE
Pass value and remove barrier between transform_reduce and reduce_over_group

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -363,7 +363,11 @@ struct __parallel_transform_reduce_impl
                         // 1. Initialization (transform part). Fill local memory
                         _Size __n_items;
 
-                        union __storage {_Tp __v; __storage(){} } __result;
+                        union __storage
+                        {
+                            _Tp __v;
+                            __storage() {}
+                        } __result;
                         if (__is_first)
                         {
                             __result.__v = __transform_pattern1(__item_id, __n, /*global_offset*/ (_Size)0, __rngs...);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -366,12 +366,12 @@ struct __parallel_transform_reduce_impl
                         _Tp __result = *std::launder(reinterpret_cast<_Tp*>(alloca(sizeof(_Tp))));
                         if (__is_first)
                         {
-                            __result = __transform_pattern1(__item_id, __n, /*global_offset*/ (_Size)0,  __rngs...);
+                            __result = __transform_pattern1(__item_id, __n, /*global_offset*/ (_Size)0, __rngs...);
                             __n_items = __transform_pattern1.output_size(__n, __work_group_size);
                         }
                         else
                         {
-                            __result = __transform_pattern2(__item_id, __n, __offset_2,  __temp_acc);
+                            __result = __transform_pattern2(__item_id, __n, __offset_2, __temp_acc);
                             __n_items = __transform_pattern2.output_size(__n, __work_group_size);
                         }
                         // 2. Reduce within work group using local memory

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -56,11 +56,10 @@ __work_group_reduce_kernel(const _NDItemId __item_id, const _Size __n, _Transfor
     auto __local_idx = __item_id.get_local_id(0);
     auto __group_size = __item_id.get_local_range().size();
     // 1. Initialization (transform part). Fill local memory
-    __transform_pattern(__item_id, __n, /*global_offset*/ (_Size)0, __local_mem, __acc...);
-    __dpl_sycl::__group_barrier(__item_id);
+    _Tp __result = __transform_pattern(__item_id, __n, /*global_offset*/ (_Size)0, __acc...);
     const _Size __n_items = __transform_pattern.output_size(__n, __group_size);
     // 2. Reduce within work group using local memory
-    _Tp __result = __reduce_pattern(__item_id, __n_items, __local_mem);
+    __result = __reduce_pattern(__item_id, __n_items, __result, __local_mem);
     if (__local_idx == 0)
     {
         __reduce_pattern.apply_init(__init, __result);
@@ -80,11 +79,10 @@ __device_reduce_kernel(const _NDItemId __item_id, const _Size __n, _TransformPat
     auto __group_idx = __item_id.get_group(0);
     auto __group_size = __item_id.get_local_range().size();
     // 1. Initialization (transform part). Fill local memory
-    __transform_pattern(__item_id, __n, /*global_offset*/ (_Size)0, __local_mem, __acc...);
-    __dpl_sycl::__group_barrier(__item_id);
+    _Tp __result = __transform_pattern(__item_id, __n, /*global_offset*/ (_Size)0, __acc...);
     const _Size __n_items = __transform_pattern.output_size(__n, __group_size);
     // 2. Reduce within work group using local memory
-    _Tp __result = __reduce_pattern(__item_id, __n_items, __local_mem);
+    __result = __reduce_pattern(__item_id, __n_items, __result, __local_mem);
     if (__local_idx == 0)
         __temp_acc[__group_idx] = __result;
 }
@@ -113,7 +111,7 @@ struct __parallel_transform_reduce_small_submitter<_Tp, __work_group_size, __ite
                _InitType __init, _Ranges&&... __rngs) const
     {
         auto __transform_pattern =
-            unseq_backend::transform_reduce<_ExecutionPolicy, __iters_per_work_item, _ReduceOp, _TransformOp,
+            unseq_backend::transform_reduce<_ExecutionPolicy, __iters_per_work_item, _ReduceOp, _TransformOp, _Tp,
                                             _Commutative>{__reduce_op, __transform_op};
         auto __reduce_pattern = unseq_backend::reduce_over_group<_ExecutionPolicy, _ReduceOp, _Tp>{__reduce_op};
 
@@ -122,7 +120,8 @@ struct __parallel_transform_reduce_small_submitter<_Tp, __work_group_size, __ite
         sycl::event __reduce_event = __exec.queue().submit([&, __n](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...); // get an access to data under SYCL buffer
             auto __res_acc = __res_container.__get_acc(__cgh);
-            __dpl_sycl::__local_accessor<_Tp> __temp_local(sycl::range<1>(__work_group_size), __cgh);
+            ::std::size_t __local_mem_size = __reduce_pattern.local_mem_req(__work_group_size);
+            __dpl_sycl::__local_accessor<_Tp> __temp_local(sycl::range<1>(__local_mem_size), __cgh);
             __cgh.parallel_for<_Name...>(
                 sycl::nd_range<1>(sycl::range<1>(__work_group_size), sycl::range<1>(__work_group_size)),
                 [=](sycl::nd_item<1> __item_id) {
@@ -173,7 +172,7 @@ struct __parallel_transform_reduce_device_kernel_submitter<_Tp, __work_group_siz
                _InitType __init, sycl::buffer<_Tp>& __temp, _Ranges&&... __rngs) const
     {
         auto __transform_pattern =
-            unseq_backend::transform_reduce<_ExecutionPolicy, __iters_per_work_item, _ReduceOp, _TransformOp,
+            unseq_backend::transform_reduce<_ExecutionPolicy, __iters_per_work_item, _ReduceOp, _TransformOp, _Tp,
                                             _Commutative>{__reduce_op, __transform_op};
         auto __reduce_pattern = unseq_backend::reduce_over_group<_ExecutionPolicy, _ReduceOp, _Tp>{__reduce_op};
 
@@ -184,7 +183,8 @@ struct __parallel_transform_reduce_device_kernel_submitter<_Tp, __work_group_siz
         return __exec.queue().submit([&, __n](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...); // get an access to data under SYCL buffer
             sycl::accessor __temp_acc{__temp, __cgh, sycl::write_only, __dpl_sycl::__no_init{}};
-            __dpl_sycl::__local_accessor<_Tp> __temp_local(sycl::range<1>(__work_group_size), __cgh);
+            ::std::size_t __local_mem_size = __reduce_pattern.local_mem_req(__work_group_size);
+            __dpl_sycl::__local_accessor<_Tp> __temp_local(sycl::range<1>(__local_mem_size), __cgh);
             __cgh.parallel_for<_KernelName...>(
                 sycl::nd_range<1>(sycl::range<1>(__n_groups * __work_group_size), sycl::range<1>(__work_group_size)),
                 [=](sycl::nd_item<1> __item_id) {
@@ -215,7 +215,7 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<
     {
         using _NoOpFunctor = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;
         auto __transform_pattern =
-            unseq_backend::transform_reduce<_ExecutionPolicy, __iters_per_work_item, _ReduceOp, _NoOpFunctor,
+            unseq_backend::transform_reduce<_ExecutionPolicy, __iters_per_work_item, _ReduceOp, _NoOpFunctor, _Tp,
                                             _Commutative>{__reduce_op, _NoOpFunctor{}};
         auto __reduce_pattern = unseq_backend::reduce_over_group<_ExecutionPolicy, _ReduceOp, _Tp>{__reduce_op};
 
@@ -238,7 +238,8 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<
 
             sycl::accessor __temp_acc{__temp, __cgh, sycl::read_only};
             auto __res_acc = __res_container.__get_acc(__cgh);
-            __dpl_sycl::__local_accessor<_Tp> __temp_local(sycl::range<1>(__work_group_size2), __cgh);
+            ::std::size_t __local_mem_size = __reduce_pattern.local_mem_req(__work_group_size2);
+            __dpl_sycl::__local_accessor<_Tp> __temp_local(sycl::range<1>(__local_mem_size), __cgh);
 
             __cgh.parallel_for<_KernelName...>(
                 sycl::nd_range<1>(sycl::range<1>(__work_group_size2), sycl::range<1>(__work_group_size2)),
@@ -304,10 +305,10 @@ struct __parallel_transform_reduce_impl
             __reduce_kernel, _CustomName, _ReduceOp, _TransformOp, _NoOpFunctor, _Ranges...>;
 
         auto __transform_pattern1 =
-            unseq_backend::transform_reduce<_ExecutionPolicy, __iters_per_work_item, _ReduceOp, _TransformOp,
+            unseq_backend::transform_reduce<_ExecutionPolicy, __iters_per_work_item, _ReduceOp, _TransformOp, _Tp,
                                             _Commutative>{__reduce_op, __transform_op};
         auto __transform_pattern2 =
-            unseq_backend::transform_reduce<_ExecutionPolicy, __iters_per_work_item, _ReduceOp, _NoOpFunctor,
+            unseq_backend::transform_reduce<_ExecutionPolicy, __iters_per_work_item, _ReduceOp, _NoOpFunctor, _Tp,
                                             _Commutative>{__reduce_op, _NoOpFunctor{}};
         auto __reduce_pattern = unseq_backend::reduce_over_group<_ExecutionPolicy, _ReduceOp, _Tp>{__reduce_op};
 
@@ -344,7 +345,8 @@ struct __parallel_transform_reduce_impl
                 oneapi::dpl::__ranges::__require_access(__cgh, __rngs...);
                 sycl::accessor __temp_acc{__temp, __cgh, sycl::read_write};
                 auto __res_acc = __res_container.__get_acc(__cgh);
-                __dpl_sycl::__local_accessor<_Tp> __temp_local(sycl::range<1>(__work_group_size), __cgh);
+                ::std::size_t __local_mem_size = __reduce_pattern.local_mem_req(__work_group_size);
+                __dpl_sycl::__local_accessor<_Tp> __temp_local(sycl::range<1>(__local_mem_size), __cgh);
 #if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
                 __cgh.use_kernel_bundle(__kernel.get_kernel_bundle());
 #endif
@@ -360,19 +362,20 @@ struct __parallel_transform_reduce_impl
                         auto __group_idx = __item_id.get_group(0);
                         // 1. Initialization (transform part). Fill local memory
                         _Size __n_items;
+
+                        _Tp __result = *std::launder(reinterpret_cast<_Tp*>(alloca(sizeof(_Tp))));
                         if (__is_first)
                         {
-                            __transform_pattern1(__item_id, __n, /*global_offset*/ (_Size)0, __temp_local, __rngs...);
+                            __result = __transform_pattern1(__item_id, __n, /*global_offset*/ (_Size)0,  __rngs...);
                             __n_items = __transform_pattern1.output_size(__n, __work_group_size);
                         }
                         else
                         {
-                            __transform_pattern2(__item_id, __n, __offset_2, __temp_local, __temp_acc);
+                            __result = __transform_pattern2(__item_id, __n, __offset_2,  __temp_acc);
                             __n_items = __transform_pattern2.output_size(__n, __work_group_size);
                         }
-                        __dpl_sycl::__group_barrier(__item_id);
                         // 2. Reduce within work group using local memory
-                        _Tp __result = __reduce_pattern(__item_id, __n_items, __temp_local);
+                        __result = __reduce_pattern(__item_id, __n_items, __result, __temp_local);
                         if (__local_idx == 0)
                         {
                             // final reduction

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -363,7 +363,7 @@ struct __parallel_transform_reduce_impl
                         // 1. Initialization (transform part). Fill local memory
                         _Size __n_items;
 
-                        _Tp __result = *std::launder(reinterpret_cast<_Tp*>(alloca(sizeof(_Tp))));
+                        _Tp __result = *::std::launder(reinterpret_cast<_Tp*>(alloca(sizeof(_Tp))));
                         if (__is_first)
                         {
                             __result = __transform_pattern1(__item_id, __n, /*global_offset*/ (_Size)0, __rngs...);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -236,7 +236,7 @@ struct transform_reduce
                 __res = __binary_op(__res, __unary_op(__adjusted_global_id + __i, __acc...));
             return __res;
         }
-        return *std::launder(reinterpret_cast<_Tp*>(alloca(sizeof(_Tp))));
+        return *::std::launder(reinterpret_cast<_Tp*>(alloca(sizeof(_Tp))));
     }
 
     template <typename _NDItemId, typename _Size, typename... _Acc>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -203,16 +203,15 @@ struct __init_processing
 // Load elements consecutively from global memory, transform them, and apply a local reduction. Each local result is
 // stored in local memory.
 template <typename _ExecutionPolicy, ::std::uint8_t __iters_per_work_item, typename _Operation1, typename _Operation2,
-          typename _Commutative>
+          typename _Tp, typename _Commutative>
 struct transform_reduce
 {
     _Operation1 __binary_op;
     _Operation2 __unary_op;
 
-    template <typename _NDItemId, typename _Size, typename _AccLocal, typename... _Acc>
-    void
-    seq_impl(const _NDItemId __item_id, const _Size __n, const _Size __global_offset, const _AccLocal& __local_mem,
-             const _Acc&... __acc) const
+    template <typename _NDItemId, typename _Size, typename... _Acc>
+    _Tp
+    seq_impl(const _NDItemId __item_id, const _Size __n, const _Size __global_offset, const _Acc&... __acc) const
     {
         auto __global_idx = __item_id.get_global_id(0);
         auto __local_idx = __item_id.get_local_id(0);
@@ -222,27 +221,27 @@ struct transform_reduce
         if (__adjusted_global_id + __iters_per_work_item < __adjusted_n)
         {
             // Keep these statements in the same scope to allow for better memory alignment
-            typename _AccLocal::value_type __res = __unary_op(__adjusted_global_id, __acc...);
+            _Tp __res = __unary_op(__adjusted_global_id, __acc...);
             _ONEDPL_PRAGMA_UNROLL
             for (_Size __i = 1; __i < __iters_per_work_item; ++__i)
                 __res = __binary_op(__res, __unary_op(__adjusted_global_id + __i, __acc...));
-            __local_mem[__local_idx] = __res;
+            return __res;
         }
         else if (__adjusted_global_id < __adjusted_n)
         {
             const _Size __items_to_process = __adjusted_n - __adjusted_global_id;
             // Keep these statements in the same scope to allow for better memory alignment
-            typename _AccLocal::value_type __res = __unary_op(__adjusted_global_id, __acc...);
+            _Tp __res = __unary_op(__adjusted_global_id, __acc...);
             for (_Size __i = 1; __i < __items_to_process; ++__i)
                 __res = __binary_op(__res, __unary_op(__adjusted_global_id + __i, __acc...));
-            __local_mem[__local_idx] = __res;
+            return __res;
         }
+        return *std::launder(reinterpret_cast<_Tp*>(alloca(sizeof(_Tp))));
     }
 
-    template <typename _NDItemId, typename _Size, typename _AccLocal, typename... _Acc>
-    void
-    nonseq_impl(const _NDItemId __item_id, const _Size __n, const _Size __global_offset, const _AccLocal& __local_mem,
-                const _Acc&... __acc) const
+    template <typename _NDItemId, typename _Size, typename... _Acc>
+    _Tp
+    nonseq_impl(const _NDItemId __item_id, const _Size __n, const _Size __global_offset, const _Acc&... __acc) const
     {
         auto __local_idx = __item_id.get_local_id(0);
         const _Size __stride = __item_id.get_local_range(0);
@@ -254,31 +253,31 @@ struct transform_reduce
         // Coalesced load and reduce from global memory
         if (__adjusted_global_id + __stride * __iters_per_work_item < __adjusted_n)
         {
-            typename _AccLocal::value_type __res = __unary_op(__adjusted_global_id, __acc...);
+            _Tp __res = __unary_op(__adjusted_global_id, __acc...);
             _ONEDPL_PRAGMA_UNROLL
             for (_Size __i = 1; __i < __iters_per_work_item; ++__i)
                 __res = __binary_op(__res, __unary_op(__adjusted_global_id + __stride * __i, __acc...));
-            __local_mem[__local_idx] = __res;
+            return __res;
         }
         else if (__adjusted_global_id < __adjusted_n)
         {
             const _Size __items_to_process =
                 std::max(((__adjusted_n - __adjusted_global_id - 1) / __stride) + 1, static_cast<_Size>(0));
-            typename _AccLocal::value_type __res = __unary_op(__adjusted_global_id, __acc...);
+            _Tp __res = __unary_op(__adjusted_global_id, __acc...);
             for (_Size __i = 1; __i < __items_to_process; ++__i)
                 __res = __binary_op(__res, __unary_op(__adjusted_global_id + __stride * __i, __acc...));
-            __local_mem[__local_idx] = __res;
+            return __res;
         }
+        return *std::launder(reinterpret_cast<_Tp*>(alloca(sizeof(_Tp))));
     }
 
     // For non-SPIR-V targets, we check if the operator is commutative before selecting the appropriate codepath.
     // On SPIR-V targets, the sequential implementation with the non-commutative operator is currently more performant.
     static constexpr bool __use_nonseq_impl = !oneapi::dpl::__internal::__is_spirv_target_v && _Commutative::value;
 
-    template <typename _NDItemId, typename _Size, typename _AccLocal, typename... _Acc>
+    template <typename _NDItemId, typename _Size, typename... _Acc>
     inline void
-    operator()(const _NDItemId& __item_id, const _Size& __n, const _Size& __global_offset, const _AccLocal& __local_mem,
-               const _Acc&... __acc) const
+    operator()(const _NDItemId& __item_id, const _Size& __n, const _Size& __global_offset, const _Acc&... __acc) const
     {
         if constexpr (__use_nonseq_impl)
             return nonseq_impl(__item_id, __n, __global_offset, __local_mem, __acc...);
@@ -315,29 +314,24 @@ struct reduce_over_group
     // Reduce on local memory with subgroups
     template <typename _NDItemId, typename _Size, typename _AccLocal>
     _Tp
-    reduce_impl(const _NDItemId __item_id, const _Size __n, const _AccLocal& __local_mem,
+    reduce_impl(const _NDItemId __item_id, const _Size __n, const _Tp& __val, const _AccLocal& /*__local_mem*/,
                 std::true_type /*has_known_identity*/) const
     {
         auto __local_idx = __item_id.get_local_id(0);
         auto __global_idx = __item_id.get_global_id(0);
-        if (__global_idx >= __n)
-        {
-            // Fill the rest of local buffer with init elements so each of inclusive_scan method could correctly work
-            // for each work-item in sub-group
-            __local_mem[__local_idx] = __known_identity<_BinaryOperation1, _Tp>;
-        }
-        return __dpl_sycl::__reduce_over_group(__item_id.get_group(), __local_mem[__local_idx], __bin_op1);
+        return __dpl_sycl::__reduce_over_group(__item_id.get_group(), __global_idx >= __n ? __known_identity<_BinaryOperation1, _Tp> : __val, __bin_op1);
     }
 
     template <typename _NDItemId, typename _Size, typename _AccLocal>
     _Tp
-    reduce_impl(const _NDItemId __item_id, const _Size __n, const _AccLocal& __local_mem,
+    reduce_impl(const _NDItemId __item_id, const _Size __n, const _Tp& __val, const _AccLocal& __local_mem,
                 std::false_type /*has_known_identity*/) const
     {
         auto __local_idx = __item_id.get_local_id(0);
         auto __global_idx = __item_id.get_global_id(0);
         auto __group_size = __item_id.get_local_range().size();
 
+        __local_mem[__local_idx] = __val;
         for (::std::uint32_t __power_2 = 1; __power_2 < __group_size; __power_2 *= 2)
         {
             __dpl_sycl::__group_barrier(__item_id);
@@ -352,9 +346,9 @@ struct reduce_over_group
 
     template <typename _NDItemId, typename _Size, typename _AccLocal>
     _Tp
-    operator()(const _NDItemId __item_id, const _Size __n, const _AccLocal& __local_mem) const
+    operator()(const _NDItemId __item_id, const _Size __n, const _Tp& __val, const _AccLocal& __local_mem) const
     {
-        return reduce_impl(__item_id, __n, __local_mem, __has_known_identity<_BinaryOperation1, _Tp>{});
+        return reduce_impl(__item_id, __n, __val, __local_mem, __has_known_identity<_BinaryOperation1, _Tp>{});
     }
 
     template <typename _InitType, typename _Result>
@@ -362,6 +356,15 @@ struct reduce_over_group
     apply_init(const _InitType& __init, _Result&& __result) const
     {
         __init_processing<_Tp>{}(__init, __result, __bin_op1);
+    }
+
+    inline ::std::size_t
+    local_mem_req(const ::std::uint16_t& __work_group_size) const
+    {
+        if (__has_known_identity<_BinaryOperation1, _Tp>{})
+            return 0;
+
+        return __work_group_size;
     }
 };
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -319,7 +319,8 @@ struct reduce_over_group
     {
         auto __local_idx = __item_id.get_local_id(0);
         auto __global_idx = __item_id.get_global_id(0);
-        return __dpl_sycl::__reduce_over_group(__item_id.get_group(), __global_idx >= __n ? __known_identity<_BinaryOperation1, _Tp> : __val, __bin_op1);
+        return __dpl_sycl::__reduce_over_group(
+            __item_id.get_group(), __global_idx >= __n ? __known_identity<_BinaryOperation1, _Tp> : __val, __bin_op1);
     }
 
     template <typename _NDItemId, typename _Size, typename _AccLocal>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -218,7 +218,11 @@ struct transform_reduce
         const _Size __adjusted_global_id = __global_offset + __iters_per_work_item * __global_idx;
         const _Size __adjusted_n = __global_offset + __n;
         // Sequential load and reduce from global memory
-        union __storage {_Tp __v; __storage(){} } __res;
+        union __storage
+        {
+            _Tp __v;
+            __storage() {}
+        } __res;
         if (__adjusted_global_id + __iters_per_work_item < __adjusted_n)
         {
             // Keep these statements in the same scope to allow for better memory alignment
@@ -250,7 +254,11 @@ struct transform_reduce
         const _Size __adjusted_n = __global_offset + __n;
 
         // Coalesced load and reduce from global memory
-        union __storage {_Tp __v; __storage(){} } __res;
+        union __storage
+        {
+            _Tp __v;
+            __storage() {}
+        } __res;
         if (__adjusted_global_id + __stride * __iters_per_work_item < __adjusted_n)
         {
             __res.__v = __unary_op(__adjusted_global_id, __acc...);


### PR DESCRIPTION
This PR modifies how values are passed between `transform_reduce` and `reduce_over_group`. As opposed to moving data into local memory, syncing the work_group, then unloading we just move the value into a register and return it.

This allows us to save local memory loads and stores, and a barrier. We have seen improved performance on both Nvidia and Intel GPUs from this PR.