### PR TITLE
Update jinja to eliminate xmlattr vulnerability.

### DIFF
--- a/documentation/library_guide/requirements.txt
+++ b/documentation/library_guide/requirements.txt
@@ -1,6 +1,6 @@
 breathe==4.9.1
 sphinx==3.4.0
-jinja2<3.1
+jinja2==3.1.3
 # https://github.com/sphinx-doc/sphinx/issues/9923
 docutils==0.15
 # Pin versions to avoid a compatibility issue: "The sphinxcontrib.<extension_name> extension used by this project needs at least Sphinx v5.0"

--- a/documentation/library_guide/requirements.txt
+++ b/documentation/library_guide/requirements.txt
@@ -1,5 +1,5 @@
 breathe==4.9.1
-sphinx==3.4.0
+sphinx==4.4.0
 jinja2==3.1.3
 # https://github.com/sphinx-doc/sphinx/issues/9923
 docutils==0.15


### PR DESCRIPTION
Older Jinja versions are vulnerable to HTML attribute injection when passing user input as keys to xmlattr filter. The issue has been resolved in Jinja 3.1.3. Updating our doc build to use the newer version and eliminate exposure to the issue.