### PR TITLE
Enable zip_iterator to satisfy C++20 std::input_iterator constraint

### DIFF
--- a/include/oneapi/dpl/pstl/tuple_impl.h
+++ b/include/oneapi/dpl/pstl/tuple_impl.h
@@ -669,6 +669,25 @@ get(const oneapi::dpl::__internal::tuple<_Tp...>&& __a)
 {
     return ::std::move(__a).template get<_Idx>();
 }
+
+#if __cplusplus >= 202002L
+template <typename... TTypes, typename... UTypes, template <typename> typename TQual,
+          template <typename> typename UQual>
+struct basic_common_reference<oneapi::dpl::__internal::tuple<TTypes...>, oneapi::dpl::__internal::tuple<UTypes...>,
+                              TQual, UQual>
+{
+    using type = oneapi::dpl::__internal::tuple<::std::common_reference_t<TQual<TTypes>, UQual<UTypes>>...>;
+};
+#endif
+
+#if __cplusplus >= 202002L && __cplusplus < 202302L
+template <typename... TTypes, typename... UTypes, template <typename> typename TQual,
+          template <typename> typename UQual>
+struct basic_common_reference<::std::tuple<TTypes...>, ::std::tuple<UTypes...>, TQual, UQual>
+{
+    using type = ::std::tuple<::std::common_reference_t<TQual<TTypes>, UQual<UTypes>>...>;
+};
+#endif
 } // namespace std
 
 #endif // _ONEDPL_TUPLE_IMPL_H


### PR DESCRIPTION
Currently with C++20, `oneapi::dpl::zip_iterator` cannot satisfy the C++20 [std::input_iterator](https://en.cppreference.com/w/cpp/iterator/input_iterator) constraint due to it's failure to satisfy [std::indirectly_readable](https://en.cppreference.com/w/cpp/iterator/indirectly_readable) which requires that the iterator's value and reference types to have a common reference.

To resolve this issue, we specialize `std::basic_common_reference` for `oneapi::dpl::__internal::tuple` to recursively fetch the common reference types of each corresponding tuple element in the input tuples.

Furthermore, the [tuple specialization of basic_common_reference](https://en.cppreference.com/w/cpp/utility/tuple/basic_common_reference) is not provided until C++23, so we must specialize this for C++20 to enable `zip_forward_iterator` support with these constraints which will meet compilation errors with the TBB backend if it is not provided.