### PR TITLE
Fix zip iterators to be device copyable, fix for require_access

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -291,6 +291,11 @@ __get_first_range_size(const _Range& __rng, const _Ranges&...) -> decltype(__rng
     return __rng.size();
 }
 
+//forward declaration required for _require_access_args
+template <typename _Range, typename... _Ranges>
+void
+__require_access(sycl::handler& __cgh, _Range&& __rng, _Ranges&&... __rest);
+
 template <typename _Cgh>
 struct _require_access_args
 {

--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -411,14 +411,8 @@ class transform_iterator
     typedef typename ::std::iterator_traits<_Iter>::iterator_category iterator_category;
 
     transform_iterator() = default;
-    transform_iterator(_Iter __it)
-        : __my_it_(__it), __my_unary_func_()
-    {
-    }
-    transform_iterator(_Iter __it, _UnaryFunc __unary_func)
-        : __my_it_(__it), __my_unary_func_(__unary_func)
-    {
-    }
+    transform_iterator(_Iter __it) : __my_it_(__it), __my_unary_func_() {}
+    transform_iterator(_Iter __it, _UnaryFunc __unary_func) : __my_it_(__it), __my_unary_func_(__unary_func) {}
     transform_iterator(const transform_iterator& __input) = default;
     transform_iterator&
     operator=(const transform_iterator& __input)

--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -410,7 +410,10 @@ class transform_iterator
     typedef typename ::std::iterator_traits<_Iter>::pointer pointer;
     typedef typename ::std::iterator_traits<_Iter>::iterator_category iterator_category;
 
-    transform_iterator(_Iter __it = _Iter(), _UnaryFunc __unary_func = _UnaryFunc()) : __my_it_(__it), __my_unary_func_(__unary_func) {}
+    transform_iterator(_Iter __it = _Iter(), _UnaryFunc __unary_func = _UnaryFunc())
+        : __my_it_(__it), __my_unary_func_(__unary_func)
+    {
+    }
     transform_iterator(const transform_iterator& __input) = default;
     transform_iterator&
     operator=(const transform_iterator& __input)

--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -89,11 +89,8 @@ class zip_forward_iterator
     typedef ::std::tuple<typename ::std::iterator_traits<_Types>::pointer...> pointer;
     typedef ::std::forward_iterator_tag iterator_category;
 
-    zip_forward_iterator() : __my_it_() {}
+    zip_forward_iterator() = default;
     explicit zip_forward_iterator(_Types... __args) : __my_it_(::std::make_tuple(__args...)) {}
-    zip_forward_iterator(const zip_forward_iterator& __input) = default;
-    zip_forward_iterator&
-    operator=(const zip_forward_iterator& __input) = default;
 
     reference operator*() const
     {
@@ -156,11 +153,8 @@ class counting_iterator
     typedef _Ip reference;
     typedef ::std::random_access_iterator_tag iterator_category;
 
-    counting_iterator() : __my_counter_() {}
+    counting_iterator() = default;
     explicit counting_iterator(_Ip __init) : __my_counter_(__init) {}
-    counting_iterator(const counting_iterator& __input) = default;
-    counting_iterator&
-    operator=(const counting_iterator& __input) = default;
 
     reference operator*() const { return __my_counter_; }
     reference operator[](difference_type __i) const { return *(*this + __i); }
@@ -274,12 +268,8 @@ class zip_iterator
     typedef ::std::random_access_iterator_tag iterator_category;
     using is_zip = ::std::true_type;
 
-    zip_iterator() : __my_it_() {}
+    zip_iterator() = default;
     explicit zip_iterator(_Types... __args) : __my_it_(::std::make_tuple(__args...)) {}
-    explicit zip_iterator(std::tuple<_Types...> __arg) : __my_it_(__arg) {}
-    zip_iterator(const zip_iterator& __input) = default;
-    zip_iterator&
-    operator=(const zip_iterator& __input) = default;
 
     reference operator*() const
     {
@@ -419,7 +409,12 @@ class transform_iterator
     typedef typename ::std::iterator_traits<_Iter>::pointer pointer;
     typedef typename ::std::iterator_traits<_Iter>::iterator_category iterator_category;
 
-    transform_iterator(_Iter __it = _Iter(), _UnaryFunc __unary_func = _UnaryFunc())
+    transform_iterator() = default;
+    transform_iterator(_Iter __it)
+        : __my_it_(__it)
+    {
+    }
+    transform_iterator(_Iter __it, _UnaryFunc __unary_func)
         : __my_it_(__it), __my_unary_func_(__unary_func)
     {
     }
@@ -594,9 +589,6 @@ class permutation_iterator
         : my_source_it(input1), my_index(counting_iterator<difference_type>(__idx), __f)
     {
     }
-    permutation_iterator(const permutation_iterator& __input) = default;
-    permutation_iterator&
-    operator=(const permutation_iterator& __input) = default;
 
   private:
     template <typename _T = _Permutation, ::std::enable_if_t<__internal::__is_functor<_T>, int> = 0>

--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -430,7 +430,6 @@ class transform_iterator
         __my_it_ = __input.__my_it_;
         return *this;
     }
-
     reference operator*() const { return __my_unary_func_(*__my_it_); }
     reference operator[](difference_type __i) const { return *(*this + __i); }
     transform_iterator&

--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -89,7 +89,7 @@ class zip_forward_iterator
     typedef ::std::tuple<typename ::std::iterator_traits<_Types>::pointer...> pointer;
     typedef ::std::forward_iterator_tag iterator_category;
 
-    zip_forward_iterator() = default;
+    zip_forward_iterator() : __my_it_() {}
     explicit zip_forward_iterator(_Types... __args) : __my_it_(::std::make_tuple(__args...)) {}
 
     reference operator*() const
@@ -153,7 +153,7 @@ class counting_iterator
     typedef _Ip reference;
     typedef ::std::random_access_iterator_tag iterator_category;
 
-    counting_iterator() = default;
+    counting_iterator() : __my_counter_() {}
     explicit counting_iterator(_Ip __init) : __my_counter_(__init) {}
 
     reference operator*() const { return __my_counter_; }
@@ -268,7 +268,7 @@ class zip_iterator
     typedef ::std::random_access_iterator_tag iterator_category;
     using is_zip = ::std::true_type;
 
-    zip_iterator() = default;
+    zip_iterator() : __my_it_() {}
     explicit zip_iterator(_Types... __args) : __my_it_(::std::make_tuple(__args...)) {}
     explicit zip_iterator(std::tuple<_Types...> __arg) : __my_it_(__arg) {}
 
@@ -410,9 +410,7 @@ class transform_iterator
     typedef typename ::std::iterator_traits<_Iter>::pointer pointer;
     typedef typename ::std::iterator_traits<_Iter>::iterator_category iterator_category;
 
-    transform_iterator() = default;
-    transform_iterator(_Iter __it) : __my_it_(__it), __my_unary_func_() {}
-    transform_iterator(_Iter __it, _UnaryFunc __unary_func) : __my_it_(__it), __my_unary_func_(__unary_func) {}
+    transform_iterator(_Iter __it = _Iter(), _UnaryFunc __unary_func = _UnaryFunc()) : __my_it_(__it), __my_unary_func_(__unary_func) {}
     transform_iterator(const transform_iterator& __input) = default;
     transform_iterator&
     operator=(const transform_iterator& __input)

--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -270,6 +270,7 @@ class zip_iterator
 
     zip_iterator() = default;
     explicit zip_iterator(_Types... __args) : __my_it_(::std::make_tuple(__args...)) {}
+    explicit zip_iterator(std::tuple<_Types...> __arg) : __my_it_(__arg) {}
 
     reference operator*() const
     {

--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -91,13 +91,9 @@ class zip_forward_iterator
 
     zip_forward_iterator() : __my_it_() {}
     explicit zip_forward_iterator(_Types... __args) : __my_it_(::std::make_tuple(__args...)) {}
-    zip_forward_iterator(const zip_forward_iterator& __input) : __my_it_(__input.__my_it_) {}
+    zip_forward_iterator(const zip_forward_iterator& __input) = default;
     zip_forward_iterator&
-    operator=(const zip_forward_iterator& __input)
-    {
-        __my_it_ = __input.__my_it_;
-        return *this;
-    }
+    operator=(const zip_forward_iterator& __input) = default;
 
     reference operator*() const
     {
@@ -162,6 +158,9 @@ class counting_iterator
 
     counting_iterator() : __my_counter_() {}
     explicit counting_iterator(_Ip __init) : __my_counter_(__init) {}
+    counting_iterator(const counting_iterator& __input) = default;
+    counting_iterator&
+    operator=(const counting_iterator& __input) = default;
 
     reference operator*() const { return __my_counter_; }
     reference operator[](difference_type __i) const { return *(*this + __i); }
@@ -278,13 +277,9 @@ class zip_iterator
     zip_iterator() : __my_it_() {}
     explicit zip_iterator(_Types... __args) : __my_it_(::std::make_tuple(__args...)) {}
     explicit zip_iterator(std::tuple<_Types...> __arg) : __my_it_(__arg) {}
-    zip_iterator(const zip_iterator& __input) : __my_it_(__input.__my_it_) {}
+    zip_iterator(const zip_iterator& __input) = default;
     zip_iterator&
-    operator=(const zip_iterator& __input)
-    {
-        __my_it_ = __input.__my_it_;
-        return *this;
-    }
+    operator=(const zip_iterator& __input) = default;
 
     reference operator*() const
     {
@@ -432,9 +427,14 @@ class transform_iterator
     transform_iterator&
     operator=(const transform_iterator& __input)
     {
+        //TODO: Investigate making transform_iterator trivially_copyable. This custom copy assignment operator prevents
+        // transform_iterator, and therefore permutation_iterator from being trivially_copyable.  Not being trivially
+        // copyable makes their device_copyable trait deprecated in SYCL2020. However, defaulting this function implies
+        // an extra requirement that __my_unary_func_ implements a copy assignment operator.
         __my_it_ = __input.__my_it_;
         return *this;
     }
+
     reference operator*() const { return __my_unary_func_(*__my_it_); }
     reference operator[](difference_type __i) const { return *(*this + __i); }
     transform_iterator&
@@ -594,6 +594,9 @@ class permutation_iterator
         : my_source_it(input1), my_index(counting_iterator<difference_type>(__idx), __f)
     {
     }
+    permutation_iterator(const permutation_iterator& __input) = default;
+    permutation_iterator&
+    operator=(const permutation_iterator& __input) = default;
 
   private:
     template <typename _T = _Permutation, ::std::enable_if_t<__internal::__is_functor<_T>, int> = 0>

--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -412,7 +412,7 @@ class transform_iterator
 
     transform_iterator() = default;
     transform_iterator(_Iter __it)
-        : __my_it_(__it)
+        : __my_it_(__it), __my_unary_func_()
     {
     }
     transform_iterator(_Iter __it, _UnaryFunc __unary_func)

--- a/test/parallel_api/iterator/iterators.pass.cpp
+++ b/test/parallel_api/iterator/iterators.pass.cpp
@@ -245,6 +245,7 @@ struct ref_transform_functor {
 
 //We need this functor to pass operator* test for transform iterator
 struct transform_functor {
+    transform_functor() = default;
     template<typename T>
     T operator()(T& x) const {
         return x + 1;

--- a/test/parallel_api/iterator/iterators.pass.cpp
+++ b/test/parallel_api/iterator/iterators.pass.cpp
@@ -32,7 +32,7 @@
 using namespace TestUtils;
 
 //common checks of a random access iterator functionality
-template <typename RandomIt>
+template <bool expect_default_constructible = true, typename RandomIt>
 void test_random_iterator(const RandomIt& it) {
     // check that RandomIt has all necessary publicly accessible member types
     {
@@ -43,7 +43,7 @@ void test_random_iterator(const RandomIt& it) {
         [[maybe_unused]] auto t4 = typename RandomIt::iterator_category{};
     }
 
-    static_assert(::std::is_default_constructible_v<RandomIt>, "iterator is not default constructible");
+    static_assert(!expect_default_constructible || ::std::is_default_constructible_v<RandomIt>, "iterator is not default constructible");
 
     EXPECT_TRUE(  it == it,      "== returned false negative");
     EXPECT_TRUE(!(it == it + 1), "== returned false positive");
@@ -313,7 +313,8 @@ struct test_permutation_iterator
         auto perm_it_fun_rev = oneapi::dpl::make_permutation_iterator(in1.begin(), [n] (auto i) { return n - i - 1;}, 1);
         EXPECT_TRUE(*++perm_it_fun_rev == *(in1.end()-3), "wrong result from permutation_iterator(base_iterator, functor)");
 
-        test_random_iterator(perm_it_fun_rev);
+        // Permutation iterator with a lambda is not default constructible because lambas are not default constructible
+        test_random_iterator</*expect_default_constructible = */false>(perm_it_fun_rev);
 
         ::std::vector<T1> res(n);
         perm_it_fun_rev -= 2;

--- a/test/parallel_api/iterator/iterators.pass.cpp
+++ b/test/parallel_api/iterator/iterators.pass.cpp
@@ -313,7 +313,6 @@ struct test_permutation_iterator
         auto perm_it_fun_rev = oneapi::dpl::make_permutation_iterator(in1.begin(), [n] (auto i) { return n - i - 1;}, 1);
         EXPECT_TRUE(*++perm_it_fun_rev == *(in1.end()-3), "wrong result from permutation_iterator(base_iterator, functor)");
 
-        // Permutation iterator with a lambda is not default constructible because lambas are not default constructible
         test_random_iterator(perm_it_fun_rev);
 
         ::std::vector<T1> res(n);

--- a/test/parallel_api/iterator/iterators.pass.cpp
+++ b/test/parallel_api/iterator/iterators.pass.cpp
@@ -32,7 +32,7 @@
 using namespace TestUtils;
 
 //common checks of a random access iterator functionality
-template <bool expect_default_constructible = true, typename RandomIt>
+template <typename RandomIt>
 void test_random_iterator(const RandomIt& it) {
     // check that RandomIt has all necessary publicly accessible member types
     {
@@ -43,7 +43,7 @@ void test_random_iterator(const RandomIt& it) {
         [[maybe_unused]] auto t4 = typename RandomIt::iterator_category{};
     }
 
-    static_assert(!expect_default_constructible || ::std::is_default_constructible_v<RandomIt>, "iterator is not default constructible");
+    static_assert(::std::is_default_constructible_v<RandomIt>, "iterator is not default constructible");
 
     EXPECT_TRUE(  it == it,      "== returned false negative");
     EXPECT_TRUE(!(it == it + 1), "== returned false positive");
@@ -245,7 +245,6 @@ struct ref_transform_functor {
 
 //We need this functor to pass operator* test for transform iterator
 struct transform_functor {
-    transform_functor() = default;
     template<typename T>
     T operator()(T& x) const {
         return x + 1;
@@ -315,7 +314,7 @@ struct test_permutation_iterator
         EXPECT_TRUE(*++perm_it_fun_rev == *(in1.end()-3), "wrong result from permutation_iterator(base_iterator, functor)");
 
         // Permutation iterator with a lambda is not default constructible because lambas are not default constructible
-        test_random_iterator</*expect_default_constructible = */false>(perm_it_fun_rev);
+        test_random_iterator(perm_it_fun_rev);
 
         ::std::vector<T1> res(n);
         perm_it_fun_rev -= 2;

--- a/test/parallel_api/iterator/permutation_iterator.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator.pass.cpp
@@ -39,7 +39,7 @@ main()
     //transform_iterator is not trivially_copyable, as it defines a copy assignment operator which does not copy
     // its unary functor.  permutation_iterator is based on transform_iterator and therefore is also not
     // trivially_copyable.  This makes permutation_iterator's device_copyable trait deprecated with sycl 2020.
-    EXPECT_TRUE(check_device_copyable_w_deprecrated_sycl2020<decltype(permItBegin)>,
+    EXPECT_TRUE(check_if_device_copyable_by_sycl2020_or_by_old_definition <decltype(permItBegin)>,
                 "permutation_iterator (counting_iterator) is not properly copyable");
 
     const std::size_t perm_size_result = std::distance(permItBegin, permItEnd);

--- a/test/parallel_api/iterator/permutation_iterator.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator.pass.cpp
@@ -35,6 +35,13 @@ main()
     const std::size_t perm_size_expected = kDefaultIndexStepOp.eval_items_count(countingItDistanceResult);
     auto permItBegin = dpl::make_permutation_iterator(countingItBegin, kDefaultIndexStepOp);
     auto permItEnd = permItBegin + perm_size_expected;
+
+    //transform_iterator is not trivially_copyable, as it defines a copy assignment operator which does not copy
+    // its unary functor.  permutation_iterator is based on transform_iterator and therefore is also not
+    // trivially_copyable.  This makes permutation_iterator's device_copyable trait deprecated with sycl 2020.
+    EXPECT_TRUE(check_device_copyable_w_deprecrated_sycl2020<decltype(permItBegin)>,
+                "permutation_iterator (counting_iterator) is not properly copyable");
+
     const std::size_t perm_size_result = std::distance(permItBegin, permItEnd);
     EXPECT_EQ(perm_size_expected, perm_size_result,
               "Wrong result of std::distance<permutationIterator1, permutationIterator2)");

--- a/test/parallel_api/iterator/transform_iterator.pass.cpp
+++ b/test/parallel_api/iterator/transform_iterator.pass.cpp
@@ -168,16 +168,16 @@ test_copyable()
     //transform_iterator is not trivially_copyable, as it defines a copy assignment operator which does not copy
     // its unary functor. This makes transform_iterator's device_copyable trait deprecated with sycl 2020.
 
-    EXPECT_TRUE(check_device_copyable_w_deprecrated_sycl2020<oneapi::dpl::counting_iterator<int>>,
+    EXPECT_TRUE(check_if_device_copyable_by_sycl2020_or_by_old_definition <oneapi::dpl::counting_iterator<int>>,
                 "counting_iterator is not device copyable");
 
     auto trans_count = ::dpl::make_transform_iterator(oneapi::dpl::counting_iterator<int>(0), [](auto i) { return i; });
-    EXPECT_TRUE(check_device_copyable_w_deprecrated_sycl2020<decltype(trans_count)>,
+    EXPECT_TRUE(check_if_device_copyable_by_sycl2020_or_by_old_definition <decltype(trans_count)>,
                 "transform_iterator(counting_iterator) is not device copyable");
 
     std::vector<int> array(10, 0);
     auto trans_array = ::dpl::make_transform_iterator(array.begin(), [](auto i) { return i; });
-    EXPECT_TRUE(check_device_copyable_w_deprecrated_sycl2020<decltype(trans_array)>,
+    EXPECT_TRUE(check_if_device_copyable_by_sycl2020_or_by_old_definition <decltype(trans_array)>,
                 "transform_iterator(host_iterator) is not device copyable");
 }
 #endif // TEST_DPCPP_BACKEND_PRESENT

--- a/test/parallel_api/iterator/zip_iterator.pass.cpp
+++ b/test/parallel_api/iterator/zip_iterator.pass.cpp
@@ -121,6 +121,8 @@ DEFINE_TEST(test_for_each)
 
         auto tuple_first1 = oneapi::dpl::make_zip_iterator(std::make_tuple(first1, first1));
         auto tuple_last1 = oneapi::dpl::make_zip_iterator(last1, last1);
+
+        //check device copyable only for usm iterator based data, it is not required or expected for sycl buffer data
         if (!this->host_buffering_required())
         {
             EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first1)>, "zip_iterator (for_each) not properly copyable");
@@ -157,6 +159,8 @@ DEFINE_TEST(test_for_each_structured_binding)
 
         auto tuple_first1 = oneapi::dpl::make_zip_iterator(first1, first1);
         auto tuple_last1 = oneapi::dpl::make_zip_iterator(last1, last1);
+
+        //check device copyable only for usm iterator based data, it is not required or expected for sycl buffer data
         if (!this->host_buffering_required())
         {
             EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first1)>, 
@@ -197,6 +201,8 @@ DEFINE_TEST(test_transform_reduce_unary)
 
         auto tuple_first1 = oneapi::dpl::make_zip_iterator(first1, first1);
         auto tuple_last1 = oneapi::dpl::make_zip_iterator(last1, last1);
+
+        //check device copyable only for usm iterator based data, it is not required or expected for sycl buffer data
         if (!this->host_buffering_required())
         {
             EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first1)>, "zip_iterator (reduce_unary) not properly copyable");
@@ -228,6 +234,8 @@ DEFINE_TEST(test_transform_reduce_binary)
 
         auto tuple_first1 = oneapi::dpl::make_zip_iterator(first1, first1);
         auto tuple_last1 = oneapi::dpl::make_zip_iterator(last1, last1);
+
+        //check device copyable only for usm iterator based data, it is not required or expected for sycl buffer data
         if (!this->host_buffering_required())
         {
             EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first1)>, "zip_iterator (reduce_binary) not properly copyable");
@@ -268,6 +276,8 @@ DEFINE_TEST(test_min_element)
 
         auto tuple_first = oneapi::dpl::make_zip_iterator(first, first);
         auto tuple_last = oneapi::dpl::make_zip_iterator(last, last);
+
+        //check device copyable only for usm iterator based data, it is not required or expected for sycl buffer data
         if (!this->host_buffering_required())
         {
             EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first)>, "zip_iterator (min_element) not properly copyable");
@@ -306,6 +316,8 @@ DEFINE_TEST(test_count_if)
 
         auto tuple_first = oneapi::dpl::make_zip_iterator(first, first);
         auto tuple_last = oneapi::dpl::make_zip_iterator(last, last);
+
+        //check device copyable only for usm iterator based data, it is not required or expected for sycl buffer data
         if (!this->host_buffering_required())
         {
             EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first)>, "zip_iterator (count_if) not properly copyable");
@@ -346,6 +358,7 @@ DEFINE_TEST(test_equal)
         auto tuple_last1 = oneapi::dpl::make_zip_iterator(last1, last1);
         auto tuple_first2 = oneapi::dpl::make_zip_iterator(first2, first2);
 
+        //check device copyable only for usm iterator based data, it is not required or expected for sycl buffer data
         if (!this->host_buffering_required())
         {
             EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first1)>, "zip_iterator (equal1) not properly copyable");
@@ -395,6 +408,7 @@ DEFINE_TEST(test_equal_structured_binding)
         auto tuple_last1 = oneapi::dpl::make_zip_iterator(last1, last1);
         auto tuple_first2 = oneapi::dpl::make_zip_iterator(first2, first2);
 
+        //check device copyable only for usm iterator based data, it is not required or expected for sycl buffer data
         if (!this->host_buffering_required())
         {
             EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first1)>,
@@ -452,6 +466,7 @@ DEFINE_TEST(test_find_if)
         auto tuple_first1 = oneapi::dpl::make_zip_iterator(first1, first1);
         auto tuple_last1 = oneapi::dpl::make_zip_iterator(last1, last1);
 
+        //check device copyable only for usm iterator based data, it is not required or expected for sycl buffer data
         if (!this->host_buffering_required())
         {
             EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first1)>, "zip_iterator (find_if) not properly copyable");
@@ -510,6 +525,7 @@ DEFINE_TEST(test_transform_inclusive_scan)
         auto tuple_first2 = oneapi::dpl::make_zip_iterator(first2, first2);
         auto tuple_last2 = oneapi::dpl::make_zip_iterator(last2, last2);
 
+        //check device copyable only for usm iterator based data, it is not required or expected for sycl buffer data
         if (!this->host_buffering_required())
         {
             EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first1)>, "zip_iterator (inclusive_scan1) not properly copyable");
@@ -550,6 +566,7 @@ DEFINE_TEST(test_unique)
         auto tuple_first1 = oneapi::dpl::make_zip_iterator(first1, first1);
         auto tuple_last1 = oneapi::dpl::make_zip_iterator(last1, last1);
 
+        //check device copyable only for usm iterator based data, it is not required or expected for sycl buffer data
         if (!this->host_buffering_required())
         {
             EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first1)>, "zip_iterator (unique) not properly copyable");
@@ -597,6 +614,7 @@ DEFINE_TEST(test_unique_copy)
         auto tuple_last1 = oneapi::dpl::make_zip_iterator(last1, last1);
         auto tuple_first2 = oneapi::dpl::make_zip_iterator(first2, first2);
 
+        //check device copyable only for usm iterator based data, it is not required or expected for sycl buffer data
         if (!this->host_buffering_required())
         {
             EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first1)>, "zip_iterator (unique_copy1) not properly copyable");
@@ -662,6 +680,7 @@ DEFINE_TEST(test_merge)
         auto tuple_last2 = oneapi::dpl::make_zip_iterator(first2 + size2, first2 + size2);
         auto tuple_first3 = oneapi::dpl::make_zip_iterator(first3, first3);
 
+        //check device copyable only for usm iterator based data, it is not required or expected for sycl buffer data
         if (!this->host_buffering_required())
         {
             EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first1)>, "zip_iterator (merge1) not properly copyable");
@@ -716,6 +735,7 @@ DEFINE_TEST(test_stable_sort)
         auto tuple_first = oneapi::dpl::make_zip_iterator(first1, first2);
         auto tuple_last = oneapi::dpl::make_zip_iterator(last1, last2);
 
+        //check device copyable only for usm iterator based data, it is not required or expected for sycl buffer data
         if (!this->host_buffering_required())
         {
             EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first)>, "zip_iterator (stable_sort) not properly copyable");
@@ -764,6 +784,7 @@ DEFINE_TEST(test_lexicographical_compare)
         auto tuple_first2 = oneapi::dpl::make_zip_iterator(first2, first2);
         auto tuple_last2 = oneapi::dpl::make_zip_iterator(last2, last2);
 
+        //check device copyable only for usm iterator based data, it is not required or expected for sycl buffer data
         if (!this->host_buffering_required())
         {
             EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first1)>,
@@ -822,6 +843,7 @@ DEFINE_TEST(test_counting_zip_transform)
         auto idx = oneapi::dpl::counting_iterator<ValueType>(0);
         auto start = oneapi::dpl::make_zip_iterator(idx, first1);
 
+        //check device copyable only for usm iterator based data, it is not required or expected for sycl buffer data
         if (!this->host_buffering_required())
         {
             EXPECT_TRUE(sycl::is_device_copyable_v<decltype(start)>, "zip_iterator (counting_iterator1) not properly copyable");
@@ -877,6 +899,7 @@ DEFINE_TEST(test_counting_zip_discard)
         auto discard = oneapi::dpl::discard_iterator();
         auto out = oneapi::dpl::make_zip_iterator(first2, discard);
 
+        //check device copyable only for usm iterator based data, it is not required or expected for sycl buffer data
         if (!this->host_buffering_required())
         {
             EXPECT_TRUE(sycl::is_device_copyable_v<decltype(start)>, "zip_iterator (discard_iterator1) not properly copyable");

--- a/test/parallel_api/iterator/zip_iterator.pass.cpp
+++ b/test/parallel_api/iterator/zip_iterator.pass.cpp
@@ -121,6 +121,10 @@ DEFINE_TEST(test_for_each)
 
         auto tuple_first1 = oneapi::dpl::make_zip_iterator(std::make_tuple(first1, first1));
         auto tuple_last1 = oneapi::dpl::make_zip_iterator(last1, last1);
+        if (!this->host_buffering_required())
+        {
+            EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first1)>, "zip_iterator (for_each) not properly copyable");
+        }
 
         ::std::for_each(make_new_policy<new_kernel_name<Policy, 0>>(exec), tuple_first1, tuple_last1,
                       TuplePredicate<decltype(f), 0>{f});
@@ -153,6 +157,11 @@ DEFINE_TEST(test_for_each_structured_binding)
 
         auto tuple_first1 = oneapi::dpl::make_zip_iterator(first1, first1);
         auto tuple_last1 = oneapi::dpl::make_zip_iterator(last1, last1);
+        if (!this->host_buffering_required())
+        {
+            EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first1)>, 
+                        "zip_iterator (structured_binding) not properly copyable");
+        }
 
         ::std::for_each(make_new_policy<new_kernel_name<Policy, 0>>(exec), tuple_first1, tuple_last1,
                         [f](auto value)
@@ -188,6 +197,10 @@ DEFINE_TEST(test_transform_reduce_unary)
 
         auto tuple_first1 = oneapi::dpl::make_zip_iterator(first1, first1);
         auto tuple_last1 = oneapi::dpl::make_zip_iterator(last1, last1);
+        if (!this->host_buffering_required())
+        {
+            EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first1)>, "zip_iterator (reduce_unary) not properly copyable");
+        }
 
         ::std::transform_reduce(make_new_policy<new_kernel_name<Policy, 0>>(exec), tuple_first1, tuple_last1,
                                 ::std::make_tuple(T1{42}, T1{42}), TupleNoOp{}, TupleNoOp{});
@@ -215,6 +228,10 @@ DEFINE_TEST(test_transform_reduce_binary)
 
         auto tuple_first1 = oneapi::dpl::make_zip_iterator(first1, first1);
         auto tuple_last1 = oneapi::dpl::make_zip_iterator(last1, last1);
+        if (!this->host_buffering_required())
+        {
+            EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first1)>, "zip_iterator (reduce_binary) not properly copyable");
+        }
 
         ::std::transform_reduce(make_new_policy<new_kernel_name<Policy, 0>>(exec), tuple_first1,
                                   tuple_last1, tuple_first1, ::std::make_tuple(T1{42}, T1{42}), TupleNoOp{}, TupleNoOp{});
@@ -251,6 +268,10 @@ DEFINE_TEST(test_min_element)
 
         auto tuple_first = oneapi::dpl::make_zip_iterator(first, first);
         auto tuple_last = oneapi::dpl::make_zip_iterator(last, last);
+        if (!this->host_buffering_required())
+        {
+            EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first)>, "zip_iterator (min_element) not properly copyable");
+        }
 
         auto tuple_result =
             ::std::min_element(make_new_policy<new_kernel_name<Policy, 0>>(exec), tuple_first, tuple_last,
@@ -285,6 +306,10 @@ DEFINE_TEST(test_count_if)
 
         auto tuple_first = oneapi::dpl::make_zip_iterator(first, first);
         auto tuple_last = oneapi::dpl::make_zip_iterator(last, last);
+        if (!this->host_buffering_required())
+        {
+            EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first)>, "zip_iterator (count_if) not properly copyable");
+        }
 
         auto comp = [](ValueType const& value) { return value % 10 == 0; };
         ReturnType expected = (n - 1) / 10 + 1;
