### PR TITLE
[test] Fix compile errors in tests of permutation iterator

### DIFF
--- a/test/parallel_api/iterator/permutation_iterator.h
+++ b/test/parallel_api/iterator/permutation_iterator.h
@@ -77,6 +77,17 @@ create_new_policy(Policy&& policy)
     return ::std::forward<Policy>(policy);
 }
 
+template <typename _NewKernelName, int idx, typename Policy>
+auto
+create_new_policy_idx(Policy&& policy)
+{
+#if TEST_DPCPP_BACKEND_PRESENT
+    return create_new_policy<TestUtils::new_kernel_name<_NewKernelName, idx>>(::std::forward<Policy>(policy));
+#else
+    return ::std::forward<Policy>(policy);
+#endif
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 /**
  * @param template typename TSourceIterator - source iterator type

--- a/test/parallel_api/iterator/permutation_iterator.h
+++ b/test/parallel_api/iterator/permutation_iterator.h
@@ -20,6 +20,7 @@
 #if TEST_DPCPP_BACKEND_PRESENT
 #include "support/utils_sycl.h"
 #endif // TEST_DPCPP_BACKEND_PRESENT
+#include "support/utils_invoke.h"
 #include "support/utils_test_base.h"
 
 #include <type_traits>

--- a/test/parallel_api/iterator/permutation_iterator.h
+++ b/test/parallel_api/iterator/permutation_iterator.h
@@ -50,6 +50,32 @@ struct perm_it_index_tags
 };
 
 ////////////////////////////////////////////////////////////////////////////////
+// Implementation of create_new_policy for all policies (host + hetero)
+#if TEST_DPCPP_BACKEND_PRESENT
+template <typename _NewKernelName, typename Policy,
+          ::std::enable_if_t<oneapi::dpl::__internal::__is_hetero_execution_policy_v<::std::decay_t<Policy>>, int> = 0>
+decltype(auto)
+create_new_policy(Policy&& policy)
+{
+    return TestUtils::make_new_policy<_NewKernelName>(::std::forward<Policy>(policy));
+}
+template <typename _NewKernelName, typename Policy,
+          ::std::enable_if_t<!oneapi::dpl::__internal::__is_hetero_execution_policy_v<::std::decay_t<Policy>>, int> = 0>
+decltype(auto)
+create_new_policy(Policy&& policy)
+{
+    return ::std::forward<Policy>(policy);
+}
+#else
+template <typename _NewKernelName, typename Policy>
+decltype(auto)
+create_new_policy(Policy&& policy)
+{
+    return ::std::forward<Policy>(policy);
+}
+#endif // TEST_DPCPP_BACKEND_PRESENT
+
+////////////////////////////////////////////////////////////////////////////////
 /**
  * @param template typename TSourceIterator - source iterator type
  * @param typename TSourceDataSize - type of source data size

--- a/test/parallel_api/iterator/permutation_iterator_common.h
+++ b/test/parallel_api/iterator/permutation_iterator_common.h
@@ -61,9 +61,13 @@ wait_and_throw(ExecutionPolicy&& exec)
 #endif // _PSTL_SYCL_TEST_USM
 }
 
+struct DefaultKernelTestName
+{
+};
+
 // DEFINE_TEST_PERM_IT should be used to declare permutation iterator tests
 #define DEFINE_TEST_PERM_IT(TestClassName, PermItIndexTag, KernelName)                                                 \
-    template <typename TestValueType, typename PermItIndexTag, typename KernelName>                                    \
+    template <typename TestValueType, typename PermItIndexTag, typename KernelName = DefaultKernelTestName>            \
     struct TestClassName : TestUtils::test_base<TestValueType>
 
 // DEFINE_TEST_PERM_IT_CONSTRUCTOR should be used to declare permutation iterator tests constructor

--- a/test/parallel_api/iterator/permutation_iterator_common.h
+++ b/test/parallel_api/iterator/permutation_iterator_common.h
@@ -62,8 +62,8 @@ wait_and_throw(ExecutionPolicy&& exec)
 }
 
 // DEFINE_TEST_PERM_IT should be used to declare permutation iterator tests
-#define DEFINE_TEST_PERM_IT(TestClassName, TemplateParams)                                                             \
-    template <typename TestValueType, typename TemplateParams>                                                         \
+#define DEFINE_TEST_PERM_IT(TestClassName, PermItIndexTag)                                                             \
+    template <typename TestValueType, typename PermItIndexTag>                                                         \
     struct TestClassName : TestUtils::test_base<TestValueType>
 
 // DEFINE_TEST_PERM_IT_CONSTRUCTOR should be used to declare permutation iterator tests constructor

--- a/test/parallel_api/iterator/permutation_iterator_common.h
+++ b/test/parallel_api/iterator/permutation_iterator_common.h
@@ -62,8 +62,8 @@ wait_and_throw(ExecutionPolicy&& exec)
 }
 
 // DEFINE_TEST_PERM_IT should be used to declare permutation iterator tests
-#define DEFINE_TEST_PERM_IT(TestClassName, PermItIndexTag)                                                             \
-    template <typename TestValueType, typename PermItIndexTag>                                                         \
+#define DEFINE_TEST_PERM_IT(TestClassName, PermItIndexTag, KernelName)                                                 \
+    template <typename TestValueType, typename PermItIndexTag, typename KernelName>                                    \
     struct TestClassName : TestUtils::test_base<TestValueType>
 
 // DEFINE_TEST_PERM_IT_CONSTRUCTOR should be used to declare permutation iterator tests constructor

--- a/test/parallel_api/iterator/permutation_iterator_parallel_find.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_find.pass.cpp
@@ -90,7 +90,7 @@ run_algo_tests()
 
     // Run tests on <std::vector::iterator> + <all_host_policies>
     // dpl::find, dpl::find_if, dpl::find_if_not -> __parallel_find -> _parallel_find_or
-    test_algo_one_sequence<ValueType, test_find<ValueType, PermItIndexTag, KernelName>>(kZeroOffset);
+    test_algo_one_sequence<ValueType, test_find<ValueType, PermItIndexTag>>(kZeroOffset);
 }
 
 int

--- a/test/parallel_api/iterator/permutation_iterator_parallel_for.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_for.pass.cpp
@@ -51,9 +51,14 @@ DEFINE_TEST_PERM_IT(test_transform, PermItIndexTag, KernelName)
     {
         if constexpr (is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>)
         {
-            auto exec = create_new_policy<TestUtils::new_kernel_name<KernelName, 0>>(::std::forward<Policy>(exec_src));
+            auto exec = create_new_policy<KernelName>(::std::forward<Policy>(exec_src));
+#if TEST_DPCPP_BACKEND_PRESENT
             auto exec1 = create_new_policy<TestUtils::new_kernel_name<KernelName, 1>>(::std::forward<Policy>(exec_src));
             auto exec2 = create_new_policy<TestUtils::new_kernel_name<KernelName, 2>>(::std::forward<Policy>(exec_src));
+#else
+            auto exec1 = exec_src;
+            auto exec2 = exec_src;
+#endif // TEST_DPCPP_BACKEND_PRESENT
 
             TestDataTransfer<UDTKind::eKeys, Size> host_keys(*this, n);     // source data for transform
             TestDataTransfer<UDTKind::eVals, Size> host_vals(*this, n);     // result data of transform

--- a/test/parallel_api/iterator/permutation_iterator_parallel_for.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_for.pass.cpp
@@ -51,14 +51,9 @@ DEFINE_TEST_PERM_IT(test_transform, PermItIndexTag, KernelName)
     {
         if constexpr (is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>)
         {
-            auto exec = create_new_policy<KernelName>(::std::forward<Policy>(exec_src));
-#if TEST_DPCPP_BACKEND_PRESENT
-            auto exec1 = create_new_policy<TestUtils::new_kernel_name<KernelName, 1>>(::std::forward<Policy>(exec_src));
-            auto exec2 = create_new_policy<TestUtils::new_kernel_name<KernelName, 2>>(::std::forward<Policy>(exec_src));
-#else
-            auto exec1 = exec_src;
-            auto exec2 = exec_src;
-#endif // TEST_DPCPP_BACKEND_PRESENT
+            auto exec  = create_new_policy_idx<KernelName, 0>(::std::forward<Policy>(exec_src));
+            auto exec1 = create_new_policy_idx<KernelName, 1>(::std::forward<Policy>(exec_src));
+            auto exec2 = create_new_policy_idx<KernelName, 2>(::std::forward<Policy>(exec_src));
 
             TestDataTransfer<UDTKind::eKeys, Size> host_keys(*this, n);     // source data for transform
             TestDataTransfer<UDTKind::eVals, Size> host_vals(*this, n);     // result data of transform

--- a/test/parallel_api/iterator/permutation_iterator_parallel_for.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_for.pass.cpp
@@ -119,7 +119,7 @@ run_algo_tests()
 
     // Run tests on <std::vector::iterator> + <all_host_policies>
     // dpl::transform -> __parallel_for (only for random_access_iterator)
-    test_algo_two_sequences<ValueType, test_transform<ValueType, PermItIndexTag, KernelName>>(kZeroOffset, kZeroOffset);
+    test_algo_two_sequences<ValueType, test_transform<ValueType, PermItIndexTag>>(kZeroOffset, kZeroOffset);
 }
 
 int

--- a/test/parallel_api/iterator/permutation_iterator_parallel_merge.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_merge.pass.cpp
@@ -34,14 +34,9 @@ DEFINE_TEST_PERM_IT(test_merge, PermItIndexTag, KernelName)
     {
         if constexpr (is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>)
         {
-            auto exec = create_new_policy<KernelName>(::std::forward<Policy>(exec_src));
-#if TEST_DPCPP_BACKEND_PRESENT
-            auto exec1 = create_new_policy<TestUtils::new_kernel_name<KernelName, 1>>(::std::forward<Policy>(exec_src));
-            auto exec2 = create_new_policy<TestUtils::new_kernel_name<KernelName, 2>>(::std::forward<Policy>(exec_src));
-#else
-            auto exec1 = exec_src;
-            auto exec2 = exec_src;
-#endif // TEST_DPCPP_BACKEND_PRESENT
+            auto exec  = create_new_policy_idx<KernelName, 0>(::std::forward<Policy>(exec_src));
+            auto exec1 = create_new_policy_idx<KernelName, 1>(::std::forward<Policy>(exec_src));
+            auto exec2 = create_new_policy_idx<KernelName, 2>(::std::forward<Policy>(exec_src));
 
             TestDataTransfer<UDTKind::eKeys, Size> host_keys(*this, n);                                 // source data(1) for merge
             TestDataTransfer<UDTKind::eVals, Size> host_vals(*this, n);                                 // source data(2) for merge

--- a/test/parallel_api/iterator/permutation_iterator_parallel_merge.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_merge.pass.cpp
@@ -120,7 +120,7 @@ run_algo_tests()
 
     // Run tests on <std::vector::iterator> + <all_host_policies>
     // dpl::merge, dpl::inplace_merge -> __parallel_merge
-    test_algo_three_sequences<ValueType, test_merge<ValueType, PermItIndexTag, KernelName>>(2, kZeroOffset, kZeroOffset, kZeroOffset);
+    test_algo_three_sequences<ValueType, test_merge<ValueType, PermItIndexTag>>(2, kZeroOffset, kZeroOffset, kZeroOffset);
 }
 
 int

--- a/test/parallel_api/iterator/permutation_iterator_parallel_merge.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_merge.pass.cpp
@@ -35,8 +35,13 @@ DEFINE_TEST_PERM_IT(test_merge, PermItIndexTag, KernelName)
         if constexpr (is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>)
         {
             auto exec = create_new_policy<KernelName>(::std::forward<Policy>(exec_src));
+#if TEST_DPCPP_BACKEND_PRESENT
             auto exec1 = create_new_policy<TestUtils::new_kernel_name<KernelName, 1>>(::std::forward<Policy>(exec_src));
             auto exec2 = create_new_policy<TestUtils::new_kernel_name<KernelName, 2>>(::std::forward<Policy>(exec_src));
+#else
+            auto exec1 = exec_src;
+            auto exec2 = exec_src;
+#endif // TEST_DPCPP_BACKEND_PRESENT
 
             TestDataTransfer<UDTKind::eKeys, Size> host_keys(*this, n);                                 // source data(1) for merge
             TestDataTransfer<UDTKind::eVals, Size> host_vals(*this, n);                                 // source data(2) for merge

--- a/test/parallel_api/iterator/permutation_iterator_parallel_or.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_or.pass.cpp
@@ -18,7 +18,7 @@
 #include "permutation_iterator_common.h"
 
 // dpl::is_heap, dpl::includes -> __parallel_or -> _parallel_find_or
-DEFINE_TEST_PERM_IT(test_is_heap, PermItIndexTag)
+DEFINE_TEST_PERM_IT(test_is_heap, PermItIndexTag, KernelName)
 {
     DEFINE_TEST_PERM_IT_CONSTRUCTOR(test_is_heap)
 
@@ -30,10 +30,12 @@ DEFINE_TEST_PERM_IT(test_is_heap, PermItIndexTag)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Size n)
+    operator()(Policy&& exec_src, Iterator1 first1, Iterator1 last1, Size n)
     {
         if constexpr (is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>)
         {
+            auto exec = create_new_policy<KernelName>(::std::forward<Policy>(exec_src));
+
             for (bool bCallMakeHeap : {false, true})
             {
                 TestDataTransfer<UDTKind::eKeys, Size> host_keys(*this, n);     // source data for is_heap check
@@ -66,7 +68,7 @@ DEFINE_TEST_PERM_IT(test_is_heap, PermItIndexTag)
     }
 };
 
-template <typename ValueType, typename PermItIndexTag>
+template <typename ValueType, typename PermItIndexTag, typename KernelName>
 void
 run_algo_tests()
 {
@@ -75,13 +77,15 @@ run_algo_tests()
 #if TEST_DPCPP_BACKEND_PRESENT
     // Run tests on <USM::shared, USM::device, sycl::buffer> + <all_hetero_policies>
     // dpl::is_heap, dpl::includes -> __parallel_or -> _parallel_find_or
-    test1buffer<sycl::usm::alloc::shared, ValueType, test_is_heap<ValueType, PermItIndexTag>>();
-    test1buffer<sycl::usm::alloc::device, ValueType, test_is_heap<ValueType, PermItIndexTag>>();
+    test1buffer<sycl::usm::alloc::shared, ValueType, test_is_heap<ValueType, PermItIndexTag, new_kernel_name<KernelName, 10>>,
+                                                     test_is_heap<ValueType, PermItIndexTag, new_kernel_name<KernelName, 15>>>();
+    test1buffer<sycl::usm::alloc::device, ValueType, test_is_heap<ValueType, PermItIndexTag, new_kernel_name<KernelName, 20>>,
+                                                     test_is_heap<ValueType, PermItIndexTag, new_kernel_name<KernelName, 25>>>();
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
     // Run tests on <std::vector::iterator> + <all_host_policies>
     // dpl::is_heap, dpl::includes -> __parallel_or -> _parallel_find_or
-    test_algo_one_sequence<ValueType, test_is_heap<ValueType, PermItIndexTag>>(kZeroOffset);
+    test_algo_one_sequence<ValueType, test_is_heap<ValueType, PermItIndexTag, KernelName>>(kZeroOffset);
 }
 
 int
@@ -90,13 +94,13 @@ main()
     using ValueType = ::std::uint32_t;
 
 #if TEST_DPCPP_BACKEND_PRESENT
-    run_algo_tests<ValueType, perm_it_index_tags::usm_shared>();
+    run_algo_tests<ValueType, perm_it_index_tags::usm_shared,         class KernelName1>();
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-    run_algo_tests<ValueType, perm_it_index_tags::counting>();
-    run_algo_tests<ValueType, perm_it_index_tags::host>();
-    run_algo_tests<ValueType, perm_it_index_tags::transform_iterator>();
-    run_algo_tests<ValueType, perm_it_index_tags::callable_object>();
+    run_algo_tests<ValueType, perm_it_index_tags::counting,           class KernelName2>();
+    run_algo_tests<ValueType, perm_it_index_tags::host,               class KernelName3>();
+    run_algo_tests<ValueType, perm_it_index_tags::transform_iterator, class KernelName4>();
+    run_algo_tests<ValueType, perm_it_index_tags::callable_object,    class KernelName5>();
 
     return TestUtils::done();
 }

--- a/test/parallel_api/iterator/permutation_iterator_parallel_or.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_or.pass.cpp
@@ -85,7 +85,7 @@ run_algo_tests()
 
     // Run tests on <std::vector::iterator> + <all_host_policies>
     // dpl::is_heap, dpl::includes -> __parallel_or -> _parallel_find_or
-    test_algo_one_sequence<ValueType, test_is_heap<ValueType, PermItIndexTag, KernelName>>(kZeroOffset);
+    test_algo_one_sequence<ValueType, test_is_heap<ValueType, PermItIndexTag>>(kZeroOffset);
 }
 
 int

--- a/test/parallel_api/iterator/permutation_iterator_parallel_partial_sort.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_partial_sort.pass.cpp
@@ -93,7 +93,7 @@ run_algo_tests()
 
     // Run tests on <std::vector::iterator> + <all_host_policies>
     // dpl::partial_sort -> __parallel_partial_sort (only for random_access_iterator)
-    test_algo_one_sequence<ValueType, test_partial_sort<ValueType, PermItIndexTag, KernelName>>(kZeroOffset);
+    test_algo_one_sequence<ValueType, test_partial_sort<ValueType, PermItIndexTag>>(kZeroOffset);
 }
 
 int

--- a/test/parallel_api/iterator/permutation_iterator_parallel_partial_sort.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_partial_sort.pass.cpp
@@ -19,7 +19,7 @@
 
 // test_partial_sort : dpl::partial_sort -> __parallel_partial_sort
 // Requirements: only for random_access_iterator
-DEFINE_TEST_PERM_IT(test_partial_sort, PermItIndexTag)
+DEFINE_TEST_PERM_IT(test_partial_sort, PermItIndexTag, KernelName)
 {
     DEFINE_TEST_PERM_IT_CONSTRUCTOR(test_partial_sort)
 
@@ -40,10 +40,12 @@ DEFINE_TEST_PERM_IT(test_partial_sort, PermItIndexTag)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Size n)
+    operator()(Policy&& exec_src, Iterator1 first1, Iterator1 last1, Size n)
     {
         if constexpr (is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>)
         {
+            auto exec = create_new_policy<KernelName>(::std::forward<Policy>(exec_src));
+
             TestDataTransfer<UDTKind::eKeys, Size> host_keys(*this, n);     // sorting data
             const auto host_keys_ptr = host_keys.get();
 
@@ -74,7 +76,7 @@ DEFINE_TEST_PERM_IT(test_partial_sort, PermItIndexTag)
     }
 };
 
-template <typename ValueType, typename PermItIndexTag>
+template <typename ValueType, typename PermItIndexTag, typename KernelName>
 void
 run_algo_tests()
 {
@@ -83,13 +85,15 @@ run_algo_tests()
 #if TEST_DPCPP_BACKEND_PRESENT
     // Run tests on <USM::shared, USM::device, sycl::buffer> + <all_hetero_policies>
     // dpl::partial_sort -> __parallel_partial_sort (only for random_access_iterator)
-    test1buffer<sycl::usm::alloc::shared, ValueType, test_partial_sort<ValueType, PermItIndexTag>>();
-    test1buffer<sycl::usm::alloc::device, ValueType, test_partial_sort<ValueType, PermItIndexTag>>();
+    test1buffer<sycl::usm::alloc::shared, ValueType, test_partial_sort<ValueType, PermItIndexTag, new_kernel_name<KernelName, 10>>,
+                                                     test_partial_sort<ValueType, PermItIndexTag, new_kernel_name<KernelName, 15>>>();
+    test1buffer<sycl::usm::alloc::device, ValueType, test_partial_sort<ValueType, PermItIndexTag, new_kernel_name<KernelName, 20>>,
+                                                     test_partial_sort<ValueType, PermItIndexTag, new_kernel_name<KernelName, 25>>>();
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
     // Run tests on <std::vector::iterator> + <all_host_policies>
     // dpl::partial_sort -> __parallel_partial_sort (only for random_access_iterator)
-    test_algo_one_sequence<ValueType, test_partial_sort<ValueType, PermItIndexTag>>(kZeroOffset);
+    test_algo_one_sequence<ValueType, test_partial_sort<ValueType, PermItIndexTag, KernelName>>(kZeroOffset);
 }
 
 int
@@ -98,13 +102,13 @@ main()
     using ValueType = ::std::uint32_t;
 
 #if TEST_DPCPP_BACKEND_PRESENT
-    run_algo_tests<ValueType, perm_it_index_tags::usm_shared>();
+    run_algo_tests<ValueType, perm_it_index_tags::usm_shared,         class KernelName1>();
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-    run_algo_tests<ValueType, perm_it_index_tags::counting>();
-    run_algo_tests<ValueType, perm_it_index_tags::host>();
-    run_algo_tests<ValueType, perm_it_index_tags::transform_iterator>();
-    run_algo_tests<ValueType, perm_it_index_tags::callable_object>();
+    run_algo_tests<ValueType, perm_it_index_tags::counting,           class KernelName2>();
+    run_algo_tests<ValueType, perm_it_index_tags::host,               class KernelName3>();
+    run_algo_tests<ValueType, perm_it_index_tags::transform_iterator, class KernelName4>();
+    run_algo_tests<ValueType, perm_it_index_tags::callable_object,    class KernelName5>();
 
     return TestUtils::done();
 }

--- a/test/parallel_api/iterator/permutation_iterator_parallel_stable_sort.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_stable_sort.pass.cpp
@@ -92,7 +92,7 @@ run_algo_tests()
 
     // Run tests on <std::vector::iterator> + <all_host_policies>
     // test_sort : dpl::sort -> __parallel_stable_sort (only for random_access_iterator)
-    test_algo_one_sequence<ValueType, test_sort<ValueType, PermItIndexTag, KernelName>>(kZeroOffset);
+    test_algo_one_sequence<ValueType, test_sort<ValueType, PermItIndexTag>>(kZeroOffset);
 }
 
 int

--- a/test/parallel_api/iterator/permutation_iterator_parallel_transform_reduce.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_transform_reduce.pass.cpp
@@ -83,7 +83,7 @@ run_algo_tests()
 
     // Run tests on <std::vector::iterator> + <all_host_policies>
     // dpl::reduce, dpl::transform_reduce -> __parallel_transform_reduce (only for random_access_iterator)
-    test_algo_one_sequence<ValueType, test_transform_reduce<ValueType, PermItIndexTag, KernelName>>(kZeroOffset);
+    test_algo_one_sequence<ValueType, test_transform_reduce<ValueType, PermItIndexTag>>(kZeroOffset);
 }
 
 int

--- a/test/parallel_api/iterator/permutation_iterator_parallel_transform_scan.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_transform_scan.pass.cpp
@@ -19,7 +19,7 @@
 
 // dpl::remove_if -> __parallel_transform_scan
 // Requirements: only for random_access_iterator
-DEFINE_TEST_PERM_IT(test_remove_if, PermItIndexTag)
+DEFINE_TEST_PERM_IT(test_remove_if, PermItIndexTag, KernelName)
 {
     DEFINE_TEST_PERM_IT_CONSTRUCTOR(test_remove_if)
 
@@ -33,10 +33,12 @@ DEFINE_TEST_PERM_IT(test_remove_if, PermItIndexTag)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
-    operator()(Policy&& exec, Iterator1 first1, Iterator1 last1, Size n)
+    operator()(Policy&& exec_src, Iterator1 first1, Iterator1 last1, Size n)
     {
         if constexpr (is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>)
         {
+            auto exec = create_new_policy<KernelName>(::std::forward<Policy>(exec_src));
+
             TestDataTransfer<UDTKind::eKeys, Size> host_keys(*this, n);     // source data for remove_if
             const auto host_keys_ptr = host_keys.get();
 
@@ -79,7 +81,7 @@ DEFINE_TEST_PERM_IT(test_remove_if, PermItIndexTag)
     }
 };
 
-template <typename ValueType, typename PermItIndexTag>
+template <typename ValueType, typename PermItIndexTag, typename KernelName>
 void
 run_algo_tests()
 {
@@ -88,13 +90,15 @@ run_algo_tests()
 #if TEST_DPCPP_BACKEND_PRESENT
     // Run tests on <USM::shared, USM::device, sycl::buffer> + <all_hetero_policies>
     // dpl::remove_if -> __parallel_transform_scan (only for random_access_iterator)
-    test1buffer<sycl::usm::alloc::shared, ValueType, test_remove_if<ValueType, PermItIndexTag>>();
-    test1buffer<sycl::usm::alloc::device, ValueType, test_remove_if<ValueType, PermItIndexTag>>();
+    test1buffer<sycl::usm::alloc::shared, ValueType, test_remove_if<ValueType, PermItIndexTag, new_kernel_name<KernelName, 10>>,
+                                                     test_remove_if<ValueType, PermItIndexTag, new_kernel_name<KernelName, 15>>>();
+    test1buffer<sycl::usm::alloc::device, ValueType, test_remove_if<ValueType, PermItIndexTag, new_kernel_name<KernelName, 20>>,
+                                                     test_remove_if<ValueType, PermItIndexTag, new_kernel_name<KernelName, 25>>>();
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
     // Run tests on <std::vector::iterator> + <all_host_policies>
     // dpl::remove_if -> __parallel_transform_scan (only for random_access_iterator)
-    test_algo_one_sequence<ValueType, test_remove_if<ValueType, PermItIndexTag>>(kZeroOffset);
+    test_algo_one_sequence<ValueType, test_remove_if<ValueType, PermItIndexTag, KernelName>>(kZeroOffset);
 }
 
 int
@@ -103,13 +107,13 @@ main()
     using ValueType = ::std::uint32_t;
 
 #if TEST_DPCPP_BACKEND_PRESENT
-    run_algo_tests<ValueType, perm_it_index_tags::usm_shared>();
+    run_algo_tests<ValueType, perm_it_index_tags::usm_shared,         class KernelName1>();
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-    run_algo_tests<ValueType, perm_it_index_tags::counting>();
-    run_algo_tests<ValueType, perm_it_index_tags::host>();
-    run_algo_tests<ValueType, perm_it_index_tags::transform_iterator>();
-    run_algo_tests<ValueType, perm_it_index_tags::callable_object>();
+    run_algo_tests<ValueType, perm_it_index_tags::counting,           class KernelName2>();
+    run_algo_tests<ValueType, perm_it_index_tags::host,               class KernelName3>();
+    run_algo_tests<ValueType, perm_it_index_tags::transform_iterator, class KernelName4>();
+    run_algo_tests<ValueType, perm_it_index_tags::callable_object,    class KernelName5>();
 
     return TestUtils::done();
 }

--- a/test/parallel_api/iterator/permutation_iterator_parallel_transform_scan.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_transform_scan.pass.cpp
@@ -98,7 +98,7 @@ run_algo_tests()
 
     // Run tests on <std::vector::iterator> + <all_host_policies>
     // dpl::remove_if -> __parallel_transform_scan (only for random_access_iterator)
-    test_algo_one_sequence<ValueType, test_remove_if<ValueType, PermItIndexTag, KernelName>>(kZeroOffset);
+    test_algo_one_sequence<ValueType, test_remove_if<ValueType, PermItIndexTag>>(kZeroOffset);
 }
 
 int

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -32,6 +32,9 @@
 #include "test_config.h"
 
 #include _PSTL_TEST_HEADER(iterator)
+
+#include <type_traits>
+
 #include "oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h"
 #include "iterator_utils.h"
 #include "utils_invoke.h"
@@ -144,7 +147,7 @@ sycl::queue get_test_queue()
     return my_queue;
 }
 
-template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName>
+template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName1, typename TestName2 = TestName1>
 void
 test1buffer()
 {
@@ -165,7 +168,7 @@ test1buffer()
 #    if _ONEDPL_DEBUG_SYCL
             ::std::cout << "n = " << n << ::std::endl;
 #    endif
-            invoke_on_all_hetero_policies<0>()(create_test_obj<TestValueType, TestName>(test_base_data),
+            invoke_on_all_hetero_policies<0>()(create_test_obj<TestValueType, TestName1>(test_base_data),
                                                inout1_offset_first, inout1_offset_first + n,
                                                n);
         }
@@ -185,14 +188,14 @@ test1buffer()
 #if _ONEDPL_DEBUG_SYCL
             ::std::cout << "n = " << n << ::std::endl;
 #endif
-            invoke_on_all_hetero_policies<1>()(create_test_obj<TestValueType, TestName>(test_base_data),
+            invoke_on_all_hetero_policies<1>()(create_test_obj<TestValueType, TestName2>(test_base_data),
                                                inout1_offset_first, inout1_offset_first + n,
                                                n);
         }
     }
 }
 
-template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName>
+template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName1, typename TestName2 = TestName1>
 void
 test2buffers()
 {
@@ -215,7 +218,7 @@ test2buffers()
 #    if _ONEDPL_DEBUG_SYCL
             ::std::cout << "n = " << n << ::std::endl;
 #    endif
-            invoke_on_all_hetero_policies<0>()(create_test_obj<TestValueType, TestName>(test_base_data),
+            invoke_on_all_hetero_policies<0>()(create_test_obj<TestValueType, TestName1>(test_base_data),
                                                inout1_offset_first, inout1_offset_first + n,
                                                inout2_offset_first, inout2_offset_first + n,
                                                n);
@@ -238,7 +241,7 @@ test2buffers()
 #if _ONEDPL_DEBUG_SYCL
             ::std::cout << "n = " << n << ::std::endl;
 #endif
-            invoke_on_all_hetero_policies<1>()(create_test_obj<TestValueType, TestName>(test_base_data),
+            invoke_on_all_hetero_policies<1>()(create_test_obj<TestValueType, TestName2>(test_base_data),
                                                inout1_offset_first, inout1_offset_first + n,
                                                inout2_offset_first, inout2_offset_first + n,
                                                n);
@@ -246,7 +249,7 @@ test2buffers()
     }
 }
 
-template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName>
+template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName1, typename TestName2 = TestName1>
 void
 test3buffers(int mult = kDefaultMultValue)
 {
@@ -272,7 +275,7 @@ test3buffers(int mult = kDefaultMultValue)
 #    if _ONEDPL_DEBUG_SYCL
             ::std::cout << "n = " << n << ::std::endl;
 #    endif
-            invoke_on_all_hetero_policies<0>()(create_test_obj<TestValueType, TestName>(test_base_data),
+            invoke_on_all_hetero_policies<0>()(create_test_obj<TestValueType, TestName1>(test_base_data),
                                                inout1_offset_first, inout1_offset_first + n,
                                                inout2_offset_first, inout2_offset_first + n,
                                                inout3_offset_first, inout3_offset_first + n * mult,
@@ -298,7 +301,7 @@ test3buffers(int mult = kDefaultMultValue)
 #if _ONEDPL_DEBUG_SYCL
             ::std::cout << "n = " << n << ::std::endl;
 #endif
-            invoke_on_all_hetero_policies<1>()(create_test_obj<TestValueType, TestName>(test_base_data),
+            invoke_on_all_hetero_policies<1>()(create_test_obj<TestValueType, TestName2>(test_base_data),
                                                inout1_offset_first, inout1_offset_first + n,
                                                inout2_offset_first, inout2_offset_first + n,
                                                inout3_offset_first, inout3_offset_first + n * mult,
@@ -307,7 +310,7 @@ test3buffers(int mult = kDefaultMultValue)
     }
 }
 
-template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName>
+template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName1, typename TestName2 = TestName1>
 void
 test4buffers(int mult = kDefaultMultValue)
 {
@@ -335,7 +338,7 @@ test4buffers(int mult = kDefaultMultValue)
 #    if _ONEDPL_DEBUG_SYCL
             ::std::cout << "n = " << n << ::std::endl;
 #    endif
-            invoke_on_all_hetero_policies<0>()(create_test_obj<TestValueType, TestName>(test_base_data),
+            invoke_on_all_hetero_policies<0>()(create_test_obj<TestValueType, TestName1>(test_base_data),
                                                inout1_offset_first, inout1_offset_first + n,
                                                inout2_offset_first, inout2_offset_first + n,
                                                inout3_offset_first, inout3_offset_first + n * mult,
@@ -364,7 +367,7 @@ test4buffers(int mult = kDefaultMultValue)
 #if _ONEDPL_DEBUG_SYCL
             ::std::cout << "n = " << n << ::std::endl;
 #endif
-            invoke_on_all_hetero_policies<1>()(create_test_obj<TestValueType, TestName>(test_base_data),
+            invoke_on_all_hetero_policies<1>()(create_test_obj<TestValueType, TestName2>(test_base_data),
                                                inout1_offset_first, inout1_offset_first + n,
                                                inout2_offset_first, inout2_offset_first + n,
                                                inout3_offset_first, inout3_offset_first + n * mult,
@@ -374,32 +377,36 @@ test4buffers(int mult = kDefaultMultValue)
     }
 }
 
-template <sycl::usm::alloc alloc_type, typename TestName>
-::std::enable_if_t<::std::is_base_of_v<test_base<typename TestName::UsedValueType>, TestName>>
+template <sycl::usm::alloc alloc_type, typename TestName1, typename TestName2 = TestName1>
+::std::enable_if_t<::std::is_base_of_v<test_base<typename TestName1::UsedValueType>, TestName1>>
 test1buffer()
 {
-    test1buffer<alloc_type, typename TestName::UsedValueType, TestName>();
+    static_assert(::std::is_same_v<typename TestName1::UsedValueType, typename TestName2::UsedValueType>);
+    test1buffer<alloc_type, typename TestName1::UsedValueType, TestName1, TestName2>();
 }
 
-template <sycl::usm::alloc alloc_type, typename TestName>
-::std::enable_if_t<::std::is_base_of_v<test_base<typename TestName::UsedValueType>, TestName>>
+template <sycl::usm::alloc alloc_type, typename TestName1, typename TestName2 = TestName1>
+::std::enable_if_t<::std::is_base_of_v<test_base<typename TestName1::UsedValueType>, TestName1>>
 test2buffers()
 {
-    test2buffers<alloc_type, typename TestName::UsedValueType, TestName>();
+    static_assert(::std::is_same_v<typename TestName1::UsedValueType, typename TestName2::UsedValueType>);
+    test2buffers<alloc_type, typename TestName1::UsedValueType, TestName1, TestName2>();
 }
 
-template <sycl::usm::alloc alloc_type, typename TestName>
-::std::enable_if_t<::std::is_base_of_v<test_base<typename TestName::UsedValueType>, TestName>>
+template <sycl::usm::alloc alloc_type, typename TestName1, typename TestName2 = TestName1>
+::std::enable_if_t<::std::is_base_of_v<test_base<typename TestName1::UsedValueType>, TestName1>>
 test3buffers(int mult = kDefaultMultValue)
 {
-    test3buffers<alloc_type, typename TestName::UsedValueType, TestName>(mult);
+    static_assert(::std::is_same_v<typename TestName1::UsedValueType, typename TestName2::UsedValueType>);
+    test3buffers<alloc_type, typename TestName1::UsedValueType, TestName1, TestName2>(mult);
 }
 
-template <sycl::usm::alloc alloc_type, typename TestName>
-::std::enable_if_t<::std::is_base_of_v<test_base<typename TestName::UsedValueType>, TestName>>
+template <sycl::usm::alloc alloc_type, typename TestName1, typename TestName2 = TestName1>
+::std::enable_if_t<::std::is_base_of_v<test_base<typename TestName1::UsedValueType>, TestName1>>
 test4buffers(int mult = kDefaultMultValue)
 {
-    test4buffers<alloc_type, typename TestName::UsedValueType, TestName>(mult);
+    static_assert(::std::is_same_v<typename TestName1::UsedValueType, typename TestName2::UsedValueType>);
+    test4buffers<alloc_type, typename TestName1::UsedValueType, TestName1, TestName2>(mult);
 }
 } /* namespace TestUtils */
 


### PR DESCRIPTION
In this PR we fix compile errors in tests of permutation iterator: they exists when we using CMake option
```-DONEDPL_USE_UNNAMED_LAMBDA=OFF``` - switching off unnamed lambda.

The source compile error:
```C++
'oneapi::dpl::_par_backend_hetero::_sort_leaf_kernel<TestUtils::unique_kernel_name<test_sort<unsigned int, perm_it_index_tags::usm_shared>, 0>, unsigned int>' is invalid; kernel name should be forward declarable at namespace scope
```

```C++
Building CXX object test/CMakeFiles/permutation_iterator_parallel_find.pass.dir/parallel_api/iterator/permutation_iterator_parallel_find.pass.cpp.o
cd /test && /compiler/bin/icpx -D_PSTL_TEST_SUCCESSFUL_KEYWORD=1 -I/test -I/include -isystem /tbb/include -DTEST_LONG_RUN=1 -O3 -DNDEBUG -fno-fast-math -fopenmp-simd -fsycl -fno-sycl-unnamed-lambda -std=c++20 -MD -MT test/CMakeFiles/permutation_iterator_parallel_find.pass.dir/parallel_api/iterator/permutation_iterator_parallel_find.pass.cpp.o -MF CMakeFiles/permutation_iterator_parallel_find.pass.dir/parallel_api/iterator/permutation_iterator_parallel_find.pass.cpp.o.d -o CMakeFiles/permutation_iterator_parallel_find.pass.dir/parallel_api/iterator/permutation_iterator_parallel_find.pass.cpp.o -c /test/parallel_api/iterator/permutation_iterator_parallel_find.pass.cpp
In file included from /test/parallel_api/iterator/permutation_iterator_parallel_find.pass.cpp:18:
In file included from /test/parallel_api/iterator/permutation_iterator_common.h:19:
In file included from /include/oneapi/dpl/execution:28:
In file included from /include/oneapi/dpl/pstl/execution_defs.h:222:
In file included from /include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h:22:
In file included from /include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h:25:
In file included from /compiler/bin/compiler/../../include/sycl/sycl.hpp:16:
In file included from /compiler/bin/compiler/../../include/sycl/backend.hpp:27:
/compiler/bin/compiler/../../include/sycl/handler.hpp:1613:59: error: 'sycl::detail::__pf_kernel_wrapper<oneapi::dpl::__internal::__walk2_brick_wrapper<TestUtils::unique_kernel_name<test_find<unsigned int, perm_it_index_tags::usm_shared>, 0>>>' is invalid; kernel name should be forward declarable at namespace scope
 1613 |       h->kernel_parallel_for<TypesToForward..., Props...>(Args...);
      |                                                           ^
/compiler/bin/compiler/../../include/sycl/handler.hpp:1699:29: note: in instantiation of function template specialization 'sycl::handler::KernelPropertiesUnpackerImpl<>::kernel_parallel_for_unpack<sycl::detail::__pf_kernel_wrapper<oneapi::dpl::__internal::__walk2_brick_wrapper<TestUtils::unique_kernel_name<test_find<unsigned int, perm_it_index_tags::usm_shared>, 0>>>, sycl::item<1, true>, sycl::detail::RoundedRangeKernel<sycl::item<1, true>, 1, (lambda at /include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:236:75)>, sycl::detail::RoundedRangeKernel<sycl::item<1, true>, 1, (lambda at /include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:236:75)>>' requested here
 1699 |           Unpacker.template kernel_parallel_for_unpack<KernelName, ElementType,
      |                             ^
/compiler/bin/compiler/../../include/sycl/handler.hpp:1695:5: note: in instantiation of function template specialization 'sycl::handler::unpack<sycl::detail::__pf_kernel_wrapper<oneapi::dpl::__internal::__walk2_brick_wrapper<TestUtils::unique_kernel_name<test_find<unsigned int, perm_it_index_tags::usm_shared>, 0>>>, sycl::detail::RoundedRangeKernel<sycl::item<1, true>, 1, (lambda at /include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:236:75)>, sycl::ext::oneapi::experimental::properties<std::tuple<>>, false, (lambda at /compiler/bin/compiler/../../include/sycl/handler.hpp:1698:21)>' requested here
 1695 |     unpack<KernelName, KernelType, PropertiesT,
      |     ^
/compiler/bin/compiler/../../include/sycl/handler.hpp:1294:7: note: in instantiation of function template specialization 'sycl::handler::kernel_parallel_for_wrapper<sycl::detail::__pf_kernel_wrapper<oneapi::dpl::__internal::__walk2_brick_wrapper<TestUtils::unique_kernel_name<test_find<unsigned int, perm_it_index_tags::usm_shared>, 0>>>, sycl::item<1, true>, sycl::detail::RoundedRangeKernel<sycl::item<1, true>, 1, (lambda at /include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:236:75)>, sycl::ext::oneapi::experimental::properties<std::tuple<>>>' requested here
 1294 |       kernel_parallel_for_wrapper<KName, TransformedArgType, decltype(Wrapper),
      |       ^
/compiler/bin/compiler/../../include/sycl/handler.hpp:2333:5: note: in instantiation of function template specialization 'sycl::handler::parallel_for_lambda_impl<oneapi::dpl::__internal::__walk2_brick_wrapper<TestUtils::unique_kernel_name<test_find<unsigned int, perm_it_index_tags::usm_shared>, 0>>, (lambda at /include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:236:75), 1, sycl::ext::oneapi::experimental::properties<std::tuple<>>>' requested here
 2333 |     parallel_for_lambda_impl<KernelName, KernelType, 1, PropertiesT>(
      |     ^
/compiler/bin/compiler/../../include/sycl/handler.hpp:2416:5: note: in instantiation of function template specialization 'sycl::handler::parallel_for<oneapi::dpl::__internal::__walk2_brick_wrapper<TestUtils::unique_kernel_name<test_find<unsigned int, perm_it_index_tags::usm_shared>, 0>>, (lambda at /include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:236:75), sycl::ext::oneapi::experimental::properties<std::tuple<>>>' requested here
 2416 |     parallel_for<KernelName>(Range,
      |     ^
/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:236:19: note: (skipping 6 contexts in backtrace; use -ftemplate-backtrace-limit=0 to see all)
  236 |             __cgh.parallel_for<_Name...>(sycl::range</*dim=*/1>(__count), [=](sycl::item</*dim=*/1> __item_id) {
      |                   ^
/test/support/iterator_utils.h:389:9: note: in instantiation of function template specialization 'TestUtils::invoke_if_<std::integral_constant<bool, false>, std::integral_constant<bool, false>>::operator()<test_find<unsigned int, perm_it_index_tags::usm_shared>, oneapi::dpl::execution::device_policy<TestUtils::unique_kernel_name<test_find<unsigned int, perm_it_index_tags::usm_shared>, 0>> &, unsigned int *, unsigned int *, unsigned long &>' requested here
  389 |         invoke_if<Iterator>()(::std::distance(inputBegin, inputEnd) <= sizeLimit, op, exec,
      |         ^
/test/support/utils_invoke.h:191:13: note: in instantiation of function template specialization 'TestUtils::iterator_invoker<std::random_access_iterator_tag, std::integral_constant<bool, false>>::operator()<oneapi::dpl::execution::device_policy<TestUtils::unique_kernel_name<test_find<unsigned int, perm_it_index_tags::usm_shared>, 0>> &, test_find<unsigned int, perm_it_index_tags::usm_shared>, unsigned int *, unsigned long &>' requested here
  191 |             iterator_invoker<::std::random_access_iterator_tag, /*IsReverse*/ ::std::false_type>()(
      |             ^
/test/support/utils_sycl.h:163:13: note: in instantiation of function template specialization 'TestUtils::invoke_on_all_hetero_policies<>::operator()<test_find<unsigned int, perm_it_index_tags::usm_shared>, unsigned int *&, unsigned int *, unsigned long &>' requested here
  163 |             invoke_on_all_hetero_policies<0>()(create_test_obj<TestValueType, TestName>(test_base_data),
      |             ^
/test/parallel_api/iterator/permutation_iterator_parallel_find.pass.cpp:83:5: note: in instantiation of function template specialization 'TestUtils::test1buffer<sycl::usm::alloc::shared, unsigned int, test_find<unsigned int, perm_it_index_tags::usm_shared>>' requested here
   83 |     test1buffer<sycl::usm::alloc::shared, ValueType, test_find<ValueType, PermItIndexTag>>();
      |     ^
/test/parallel_api/iterator/permutation_iterator_parallel_find.pass.cpp:98:5: note: in instantiation of function template specialization 'run_algo_tests<unsigned int, perm_it_index_tags::usm_shared>' requested here
   98 |     run_algo_tests<ValueType, perm_it_index_tags::usm_shared>();
      |     ^
In file included from /test/parallel_api/iterator/permutation_iterator_parallel_find.pass.cpp:18:
In file included from /test/parallel_api/iterator/permutation_iterator_common.h:19:
In file included from /include/oneapi/dpl/execution:28:
In file included from /include/oneapi/dpl/pstl/execution_defs.h:222:
In file included from /include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h:22:
In file included from /include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h:25:
In file included from /compiler/bin/compiler/../../include/sycl/sycl.hpp:16:
In file included from /compiler/bin/compiler/../../include/sycl/backend.hpp:27:
/compiler/bin/compiler/../../include/sycl/handler.hpp:1613:59: error: 'oneapi::dpl::__internal::__walk2_brick_wrapper<TestUtils::unique_kernel_name<test_find<unsigned int, perm_it_index_tags::usm_shared>, 0>>' is invalid; kernel name should be forward declarable at namespace scope
 1613 |       h->kernel_parallel_for<TypesToForward..., Props...>(Args...);
      |                                                           ^
/compiler/bin/compiler/../../include/sycl/handler.hpp:1699:29: note: in instantiation of function template specialization 'sycl::handler::KernelPropertiesUnpackerImpl<>::kernel_parallel_for_unpack<oneapi::dpl::__internal::__walk2_brick_wrapper<TestUtils::unique_kernel_name<test_find<unsigned int, perm_it_index_tags::usm_shared>, 0>>, sycl::item<1, true>, (lambda at /include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:236:75), (lambda at /include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:236:75)>' requested here
 1699 |           Unpacker.template kernel_parallel_for_unpack<KernelName, ElementType,
      |                             ^
/compiler/bin/compiler/../../include/sycl/handler.hpp:1695:5: note: in instantiation of function template specialization 'sycl::handler::unpack<oneapi::dpl::__internal::__walk2_brick_wrapper<TestUtils::unique_kernel_name<test_find<unsigned int, perm_it_index_tags::usm_shared>, 0>>, (lambda at /include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:236:75), sycl::ext::oneapi::experimental::properties<std::tuple<>>, false, (lambda at /compiler/bin/compiler/../../include/sycl/handler.hpp:1698:21)>' requested here
 1695 |     unpack<KernelName, KernelType, PropertiesT,
      |     ^
/compiler/bin/compiler/../../include/sycl/handler.hpp:1315:7: note: in instantiation of function template specialization 'sycl::handler::kernel_parallel_for_wrapper<oneapi::dpl::__internal::__walk2_brick_wrapper<TestUtils::unique_kernel_name<test_find<unsigned int, perm_it_index_tags::usm_shared>, 0>>, sycl::item<1, true>, (lambda at /include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:236:75), sycl::ext::oneapi::experimental::properties<std::tuple<>>>' requested here
 1315 |       kernel_parallel_for_wrapper<NameT, TransformedArgType, KernelType,
      |       ^
/compiler/bin/compiler/../../include/sycl/handler.hpp:2333:5: note: in instantiation of function template specialization 'sycl::handler::parallel_for_lambda_impl<oneapi::dpl::__internal::__walk2_brick_wrapper<TestUtils::unique_kernel_name<test_find<unsigned int, perm_it_index_tags::usm_shared>, 0>>, (lambda at /include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:236:75), 1, sycl::ext::oneapi::experimental::properties<std::tuple<>>>' requested here
 2333 |     parallel_for_lambda_impl<KernelName, KernelType, 1, PropertiesT>(
      |     ^
/compiler/bin/compiler/../../include/sycl/handler.hpp:2416:5: note: in instantiation of function template specialization 'sycl::handler::parallel_for<oneapi::dpl::__internal::__walk2_brick_wrapper<TestUtils::unique_kernel_name<test_find<unsigned int, perm_it_index_tags::usm_shared>, 0>>, (lambda at /include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:236:75), sycl::ext::oneapi::experimental::properties<std::tuple<>>>' requested here
 2416 |     parallel_for<KernelName>(Range,
      |     ^
/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:236:19: note: (skipping 6 contexts in backtrace; use -ftemplate-backtrace-limit=0 to see all)
  236 |             __cgh.parallel_for<_Name...>(sycl::range</*dim=*/1>(__count), [=](sycl::item</*dim=*/1> __item_id) {
      |                   ^
/test/support/iterator_utils.h:389:9: note: in instantiation of function template specialization 'TestUtils::invoke_if_<std::integral_constant<bool, false>, std::integral_constant<bool, false>>::operator()<test_find<unsigned int, perm_it_index_tags::usm_shared>, oneapi::dpl::execution::device_policy<TestUtils::unique_kernel_name<test_find<unsigned int, perm_it_index_tags::usm_shared>, 0>> &, unsigned int *, unsigned int *, unsigned long &>' requested here
  389 |         invoke_if<Iterator>()(::std::distance(inputBegin, inputEnd) <= sizeLimit, op, exec,
      |         ^
/test/support/utils_invoke.h:191:13: note: in instantiation of function template specialization 'TestUtils::iterator_invoker<std::random_access_iterator_tag, std::integral_constant<bool, false>>::operator()<oneapi::dpl::execution::device_policy<TestUtils::unique_kernel_name<test_find<unsigned int, perm_it_index_tags::usm_shared>, 0>> &, test_find<unsigned int, perm_it_index_tags::usm_shared>, unsigned int *, unsigned long &>' requested here
  191 |             iterator_invoker<::std::random_access_iterator_tag, /*IsReverse*/ ::std::false_type>()(
      |             ^
/test/support/utils_sycl.h:163:13: note: in instantiation of function template specialization 'TestUtils::invoke_on_all_hetero_policies<>::operator()<test_find<unsigned int, perm_it_index_tags::usm_shared>, unsigned int *&, unsigned int *, unsigned long &>' requested here
  163 |             invoke_on_all_hetero_policies<0>()(create_test_obj<TestValueType, TestName>(test_base_data),
      |             ^
/test/parallel_api/iterator/permutation_iterator_parallel_find.pass.cpp:83:5: note: in instantiation of function template specialization 'TestUtils::test1buffer<sycl::usm::alloc::shared, unsigned int, test_find<unsigned int, perm_it_index_tags::usm_shared>>' requested here
   83 |     test1buffer<sycl::usm::alloc::shared, ValueType, test_find<ValueType, PermItIndexTag>>();
      |     ^
/test/parallel_api/iterator/permutation_iterator_parallel_find.pass.cpp:98:5: note: in instantiation of function template specialization 'run_algo_tests<unsigned int, perm_it_index_tags::usm_shared>' requested here
   98 |     run_algo_tests<ValueType, perm_it_index_tags::usm_shared>();
      |     ^
In file included from /test/parallel_api/iterator/permutation_iterator_parallel_find.pass.cpp:18:
In file included from /test/parallel_api/iterator/permutation_iterator_common.h:19:
In file included from /include/oneapi/dpl/execution:28:
In file included from /include/oneapi/dpl/pstl/execution_defs.h:222:
In file included from /include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h:22:
In file included from /include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h:25:
In file included from /compiler/bin/compiler/../../include/sycl/sycl.hpp:16:
In file included from /compiler/bin/compiler/../../include/sycl/backend.hpp:27:
/compiler/bin/compiler/../../include/sycl/handler.hpp:1613:59: error: 'oneapi::dpl::__par_backend_hetero::__find_or_kernel<oneapi::dpl::__par_backend_hetero::__find_policy_wrapper<TestUtils::unique_kernel_name<test_find<unsigned int, perm_it_index_tags::usm_shared>, 0>>>' is invalid; kernel name should be forward declarable at namespace scope
 1613 |       h->kernel_parallel_for<TypesToForward..., Props...>(Args...);
      |                                                           ^
/compiler/bin/compiler/../../include/sycl/handler.hpp:1699:29: note: in instantiation of function template specialization 'sycl::handler::KernelPropertiesUnpackerImpl<>::kernel_parallel_for_unpack<oneapi::dpl::__par_backend_hetero::__find_or_kernel<oneapi::dpl::__par_backend_hetero::__find_policy_wrapper<TestUtils::unique_kernel_name<test_find<unsigned int, perm_it_index_tags::usm_shared>, 0>>>, sycl::nd_item<>, (lambda at /include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:1132:17), (lambda at /include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:1132:17)>' requested here
 1699 |           Unpacker.template kernel_parallel_for_unpack<KernelName, ElementType,
      |                             ^
/compiler/bin/compiler/../../include/sycl/handler.hpp:1695:5: note: in instantiation of function template specialization 'sycl::handler::unpack<oneapi::dpl::__par_backend_hetero::__find_or_kernel<oneapi::dpl::__par_backend_hetero::__find_policy_wrapper<TestUtils::unique_kernel_name<test_find<unsigned int, perm_it_index_tags::usm_shared>, 0>>>, (lambda at /include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:1132:17), sycl::ext::oneapi::experimental::properties<std::tuple<>>, false, (lambda at /compiler/bin/compiler/../../include/sycl/handler.hpp:1698:21)>' requested here
 1695 |     unpack<KernelName, KernelType, PropertiesT,
      |     ^
```