### PR TITLE
[test] Fix Kernel names in tests

### DIFF
--- a/test/parallel_api/algorithm/alg.modifying.operations/transform_binary.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/transform_binary.pass.cpp
@@ -93,8 +93,8 @@ struct test_one_policy
     }
 };
 
-template <::std::size_t CallNumber, typename In1, typename In2, typename Out, typename Predicate,
-          typename _IteratorAdapter = _Identity>
+template <typename In1, typename In2, typename Out, typename Predicate,
+          typename _IteratorAdapter = _Identity, ::std::size_t CallNumber = 0>
 void
 test(Predicate pred, _IteratorAdapter adap = {})
 {
@@ -107,7 +107,7 @@ test(Predicate pred, _IteratorAdapter adap = {})
 
         invoke_on_all_policies<CallNumber>()(test_one_policy(), adap(in1.begin()), adap(in1.end()), adap(in2.begin()),
                                              adap(in2.end()), adap(out.begin()), adap(out.end()), pred);
-        invoke_on_all_policies<CallNumber + 1>()(test_one_policy(), adap(in1.cbegin()), adap(in1.cend()),
+        invoke_on_all_policies<CallNumber + 10>()(test_one_policy(), adap(in1.cbegin()), adap(in1.cend()),
                                                  adap(in2.cbegin()), adap(in2.cend()), adap(out.begin()),
                                                  adap(out.end()), pred);
     }
@@ -131,19 +131,19 @@ int
 main()
 {
     //const operator()
-    test<0, std::int32_t, std::int32_t, std::int32_t>(TheOperation<std::int32_t, std::int32_t, std::int32_t>(1));
-    test<10, float32_t, float32_t, float32_t>(TheOperation<float32_t, float32_t, float32_t>(1.5));
+    test<std::int32_t, std::int32_t, std::int32_t>(TheOperation<std::int32_t, std::int32_t, std::int32_t>(1));
+    test<float32_t, float32_t, float32_t>(TheOperation<float32_t, float32_t, float32_t>(1.5));
     //non-const operator()
 #if !TEST_DPCPP_BACKEND_PRESENT
-    test<20, std::int32_t, float32_t, float32_t>(non_const(TheOperation<std::int32_t, float32_t, float32_t>(1.5)));
-    test<30, std::int64_t, float64_t, float32_t>(non_const(TheOperation<std::int64_t, float64_t, float32_t>(1.5)));
+    test<std::int32_t, float32_t, float32_t>(non_const(TheOperation<std::int32_t, float32_t, float32_t>(1.5)));
+    test<std::int64_t, float64_t, float32_t>(non_const(TheOperation<std::int64_t, float64_t, float32_t>(1.5)));
 #endif
-    test<40, std::int32_t, float64_t, std::int32_t>([](const std::int32_t& x, const float64_t& y) { return std::int32_t(std::int32_t(1.5) + x - y); });
+    test<std::int32_t, float64_t, std::int32_t>([](const std::int32_t& x, const float64_t& y) { return std::int32_t(std::int32_t(1.5) + x - y); });
 
     test_algo_basic_double<std::int16_t>(run_for_rnd_fw<test_non_const<std::int16_t>>());
 
     //test case for zip iterator
-    test<50, std::int32_t, std::int32_t, std::int32_t>(TheOperationZip<std::int32_t>(1), _ZipIteratorAdapter{});
+    test<std::int32_t, std::int32_t, std::int32_t, 1>(TheOperationZip<std::int32_t>(1), _ZipIteratorAdapter{});
 
     return done();
 }

--- a/test/parallel_api/algorithm/alg.modifying.operations/transform_binary.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/transform_binary.pass.cpp
@@ -93,7 +93,8 @@ struct test_one_policy
     }
 };
 