@@ -320,6 +345,12 @@ DEFINE_TEST(test_equal)
         auto tuple_first1 = oneapi::dpl::make_zip_iterator(first1, first1);
         auto tuple_last1 = oneapi::dpl::make_zip_iterator(last1, last1);
         auto tuple_first2 = oneapi::dpl::make_zip_iterator(first2, first2);
+
+        if (!this->host_buffering_required())
+        {
+            EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first1)>, "zip_iterator (equal1) not properly copyable");
+            EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first2)>, "zip_iterator (equal2) not properly copyable");
+        }
 
         bool is_equal = ::std::equal(make_new_policy<new_kernel_name<Policy, 0>>(exec), tuple_first1, tuple_last1, tuple_first2,
                                    TuplePredicate<::std::equal_to<T>, 0>{::std::equal_to<T>{}});
@@ -363,6 +394,14 @@ DEFINE_TEST(test_equal_structured_binding)
         auto tuple_first1 = oneapi::dpl::make_zip_iterator(first1, first1);
         auto tuple_last1 = oneapi::dpl::make_zip_iterator(last1, last1);
         auto tuple_first2 = oneapi::dpl::make_zip_iterator(first2, first2);
+
+        if (!this->host_buffering_required())
+        {
+            EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first1)>,
+                        "zip_iterator (equal_structured_binding1) not properly copyable");
+            EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first2)>,
+                        "zip_iterator (equal_structured_binding2) not properly copyable");
+        }
 
         auto compare = [](auto tuple_first1, auto tuple_first2)
         {
@@ -412,6 +451,11 @@ DEFINE_TEST(test_find_if)
 
         auto tuple_first1 = oneapi::dpl::make_zip_iterator(first1, first1);
         auto tuple_last1 = oneapi::dpl::make_zip_iterator(last1, last1);
+
+        if (!this->host_buffering_required())
+        {
+            EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first1)>, "zip_iterator (find_if) not properly copyable");
+        }
 
         auto f_for_last = [n](T1 x) { return x == n - 1; };
         auto f_for_none = [](T1 x) { return x == -1; };
