### PR TITLE
[test] Fix for kernel names issues in permutation iterator tests

### DIFF
--- a/test/parallel_api/iterator/permutation_iterator.h
+++ b/test/parallel_api/iterator/permutation_iterator.h
@@ -26,38 +26,35 @@
 #include <vector>
 #include <iterator>
 
-/// struct perm_it_index_tags - describe indexes of permutation iterator
-struct perm_it_index_tags
-{
-    // Index of permutation iterator is based on counting iterator
-    struct counting { };
+// Index of permutation iterator is based on counting iterator
+struct perm_it_index_tags_counting { };
 
-    // Index of permutation iterator is based on host iterator
-    struct host { };
+// Index of permutation iterator is based on host iterator
+struct perm_it_index_tags_host { };
 
 #if TEST_DPCPP_BACKEND_PRESENT
-    // Index of permutation iterator is based on USM shared memory
-    struct usm_shared { };
-    // Test case is for USM device memory is unavailable to implement due to indexes
-    // cannot be initialized on the host (USM device is not accessible on the host)
+// Index of permutation iterator is based on USM shared memory
+struct perm_it_index_tags_usm_shared { };
+// Test case is for USM device memory is unavailable to implement due to indexes
+// cannot be initialized on the host (USM device is not accessible on the host)
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-    // Index of permutation iterator is based on transform iterator
-    struct transform_iterator { };
+// Index of permutation iterator is based on transform iterator
+struct perm_it_index_tags_transform_iterator { };
 
-    // Index of permutation iterator is based on callable object
-    struct callable_object { };
-};
+// Index of permutation iterator is based on callable object
+struct perm_it_index_tags_callable_object { };
+
 
 ////////////////////////////////////////////////////////////////////////////////
 /**
  * @param template typename TSourceIterator - source iterator type
  * @param typename TSourceDataSize - type of source data size
  * @param typename PermItIndexTag - tag permutation iterator base kind:
- *          - perm_it_index_tags::counting;
- *          - perm_it_index_tags::host;
- *          - perm_it_index_tags::usm_shared;
- *          - perm_it_index_tags::transform_iterator.
+ *          - perm_it_index_tags_counting;
+ *          - perm_it_index_tags_host;
+ *          - perm_it_index_tags_usm_shared;
+ *          - perm_it_index_tags_transform_iterator.
  */
 template <typename TSourceIterator, typename TSourceDataSize>
 struct test_through_permutation_iterator_data
@@ -92,7 +89,7 @@ struct test_through_permutation_iterator
 
 ////////////////////////////////////////////////////////////////////////////////
 template <typename TSourceIterator, typename TSourceDataSize>
