### PR TITLE
[tests] Remove std::distance calls for random access iters in permutation_iterator tests

### DIFF
--- a/test/parallel_api/iterator/permutation_iterator_parallel_find.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_find.pass.cpp
@@ -46,7 +46,7 @@ DEFINE_TEST_PERM_IT(test_find, PermItIndexTag)
             test_through_permutation_iterator<Iterator1, Size, PermItIndexTag>{first1, n}(
                 [&](auto permItBegin, auto permItEnd)
                 {
-                    const auto testing_n = ::std::distance(permItBegin, permItEnd);
+                    const auto testing_n = permItEnd - permItBegin;
 
                     if (testing_n >= 2)
                     {

--- a/test/parallel_api/iterator/permutation_iterator_parallel_for.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_for.pass.cpp
@@ -67,7 +67,7 @@ DEFINE_TEST_PERM_IT(test_transform, PermItIndexTag)
             test_through_permutation_iterator<Iterator1, Size, PermItIndexTag>{first1, n}(
                 [&](auto permItBegin, auto permItEnd)
                 {
-                    const auto testing_n = ::std::distance(permItBegin, permItEnd);
+                    const auto testing_n = permItEnd - permItBegin;
 
                     clear_output_data(host_vals_ptr, host_vals_ptr + n);
                     host_vals.update_data();
@@ -75,7 +75,7 @@ DEFINE_TEST_PERM_IT(test_transform, PermItIndexTag)
                     auto itResultEnd = dpl::transform(exec, permItBegin, permItEnd, first2, TransformOp{});
                     wait_and_throw(exec);
 
-                    const auto resultSize = ::std::distance(first2, itResultEnd);
+                    const auto resultSize = itResultEnd - first2;
 
                     // Copy data back
                     std::vector<TestValueType> sourceData(testing_n);
@@ -88,7 +88,7 @@ DEFINE_TEST_PERM_IT(test_transform, PermItIndexTag)
                     // Check results
                     std::vector<TestValueType> transformedDataExpected(testing_n);
                     const auto itExpectedEnd = ::std::transform(sourceData.begin(), sourceData.end(), transformedDataExpected.begin(), TransformOp{});
-                    const auto expectedSize = ::std::distance(transformedDataExpected.begin(), itExpectedEnd);
+                    const auto expectedSize = itExpectedEnd - transformedDataExpected.begin();
                     EXPECT_EQ(expectedSize, resultSize, "Wrong size from dpl::transform");
                     EXPECT_EQ_N(transformedDataExpected.begin(), transformedDataResult.begin(), expectedSize, "Wrong result of dpl::transform");
                 });

--- a/test/parallel_api/iterator/permutation_iterator_parallel_merge.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_merge.pass.cpp
@@ -61,7 +61,7 @@ DEFINE_TEST_PERM_IT(test_merge, PermItIndexTag)
             test_through_permutation_iterator<Iterator1, Size, PermItIndexTag>{first1, n}(
                 [&](auto permItBegin1, auto permItEnd1)
                 {
-                    const auto testing_n1 = ::std::distance(permItBegin1, permItEnd1);
+                    const auto testing_n1 = permItEnd1 - permItBegin1;
 
                     //ensure list is sorted (not necessarily true after permutation)
                     dpl::sort(exec, permItBegin1, permItEnd1);
@@ -75,7 +75,7 @@ DEFINE_TEST_PERM_IT(test_merge, PermItIndexTag)
                     test_through_permutation_iterator<Iterator2, Size, PermItIndexTag>{first2, n}(
                         [&](auto permItBegin2, auto permItEnd2)
                         {
-                            const auto testing_n2 = ::std::distance(permItBegin2, permItEnd2);
+                            const auto testing_n2 = permItEnd2 - permItBegin2;
 
                             //ensure list is sorted (not necessarily true after permutation)
                             dpl::sort(exec, permItBegin2, permItEnd2);
@@ -83,7 +83,7 @@ DEFINE_TEST_PERM_IT(test_merge, PermItIndexTag)
 
                             const auto resultEnd = dpl::merge(exec, permItBegin1, permItEnd1, permItBegin2, permItEnd2, first3);
                             wait_and_throw(exec);
-                            const auto resultSize = ::std::distance(first3, resultEnd);
+                            const auto resultSize = resultEnd - first3;
 
                             // Copy data back
                             std::vector<TestValueType> srcData2(testing_n2);
@@ -97,7 +97,7 @@ DEFINE_TEST_PERM_IT(test_merge, PermItIndexTag)
                             // Check results
                             std::vector<TestValueType> mergedDataExpected(testing_n1 + testing_n2);
                             auto expectedEnd = std::merge(srcData1.begin(), srcData1.end(), srcData2.begin(), srcData2.end(), mergedDataExpected.begin());
-                            const auto expectedSize = ::std::distance(mergedDataExpected.begin(), expectedEnd);
+                            const auto expectedSize = expectedEnd - mergedDataExpected.begin();
                             EXPECT_EQ(expectedSize, resultSize, "Wrong size from dpl::merge");
                             EXPECT_EQ_N(mergedDataExpected.begin(), mergedDataResult.begin(), expectedSize, "Wrong result of dpl::merge");
                         });

--- a/test/parallel_api/iterator/permutation_iterator_parallel_or.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_or.pass.cpp
@@ -48,7 +48,7 @@ DEFINE_TEST_PERM_IT(test_is_heap, PermItIndexTag)
                 test_through_permutation_iterator<Iterator1, Size, PermItIndexTag>{first1, n}(
                     [&](auto permItBegin, auto permItEnd)
                     {
-                        const auto testing_n = ::std::distance(permItBegin, permItEnd);
+                        const auto testing_n = permItEnd - permItBegin;
 
                         const auto resultIsHeap = dpl::is_heap(exec, permItBegin, permItEnd);
                         wait_and_throw(exec);

--- a/test/parallel_api/iterator/permutation_iterator_parallel_partial_sort.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_partial_sort.pass.cpp
@@ -54,7 +54,7 @@ DEFINE_TEST_PERM_IT(test_partial_sort, PermItIndexTag)
             test_through_permutation_iterator<Iterator1, Size, PermItIndexTag>{first1, n}(
                 [&](auto permItBegin, auto permItEnd)
                 {
-                    const auto testing_n = ::std::distance(permItBegin, permItEnd);
+                    const auto testing_n = permItEnd - permItBegin;
 
                     for (::std::size_t p = 0; p < testing_n; p = p <= 16 ? p + 1 : ::std::size_t(31.415 * p))
                     {

--- a/test/parallel_api/iterator/permutation_iterator_parallel_stable_sort.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_stable_sort.pass.cpp
@@ -52,7 +52,7 @@ DEFINE_TEST_PERM_IT(test_sort, PermItIndexTag)
                 {
                     using ValueType = typename ::std::iterator_traits<decltype(permItBegin)>::value_type;
 
-                    const auto testing_n = ::std::distance(permItBegin, permItEnd);
+                    const auto testing_n = permItEnd - permItBegin;
 
                     // Fill full source data set (not only values iterated by permutation iterator)
                     generate_data(host_keys_ptr, host_keys_ptr + n, n);

--- a/test/parallel_api/iterator/permutation_iterator_parallel_transform_reduce.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_transform_reduce.pass.cpp
@@ -45,7 +45,7 @@ DEFINE_TEST_PERM_IT(test_transform_reduce, PermItIndexTag)
             test_through_permutation_iterator<Iterator1, Size, PermItIndexTag>{first1, n}(
                 [&](auto permItBegin, auto permItEnd)
                 {
-                    const auto testing_n = ::std::distance(permItBegin, permItEnd);
+                    const auto testing_n = permItEnd - permItBegin;
 
                     const auto result = dpl::transform_reduce(exec, permItBegin, permItEnd, TestValueType{},
                                                               ::std::plus<TestValueType>(), ::std::negate<TestValueType>());

--- a/test/parallel_api/iterator/permutation_iterator_parallel_transform_scan.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_transform_scan.pass.cpp
@@ -43,7 +43,7 @@ DEFINE_TEST_PERM_IT(test_remove_if, PermItIndexTag)
             test_through_permutation_iterator<Iterator1, Size, PermItIndexTag>{first1, n}(
                 [&](auto permItBegin, auto permItEnd)
                 {
-                    const auto testing_n = ::std::distance(permItBegin, permItEnd);
+                    const auto testing_n = permItEnd - permItBegin;
 
                     // Fill full source data set (not only values iterated by permutation iterator)
                     generate_data(host_keys_ptr, host_keys_ptr + n, n);
@@ -59,7 +59,7 @@ DEFINE_TEST_PERM_IT(test_remove_if, PermItIndexTag)
                     auto itEndNewRes = dpl::remove_if(exec, permItBegin, permItEnd, op);
                     wait_and_throw(exec);
 
-                    const auto newSizeResult = ::std::distance(permItBegin, itEndNewRes);
+                    const auto newSizeResult = itEndNewRes - permItBegin;
 
                     // Copy modified data back
                     std::vector<TestValueType> resultRemoveIf(newSizeResult);
@@ -69,7 +69,7 @@ DEFINE_TEST_PERM_IT(test_remove_if, PermItIndexTag)
                     // Eval expected result
                     auto expectedRemoveIf = sourceData;
                     auto itEndNewExpected = ::std::remove_if(expectedRemoveIf.begin(), expectedRemoveIf.end(), op);
-                    const auto newSizeExpected = ::std::distance(expectedRemoveIf.begin(), itEndNewExpected);
+                    const auto newSizeExpected = itEndNewExpected - expectedRemoveIf.begin();
 
                     // Check results
                     EXPECT_EQ(newSizeExpected, newSizeResult, "Wrong result size after dpl::remove_if");


### PR DESCRIPTION
`std::distance` calls on random access iterator (`permutation_iterator<sycl_iterator, ...>`) typed variables cause compiler errors in MSVC C++20.
Somehow, `std::ranges::iter_move` is called within `std::distance`, resulting in an compiler error because `sycl_iterator` is not dereference-able.  

A simple subtraction will reliably suffice for these iterators to determine the size of the range between iterators, so this PR switches to this method, avoiding the compiler error.

This is a better alternative to https://github.com/oneapi-src/oneDPL/pull/1406, which simply turned off these tests, as we don't need to turn the tests off.