@@ -465,6 +509,13 @@ DEFINE_TEST(test_transform_inclusive_scan)
         auto tuple_last1 = oneapi::dpl::make_zip_iterator(last1, last1);
         auto tuple_first2 = oneapi::dpl::make_zip_iterator(first2, first2);
         auto tuple_last2 = oneapi::dpl::make_zip_iterator(last2, last2);
+
+        if (!this->host_buffering_required())
+        {
+            EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first1)>, "zip_iterator (inclusive_scan1) not properly copyable");
+            EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first2)>, "zip_iterator (inclusive_scan2) not properly copyable");
+        }
+
         auto value = T1(333);
 
         auto res = ::std::transform_inclusive_scan(make_new_policy<new_kernel_name<Policy, 0>>(exec), tuple_first1,
@@ -498,6 +549,11 @@ DEFINE_TEST(test_unique)
 
         auto tuple_first1 = oneapi::dpl::make_zip_iterator(first1, first1);
         auto tuple_last1 = oneapi::dpl::make_zip_iterator(last1, last1);
+
+        if (!this->host_buffering_required())
+        {
+            EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first1)>, "zip_iterator (unique) not properly copyable");
+        }
 
         auto tuple_lastnew =
             ::std::unique(make_new_policy<new_kernel_name<Policy, 0>>(exec), tuple_first1, tuple_last1,
@@ -540,6 +596,12 @@ DEFINE_TEST(test_unique_copy)
         auto tuple_first1 = oneapi::dpl::make_zip_iterator(first1, first1);
         auto tuple_last1 = oneapi::dpl::make_zip_iterator(last1, last1);
         auto tuple_first2 = oneapi::dpl::make_zip_iterator(first2, first2);
+
+        if (!this->host_buffering_required())
+        {
+            EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first1)>, "zip_iterator (unique_copy1) not properly copyable");
+            EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first2)>, "zip_iterator (unique_copy2) not properly copyable");
+        }
 
         auto tuple_last2 = ::std::unique_copy(
             make_new_policy<new_kernel_name<Policy, 0>>(exec), tuple_first1, tuple_last1, tuple_first2,
@@ -600,6 +662,13 @@ DEFINE_TEST(test_merge)
         auto tuple_last2 = oneapi::dpl::make_zip_iterator(first2 + size2, first2 + size2);
         auto tuple_first3 = oneapi::dpl::make_zip_iterator(first3, first3);
 
+        if (!this->host_buffering_required())
+        {
+            EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first1)>, "zip_iterator (merge1) not properly copyable");
+            EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first2)>, "zip_iterator (merge2) not properly copyable");
+            EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first3)>, "zip_iterator (merge3) not properly copyable");
+        }
+
         auto tuple_last3 = ::std::merge(make_new_policy<new_kernel_name<Policy, 0>>(exec), tuple_first1, tuple_last1, tuple_first2,
                                       tuple_last2, tuple_first3, TuplePredicate<::std::less<T2>, 0>{::std::less<T2>{}});
 #if _PSTL_SYCL_TEST_USM
