### PR TITLE
[test] Introduce broken macro if workaround for reduce_by_segment is not used

### DIFF
--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -368,7 +368,7 @@ run_test()
     std::cout << "\t" << "run_test<float,  BinaryPredicate<float>,  BinaryOperation<float>>();" << std::endl;
 #endif
     run_test<float,  BinaryPredicate<float>,  BinaryOperation<float>>();
-#ifndef _PSTL_ICPX_TEST_RED_BY_SEG_BROKEN_64BIT_TYPES
+#if !_PSTL_ICPX_TEST_RED_BY_SEG_BROKEN_64BIT_TYPES || ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION
 #if LOG_TEST_INFO
     std::cout << "\t" << "run_test<double, BinaryPredicate<double>, BinaryOperation<double>>();" << std::endl;
 #endif
@@ -389,19 +389,17 @@ main()
 
 #if TEST_DPCPP_BACKEND_PRESENT
     // test with flag pred
-#ifndef _PSTL_ICPX_TEST_RED_BY_SEG_BROKEN_64BIT_TYPES
 #if LOG_TEST_INFO
     std::cout << "test_flag_pred<sycl::usm::alloc::device, class KernelName1, std::uint64_t>();" << std::endl;
 #endif
     test_flag_pred<sycl::usm::alloc::device, class KernelName1, std::uint64_t>();
-#endif
 #if LOG_TEST_INFO
     std::cout << "test_flag_pred<sycl::usm::alloc::device, class KernelName2, dpl::complex<float>>();" << std::endl;
 #endif
     test_flag_pred<sycl::usm::alloc::device, class KernelName2, dpl::complex<float>>();
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-#ifndef _PSTL_ICPX_TEST_RED_BY_SEG_BROKEN_64BIT_TYPES
+#if !_PSTL_ICPX_TEST_RED_BY_SEG_BROKEN_64BIT_TYPES || ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION
 #if LOG_TEST_INFO
     std::cout << "run_test<::std::uint64_t,       UserBinaryPredicate<::std::uint64_t>,       MaxFunctor<::std::uint64_t>>();" << std::endl;
 #endif

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -368,10 +368,12 @@ run_test()
     std::cout << "\t" << "run_test<float,  BinaryPredicate<float>,  BinaryOperation<float>>();" << std::endl;
 #endif
     run_test<float,  BinaryPredicate<float>,  BinaryOperation<float>>();
+#ifndef _PSTL_ICPX_TEST_RED_BY_SEG_BROKEN_64BIT_TYPES
 #if LOG_TEST_INFO
     std::cout << "\t" << "run_test<double, BinaryPredicate<double>, BinaryOperation<double>>();" << std::endl;
 #endif
     run_test<double, BinaryPredicate<double>, BinaryOperation<double>>();
+#endif
 }
 
 int
@@ -387,20 +389,24 @@ main()
 
 #if TEST_DPCPP_BACKEND_PRESENT
     // test with flag pred
+#ifndef _PSTL_ICPX_TEST_RED_BY_SEG_BROKEN_64BIT_TYPES
 #if LOG_TEST_INFO
     std::cout << "test_flag_pred<sycl::usm::alloc::device, class KernelName1, std::uint64_t>();" << std::endl;
 #endif
     test_flag_pred<sycl::usm::alloc::device, class KernelName1, std::uint64_t>();
+#endif
 #if LOG_TEST_INFO
     std::cout << "test_flag_pred<sycl::usm::alloc::device, class KernelName2, dpl::complex<float>>();" << std::endl;
 #endif
     test_flag_pred<sycl::usm::alloc::device, class KernelName2, dpl::complex<float>>();
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
+#ifndef _PSTL_ICPX_TEST_RED_BY_SEG_BROKEN_64BIT_TYPES
 #if LOG_TEST_INFO
     std::cout << "run_test<::std::uint64_t,       UserBinaryPredicate<::std::uint64_t>,       MaxFunctor<::std::uint64_t>>();" << std::endl;
 #endif
     run_test<::std::uint64_t,       UserBinaryPredicate<::std::uint64_t>,       MaxFunctor<::std::uint64_t>>();
