### PR TITLE
Adding legacy is_hetero trait and supporting it more fully

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -120,7 +120,7 @@ struct sycl_iterator
     }
 
     Size
-    get_buffer_offset() const
+    get_idx() const
     {
         return idx;
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -118,6 +118,12 @@ struct sycl_iterator
     {
         return buffer;
     }
+
+    Size
+    get_buffer_offset() const
+    {
+        return idx;
+    }
 };
 
 // mode converter when property::noinit present

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -258,7 +258,12 @@ struct is_sycl_iterator<oneapi::dpl::__internal::sycl_iterator<Mode, Types...>> 
 };
 
 template <typename Iter>
-inline constexpr bool is_sycl_iterator_v = is_sycl_iterator<Iter>::value;
+struct is_hetero_legacy_trait<Iter, ::std::enable_if_t<Iter::is_hetero::value>> : ::std::true_type
+{
+};
+
+template <typename Iter>
+inline constexpr bool is_sycl_iterator_v = is_sycl_iterator<Iter>::value || is_hetero_legacy_trait<Iter>::value;
 
 //A trait for checking if it needs to create a temporary SYCL buffer or not
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -515,8 +515,10 @@ struct __get_sycl_range
         auto __n = __last - __first;
         assert(__n > 0);
 
-        auto res_src = __process_input_iter<_LocalAccMode>(oneapi::dpl::begin(__first.base().get_buffer()),
-                                                           oneapi::dpl::end(__first.base().get_buffer()));
+        auto __base_iter = __first.base();
+        auto __base_buffer = __base_iter.get_buffer();
+        auto res_src = __process_input_iter<_LocalAccMode>(
+            oneapi::dpl::begin(__base_buffer) + __base_iter.get_buffer_offset(), oneapi::dpl::end(__base_buffer));
 
         //_Map is handled by recursively calling __get_sycl_range() in __get_permutation_view.
         auto rng = __get_permutation_view(res_src.all_view(), __first.map(), __n);
@@ -591,7 +593,7 @@ struct __get_sycl_range
         assert(__first < __last);
         using value_type = val_t<_Iter>;
 
-        const auto __offset = __first - oneapi::dpl::begin(__first.get_buffer());
+        const auto __offset = __first.get_buffer_offset();
         const auto __size = __dpl_sycl::__get_buffer_size(__first.get_buffer());
         const auto __n = ::std::min(decltype(__size)(__last - __first), __size);
         assert(__offset + __n <= __size);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -518,7 +518,7 @@ struct __get_sycl_range
         auto __base_iter = __first.base();
         auto __base_buffer = __base_iter.get_buffer();
         auto res_src = __process_input_iter<_LocalAccMode>(
-            oneapi::dpl::begin(__base_buffer) + __base_iter.get_buffer_offset(), oneapi::dpl::end(__base_buffer));
+            oneapi::dpl::begin(__base_buffer) + __base_iter.get_idx(), oneapi::dpl::end(__base_buffer));
 
         //_Map is handled by recursively calling __get_sycl_range() in __get_permutation_view.
         auto rng = __get_permutation_view(res_src.all_view(), __first.map(), __n);
@@ -593,7 +593,7 @@ struct __get_sycl_range
         assert(__first < __last);
         using value_type = val_t<_Iter>;
 
-        const auto __offset = __first.get_buffer_offset();
+        const auto __offset = __first.get_idx();
         const auto __size = __dpl_sycl::__get_buffer_size(__first.get_buffer());
         const auto __n = ::std::min(decltype(__size)(__last - __first), __size);
         assert(__offset + __n <= __size);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -257,6 +257,11 @@ struct is_sycl_iterator<oneapi::dpl::__internal::sycl_iterator<Mode, Types...>> 
 {
 };
 
+template <typename Iter, typename Void = void>
+struct is_hetero_legacy_trait : ::std::false_type
+{
+};
+
 template <typename Iter>
 struct is_hetero_legacy_trait<Iter, ::std::enable_if_t<Iter::is_hetero::value>> : ::std::true_type
 {
@@ -510,8 +515,8 @@ struct __get_sycl_range
         auto __n = __last - __first;
         assert(__n > 0);
 
-        auto res_src =
-            __process_input_iter<_LocalAccMode>(__first.base(), oneapi::dpl::end(__first.base().get_buffer()));
+        auto res_src = __process_input_iter<_LocalAccMode>(oneapi::dpl::begin(__first.base().get_buffer()),
+                                                           oneapi::dpl::end(__first.base().get_buffer()));
 
         //_Map is handled by recursively calling __get_sycl_range() in __get_permutation_view.
         auto rng = __get_permutation_view(res_src.all_view(), __first.map(), __n);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -517,8 +517,8 @@ struct __get_sycl_range
 
         auto __base_iter = __first.base();
         auto __base_buffer = __base_iter.get_buffer();
-        auto res_src = __process_input_iter<_LocalAccMode>(
-            oneapi::dpl::begin(__base_buffer) + __base_iter.get_idx(), oneapi::dpl::end(__base_buffer));
+        auto res_src = __process_input_iter<_LocalAccMode>(oneapi::dpl::begin(__base_buffer) + __base_iter.get_idx(),
+                                                           oneapi::dpl::end(__base_buffer));
 
         //_Map is handled by recursively calling __get_sycl_range() in __get_permutation_view.
         auto rng = __get_permutation_view(res_src.all_view(), __first.map(), __n);


### PR DESCRIPTION
Re-add legacy trait `is_hetero`, but supporting it more fully by adding an additional requirement for the `is_hetero` type to provide `get_idx()` which returns the buffer offset this iterator has to its base buffer.

Adding this function to `sycl_iterator`, incorporating it into `__get_sycl_range` implementation.  
This allows us to support hetero types other than `sycl_iterator` if they support `get_buffer()` and `get_idx()`.