@@ -644,8 +713,15 @@ DEFINE_TEST(test_stable_sort)
         ::std::copy_n(host_keys.get(), n, host_vals.get());
         update_data(host_keys, host_vals);
 
-        ::std::stable_sort(make_new_policy<new_kernel_name<Policy, 0>>(exec), oneapi::dpl::make_zip_iterator(first1, first2),
-                         oneapi::dpl::make_zip_iterator(last1, last2),
+        auto tuple_first = oneapi::dpl::make_zip_iterator(first1, first2);
+        auto tuple_last = oneapi::dpl::make_zip_iterator(last1, last2);
+
+        if (!this->host_buffering_required())
+        {
+            EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first)>, "zip_iterator (stable_sort) not properly copyable");
+        }
+
+        ::std::stable_sort(make_new_policy<new_kernel_name<Policy, 0>>(exec), tuple_first, tuple_last,
                          TuplePredicate<::std::greater<T>, 0>{::std::greater<T>{}});
 #if _PSTL_SYCL_TEST_USM
         exec.queue().wait_and_throw();
@@ -687,6 +763,14 @@ DEFINE_TEST(test_lexicographical_compare)
         auto tuple_last1 = oneapi::dpl::make_zip_iterator(last1, last1);
         auto tuple_first2 = oneapi::dpl::make_zip_iterator(first2, first2);
         auto tuple_last2 = oneapi::dpl::make_zip_iterator(last2, last2);