-template <typename In1, typename In2, typename Out, typename Predicate, typename _IteratorAdapter = _Identity>
+template <::std::size_t CallNumber, typename In1, typename In2, typename Out, typename Predicate,
+          typename _IteratorAdapter = _Identity>
 void
 test(Predicate pred, _IteratorAdapter adap = {})
 {
@@ -104,10 +105,11 @@ test(Predicate pred, _IteratorAdapter adap = {})
 
         Sequence<Out> out(n, [](size_t) { return -1; });
 
-        invoke_on_all_policies<0>()(test_one_policy(), adap(in1.begin()), adap(in1.end()), adap(in2.begin()),
-                                    adap(in2.end()), adap(out.begin()), adap(out.end()), pred);
-        invoke_on_all_policies<1>()(test_one_policy(), adap(in1.cbegin()), adap(in1.cend()), adap(in2.cbegin()),
-                                    adap(in2.cend()), adap(out.begin()), adap(out.end()), pred);
+        invoke_on_all_policies<CallNumber>()(test_one_policy(), adap(in1.begin()), adap(in1.end()), adap(in2.begin()),
+                                             adap(in2.end()), adap(out.begin()), adap(out.end()), pred);
+        invoke_on_all_policies<CallNumber + 1>()(test_one_policy(), adap(in1.cbegin()), adap(in1.cend()),
+                                                 adap(in2.cbegin()), adap(in2.cend()), adap(out.begin()),
+                                                 adap(out.end()), pred);
     }
 }
 
@@ -129,19 +131,19 @@ int
 main()
 {
     //const operator()
-    test<std::int32_t, std::int32_t, std::int32_t>(TheOperation<std::int32_t, std::int32_t, std::int32_t>(1));
-    test<float32_t, float32_t, float32_t>(TheOperation<float32_t, float32_t, float32_t>(1.5));
+    test<0, std::int32_t, std::int32_t, std::int32_t>(TheOperation<std::int32_t, std::int32_t, std::int32_t>(1));
+    test<10, float32_t, float32_t, float32_t>(TheOperation<float32_t, float32_t, float32_t>(1.5));
     //non-const operator()
 #if !TEST_DPCPP_BACKEND_PRESENT
-    test<std::int32_t, float32_t, float32_t>(non_const(TheOperation<std::int32_t, float32_t, float32_t>(1.5)));
-    test<std::int64_t, float64_t, float32_t>(non_const(TheOperation<std::int64_t, float64_t, float32_t>(1.5)));
+    test<20, std::int32_t, float32_t, float32_t>(non_const(TheOperation<std::int32_t, float32_t, float32_t>(1.5)));
+    test<30, std::int64_t, float64_t, float32_t>(non_const(TheOperation<std::int64_t, float64_t, float32_t>(1.5)));
 #endif
-    test<std::int32_t, float64_t, std::int32_t>([](const std::int32_t& x, const float64_t& y) { return std::int32_t(std::int32_t(1.5) + x - y); });
+    test<40, std::int32_t, float64_t, std::int32_t>([](const std::int32_t& x, const float64_t& y) { return std::int32_t(std::int32_t(1.5) + x - y); });
 
     test_algo_basic_double<std::int16_t>(run_for_rnd_fw<test_non_const<std::int16_t>>());
 
     //test case for zip iterator
-    test<std::int32_t, std::int32_t, std::int32_t>(TheOperationZip<std::int32_t>(1), _ZipIteratorAdapter{});
+    test<50, std::int32_t, std::int32_t, std::int32_t>(TheOperationZip<std::int32_t>(1), _ZipIteratorAdapter{});
 
     return done();
 }

--- a/test/parallel_api/algorithm/alg.modifying.operations/transform_binary.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/transform_binary.pass.cpp
@@ -93,8 +93,8 @@ struct test_one_policy
     }
 };
 
