### PR TITLE
Fix type limitations for scan algorithms, add reduce_by_segment

### DIFF
--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -129,9 +129,8 @@ Known Limitations
   for double precision. 
 * When ``exclusive_scan``, ``inclusive_scan``, ``exclusive_scan_by_segment``, ``inclusive_scan_by_segment``,
   ``transform_exclusive_scan``, ``transform_inclusive_scan``, ``reduce_by_segment`` algorithms are used with
-  C++ standard policies, the initial value type must satisfy the ``DefaultConstructible`` requirements.
-  Additionally, a default-constructed instance of that type should act as
-  the identity element for the provided binary operation.
+  C++ standard policies, the initial value type must satisfy the ``DefaultConstructible`` requirements;
+  a default-constructed instance of that type should act as the identity element for the provided binary operation.
 * The initial value type for ``exclusive_scan``, ``inclusive_scan``, ``exclusive_scan_by_segment``,
   ``inclusive_scan_by_segment``, ``reduce``, ``reduce_by_segment``, ``transform_reduce``, ``transform_exclusive_scan``,
   ``transform_inclusive_scan`` should satisfy the ``MoveAssignable`` and the ``CopyConstructible`` requirements.

--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -127,10 +127,14 @@ Known Limitations
 * Due to specifics of Microsoft* Visual C++, some standard floating-point math functions
   (including ``std::ldexp``, ``std::frexp``, ``std::sqrt(std::complex<float>)``) require device support
   for double precision. 
-* When ``exclusive_scan``, ``inclusive_scan``, ``exclusive_scan_by_segment``, ``inclusive_scan_by_segment``,
-  ``transform_exclusive_scan``, ``transform_inclusive_scan``, ``reduce_by_segment`` algorithms are used with
-  C++ standard policies, the initial value type must satisfy the ``DefaultConstructible`` requirements;
-  a default-constructed instance of that type should act as the identity element for the provided binary operation.
+* ``exclusive_scan``, ``inclusive_scan``, ``exclusive_scan_by_segment``,
+  ``inclusive_scan_by_segment``, ``transform_exclusive_scan``, ``transform_inclusive_scan``,
+  when used with C++ standard policies, impose limitations on the initial value type.
+  Firstly, it must satisfy the ``DefaultConstructible`` requirements.
+  Secondly, a default-constructed instance of that type should act as the identity element for the binary scan function.
+* ``reduce_by_segment``, when used with C++ standard policies, imposes limitations on the value type.
+  Firstly, it must satisfy the ``DefaultConstructible`` requirements.
+  Secondly, a default-constructed instance of that type should act as the identity element for the binary reduction function.
 * The initial value type for ``exclusive_scan``, ``inclusive_scan``, ``exclusive_scan_by_segment``,
   ``inclusive_scan_by_segment``, ``reduce``, ``reduce_by_segment``, ``transform_reduce``, ``transform_exclusive_scan``,
   ``transform_inclusive_scan`` should satisfy the ``MoveAssignable`` and the ``CopyConstructible`` requirements.

--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -45,7 +45,7 @@ Prerequisites
 C++17 is the minimal supported version of the C++ standard.
 That means, any use of |onedpl_short| may require a C++17 compiler.
 While some APIs of the library may accidentally work with earlier versions of the C++ standard, it is no more guaranteed.
- 
+
 To call Parallel API with the C++ standard policies, you need to install the following software:
 
 * A C++ compiler with support for OpenMP* 4.0 (or higher) SIMD constructs
@@ -127,11 +127,11 @@ Known Limitations
 * Due to specifics of Microsoft* Visual C++, some standard floating-point math functions
   (including ``std::ldexp``, ``std::frexp``, ``std::sqrt(std::complex<float>)``) require device support
   for double precision. 
-* The initial value type for ``exclusive_scan``, ``inclusive_scan``, ``exclusive_scan_by_segment``,
-  ``inclusive_scan_by_segment``, ``transform_exclusive_scan``, ``transform_inclusive_scan``, ``reduce_by_segment``
-  should satisfy the ``DefaultConstructible`` requirements for C++ standard policies.
-  Additionally, a default-constructed instance of that type should be
-  the identity element for the provided scan binary operation.
+* When ``exclusive_scan``, ``inclusive_scan``, ``exclusive_scan_by_segment``, ``inclusive_scan_by_segment``,
+  ``transform_exclusive_scan``, ``transform_inclusive_scan``, ``reduce_by_segment`` algorithms are used with
+  C++ standard policies, the initial value type must satisfy the ``DefaultConstructible`` requirements.
+  Additionally, a default-constructed instance of that type should act as
+  the identity element for the provided binary operation.
 * The initial value type for ``exclusive_scan``, ``inclusive_scan``, ``exclusive_scan_by_segment``,
   ``inclusive_scan_by_segment``, ``reduce``, ``reduce_by_segment``, ``transform_reduce``, ``transform_exclusive_scan``,
   ``transform_inclusive_scan`` should satisfy the ``MoveAssignable`` and the ``CopyConstructible`` requirements.
