### PR TITLE
Three fixes for permutation_iterator

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -120,7 +120,7 @@ struct sycl_iterator
     }
 
     Size
-    get_buffer_offset() const
+    get_idx() const
     {
         return idx;
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -118,6 +118,12 @@ struct sycl_iterator
     {
         return buffer;
     }
+
+    Size
+    get_buffer_offset() const
+    {
+        return idx;
+    }
 };
 
 // mode converter when property::noinit present

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -113,12 +113,16 @@ struct sycl_iterator
         return *this - it < 0;
     }
 
+    // This function is required for types for which oneapi::dpl::__ranges::is_sycl_iterator_v = true to ensure proper
+    //  handling by oneapi::dpl::__ranges::__get_sycl_range
     sycl::buffer<T, dim, Allocator>
     get_buffer() const
     {
         return buffer;
     }
 
+    // This function is required for types for which oneapi::dpl::__ranges::is_sycl_iterator_v = true to ensure proper
+    //  handling by oneapi::dpl::__ranges::__get_sycl_range
     Size
     get_idx() const
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -510,6 +510,9 @@ struct __get_sycl_range
         auto __n = __last - __first;
         assert(__n > 0);
 
+        // Types for which oneapi::dpl::__ranges::is_sycl_iterator_v = true should have both:
+        //  "get_buffer()" to return the buffer they are base upon and 
+        //  "get_idx()" to return the buffer offset
         auto __base_iter = __first.base();
         auto __base_buffer = __base_iter.get_buffer();
         auto res_src = __process_input_iter<_LocalAccMode>(oneapi::dpl::begin(__base_buffer) + __base_iter.get_idx(),
@@ -594,6 +597,9 @@ struct __get_sycl_range
         assert(__first < __last);
         using value_type = val_t<_Iter>;
 
+        // Types for which oneapi::dpl::__ranges::is_sycl_iterator_v = true should have both:
+        //  "get_buffer()" to return the buffer they are base upon and 
+        //  "get_idx()" to return the buffer offset
         const auto __offset = __first.get_idx();
         const auto __size = __dpl_sycl::__get_buffer_size(__first.get_buffer());
         const auto __n = ::std::min(decltype(__size)(__last - __first), __size);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -258,7 +258,12 @@ struct is_sycl_iterator<oneapi::dpl::__internal::sycl_iterator<Mode, Types...>> 
 };
 
 template <typename Iter>
-inline constexpr bool is_sycl_iterator_v = is_sycl_iterator<Iter>::value;
+struct is_hetero_legacy_trait<Iter, ::std::enable_if_t<Iter::is_hetero::value>> : ::std::true_type
+{
+};
+
+template <typename Iter>
+inline constexpr bool is_sycl_iterator_v = is_sycl_iterator<Iter>::value || is_hetero_legacy_trait<Iter>::value;
 
 //A trait for checking if it needs to create a temporary SYCL buffer or not
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -511,7 +511,7 @@ struct __get_sycl_range
         assert(__n > 0);
 
         // Types for which oneapi::dpl::__ranges::is_sycl_iterator_v = true should have both:
-        //  "get_buffer()" to return the buffer they are base upon and 
+        //  "get_buffer()" to return the buffer they are base upon and
         //  "get_idx()" to return the buffer offset
         auto __base_iter = __first.base();
         auto __base_buffer = __base_iter.get_buffer();
@@ -598,7 +598,7 @@ struct __get_sycl_range
         using value_type = val_t<_Iter>;
 
         // Types for which oneapi::dpl::__ranges::is_sycl_iterator_v = true should have both:
-        //  "get_buffer()" to return the buffer they are base upon and 
+        //  "get_buffer()" to return the buffer they are base upon and
         //  "get_idx()" to return the buffer offset
         const auto __offset = __first.get_idx();
         const auto __size = __dpl_sycl::__get_buffer_size(__first.get_buffer());

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -195,8 +195,14 @@ struct is_permutation<Iter, ::std::enable_if_t<Iter::is_permutation::value>> : :
 
 //is_passed_directly trait definition; specializations for the oneDPL iterators
 
-template <typename Iter>
+template <typename Iter, typename Void = void>
 struct is_passed_directly : ::std::is_pointer<Iter>
+{
+};
+
+//support legacy "is_passed_directly" trait
+template <typename Iter>
+struct is_passed_directly<Iter, ::std::enable_if_t<Iter::is_passed_directly::value>> : ::std::true_type
 {
 };
 
@@ -231,19 +237,8 @@ struct is_passed_directly<zip_iterator<Iters...>> : ::std::conjunction<is_passed
 {
 };
 
-template <typename Iter, typename Void = void>
-struct is_passed_directly_legacy_trait : ::std::false_type
-{
-};
-
 template <typename Iter>
-struct is_passed_directly_legacy_trait<Iter, ::std::enable_if_t<Iter::is_passed_directly::value>> : ::std::true_type
-{
-};
-
-template <typename Iter>
-inline constexpr bool is_passed_directly_v =
-    is_passed_directly<Iter>::value || is_passed_directly_legacy_trait<Iter>::value;
+inline constexpr bool is_passed_directly_v = is_passed_directly<Iter>::value;
 
 // A trait for checking if iterator is heterogeneous or not
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -515,8 +515,10 @@ struct __get_sycl_range
         auto __n = __last - __first;
         assert(__n > 0);
 
