### PR TITLE
Bugfix permutation iterator, recursion for fancy iterators composed of passed directly components

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -524,9 +524,16 @@ struct __get_sycl_range
         auto __n = __last - __first;
         assert(__n > 0);
 
-        // The size of the source range is unknown. So, just base iterator is passing to permutation_view
+        // The size of the source range is unknown. However, we know the base is passed directly,
+        // therefore we know that it is composed of purely passed directly components. To properly
+        // wrap the underlying ranges in views to be handled by require access properly, we must recurse.
+        // We will not require any real "processing" of the data, so the length of the range is
+        // unimportant. We use length one here as we don't have anything better.
+        auto base_src = __first.base();
+        auto res_src = __process_input_iter<_LocalAccMode>(base_src, base_src + 1);
+
         //_Map is handled by recursively calling __get_sycl_range() in __get_permutation_view.
-        auto rng = __get_permutation_view(__first.base(), __first.map(), __n);
+        auto rng = __get_permutation_view(res_src.all_view(), __first.map(), __n);
 
         return __range_holder<decltype(rng)>{rng};
     }


### PR DESCRIPTION
This resolves an issue with `permutation_iterator` using a source iterator that is a fancy iterator fully composed of "passed directly" components.

This includes: 
`permutation_iterator`, `zip_iterator`, transform_iterator` and any combination of them using passed directly components (usm pointers, etc.)

Before this fix, this overload of the handling of `permutation_iterator` did not recurse, causing problems during the `_require_access` call for kernels, as these functions do not know how to fancy iterator typed directly.  Instead they know how to handle views which match each of these types, which are generated via recursion within the `__get_sycl_range` struct.

With permutation iterator we do not know the size of the source iterator which will be used.  However, since no real processing (transform, copy, require...) will occur for "passed directly" components, we can reasonably just use a length of one, and be confident this will not cause extra overhead, or missing data.  

This of course still assumes that the user's map indices fall within bounds of the source data for the `permutation_iterator`, but that requirement is always inherent with its usage.