@@ -143,7 +143,7 @@ Known Limitations
   ``uninitialized_move_n``, ``uninitialized_default_construct``, ``uninitialized_default_construct_n``, ``uninitialized_value_construct``, ``uninitialized_value_construct_n``
   should be called with a device policy when using device data and should be called with a host policy when using host data. Otherwise, the result is undefined.
 * The algorithms that destroy data: ``destroy`` and ``destroy_n`` should be called with a host policy when using host data that was initialized on the host, and should be called with a device policy when using device data that was initialized on the device. Otherwise, the result is undefined.
-        
+
 
 Build Your Code with |onedpl_short|
 ===================================

--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -128,9 +128,10 @@ Known Limitations
   (including ``std::ldexp``, ``std::frexp``, ``std::sqrt(std::complex<float>)``) require device support
   for double precision. 
 * The initial value type for ``exclusive_scan``, ``inclusive_scan``, ``exclusive_scan_by_segment``,
-  ``inclusive_scan_by_segment``, ``transform_exclusive_scan``, ``transform_inclusive_scan`` should satisfy
-  the ``DefaultConstructible`` requirements. Additionally, a default-constructed instance of that type should be
-  the identity element for the provided scan binary operation. 
+  ``inclusive_scan_by_segment``, ``transform_exclusive_scan``, ``transform_inclusive_scan``, ``reduce_by_segment``
+  should satisfy the ``DefaultConstructible`` requirements for C++ standard policies.
+  Additionally, a default-constructed instance of that type should be
+  the identity element for the provided scan binary operation.
 * The initial value type for ``exclusive_scan``, ``inclusive_scan``, ``exclusive_scan_by_segment``,
   ``inclusive_scan_by_segment``, ``reduce``, ``reduce_by_segment``, ``transform_reduce``, ``transform_exclusive_scan``,
   ``transform_inclusive_scan`` should satisfy the ``MoveAssignable`` and the ``CopyConstructible`` requirements.

--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -129,7 +129,9 @@ Known Limitations
   for double precision. 
 * ``exclusive_scan``, ``inclusive_scan``, ``exclusive_scan_by_segment``,
   ``inclusive_scan_by_segment``, ``transform_exclusive_scan``, ``transform_inclusive_scan``,
-  when used with C++ standard policies, impose limitations on the initial value type.
+  when used with C++ standard policies, impose limitations on the initial value type if an 
+  initial value is provided, and on the value type of the input iterator if an initial value is 
+  not provided.
   Firstly, it must satisfy the ``DefaultConstructible`` requirements.
   Secondly, a default-constructed instance of that type should act as the identity element for the binary scan function.
 * ``reduce_by_segment``, when used with C++ standard policies, imposes limitations on the value type.

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
@@ -230,14 +230,6 @@ DEFINE_TEST_2(test_exclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
     }
 };
 
-template <typename ValueType, typename BinaryPredicate, typename BinaryOperation>
-void
-run_test()
-{
-    run_test_on_host<ValueType, BinaryPredicate, BinaryOperation>();
-    run_test_on_device<ValueType, BinaryPredicate, BinaryOperation>();
-}
-
 int
 main()
 {

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
@@ -230,6 +230,14 @@ DEFINE_TEST_2(test_exclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
     }
 };
 