-        auto res_src = __process_input_iter<_LocalAccMode>(oneapi::dpl::begin(__first.base().get_buffer()),
-                                                           oneapi::dpl::end(__first.base().get_buffer()));
+        auto __base_iter = __first.base();
+        auto __base_buffer = __base_iter.get_buffer();
+        auto res_src = __process_input_iter<_LocalAccMode>(
+            oneapi::dpl::begin(__base_buffer) + __base_iter.get_buffer_offset(), oneapi::dpl::end(__base_buffer));
 
         //_Map is handled by recursively calling __get_sycl_range() in __get_permutation_view.
         auto rng = __get_permutation_view(res_src.all_view(), __first.map(), __n);
@@ -591,7 +593,7 @@ struct __get_sycl_range
         assert(__first < __last);
         using value_type = val_t<_Iter>;
 
-        const auto __offset = __first - oneapi::dpl::begin(__first.get_buffer());
+        const auto __offset = __first.get_buffer_offset();
         const auto __size = __dpl_sycl::__get_buffer_size(__first.get_buffer());
         const auto __n = ::std::min(decltype(__size)(__last - __first), __size);
         assert(__offset + __n <= __size);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -518,7 +518,7 @@ struct __get_sycl_range
         auto __base_iter = __first.base();
         auto __base_buffer = __base_iter.get_buffer();
         auto res_src = __process_input_iter<_LocalAccMode>(
-            oneapi::dpl::begin(__base_buffer) + __base_iter.get_buffer_offset(), oneapi::dpl::end(__base_buffer));
+            oneapi::dpl::begin(__base_buffer) + __base_iter.get_idx(), oneapi::dpl::end(__base_buffer));
 
         //_Map is handled by recursively calling __get_sycl_range() in __get_permutation_view.
         auto rng = __get_permutation_view(res_src.all_view(), __first.map(), __n);
@@ -593,7 +593,7 @@ struct __get_sycl_range
         assert(__first < __last);
         using value_type = val_t<_Iter>;
 
-        const auto __offset = __first.get_buffer_offset();
+        const auto __offset = __first.get_idx();
         const auto __size = __dpl_sycl::__get_buffer_size(__first.get_buffer());
         const auto __n = ::std::min(decltype(__size)(__last - __first), __size);
         assert(__offset + __n <= __size);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -513,6 +513,10 @@ struct __get_sycl_range
         // Types for which oneapi::dpl::__ranges::is_sycl_iterator_v = true should have both:
         //  "get_buffer()" to return the buffer they are base upon and
         //  "get_idx()" to return the buffer offset
+
+        //  __first.base() is not guaranteed to be a sycl_iterator, it may be another type which sets the trait
+        //   is_hetero = ::std::true_type.  Therefore, to make sure our types match, we use get_idx() to get the buffer
+        //   offset, and use that to recurse as a sycl_iterator over the __base_buffer.
         auto __base_iter = __first.base();
         auto __base_buffer = __base_iter.get_buffer();
         auto res_src = __process_input_iter<_LocalAccMode>(oneapi::dpl::begin(__base_buffer) + __base_iter.get_idx(),
@@ -600,6 +604,10 @@ struct __get_sycl_range
         // Types for which oneapi::dpl::__ranges::is_sycl_iterator_v = true should have both:
         //  "get_buffer()" to return the buffer they are base upon and
         //  "get_idx()" to return the buffer offset
+
+        //  __first is not guaranteed to be a sycl_iterator, it may be another type which sets the trait
+        //   is_hetero = ::std::true_type. We use get_idx() to get the buffer offset, use get_buffer() to get the
+        //   buffer and use those to create the range.
         const auto __offset = __first.get_idx();
         const auto __size = __dpl_sycl::__get_buffer_size(__first.get_buffer());
         const auto __n = ::std::min(decltype(__size)(__last - __first), __size);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -257,6 +257,11 @@ struct is_sycl_iterator<oneapi::dpl::__internal::sycl_iterator<Mode, Types...>> 
 {
 };
 
+template <typename Iter, typename Void = void>
+struct is_hetero_legacy_trait : ::std::false_type
+{
+};
+
 template <typename Iter>
 struct is_hetero_legacy_trait<Iter, ::std::enable_if_t<Iter::is_hetero::value>> : ::std::true_type
 {
@@ -510,8 +515,8 @@ struct __get_sycl_range
         auto __n = __last - __first;
         assert(__n > 0);
 
-        auto res_src =
-            __process_input_iter<_LocalAccMode>(__first.base(), oneapi::dpl::end(__first.base().get_buffer()));
+        auto res_src = __process_input_iter<_LocalAccMode>(oneapi::dpl::begin(__first.base().get_buffer()),
+                                                           oneapi::dpl::end(__first.base().get_buffer()));
 
         //_Map is handled by recursively calling __get_sycl_range() in __get_permutation_view.
         auto rng = __get_permutation_view(res_src.all_view(), __first.map(), __n);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -517,8 +517,8 @@ struct __get_sycl_range
 
         auto __base_iter = __first.base();
         auto __base_buffer = __base_iter.get_buffer();
-        auto res_src = __process_input_iter<_LocalAccMode>(
-            oneapi::dpl::begin(__base_buffer) + __base_iter.get_idx(), oneapi::dpl::end(__base_buffer));
+        auto res_src = __process_input_iter<_LocalAccMode>(oneapi::dpl::begin(__base_buffer) + __base_iter.get_idx(),
+                                                           oneapi::dpl::end(__base_buffer));
 
         //_Map is handled by recursively calling __get_sycl_range() in __get_permutation_view.
         auto rng = __get_permutation_view(res_src.all_view(), __first.map(), __n);


### PR DESCRIPTION
Three fixes for permutation_iterator:

1. Legacy `is_hetero` trait #1380 (for the sake of time, closing that PR in favor of this one combined)
2. Fix for `is_passed_directly` legacy trait to be usable recursively
3. Restore "general case" with recursion with size of 1 for base iterator of a `permutation_iterator`