### PR TITLE
Disallowing histogram with 64 bit output on FPGA

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_fpga.h
@@ -277,10 +277,18 @@ auto
 __parallel_histogram(_ExecutionPolicy&& __exec, const _Event& __init_event, _Range1&& __input, _Range2&& __bins,
                      const _BinHashMgr& __binhash_manager)
 {
-    // workaround until we implement more performant version for patterns
-    return oneapi::dpl::__par_backend_hetero::__parallel_histogram(__exec.__device_policy(), __init_event,
-                                                                   ::std::forward<_Range1>(__input),
-                                                                   ::std::forward<_Range2>(__bins), __binhash_manager);
+    if constexpr (sizeof(oneapi::dpl::__internal::__value_t<_Range2>) <= sizeof(::std::uint32_t))
+    {
+        // workaround until we implement more performant version for patterns
+        return oneapi::dpl::__par_backend_hetero::__parallel_histogram(
+            __exec.__device_policy(), __init_event, ::std::forward<_Range1>(__input), ::std::forward<_Range2>(__bins),
+            __binhash_manager);
+    }
+    else
+    {
+        static_assert(false, "histogram is not supported on FPGA devices with output types greater than 32 bits");
+        return __future(sycl::event{});
+    }
 }
 
 } // namespace __par_backend_hetero

--- a/test/parallel_api/numeric/numeric.ops/histogram.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/histogram.pass.cpp
@@ -114,8 +114,12 @@ int
 main()
 {
 #if TEST_DPCPP_BACKEND_PRESENT
-    test_histogram<0, float, int64_t>(10000.0f, 110000.0f, 300.0f, int64_t(50), int64_t(99999));
-    test_histogram<1, std::int32_t, int64_t>(-50000, 50000, 10000, int64_t(5), int64_t(99999));
+    test_histogram<0, float, uint32_t>(10000.0f, 110000.0f, 300.0f, uint32_t(50), uint32_t(99999));
+
+#if !ONEDPL_FPGA_DEVICE
+    test_histogram<1, std::int32_t, uint64_t>(-50000, 50000, 10000, uint64_t(5), uint64_t(99999));
+#endif //!ONEDPL_FPGA_DEVICE
+
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
     return done(TEST_DPCPP_BACKEND_PRESENT);


### PR DESCRIPTION
FPGAs do not support 64 bit atomics.  The histogram pattern uses atomics of the value type of the output sequence.  
Adding static assertion for FPGAs to only allow sequences with a value type of 32bit or less.
Adjusting the tests to match.

Its rare that a 64 bit output type should be necessary for histogram.  Input sequences would only start to need 64 bit output with sizes greater than 4Billion (and that would only overflow if all elements map to a single bin).  