+template <typename ValueType, typename BinaryPredicate, typename BinaryOperation>
+void
+run_test()
+{
+    run_test_on_host<ValueType, BinaryPredicate, BinaryOperation>();
+    run_test_on_device<ValueType, BinaryPredicate, BinaryOperation>();
+}
+
 int
 main()
 {

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -343,7 +343,7 @@ void
 run_test_on_host()
 {
 #if !_PSTL_ICC_TEST_SIMD_UDS_BROKEN && !_PSTL_ICPX_TEST_RED_BY_SEG_OPTIMIZER_CRASH
-#if     TEST_DPCPP_BACKEND_PRESENT
+#if TEST_DPCPP_BACKEND_PRESENT
     test_algo_four_sequences<test_reduce_by_segment<ValueType, BinaryPredicate, BinaryOperation>>();
 #   else
     test_algo_four_sequences<ValueType, test_reduce_by_segment<BinaryPredicate, BinaryOperation>>();

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -322,7 +322,11 @@ void
 run_test_on_device()
 {
 #if TEST_DPCPP_BACKEND_PRESENT
-    auto test = []() {
+    // Skip 64-byte types testing when the algorithm is broken and there is no the workaround
+#if _PSTL_ICPX_TEST_RED_BY_SEG_BROKEN_64BIT_TYPES && !ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION
+    if constexpr (sizeof(ValueType) != 8)
+#endif
+    {
         if (TestUtils::has_type_support<ValueType>(TestUtils::get_test_queue().get_device()))
         {
             // Run tests for USM shared memory
@@ -330,17 +334,6 @@ run_test_on_device()
             // Run tests for USM device memory
             test4buffers<sycl::usm::alloc::device, test_reduce_by_segment<ValueType, BinaryPredicate, BinaryOperation>>();
         }
-    };
-
-    if constexpr (sizeof(ValueType) == 8)
-    {
-#if !_PSTL_ICPX_TEST_RED_BY_SEG_BROKEN_64BIT_TYPES || ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION
-        test();
-#endif
-    }
-    else
-    {
-        test();
     }
 #endif // TEST_DPCPP_BACKEND_PRESENT
 }

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -378,9 +378,10 @@ main()
     run_test<float, ::std::equal_to<float>, ::std::plus<float>>();
     run_test<double, ::std::equal_to<double>, ::std::plus<double>>();
 
-    // TODO investigate possible overflow
+    // TODO investigate possible overflow: see issue #1416
+    run_test_on_device<int, ::std::equal_to<int>, ::std::multiplies<int>>();
+    run_test_on_device<float, ::std::equal_to<float>, ::std::multiplies<float>>();
     run_test_on_device<double, ::std::equal_to<double>, ::std::multiplies<double>>();
-    run_test_on_device<::std::uint64_t, ::std::equal_to<::std::uint64_t>, ::std::multiplies<::std::uint64_t>>();
 
     return TestUtils::done();
 }

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -343,8 +343,12 @@ void
 run_test_on_host()
 {
 #if !_PSTL_ICC_TEST_SIMD_UDS_BROKEN && !_PSTL_ICPX_TEST_RED_BY_SEG_OPTIMIZER_CRASH
+#if     TEST_DPCPP_BACKEND_PRESENT
+    test_algo_four_sequences<test_reduce_by_segment<ValueType, BinaryPredicate, BinaryOperation>>();
+#   else
     test_algo_four_sequences<ValueType, test_reduce_by_segment<BinaryPredicate, BinaryOperation>>();
-#endif     // !_PSTL_ICC_TEST_SIMD_UDS_BROKEN && !_PSTL_ICPX_TEST_RED_BY_SEG_OPTIMIZER_CRASH
+#   endif
+#endif // !_PSTL_ICC_TEST_SIMD_UDS_BROKEN && !_PSTL_ICPX_TEST_RED_BY_SEG_OPTIMIZER_CRASH
 }
 
 template <typename ValueType, typename BinaryPredicate, typename BinaryOperation>

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -350,8 +350,7 @@ void
 run_test_on_host()
 {
 #if !_PSTL_ICC_TEST_SIMD_UDS_BROKEN && !_PSTL_ICPX_TEST_RED_BY_SEG_OPTIMIZER_CRASH
-    test_algo_four_sequences<ValueType, test_reduce_by_segment<BinaryPredicate, BinaryOperation>,
-                             TestUtils::invoke_on_all_host_policies>();
+    test_algo_four_sequences<ValueType, test_reduce_by_segment<BinaryPredicate, BinaryOperation>>();
 #endif     // !_PSTL_ICC_TEST_SIMD_UDS_BROKEN && !_PSTL_ICPX_TEST_RED_BY_SEG_OPTIMIZER_CRASH
 }
 

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -41,9 +41,6 @@
 #endif // TEST_DPCPP_BACKEND_PRESENT
 using namespace TestUtils;
 
-// Please uncomment this define investigation issues in this test
-//#define LOG_TEST_INFO 1
-
 // This macro may be used to analyze source data and test results in test_reduce_by_segment
 // WARNING: in the case of using this macro debug output is very large.
 // #define DUMP_CHECK_RESULTS

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -322,103 +322,69 @@ test_flag_pred()
 
 template <typename ValueType, typename BinaryPredicate, typename BinaryOperation>
 void
-run_test()
+run_test_on_device()
 {
 #if TEST_DPCPP_BACKEND_PRESENT
-    if (TestUtils::has_type_support<ValueType>(TestUtils::get_test_queue().get_device()))
+    auto test = []() {
+        if (TestUtils::has_type_support<ValueType>(TestUtils::get_test_queue().get_device()))
+        {
+            // Run tests for USM shared memory
+            test4buffers<sycl::usm::alloc::shared, test_reduce_by_segment<ValueType, BinaryPredicate, BinaryOperation>>();
+            // Run tests for USM device memory
+            test4buffers<sycl::usm::alloc::device, test_reduce_by_segment<ValueType, BinaryPredicate, BinaryOperation>>();
+        }
+    };
+
+    if constexpr (sizeof(ValueType) == 8)
     {
-        // Run tests for USM shared memory
-#if LOG_TEST_INFO
-        std::cout << "\t\t" << "test4buffers<sycl::usm::alloc::shared, test_reduce_by_segment<ValueType, BinaryPredicate, BinaryOperation>>();" << std::endl;
-#endif        
-        test4buffers<sycl::usm::alloc::shared, test_reduce_by_segment<ValueType, BinaryPredicate, BinaryOperation>>();
-        // Run tests for USM device memory
-#if LOG_TEST_INFO
-        std::cout << "\t\t" << "test4buffers<sycl::usm::alloc::device, test_reduce_by_segment<ValueType, BinaryPredicate, BinaryOperation>>();" << std::endl;
+#if !_PSTL_ICPX_TEST_RED_BY_SEG_BROKEN_64BIT_TYPES || ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION
+        test();
 #endif
-        test4buffers<sycl::usm::alloc::device, test_reduce_by_segment<ValueType, BinaryPredicate, BinaryOperation>>();
+    }
+    else
+    {
+        test();
     }
 #endif // TEST_DPCPP_BACKEND_PRESENT
+}
 
+template <typename ValueType, typename BinaryPredicate, typename BinaryOperation>
+void
+run_test_on_host()
+{
 #if !_PSTL_ICC_TEST_SIMD_UDS_BROKEN && !_PSTL_ICPX_TEST_RED_BY_SEG_OPTIMIZER_CRASH
-#    if TEST_DPCPP_BACKEND_PRESENT
-#if LOG_TEST_INFO
-        std::cout << "\t\ttest_algo_four_sequences<test_reduce_by_segment<ValueType, BinaryPredicate, BinaryOperation>>();" << "" << std::endl;
-#endif
-        test_algo_four_sequences<test_reduce_by_segment<ValueType, BinaryPredicate, BinaryOperation>>();
-#    else
-#if LOG_TEST_INFO
-        std::cout << "\t\ttest_algo_four_sequences<ValueType, test_reduce_by_segment<BinaryPredicate, BinaryOperation>>();" << "" << std::endl;
-#endif
-        test_algo_four_sequences<ValueType, test_reduce_by_segment<BinaryPredicate, BinaryOperation>>();
-#    endif // TEST_DPCPP_BACKEND_PRESENT
+    test_algo_four_sequences<ValueType, test_reduce_by_segment<BinaryPredicate, BinaryOperation>,
+                             TestUtils::invoke_on_all_host_policies>();
 #endif     // !_PSTL_ICC_TEST_SIMD_UDS_BROKEN && !_PSTL_ICPX_TEST_RED_BY_SEG_OPTIMIZER_CRASH
 }
 
-template <template <typename T> typename BinaryPredicate, 
-          template <typename T> typename BinaryOperation>
+template <typename ValueType, typename BinaryPredicate, typename BinaryOperation>
 void
 run_test()
 {
-#if LOG_TEST_INFO
-    std::cout << "\t" << "run_test<int,    BinaryPredicate<int>,    BinaryOperation<int>>();" << std::endl;
-#endif
-    run_test<int,    BinaryPredicate<int>,    BinaryOperation<int>>();
-#if LOG_TEST_INFO
-    std::cout << "\t" << "run_test<float,  BinaryPredicate<float>,  BinaryOperation<float>>();" << std::endl;
-#endif
-    run_test<float,  BinaryPredicate<float>,  BinaryOperation<float>>();
-#if !_PSTL_ICPX_TEST_RED_BY_SEG_BROKEN_64BIT_TYPES || ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION
-#if LOG_TEST_INFO
-    std::cout << "\t" << "run_test<double, BinaryPredicate<double>, BinaryOperation<double>>();" << std::endl;
-#endif
-    run_test<double, BinaryPredicate<double>, BinaryOperation<double>>();
-#endif
+    run_test_on_host<ValueType, BinaryPredicate, BinaryOperation>();
+    run_test_on_device<ValueType, BinaryPredicate, BinaryOperation>();
 }
 
 int
 main()
 {
-#if LOG_TEST_INFO
-#if ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION
-    std::cout << "ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION is defined to " << ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION << std::endl;
-#else
-    std::cout << "ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION is not defined" << std::endl;
-#endif
-#endif
-
 #if TEST_DPCPP_BACKEND_PRESENT
     // test with flag pred
-#if LOG_TEST_INFO
-    std::cout << "test_flag_pred<sycl::usm::alloc::device, class KernelName1, std::uint64_t>();" << std::endl;
-#endif
     test_flag_pred<sycl::usm::alloc::device, class KernelName1, std::uint64_t>();
-#if LOG_TEST_INFO
-    std::cout << "test_flag_pred<sycl::usm::alloc::device, class KernelName2, dpl::complex<float>>();" << std::endl;
-#endif
     test_flag_pred<sycl::usm::alloc::device, class KernelName2, dpl::complex<float>>();
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-#if !_PSTL_ICPX_TEST_RED_BY_SEG_BROKEN_64BIT_TYPES || ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION
-#if LOG_TEST_INFO
-    std::cout << "run_test<::std::uint64_t,       UserBinaryPredicate<::std::uint64_t>,       MaxFunctor<::std::uint64_t>>();" << std::endl;
-#endif
-    run_test<::std::uint64_t,       UserBinaryPredicate<::std::uint64_t>,       MaxFunctor<::std::uint64_t>>();
-#endif
-#if LOG_TEST_INFO
-    std::cout << "run_test<::std::complex<float>, UserBinaryPredicate<::std::complex<float>>, MaxFunctor<::std::complex<float>>>();" << std::endl;
-#endif
+    run_test<::std::uint64_t, UserBinaryPredicate<::std::uint64_t>, MaxFunctor<::std::uint64_t>>();
     run_test<::std::complex<float>, UserBinaryPredicate<::std::complex<float>>, MaxFunctor<::std::complex<float>>>();
 
-#if LOG_TEST_INFO
-    std::cout << "run_test<::std::equal_to, ::std::plus>();" << std::endl;
-#endif
-    run_test<::std::equal_to, ::std::plus>();
-#if LOG_TEST_INFO
-    std::cout << "run_test<::std::equal_to, ::std::multiplies>();" << std::endl;
-#endif
+    run_test<int, ::std::equal_to<int>, ::std::plus<int>>();
+    run_test<float, ::std::equal_to<float>, ::std::plus<float>>();
+    run_test<double, ::std::equal_to<double>, ::std::plus<double>>();
+
     // TODO investigate possible overflow
-    run_test<::std::equal_to, ::std::multiplies>();
+    run_test_on_device<double, ::std::equal_to<double>, ::std::multiplies<double>>();
+    run_test_on_device<::std::uint64_t, ::std::equal_to<::std::uint64_t>, ::std::multiplies<::std::uint64_t>>();
 
     return TestUtils::done();
 }


### PR DESCRIPTION
Device backend does not require a value type to have a default constructor which provides an identity value. Let's remove that limitation for device policies.
Additionally, `reduce_by_segment` is based on the scan pattern, so this limitation applies to that algorithm for host policies.


Note:
Theoretically, the limitation should be imposed only on `unseq` and `par_unseq` policies. However, there is (at least one) instance of using a default constructor on non-vector path. Thus, the limitation can be relaxed after further investigation.

The PR also removes cases for `reduce_by_segment` for `std::multiplies` + host policies, and adds a trivial case for scan test with `std::multiplies` + device policies.

There are other potential solutions for `reduce_by_segment`:

- Make a wrapper in `reduce_by_segment` implementation over a value type and infer an identity basing on a type and an operation.
- Fall back to supported policies `reduce_by_segment`: implemented in #1404 as a draft.