### PR TITLE
[Dynamic Selection] Addressed comments to sycl_backend

### DIFF
--- a/include/oneapi/dpl/internal/dynamic_selection_impl/sycl_backend.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/sycl_backend.h
@@ -41,7 +41,7 @@ class sycl_backend
         sycl::event e_;
 
       public:
-        async_waiter(sycl::event e) : e_(e) {}
+        async_waiter(const sycl::event& e) : e_(e) {}
         sycl::event
         unwrap()
         {
@@ -114,12 +114,12 @@ class sycl_backend
             auto e2 = q.submit([=](sycl::handler& h) {
                 h.depends_on(e1);
                 h.host_task([=]() {
+                    if constexpr (report_value_v<SelectionHandle, execution_info::task_time_t>)
+                        s.report(execution_info::task_time, (std::chrono::steady_clock::now() - t0).count());
                     if constexpr (report_info_v<SelectionHandle, execution_info::task_completion_t>)
                     {
                         s.report(execution_info::task_completion);
                     }
-                    if constexpr (report_value_v<SelectionHandle, execution_info::task_time_t>)
-                        s.report(execution_info::task_time, (std::chrono::steady_clock::now() - t0).count());
                 });
             });
             return async_waiter{e2};

--- a/test/parallel_api/dynamic_selection/sycl/test_internal_sycl_scheduler.pass.cpp
+++ b/test/parallel_api/dynamic_selection/sycl/test_internal_sycl_scheduler.pass.cpp
@@ -7,10 +7,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "support/test_config.h"
+
 #include "oneapi/dpl/dynamic_selection"
 #include <atomic>
 #include <iostream>
-#include "support/test_config.h"
+#include "support/utils.h"
 
 #if TEST_DYNAMIC_SELECTION_AVAILABLE
 class fake_selection_handle_t
@@ -45,20 +47,17 @@ test_submit_and_wait_on_scheduler()
 
     for (int i = 1; i <= N; ++i)
     {
-        s.submit(h,
-                 [&](sycl::queue q, int i) {
-                     ecount += i;
-                     return sycl::event{};
-                 },
-                 i);
+        s.submit(
+            h,
+            [&](sycl::queue q, int i) {
+                ecount += i;
+                return sycl::event{};
+            },
+            i);
     }
     s.get_submission_group().wait();
     int count = ecount.load();
-    if (count != N * (N + 1) / 2)
-    {
-        std::cout << "ERROR: scheduler did not execute all tasks exactly once\n";
-        return 1;
-    }
+    EXPECT_EQ(N * (N + 1) / 2, count, "ERROR: scheduler did not execute all tasks exactly once\n");
     std::cout << "wait_on_scheduler: OK\n";
     return 0;
 }
@@ -74,20 +73,17 @@ test_submit_and_wait_on_scheduler_single_element()
 
     for (int i = 1; i <= N; ++i)
     {
-        s.submit(h,
-                 [&](sycl::queue q, int i) {
-                     ecount += i;
-                     return sycl::event{};
-                 },
-                 i);
+        s.submit(
+            h,
+            [&](sycl::queue q, int i) {
+                ecount += i;
+                return sycl::event{};
+            },
+            i);
     }
     s.get_submission_group().wait();
     int count = ecount.load();
-    if (count != 1)
-    {
-        std::cout << "ERROR: scheduler did not execute all tasks exactly once\n";
-        return 1;
-    }
+    EXPECT_EQ(1, count, "ERROR: scheduler did not execute all tasks exactly once\n");
     std::cout << "wait_on_scheduler single element: OK\n";
     return 0;
 }
@@ -103,20 +99,17 @@ test_submit_and_wait_on_scheduler_empty()
 
     for (int i = 1; i <= N; ++i)
     {
-        s.submit(h,
-                 [&](sycl::queue q, int i) {
-                     ecount += i;
-                     return sycl::event{};
-                 },
-                 i);
+        s.submit(
+            h,
+            [&](sycl::queue q, int i) {
+                ecount += i;
+                return sycl::event{};
+            },
+            i);
     }
     s.get_submission_group().wait();
     int count = ecount.load();
-    if (count != 0)
-    {
-        std::cout << "ERROR: scheduler did not execute all tasks exactly once\n";
-        return 1;
-    }
+    EXPECT_EQ(0, count, "ERROR: scheduler did not execute all tasks exactly once\n");
     std::cout << "wait_on_scheduler empty list: OK\n";
     return 0;
 }
