### PR TITLE
Histogram bugfixes for FPGA and icpx 2022.3 

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
@@ -65,7 +65,7 @@ struct __parallel_for_fpga_submitter<__internal::__optional_kernel_name<_Name...
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...);
 
             __cgh.single_task<_Name...>([=]() {
-#pragma unroll(::std::decay<_ExecutionPolicy>::type::unroll_factor)
+#pragma unroll(::std::decay <_ExecutionPolicy>::type::unroll_factor)
                 for (auto __idx = 0; __idx < __count; ++__idx)
                 {
                     __brick(__idx, __rngs...);
@@ -146,7 +146,8 @@ __parallel_copy_if(_ExecutionPolicy&& __exec, _InRng&& __in_rng, _OutRng&& __out
 }
 
 template <typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _Size, typename _CreateMaskOp,
-          typename _CopyByMaskOp, oneapi::dpl::__internal::__enable_if_fpga_execution_policy<_ExecutionPolicy, int> = 0>
+          typename _CopyByMaskOp,
+          oneapi::dpl::__internal::__enable_if_fpga_execution_policy<_ExecutionPolicy, int> = 0>
 auto
 __parallel_scan_copy(_ExecutionPolicy&& __exec, _InRng&& __in_rng, _OutRng&& __out_rng, _Size __n,
                      _CreateMaskOp __create_mask_op, _CopyByMaskOp __copy_by_mask_op)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
@@ -28,6 +28,7 @@
 #include "parallel_backend_sycl_utils.h"
 // workaround until we implement more performant optimization for patterns
 #include "parallel_backend_sycl.h"
+#include "parallel_backend_sycl_histogram.h"
 #include "../../execution_impl.h"
 #include "execution_sycl_defs.h"
 #include "../../iterator_impl.h"

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
@@ -65,7 +65,7 @@ struct __parallel_for_fpga_submitter<__internal::__optional_kernel_name<_Name...
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...);
 
             __cgh.single_task<_Name...>([=]() {
-#pragma unroll(::std::decay <_ExecutionPolicy>::type::unroll_factor)
+#pragma unroll(::std::decay<_ExecutionPolicy>::type::unroll_factor)
                 for (auto __idx = 0; __idx < __count; ++__idx)
                 {
                     __brick(__idx, __rngs...);
@@ -146,8 +146,7 @@ __parallel_copy_if(_ExecutionPolicy&& __exec, _InRng&& __in_rng, _OutRng&& __out
 }
 
 template <typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _Size, typename _CreateMaskOp,
-          typename _CopyByMaskOp,
-          oneapi::dpl::__internal::__enable_if_fpga_execution_policy<_ExecutionPolicy, int> = 0>
+          typename _CopyByMaskOp, oneapi::dpl::__internal::__enable_if_fpga_execution_policy<_ExecutionPolicy, int> = 0>
 auto
 __parallel_scan_copy(_ExecutionPolicy&& __exec, _InRng&& __in_rng, _OutRng&& __out_rng, _Size __n,
                      _CreateMaskOp __create_mask_op, _CopyByMaskOp __copy_by_mask_op)
@@ -274,12 +273,12 @@ template <typename _ExecutionPolicy, typename _Event, typename _Range1, typename
           oneapi::dpl::__internal::__enable_if_fpga_execution_policy<_ExecutionPolicy, int> = 0>
 auto
 __parallel_histogram(_ExecutionPolicy&& __exec, const _Event& __init_event, _Range1&& __input, _Range2&& __bins,
-                     _BinHashMgr&& __binhash_manager)
+                     const _BinHashMgr& __binhash_manager)
 {
     // workaround until we implement more performant version for patterns
-    return oneapi::dpl::__par_backend_hetero::__parallel_histogram(
-        __device_policy(__exec), __init_event, ::std::forward<_Range1>(__input), ::std::forward<_Range2>(__bins),
-        ::std::forward<_BinHashMgr>(__binhash_manager));
+    return oneapi::dpl::__par_backend_hetero::__parallel_histogram(__exec.__device_policy(), __init_event,
+                                                                   ::std::forward<_Range1>(__input),
+                                                                   ::std::forward<_Range2>(__bins), __binhash_manager);
 }
 
 } // namespace __par_backend_hetero

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -27,7 +27,6 @@
 #include "utils_ranges_sycl.h"
 
 #include "../../histogram_binhash_utils.h"
-#include "../../../internal/async_impl/async_impl_hetero.h"
 #include "../../utils.h"
 
 namespace oneapi

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -105,8 +105,8 @@ struct __binhash_SLM_wrapper<__custom_boundary_range_binhash<_Range>, _ExtraMemA
     get_bin(_T __value) const
     {
         auto __size = __slm_mem.size();
-        return oneapi::dpl::__internal::__custom_boundary_get_bin_helper(__slm_mem.begin(), __size, __value,
-                                                                         __slm_mem[0], __slm_mem[__size - 1]);
+        return oneapi::dpl::__internal::__custom_boundary_get_bin_helper(__slm_mem, __size, __value, __slm_mem[0],
+                                                                         __slm_mem[__size - 1]);
     }
 };
 


### PR DESCRIPTION
This PR addresses two bugfixes for histogram

1. FPGA handling for converting to device policy, bad rebase did not change with some refactoring to handling of policy (and correcting a universal reference to a const lvalue ref to be consistent with device policy)
2. Removing unnecessary `begin()` call for a local_accessor, which caused problems on icpx 2022.3.  We only need an accessor which supports bracket operators in the function we are calling, so we can just pass the `local_accessor` itself.
3. Removing unnecessary and problematic include of `async_impl_hetero.h`