### PR TITLE
Add methods to satisfy Rule of 3/5 best practice.

### DIFF
--- a/test/parallel_api/algorithm/alg.nonmodifying/equal.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/equal.pass.cpp
@@ -85,6 +85,19 @@ struct UserType
         key = other.key;
         return *this;
     }
+    UserType&
+    operator=(UserType&& other)
+    {
+        key = other.key;
+        f = other.f;
+        u = other.u;
+        i = other.i;
+        other.key = -1;
+        other.f = 0.0f;
+        other.u = 0;
+        other.i = 0;
+        return *this;
+    }
     UserType(const UserType& other) : key(other.key), f(other.f), u(other.u), i(other.i) {}
     UserType(UserType&& other) : key(other.key), f(other.f), u(other.u), i(other.i)
     {


### PR DESCRIPTION
https://en.cppreference.com/w/cpp/language/rule_of_three defines the best practice of providing no user-defined ctors/assignment/dtor or providing all of them.  A review of oneDPL code found that in most places where methods are missing they are in fact not needed, but there are some instances where adding the missing methods allows for more consistent behavior from the structs and classes.