-template <typename In1, typename In2, typename Out, typename Predicate,
-          typename _IteratorAdapter = _Identity, ::std::size_t CallNumber = 0>
+template <::std::size_t CallNumber, typename In1, typename In2, typename Out, typename Predicate,
+          typename _IteratorAdapter = _Identity>
 void
 test(Predicate pred, _IteratorAdapter adap = {})
 {
@@ -107,7 +107,7 @@ test(Predicate pred, _IteratorAdapter adap = {})
 
         invoke_on_all_policies<CallNumber>()(test_one_policy(), adap(in1.begin()), adap(in1.end()), adap(in2.begin()),
                                              adap(in2.end()), adap(out.begin()), adap(out.end()), pred);
-        invoke_on_all_policies<CallNumber + 10>()(test_one_policy(), adap(in1.cbegin()), adap(in1.cend()),
+        invoke_on_all_policies<CallNumber + 1>()(test_one_policy(), adap(in1.cbegin()), adap(in1.cend()),
                                                  adap(in2.cbegin()), adap(in2.cend()), adap(out.begin()),
                                                  adap(out.end()), pred);
     }
@@ -131,19 +131,19 @@ int
 main()
 {
     //const operator()
-    test<std::int32_t, std::int32_t, std::int32_t>(TheOperation<std::int32_t, std::int32_t, std::int32_t>(1));
-    test<float32_t, float32_t, float32_t>(TheOperation<float32_t, float32_t, float32_t>(1.5));
+    test<0, std::int32_t, std::int32_t, std::int32_t>(TheOperation<std::int32_t, std::int32_t, std::int32_t>(1));
+    test<10, float32_t, float32_t, float32_t>(TheOperation<float32_t, float32_t, float32_t>(1.5));
     //non-const operator()
 #if !TEST_DPCPP_BACKEND_PRESENT
-    test<std::int32_t, float32_t, float32_t>(non_const(TheOperation<std::int32_t, float32_t, float32_t>(1.5)));
-    test<std::int64_t, float64_t, float32_t>(non_const(TheOperation<std::int64_t, float64_t, float32_t>(1.5)));
+    test<20, std::int32_t, float32_t, float32_t>(non_const(TheOperation<std::int32_t, float32_t, float32_t>(1.5)));
+    test<30, std::int64_t, float64_t, float32_t>(non_const(TheOperation<std::int64_t, float64_t, float32_t>(1.5)));
 #endif
-    test<std::int32_t, float64_t, std::int32_t>([](const std::int32_t& x, const float64_t& y) { return std::int32_t(std::int32_t(1.5) + x - y); });
+    test<40, std::int32_t, float64_t, std::int32_t>([](const std::int32_t& x, const float64_t& y) { return std::int32_t(std::int32_t(1.5) + x - y); });
 
     test_algo_basic_double<std::int16_t>(run_for_rnd_fw<test_non_const<std::int16_t>>());
 
     //test case for zip iterator
-    test<std::int32_t, std::int32_t, std::int32_t, 1>(TheOperationZip<std::int32_t>(1), _ZipIteratorAdapter{});
+    test<50, std::int32_t, std::int32_t, std::int32_t>(TheOperationZip<std::int32_t>(1), _ZipIteratorAdapter{});
 
     return done();
 }

--- a/test/parallel_api/algorithm/alg.modifying.operations/transform_unary.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/transform_unary.pass.cpp
@@ -79,8 +79,8 @@ private:
     }
 };
 
-template <typename Tin, typename Tout, typename _Op = Complement<Tin, Tout>,
-          typename _IteratorAdapter = _Identity, ::std::size_t CallNumber = 0>
+template <::std::size_t CallNumber, typename Tin, typename Tout, typename _Op = Complement<Tin, Tout>,
+          typename _IteratorAdapter = _Identity>
 void
 test()
 {
@@ -95,7 +95,7 @@ test()
                                              adap(out.end()), _Op{});
 
 #if !ONEDPL_FPGA_DEVICE
-        invoke_on_all_policies<CallNumber + 10>()(test_one_policy(), adap(in.cbegin()), adap(in.cend()),
+        invoke_on_all_policies<CallNumber + 1>()(test_one_policy(), adap(in.cbegin()), adap(in.cend()),
                                                  adap(out.begin()), adap(out.end()), _Op{});
 #endif
     }
@@ -115,16 +115,16 @@ struct test_non_const
 int
 main()
 {
-    test<std::int32_t, std::int32_t>();
-    test<std::int32_t, float32_t>();
-    test<std::uint16_t, float32_t>();
-    test<float64_t, float64_t>();
+    test<0, std::int32_t, std::int32_t>();
+    test<10, std::int32_t, float32_t>();
+    test<20, std::uint16_t, float32_t>();
+    test<30, float64_t, float64_t>();
 
     test_algo_basic_double<std::int32_t>(run_for_rnd_fw<test_non_const<std::int32_t>>());
     test_algo_basic_double<std::int64_t>(run_for_rnd_fw<test_non_const<std::int32_t>>());
 
     //test case for zip iterator
-    test<std::int32_t, std::int32_t, ComplementZip, _ZipIteratorAdapter, 1>();
+    test<40, std::int32_t, std::int32_t, ComplementZip, _ZipIteratorAdapter>();
 
     return done();
 }

--- a/test/parallel_api/algorithm/alg.modifying.operations/transform_unary.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/transform_unary.pass.cpp
@@ -79,7 +79,8 @@ private:
     }
 };
 
