### PR TITLE
[Tests]Permutation_iterator test fix use local transform_reduce_serial

### DIFF
--- a/test/parallel_api/iterator/permutation_iterator_parallel_transform_reduce.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_transform_reduce.pass.cpp
@@ -56,7 +56,7 @@ DEFINE_TEST_PERM_IT(test_transform_reduce, PermItIndexTag)
                     dpl::copy(exec, permItBegin, permItEnd, sourceData.begin());
                     wait_and_throw(exec);
 
-                    const auto expected = ::std::transform_reduce(sourceData.begin(), sourceData.end(), TestValueType{},
+                    const auto expected = transform_reduce_serial(sourceData.begin(), sourceData.end(), TestValueType{},
                                                                   ::std::plus<TestValueType>(), ::std::negate<TestValueType>());
                     EXPECT_EQ(expected, result, "Wrong result of dpl::transform_reduce");
                 });


### PR DESCRIPTION
Some standard library configurations are missing std::transform_reduce.  Using transform_reduce_serial from utils to provide serial result to check against.