+
+        if (!this->host_buffering_required())
+        {
+            EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first1)>,
+                         "zip_iterator (lexicographical_compare1) not properly copyable");
+            EXPECT_TRUE(sycl::is_device_copyable_v<decltype(tuple_first2)>,
+                         "zip_iterator (lexicographical_compare2) not properly copyable");
+        }
 
         auto comp = [](ValueType const& first, ValueType const& second) { return first < second; };
 
@@ -738,6 +822,11 @@ DEFINE_TEST(test_counting_zip_transform)
         auto idx = oneapi::dpl::counting_iterator<ValueType>(0);
         auto start = oneapi::dpl::make_zip_iterator(idx, first1);
 
+        if (!this->host_buffering_required())
+        {
+            EXPECT_TRUE(sycl::is_device_copyable_v<decltype(start)>, "zip_iterator (counting_iterator1) not properly copyable");
+        }
+
         // This usage pattern can be rewritten equivalently and more simply using zip_iterator and discard_iterator,
         // see test_counting_zip_discard
         auto res =
@@ -787,6 +876,13 @@ DEFINE_TEST(test_counting_zip_discard)
         auto start = oneapi::dpl::make_zip_iterator(idx, first1);
         auto discard = oneapi::dpl::discard_iterator();
         auto out = oneapi::dpl::make_zip_iterator(first2, discard);