-template <typename Tin, typename Tout, typename _Op = Complement<Tin, Tout>, typename _IteratorAdapter = _Identity>
+template <::std::size_t CallNumber, typename Tin, typename Tout, typename _Op = Complement<Tin, Tout>,
+          typename _IteratorAdapter = _Identity>
 void
 test()
 {
@@ -90,12 +91,12 @@ test()
         Sequence<Tout> out(n);
 
         _IteratorAdapter adap;
-        invoke_on_all_policies<0>()(test_one_policy(), adap(in.begin()), adap(in.end()), adap(out.begin()),
-                                    adap(out.end()), _Op{});
+        invoke_on_all_policies<CallNumber>()(test_one_policy(), adap(in.begin()), adap(in.end()), adap(out.begin()),
+                                             adap(out.end()), _Op{});
 
 #if !ONEDPL_FPGA_DEVICE
-        invoke_on_all_policies<1>()(test_one_policy(), adap(in.cbegin()), adap(in.cend()), adap(out.begin()),
-                                    adap(out.end()), _Op{});
+        invoke_on_all_policies<CallNumber + 1>()(test_one_policy(), adap(in.cbegin()), adap(in.cend()),
+                                                 adap(out.begin()), adap(out.end()), _Op{});
 #endif
     }
 }
@@ -114,16 +115,16 @@ struct test_non_const
 int
 main()
 {
-    test<std::int32_t, std::int32_t>();
-    test<std::int32_t, float32_t>();
-    test<std::uint16_t, float32_t>();
-    test<float64_t, float64_t>();
+    test<0, std::int32_t, std::int32_t>();
+    test<10, std::int32_t, float32_t>();
+    test<20, std::uint16_t, float32_t>();
+    test<30, float64_t, float64_t>();
 
     test_algo_basic_double<std::int32_t>(run_for_rnd_fw<test_non_const<std::int32_t>>());
     test_algo_basic_double<std::int64_t>(run_for_rnd_fw<test_non_const<std::int32_t>>());
 
     //test case for zip iterator
-    test<std::int32_t, std::int32_t, ComplementZip, _ZipIteratorAdapter>();
+    test<40, std::int32_t, std::int32_t, ComplementZip, _ZipIteratorAdapter>();
 
     return done();
 }

--- a/test/parallel_api/algorithm/alg.modifying.operations/transform_unary.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/transform_unary.pass.cpp
@@ -79,8 +79,8 @@ private:
     }
 };
 
-template <::std::size_t CallNumber, typename Tin, typename Tout, typename _Op = Complement<Tin, Tout>,
-          typename _IteratorAdapter = _Identity>
+template <typename Tin, typename Tout, typename _Op = Complement<Tin, Tout>,
+          typename _IteratorAdapter = _Identity, ::std::size_t CallNumber = 0>
 void
 test()
 {
@@ -95,7 +95,7 @@ test()
                                              adap(out.end()), _Op{});
 
 #if !ONEDPL_FPGA_DEVICE
-        invoke_on_all_policies<CallNumber + 1>()(test_one_policy(), adap(in.cbegin()), adap(in.cend()),
+        invoke_on_all_policies<CallNumber + 10>()(test_one_policy(), adap(in.cbegin()), adap(in.cend()),
                                                  adap(out.begin()), adap(out.end()), _Op{});
 #endif
     }
@@ -115,16 +115,16 @@ struct test_non_const
 int
 main()
 {
-    test<0, std::int32_t, std::int32_t>();
-    test<10, std::int32_t, float32_t>();
-    test<20, std::uint16_t, float32_t>();
-    test<30, float64_t, float64_t>();
+    test<std::int32_t, std::int32_t>();
+    test<std::int32_t, float32_t>();
+    test<std::uint16_t, float32_t>();
+    test<float64_t, float64_t>();
 
     test_algo_basic_double<std::int32_t>(run_for_rnd_fw<test_non_const<std::int32_t>>());
     test_algo_basic_double<std::int64_t>(run_for_rnd_fw<test_non_const<std::int32_t>>());
 
     //test case for zip iterator
-    test<40, std::int32_t, std::int32_t, ComplementZip, _ZipIteratorAdapter>();
+    test<std::int32_t, std::int32_t, ComplementZip, _ZipIteratorAdapter, 1>();
 
     return done();
 }


### PR DESCRIPTION
In this PR we fix compile errors in some tests for CMake option `ONEDPL_USE_UNNAMED_LAMBDA=OFF`