+#endif
 #if LOG_TEST_INFO
     std::cout << "run_test<::std::complex<float>, UserBinaryPredicate<::std::complex<float>>, MaxFunctor<::std::complex<float>>>();" << std::endl;
 #endif

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -155,8 +155,8 @@
 // in reduce_by_segment.pass.cpp.
 // TODO: When a driver fix is provided to resolve this issue, consider altering this macro or checking the driver version at runtime
 // of the underlying sycl::device to determine whether to include or exclude 64-bit type tests.
-#if !defined(ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION) && defined(__INTEL_LLVM_COMPILER)
-#    define _PSTL_ICPX_TEST_RED_BY_SEG_BROKEN_64BIT_TYPES
+#if !PSTL_USE_DEBUG && defined(__INTEL_LLVM_COMPILER)
+#    define _PSTL_ICPX_TEST_RED_BY_SEG_BROKEN_64BIT_TYPES 1
 #endif
 
 #endif // _TEST_CONFIG_H

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -155,7 +155,7 @@
 // in reduce_by_segment.pass.cpp.
 // TODO: When a driver fix is provided to resolve this issue, consider altering this macro or checking the driver version at runtime
 // of the underlying sycl::device to determine whether to include or exclude 64-bit type tests.
-#if !ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION && defined(__INTEL_LLVM_COMPILER)
+#if !defined(ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION) && defined(__INTEL_LLVM_COMPILER)
 #    define _PSTL_ICPX_TEST_RED_BY_SEG_BROKEN_64BIT_TYPES
 #endif
 

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -155,7 +155,7 @@
 // in reduce_by_segment.pass.cpp.
 // TODO: When a driver fix is provided to resolve this issue, consider altering this macro or checking the driver version at runtime
 // of the underlying sycl::device to determine whether to include or exclude 64-bit type tests.
-#if !_ONEDPL_TEST_FORCE_WORKAROUND_FOR_IGPU_64BIT_REDUCTION && defined(__INTEL_LLVM_COMPILER)
+#if !ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION && defined(__INTEL_LLVM_COMPILER)
 #    define _PSTL_ICPX_TEST_RED_BY_SEG_BROKEN_64BIT_TYPES
 #endif
 

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -151,4 +151,12 @@
 #   define _PSTL_ICPX_TEST_RED_BY_SEG_OPTIMIZER_CRASH 0
 #endif
 
+// If the workaround macro for the 64-bit type bug is not defined by the user, then exclude 64-bit type testing
+// in reduce_by_segment.pass.cpp.
+// TODO: When a driver fix is provided to resolve this issue, consider altering this macro or checking the driver version at runtime
+// of the underlying sycl::device to determine whether to include or exclude 64-bit type tests.
+#if !_ONEDPL_TEST_FORCE_WORKAROUND_FOR_IGPU_64BIT_REDUCTION && defined(__INTEL_LLVM_COMPILER)
+#    define _PSTL_ICPX_TEST_RED_BY_SEG_BROKEN_64BIT_TYPES
+#endif
+
 #endif // _TEST_CONFIG_H


### PR DESCRIPTION
https://github.com/oneapi-src/oneDPL/pull/1360 introduced `ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION` which forces a different code path in `reduce_by_segment` to avoid a driver bug that causes incorrect results on certain hardware.

Currently, if this macro is not set, then `reduce_by_segment.pass` will fail with the DPCPP backend with 64-bit types on certain Intel GPUs. This PR excludes these tests when `ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION` is `0` or undefined to avoid these known failures.

The solution currently is implemented with a compile-time preprocessor check. However, when a driver fix is provided the long-term solution may involve a runtime check by checking the driver version of the `sycl::device`. I have marked this as a todo in the code.