+
+        if (!this->host_buffering_required())
+        {
+            EXPECT_TRUE(sycl::is_device_copyable_v<decltype(start)>, "zip_iterator (discard_iterator1) not properly copyable");
+            EXPECT_TRUE(sycl::is_device_copyable_v<decltype(out)>, "zip_iterator (discard_iterator2) not properly copyable");
+        }
+
         auto res = ::std::copy_if(make_new_policy<new_kernel_name<Policy, 0>>(exec), start, start + n, out, Assigner{});
 
 #if _PSTL_SYCL_TEST_USM

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -79,6 +79,11 @@ auto async_handler = [](sycl::exception_list ex_list) {
     }
 };
 
+//Check that type is device copyable including types which are deprecated in sycl 2020
+template <typename T>
+static constexpr bool check_device_copyable_w_deprecrated_sycl2020 =
+    sycl::is_device_copyable_v<T> || (std::is_trivially_copy_constructible_v<T> && std::is_trivially_destructible_v<T>);
+
 //function is needed to wrap kernel name into another class
 template <typename _NewKernelName, typename _Policy,
           oneapi::dpl::__internal::__enable_if_device_execution_policy<_Policy, int> = 0>

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -81,7 +81,7 @@ auto async_handler = [](sycl::exception_list ex_list) {
 
 //Check that type is device copyable including types which are deprecated in sycl 2020
 template <typename T>
-static constexpr bool check_device_copyable_w_deprecrated_sycl2020 =
+static constexpr bool check_if_device_copyable_by_sycl2020_or_by_old_definition  =
     sycl::is_device_copyable_v<T> || (std::is_trivially_copy_constructible_v<T> && std::is_trivially_destructible_v<T>);
 
 //function is needed to wrap kernel name into another class


### PR DESCRIPTION
This PR contains two bugfixes, which both impact the handling of  `permutation_iterator<zip_iterator<usm_ptr,usm_ptr>,usm_ptr>` and similar types as input data to oneDPL APIs.  These bugs were originated in #1254.

1. Make the fancy iterators: `zip_iterator` and `zip_forward_iterator` trivially copyable, and therefore device copyable, along with tests to check this
2. Add forward declaration for `__require_access`, which is to be necessary for `_require_access_args` to find this overload.


During investigation of this error, we discovered that transform_iterator and therefore permutation_iterator were not officially SYCL 2020 device copyable (although the work in practice with icpx's implementation of SYCL as if they were device copyable).  An issue #1386 has been created to record this, and define the plan for resolving this soon.
  