@@ -132,19 +125,16 @@ test_submit_and_wait_on_sync()
 
     for (int i = 1; i <= N; ++i)
     {
-        auto w = s.submit(h,
-                          [&](sycl::queue q, int i) {
-                              ecount += i;
-                              return sycl::event{};
-                          },
-                          i);
+        auto w = s.submit(
+            h,
+            [&](sycl::queue q, int i) {
+                ecount += i;
+                return sycl::event{};
+            },
+            i);
         w.wait();
         int count = ecount.load();
-        if (count != i * (i + 1) / 2)
-        {
-            std::cout << "ERROR: scheduler did not execute all tasks exactly once\n";
-            return 1;
-        }
+        EXPECT_EQ(i * (i + 1) / 2, count, "ERROR: scheduler did not execute all tasks exactly once\n");
     }
     std::cout << "wait_on_sync: OK\n";
     return 0;
@@ -161,19 +151,16 @@ test_submit_and_wait_on_sync_single_element()
 
     for (int i = 1; i <= N; ++i)
     {
-        auto w = s.submit(h,
-                          [&](sycl::queue q, int i) {
-                              ecount += i;
-                              return sycl::event{};
-                          },
-                          i);
+        auto w = s.submit(
+            h,
+            [&](sycl::queue q, int i) {
+                ecount += i;
+                return sycl::event{};
+            },
+            i);
         w.wait();
         int count = ecount.load();
-        if (count != 1)
-        {
-            std::cout << "ERROR: scheduler did not execute all tasks exactly once\n";
-            return 1;
-        }
+        EXPECT_EQ(1, count, "ERROR: scheduler did not execute all tasks exactly once\n");
     }
     std::cout << "wait_on_sync single element: OK\n";
     return 0;
@@ -190,19 +177,16 @@ test_submit_and_wait_on_sync_empty()
 
     for (int i = 1; i <= N; ++i)
     {
-        auto w = s.submit(h,
-                          [&](sycl::queue q, int i) {
-                              ecount += i;
-                              return sycl::event{};
-                          },
-                          i);
+        auto w = s.submit(
+            h,
+            [&](sycl::queue q, int i) {
+                ecount += i;
+                return sycl::event{};
+            },
+            i);
         w.wait();
         int count = ecount.load();
-        if (count != 0)
-        {
-            std::cout << "ERROR: scheduler did not execute all tasks exactly once\n";
-            return 1;
-        }
+        EXPECT_EQ(0, count, "ERROR: scheduler did not execute all tasks exactly once\n");
     }
     std::cout << "wait_on_sync empty list: OK\n";
     return 0;
@@ -236,11 +220,7 @@ test_properties()
     oneapi::dpl::experimental::sycl_backend s(v);
     auto v2 = s.get_resources();
     auto v2s = v2.size();
-    if (v2s != v.size())
-    {
-        std::cout << "ERROR: reported universe and queried universe are not equal in size\n";
-        return 1;
-    }
+    EXPECT_EQ(v2s, v.size(), "ERROR: reported universe and queried universe are not equal in size\n");
     for (int i = 0; i < v2s; ++i)
     {
         if (v[i] != oneapi::dpl::experimental::unwrap(v2[i]))
@@ -257,31 +237,30 @@ test_properties()
 int
 main()
 {
+    bool bProcessed = false;
+
 #if TEST_DYNAMIC_SELECTION_AVAILABLE
     try
     {
         sycl::queue q;
+
+        auto actual = test_cout();
+        EXPECT_EQ(0, actual, "test_cout failed");
+        actual = test_submit_and_wait_on_scheduler();
+        actual = test_submit_and_wait_on_scheduler_single_element();
+        actual = test_submit_and_wait_on_scheduler_empty();
+        actual = test_submit_and_wait_on_sync();
+        actual = test_submit_and_wait_on_sync_single_element();
+        actual = test_submit_and_wait_on_sync_empty();
+        actual = test_properties();
+
+        bProcessed = true;
     }
     catch (const sycl::exception&)
     {
         std::cout << "SKIPPED: Unable to use sycl at all\n";
-        return 0;
     }
+#endif // TEST_DYNAMIC_SELECTION_AVAILABLE    
 
-    if (test_cout() || test_submit_and_wait_on_scheduler() || test_submit_and_wait_on_scheduler_single_element() ||
-        test_submit_and_wait_on_scheduler_empty() || test_submit_and_wait_on_sync() ||
-        test_submit_and_wait_on_sync_single_element() || test_submit_and_wait_on_sync_empty() || test_properties())
-    {
-        std::cout << "FAIL\n";
-        return 1;
-    }
-    else
-    {
-        std::cout << "PASS\n";
-        return 0;
-    }
-#else
-    std::cout << "SKIPPED\n";
-    return 0;
-#endif // TEST_DYNAMIC_SELECTION_AVAILABLE
+    return TestUtils::done(bProcessed);
 }


### PR DESCRIPTION
Addressed comments in https://github.com/oneapi-src/oneDPL/pull/1085 directed for sycl_backend.h

Change order of execution_info::task_completion_t and execution_info::task_time_t