-struct test_through_permutation_iterator<TSourceIterator, TSourceDataSize, perm_it_index_tags::counting>
+struct test_through_permutation_iterator<TSourceIterator, TSourceDataSize, perm_it_index_tags_counting>
 {
     test_through_permutation_iterator_data<TSourceIterator, TSourceDataSize> data;
 
@@ -116,7 +113,7 @@ struct test_through_permutation_iterator<TSourceIterator, TSourceDataSize, perm_
 
 ////////////////////////////////////////////////////////////////////////////////
 template <typename TSourceIterator, typename TSourceDataSize>
-struct test_through_permutation_iterator<TSourceIterator, TSourceDataSize, perm_it_index_tags::host>
+struct test_through_permutation_iterator<TSourceIterator, TSourceDataSize, perm_it_index_tags_host>
 {
     test_through_permutation_iterator_data<TSourceIterator, TSourceDataSize> data;
 
@@ -150,7 +147,7 @@ struct test_through_permutation_iterator<TSourceIterator, TSourceDataSize, perm_
 
 ////////////////////////////////////////////////////////////////////////////////
 template <typename TSourceIterator, typename TSourceDataSize>
-struct test_through_permutation_iterator<TSourceIterator, TSourceDataSize, perm_it_index_tags::usm_shared>
+struct test_through_permutation_iterator<TSourceIterator, TSourceDataSize, perm_it_index_tags_usm_shared>
 {
     test_through_permutation_iterator_data<TSourceIterator, TSourceDataSize> data;
 
@@ -191,7 +188,7 @@ struct test_through_permutation_iterator<TSourceIterator, TSourceDataSize, perm_
 
 ////////////////////////////////////////////////////////////////////////////////
 template <typename TSourceIterator, typename TSourceDataSize>
-struct test_through_permutation_iterator<TSourceIterator, TSourceDataSize, perm_it_index_tags::transform_iterator>
+struct test_through_permutation_iterator<TSourceIterator, TSourceDataSize, perm_it_index_tags_transform_iterator>
 {
     test_through_permutation_iterator_data<TSourceIterator, TSourceDataSize> data;
 
@@ -227,7 +224,7 @@ struct test_through_permutation_iterator<TSourceIterator, TSourceDataSize, perm_
 
 ////////////////////////////////////////////////////////////////////////////////
 template <typename TSourceIterator, typename TSourceDataSize>
-struct test_through_permutation_iterator<TSourceIterator, TSourceDataSize, perm_it_index_tags::callable_object>
+struct test_through_permutation_iterator<TSourceIterator, TSourceDataSize, perm_it_index_tags_callable_object>
 {
     test_through_permutation_iterator_data<TSourceIterator, TSourceDataSize> data;
 

--- a/test/parallel_api/iterator/permutation_iterator_parallel_find.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_find.pass.cpp
@@ -95,13 +95,13 @@ main()
     using ValueType = ::std::uint32_t;
 
 #if TEST_DPCPP_BACKEND_PRESENT
-    run_algo_tests<ValueType, perm_it_index_tags::usm_shared>();
+    run_algo_tests<ValueType, perm_it_index_tags_usm_shared>();
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-    run_algo_tests<ValueType, perm_it_index_tags::counting>();
-    run_algo_tests<ValueType, perm_it_index_tags::host>();
-    run_algo_tests<ValueType, perm_it_index_tags::transform_iterator>();
-    run_algo_tests<ValueType, perm_it_index_tags::callable_object>();
+    run_algo_tests<ValueType, perm_it_index_tags_counting>();
+    run_algo_tests<ValueType, perm_it_index_tags_host>();
+    run_algo_tests<ValueType, perm_it_index_tags_transform_iterator>();
+    run_algo_tests<ValueType, perm_it_index_tags_callable_object>();
 
     return TestUtils::done();
 }

--- a/test/parallel_api/iterator/permutation_iterator_parallel_for.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_for.pass.cpp
@@ -64,6 +64,9 @@ DEFINE_TEST_PERM_IT(test_transform, PermItIndexTag)
             test_through_permutation_iterator<Iterator1, Size, PermItIndexTag>{first1, n}(
                 [&](auto permItBegin, auto permItEnd)
                 {
+                    auto exec1 = TestUtils::create_new_policy_idx<Policy, 0>(exec);
+                    auto exec2 = TestUtils::create_new_policy_idx<Policy, 1>(exec);
+
                     const auto testing_n = ::std::distance(permItBegin, permItEnd);
 
                     clear_output_data(host_vals_ptr, host_vals_ptr + n);
@@ -76,13 +79,11 @@ DEFINE_TEST_PERM_IT(test_transform, PermItIndexTag)
 
                     // Copy data back
                     std::vector<TestValueType> sourceData(testing_n);
-                    dpl::copy(TestUtils::create_new_policy_idx<Policy, 0>(exec), permItBegin, permItEnd,
-                              sourceData.begin());
-                    wait_and_throw(exec);
+                    dpl::copy(exec1, permItBegin, permItEnd, sourceData.begin());
+                    wait_and_throw(exec1);
                     std::vector<TestValueType> transformedDataResult(testing_n);
-                    dpl::copy(TestUtils::create_new_policy_idx<Policy, 1>(exec), first2, itResultEnd,
-                              transformedDataResult.begin());
-                    wait_and_throw(exec);
+                    dpl::copy(exec2, first2, itResultEnd, transformedDataResult.begin());
+                    wait_and_throw(exec2);
 
                     // Check results
                     std::vector<TestValueType> transformedDataExpected(testing_n);

--- a/test/parallel_api/iterator/permutation_iterator_parallel_for.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_for.pass.cpp
@@ -117,13 +117,13 @@ main()
     using ValueType = ::std::uint32_t;
 
 #if TEST_DPCPP_BACKEND_PRESENT
-    run_algo_tests<ValueType, perm_it_index_tags::usm_shared>();
+    run_algo_tests<ValueType, perm_it_index_tags_usm_shared>();
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-    run_algo_tests<ValueType, perm_it_index_tags::counting>();
-    run_algo_tests<ValueType, perm_it_index_tags::host>();
-    run_algo_tests<ValueType, perm_it_index_tags::transform_iterator>();
-    run_algo_tests<ValueType, perm_it_index_tags::callable_object>();
+    run_algo_tests<ValueType, perm_it_index_tags_counting>();
+    run_algo_tests<ValueType, perm_it_index_tags_host>();
+    run_algo_tests<ValueType, perm_it_index_tags_transform_iterator>();
+    run_algo_tests<ValueType, perm_it_index_tags_callable_object>();
 
     return TestUtils::done();
 }

--- a/test/parallel_api/iterator/permutation_iterator_parallel_for.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_for.pass.cpp
@@ -76,10 +76,12 @@ DEFINE_TEST_PERM_IT(test_transform, PermItIndexTag)
 
                     // Copy data back
                     std::vector<TestValueType> sourceData(testing_n);
-                    dpl::copy(TestUtils::create_new_policy_idx<Policy, 0>(exec), permItBegin, permItEnd, sourceData.begin());
+                    dpl::copy(TestUtils::create_new_policy_idx<Policy, 0>(exec), permItBegin, permItEnd,
+                              sourceData.begin());
                     wait_and_throw(exec);
                     std::vector<TestValueType> transformedDataResult(testing_n);
-                    dpl::copy(TestUtils::create_new_policy_idx<Policy, 1>(exec), first2, itResultEnd, transformedDataResult.begin());
+                    dpl::copy(TestUtils::create_new_policy_idx<Policy, 1>(exec), first2, itResultEnd,
+                              transformedDataResult.begin());
                     wait_and_throw(exec);
 
                     // Check results

--- a/test/parallel_api/iterator/permutation_iterator_parallel_for.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_for.pass.cpp
@@ -76,10 +76,10 @@ DEFINE_TEST_PERM_IT(test_transform, PermItIndexTag)
 
                     // Copy data back
                     std::vector<TestValueType> sourceData(testing_n);
-                    dpl::copy(exec, permItBegin, permItEnd, sourceData.begin());
+                    dpl::copy(TestUtils::create_new_policy_idx<Policy, 0>(exec), permItBegin, permItEnd, sourceData.begin());
                     wait_and_throw(exec);
                     std::vector<TestValueType> transformedDataResult(testing_n);
-                    dpl::copy(exec, first2, itResultEnd, transformedDataResult.begin());
+                    dpl::copy(TestUtils::create_new_policy_idx<Policy, 1>(exec), first2, itResultEnd, transformedDataResult.begin());
                     wait_and_throw(exec);
 
                     // Check results

--- a/test/parallel_api/iterator/permutation_iterator_parallel_for.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_for.pass.cpp
@@ -51,6 +51,9 @@ DEFINE_TEST_PERM_IT(test_transform, PermItIndexTag)
     {
         if constexpr (is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>)
         {
+            auto exec1 = TestUtils::create_new_policy_idx<Policy, 0>(exec);
+            auto exec2 = TestUtils::create_new_policy_idx<Policy, 1>(exec);
+
             TestDataTransfer<UDTKind::eKeys, Size> host_keys(*this, n);     // source data for transform
             TestDataTransfer<UDTKind::eVals, Size> host_vals(*this, n);     // result data of transform
 
@@ -64,9 +67,6 @@ DEFINE_TEST_PERM_IT(test_transform, PermItIndexTag)
             test_through_permutation_iterator<Iterator1, Size, PermItIndexTag>{first1, n}(
                 [&](auto permItBegin, auto permItEnd)
                 {
-                    auto exec1 = TestUtils::create_new_policy_idx<Policy, 0>(exec);
-                    auto exec2 = TestUtils::create_new_policy_idx<Policy, 1>(exec);
-
                     const auto testing_n = ::std::distance(permItBegin, permItEnd);
 
                     clear_output_data(host_vals_ptr, host_vals_ptr + n);

--- a/test/parallel_api/iterator/permutation_iterator_parallel_merge.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_merge.pass.cpp
@@ -75,11 +75,13 @@ DEFINE_TEST_PERM_IT(test_merge, PermItIndexTag)
 
                             // Copy data back
                             std::vector<TestValueType> srcData2(testing_n2);
-                            dpl::copy(exec, permItBegin2, permItEnd2, srcData2.begin());
+                            dpl::copy(TestUtils::create_new_policy_idx<Policy, 0>(exec), permItBegin2, permItEnd2,
+                                      srcData2.begin());
                             wait_and_throw(exec);
 
                             std::vector<TestValueType> mergedDataResult(resultSize);
-                            dpl::copy(exec, first3, resultEnd, mergedDataResult.begin());
+                            dpl::copy(TestUtils::create_new_policy_idx<Policy, 1>(exec), first3, resultEnd,
+                                      mergedDataResult.begin());
                             wait_and_throw(exec);
 
                             // Check results

--- a/test/parallel_api/iterator/permutation_iterator_parallel_merge.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_merge.pass.cpp
@@ -34,6 +34,10 @@ DEFINE_TEST_PERM_IT(test_merge, PermItIndexTag)
     {
         if constexpr (is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>)
         {
+            auto exec1 = TestUtils::create_new_policy_idx<Policy, 0>(exec);
+            auto exec2 = TestUtils::create_new_policy_idx<Policy, 1>(exec);
+            auto exec3 = TestUtils::create_new_policy_idx<Policy, 2>(exec);
+
             TestDataTransfer<UDTKind::eKeys, Size> host_keys(*this, n);                                 // source data(1) for merge
             TestDataTransfer<UDTKind::eVals, Size> host_vals(*this, n);                                 // source data(2) for merge
             TestDataTransfer<UDTKind::eRes,  Size> host_res (*this, ::std::distance(first3, last3));    // merge results
@@ -61,14 +65,12 @@ DEFINE_TEST_PERM_IT(test_merge, PermItIndexTag)
 
                     // Copy data back
                     std::vector<TestValueType> srcData1(testing_n1);
-                    dpl::copy(exec, permItBegin1, permItEnd1, srcData1.begin());
-                    wait_and_throw(exec);
+                    dpl::copy(exec1, permItBegin1, permItEnd1, srcData1.begin());
+                    wait_and_throw(exec1);
 
                     test_through_permutation_iterator<Iterator2, Size, PermItIndexTag>{first2, n}(
                         [&](auto permItBegin2, auto permItEnd2)
                         {
-                            auto exec1 = TestUtils::create_new_policy_idx<Policy, 0>(exec);
-                            auto exec2 = TestUtils::create_new_policy_idx<Policy, 1>(exec);
 
                             const auto testing_n2 = ::std::distance(permItBegin2, permItEnd2);
 
@@ -78,12 +80,12 @@ DEFINE_TEST_PERM_IT(test_merge, PermItIndexTag)
 
                             // Copy data back
                             std::vector<TestValueType> srcData2(testing_n2);
-                            dpl::copy(exec1, permItBegin2, permItEnd2, srcData2.begin());
-                            wait_and_throw(exec1);
+                            dpl::copy(exec2, permItBegin2, permItEnd2, srcData2.begin());
+                            wait_and_throw(exec2);
 
                             std::vector<TestValueType> mergedDataResult(resultSize);
-                            dpl::copy(exec2, first3, resultEnd, mergedDataResult.begin());
-                            wait_and_throw(exec2);
+                            dpl::copy(exec3, first3, resultEnd, mergedDataResult.begin());
+                            wait_and_throw(exec3);
 
                             // Check results
                             std::vector<TestValueType> mergedDataExpected(testing_n1 + testing_n2);

--- a/test/parallel_api/iterator/permutation_iterator_parallel_merge.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_merge.pass.cpp
@@ -67,6 +67,9 @@ DEFINE_TEST_PERM_IT(test_merge, PermItIndexTag)
                     test_through_permutation_iterator<Iterator2, Size, PermItIndexTag>{first2, n}(
                         [&](auto permItBegin2, auto permItEnd2)
                         {
+                            auto exec1 = TestUtils::create_new_policy_idx<Policy, 0>(exec);
+                            auto exec2 = TestUtils::create_new_policy_idx<Policy, 1>(exec);
+
                             const auto testing_n2 = ::std::distance(permItBegin2, permItEnd2);
 
                             const auto resultEnd = dpl::merge(exec, permItBegin1, permItEnd1, permItBegin2, permItEnd2, first3);
@@ -75,14 +78,12 @@ DEFINE_TEST_PERM_IT(test_merge, PermItIndexTag)
 
                             // Copy data back
                             std::vector<TestValueType> srcData2(testing_n2);
-                            dpl::copy(TestUtils::create_new_policy_idx<Policy, 0>(exec), permItBegin2, permItEnd2,
-                                      srcData2.begin());
-                            wait_and_throw(exec);
+                            dpl::copy(exec1, permItBegin2, permItEnd2, srcData2.begin());
+                            wait_and_throw(exec1);
 
                             std::vector<TestValueType> mergedDataResult(resultSize);
-                            dpl::copy(TestUtils::create_new_policy_idx<Policy, 1>(exec), first3, resultEnd,
-                                      mergedDataResult.begin());
-                            wait_and_throw(exec);
+                            dpl::copy(exec2, first3, resultEnd, mergedDataResult.begin());
+                            wait_and_throw(exec2);
 
                             // Check results
                             std::vector<TestValueType> mergedDataExpected(testing_n1 + testing_n2);

--- a/test/parallel_api/iterator/permutation_iterator_parallel_merge.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_merge.pass.cpp
@@ -118,13 +118,13 @@ main()
     using ValueType = ::std::uint32_t;
 
 #if TEST_DPCPP_BACKEND_PRESENT
-    run_algo_tests<ValueType, perm_it_index_tags::usm_shared>();
+    run_algo_tests<ValueType, perm_it_index_tags_usm_shared>();
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-    run_algo_tests<ValueType, perm_it_index_tags::counting>();
-    run_algo_tests<ValueType, perm_it_index_tags::host>();
-    run_algo_tests<ValueType, perm_it_index_tags::transform_iterator>();
-    run_algo_tests<ValueType, perm_it_index_tags::callable_object>();
+    run_algo_tests<ValueType, perm_it_index_tags_counting>();
+    run_algo_tests<ValueType, perm_it_index_tags_host>();
+    run_algo_tests<ValueType, perm_it_index_tags_transform_iterator>();
+    run_algo_tests<ValueType, perm_it_index_tags_callable_object>();
 
     return TestUtils::done();
 }

--- a/test/parallel_api/iterator/permutation_iterator_parallel_or.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_or.pass.cpp
@@ -90,13 +90,13 @@ main()
     using ValueType = ::std::uint32_t;
 
 #if TEST_DPCPP_BACKEND_PRESENT
-    run_algo_tests<ValueType, perm_it_index_tags::usm_shared>();
+    run_algo_tests<ValueType, perm_it_index_tags_usm_shared>();
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-    run_algo_tests<ValueType, perm_it_index_tags::counting>();
-    run_algo_tests<ValueType, perm_it_index_tags::host>();
-    run_algo_tests<ValueType, perm_it_index_tags::transform_iterator>();
-    run_algo_tests<ValueType, perm_it_index_tags::callable_object>();
+    run_algo_tests<ValueType, perm_it_index_tags_counting>();
+    run_algo_tests<ValueType, perm_it_index_tags_host>();
+    run_algo_tests<ValueType, perm_it_index_tags_transform_iterator>();
+    run_algo_tests<ValueType, perm_it_index_tags_callable_object>();
 
     return TestUtils::done();
 }

--- a/test/parallel_api/iterator/permutation_iterator_parallel_partial_sort.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_partial_sort.pass.cpp
@@ -98,13 +98,13 @@ main()
     using ValueType = ::std::uint32_t;
 
 #if TEST_DPCPP_BACKEND_PRESENT
-    run_algo_tests<ValueType, perm_it_index_tags::usm_shared>();
+    run_algo_tests<ValueType, perm_it_index_tags_usm_shared>();
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-    run_algo_tests<ValueType, perm_it_index_tags::counting>();
-    run_algo_tests<ValueType, perm_it_index_tags::host>();
-    run_algo_tests<ValueType, perm_it_index_tags::transform_iterator>();
-    run_algo_tests<ValueType, perm_it_index_tags::callable_object>();
+    run_algo_tests<ValueType, perm_it_index_tags_counting>();
+    run_algo_tests<ValueType, perm_it_index_tags_host>();
+    run_algo_tests<ValueType, perm_it_index_tags_transform_iterator>();
+    run_algo_tests<ValueType, perm_it_index_tags_callable_object>();
 
     return TestUtils::done();
 }

--- a/test/parallel_api/iterator/permutation_iterator_parallel_stable_sort.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_stable_sort.pass.cpp
@@ -97,13 +97,13 @@ main()
     using ValueType = ::std::uint32_t;
 
 #if TEST_DPCPP_BACKEND_PRESENT
-    run_algo_tests<ValueType, perm_it_index_tags::usm_shared>();
+    run_algo_tests<ValueType, perm_it_index_tags_usm_shared>();
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-    run_algo_tests<ValueType, perm_it_index_tags::counting>();
-    run_algo_tests<ValueType, perm_it_index_tags::host>();
-    run_algo_tests<ValueType, perm_it_index_tags::transform_iterator>();
-    run_algo_tests<ValueType, perm_it_index_tags::callable_object>();
+    run_algo_tests<ValueType, perm_it_index_tags_counting>();
+    run_algo_tests<ValueType, perm_it_index_tags_host>();
+    run_algo_tests<ValueType, perm_it_index_tags_transform_iterator>();
+    run_algo_tests<ValueType, perm_it_index_tags_callable_object>();
 
     return TestUtils::done();
 }

--- a/test/parallel_api/iterator/permutation_iterator_parallel_transform_reduce.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_transform_reduce.pass.cpp
@@ -88,13 +88,13 @@ main()
     using ValueType = ::std::uint32_t;
 
 #if TEST_DPCPP_BACKEND_PRESENT
-    run_algo_tests<ValueType, perm_it_index_tags::usm_shared>();
+    run_algo_tests<ValueType, perm_it_index_tags_usm_shared>();
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-    run_algo_tests<ValueType, perm_it_index_tags::counting>();
-    run_algo_tests<ValueType, perm_it_index_tags::host>();
-    run_algo_tests<ValueType, perm_it_index_tags::transform_iterator>();
-    run_algo_tests<ValueType, perm_it_index_tags::callable_object>();
+    run_algo_tests<ValueType, perm_it_index_tags_counting>();
+    run_algo_tests<ValueType, perm_it_index_tags_host>();
+    run_algo_tests<ValueType, perm_it_index_tags_transform_iterator>();
+    run_algo_tests<ValueType, perm_it_index_tags_callable_object>();
 
     return TestUtils::done();
 }

--- a/test/parallel_api/iterator/permutation_iterator_parallel_transform_scan.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_transform_scan.pass.cpp
@@ -103,13 +103,13 @@ main()
     using ValueType = ::std::uint32_t;
 
 #if TEST_DPCPP_BACKEND_PRESENT
-    run_algo_tests<ValueType, perm_it_index_tags::usm_shared>();
+    run_algo_tests<ValueType, perm_it_index_tags_usm_shared>();
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-    run_algo_tests<ValueType, perm_it_index_tags::counting>();
-    run_algo_tests<ValueType, perm_it_index_tags::host>();
-    run_algo_tests<ValueType, perm_it_index_tags::transform_iterator>();
-    run_algo_tests<ValueType, perm_it_index_tags::callable_object>();
+    run_algo_tests<ValueType, perm_it_index_tags_counting>();
+    run_algo_tests<ValueType, perm_it_index_tags_host>();
+    run_algo_tests<ValueType, perm_it_index_tags_transform_iterator>();
+    run_algo_tests<ValueType, perm_it_index_tags_callable_object>();
 
     return TestUtils::done();
 }


### PR DESCRIPTION
This PR is being proposed as an alternative to #1370

According to the SYCL 2020 spec [Section 5.2 Naming of kernels](https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:naming.kernels), "kernel names must be forward declarable at namespace scope".  
It seems that the tags we were using to signify test types for permutation iterator map methods, which are a group of structs inside a struct do not meet this criteria.  

Changing them to be base level structures with the outer name incorporated resolves this issue.

We also have a few kernel naming clashes for `permutation_iterator_parallel_for.pass` and `permutation_iterator_parallel_merge.pass`.  This was fixed with help from @SergeyKopienko and #1370, to add utility functions to wrap of kernel names for hetero policies and just pass through host policies.
