### PR TITLE
Extend compiler support for the unified USM and buffer storage

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -126,7 +126,9 @@ struct __parallel_transform_reduce_small_submitter<_Tp, __work_group_size, __ite
             __cgh.parallel_for<_Name...>(
                 sycl::nd_range<1>(sycl::range<1>(__work_group_size), sycl::range<1>(__work_group_size)),
                 [=](sycl::nd_item<1> __item_id) {
-                    auto __res_ptr = __get_usm_host_or_buffer_accessor_ptr(__res_acc);
+                    auto __res_ptr =
+                        __usm_host_or_buffer_storage<_ExecutionPolicy, _Tp>::__get_usm_host_or_buffer_accessor_ptr(
+                            __res_acc);
                     __work_group_reduce_kernel<_Tp>(__item_id, __n, __transform_pattern, __reduce_pattern, __init,
                                                     __temp_local, __res_ptr, __rngs...);
                 });
@@ -243,7 +245,9 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<
             __cgh.parallel_for<_KernelName...>(
                 sycl::nd_range<1>(sycl::range<1>(__work_group_size2), sycl::range<1>(__work_group_size2)),
                 [=](sycl::nd_item<1> __item_id) {
-                    auto __res_ptr = __get_usm_host_or_buffer_accessor_ptr(__res_acc);
+                    auto __res_ptr =
+                        __usm_host_or_buffer_storage<_ExecutionPolicy, _Tp>::__get_usm_host_or_buffer_accessor_ptr(
+                            __res_acc);
                     __work_group_reduce_kernel<_Tp>(__item_id, __n, __transform_pattern, __reduce_pattern, __init,
                                                     __temp_local, __res_ptr, __temp_acc);
                 });
@@ -355,7 +359,9 @@ struct __parallel_transform_reduce_impl
                     sycl::nd_range<1>(sycl::range<1>(__n_groups * __work_group_size),
                                       sycl::range<1>(__work_group_size)),
                     [=](sycl::nd_item<1> __item_id) {
-                        auto __res_ptr = __get_usm_host_or_buffer_accessor_ptr(__res_acc);
+                        auto __res_ptr =
+                            __usm_host_or_buffer_storage<_ExecutionPolicy, _Tp>::__get_usm_host_or_buffer_accessor_ptr(
+                                __res_acc);
                         auto __local_idx = __item_id.get_local_id(0);
                         auto __group_idx = __item_id.get_group(0);
                         // 1. Initialization (transform part). Fill local memory

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -126,7 +126,7 @@ struct __parallel_transform_reduce_small_submitter<_Tp, __work_group_size, __ite
             __cgh.parallel_for<_Name...>(
                 sycl::nd_range<1>(sycl::range<1>(__work_group_size), sycl::range<1>(__work_group_size)),
                 [=](sycl::nd_item<1> __item_id) {
-                    auto __res_ptr = __res_acc.template get_multi_ptr<sycl::access::decorated::yes>();
+                    auto __res_ptr = __get_usm_host_or_buffer_accessor_ptr(__res_acc);
                     __work_group_reduce_kernel<_Tp>(__item_id, __n, __transform_pattern, __reduce_pattern, __init,
                                                     __temp_local, __res_ptr, __rngs...);
                 });
@@ -243,7 +243,7 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<
             __cgh.parallel_for<_KernelName...>(
                 sycl::nd_range<1>(sycl::range<1>(__work_group_size2), sycl::range<1>(__work_group_size2)),
                 [=](sycl::nd_item<1> __item_id) {
-                    auto __res_ptr = __res_acc.template get_multi_ptr<sycl::access::decorated::yes>();
+                    auto __res_ptr = __get_usm_host_or_buffer_accessor_ptr(__res_acc);
                     __work_group_reduce_kernel<_Tp>(__item_id, __n, __transform_pattern, __reduce_pattern, __init,
                                                     __temp_local, __res_ptr, __temp_acc);
                 });
@@ -355,7 +355,7 @@ struct __parallel_transform_reduce_impl
                     sycl::nd_range<1>(sycl::range<1>(__n_groups * __work_group_size),
                                       sycl::range<1>(__work_group_size)),
                     [=](sycl::nd_item<1> __item_id) {
-                        auto __res_ptr = __res_acc.template get_multi_ptr<sycl::access::decorated::yes>();
+                        auto __res_ptr = __get_usm_host_or_buffer_accessor_ptr(__res_acc);
                         auto __local_idx = __item_id.get_local_id(0);
                         auto __group_idx = __item_id.get_group(0);
                         // 1. Initialization (transform part). Fill local memory

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -126,7 +126,7 @@ struct __parallel_transform_reduce_small_submitter<_Tp, __work_group_size, __ite
             __cgh.parallel_for<_Name...>(
                 sycl::nd_range<1>(sycl::range<1>(__work_group_size), sycl::range<1>(__work_group_size)),
                 [=](sycl::nd_item<1> __item_id) {
-                    auto __res_ptr = __res_acc.__get_pointer();
+                    auto __res_ptr = __res_acc.template get_multi_ptr<sycl::access::decorated::yes>();
                     __work_group_reduce_kernel<_Tp>(__item_id, __n, __transform_pattern, __reduce_pattern, __init,
                                                     __temp_local, __res_ptr, __rngs...);
                 });
@@ -243,7 +243,7 @@ struct __parallel_transform_reduce_work_group_kernel_submitter<
             __cgh.parallel_for<_KernelName...>(
                 sycl::nd_range<1>(sycl::range<1>(__work_group_size2), sycl::range<1>(__work_group_size2)),
                 [=](sycl::nd_item<1> __item_id) {
-                    auto __res_ptr = __res_acc.__get_pointer();
+                    auto __res_ptr = __res_acc.template get_multi_ptr<sycl::access::decorated::yes>();
                     __work_group_reduce_kernel<_Tp>(__item_id, __n, __transform_pattern, __reduce_pattern, __init,
                                                     __temp_local, __res_ptr, __temp_acc);
                 });
@@ -355,7 +355,7 @@ struct __parallel_transform_reduce_impl
                     sycl::nd_range<1>(sycl::range<1>(__n_groups * __work_group_size),
                                       sycl::range<1>(__work_group_size)),
                     [=](sycl::nd_item<1> __item_id) {
-                        auto __res_ptr = __res_acc.__get_pointer();
+                        auto __res_ptr = __res_acc.template get_multi_ptr<sycl::access::decorated::yes>();
                         auto __local_idx = __item_id.get_local_id(0);
                         auto __group_idx = __item_id.get_group(0);
                         // 1. Initialization (transform part). Fill local memory

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -489,9 +489,8 @@ struct __usm_host_or_buffer_accessor
     // USM pointer
     __usm_host_or_buffer_accessor(sycl::handler& __cgh, _T* __usm_buf) : __ptr(__usm_buf), __usm(true) {}
 
-    template <sycl::access::decorated> // Mirror sycl::accessor::get_multi_ptr
     auto
-    get_multi_ptr() const // should be cached within a kernel
+    __get_pointer() const // should be cached within a kernel
     {
         return __usm ? __ptr : &__acc[0];
     }
@@ -564,6 +563,17 @@ struct __usm_host_or_buffer_storage
         return __usm;
     }
 };
+
+template <typename _Acc>
+auto
+__get_usm_host_or_buffer_accessor_ptr(const _Acc& __acc)
+{
+#if _ONEDPL_SYCL_UNIFIED_USM_BUFFER_PRESENT
+    return __acc.__get_pointer();
+#else
+    return &__acc[0];
+#endif
+}
 
 //A contract for future class: <sycl::event or other event, a value, sycl::buffers..., or __usm_host_or_buffer_storage>
 //Impl details: inheritance (private) instead of aggregation for enabling the empty base optimization.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -540,6 +540,17 @@ struct __usm_host_or_buffer_storage
         }
     }
 
+    template <typename _Acc>
+    static auto
+    __get_usm_host_or_buffer_accessor_ptr(const _Acc& __acc)
+    {
+#if _ONEDPL_SYCL_UNIFIED_USM_BUFFER_PRESENT
+        return __acc.__get_pointer();
+#else
+        return &__acc[0];
+#endif
+    }
+
     auto
     __get_acc(sycl::handler& __cgh)
     {
@@ -563,17 +574,6 @@ struct __usm_host_or_buffer_storage
         return __usm;
     }
 };
-
-template <typename _Acc>
-auto
-__get_usm_host_or_buffer_accessor_ptr(const _Acc& __acc)
-{
-#if _ONEDPL_SYCL_UNIFIED_USM_BUFFER_PRESENT
-    return __acc.__get_pointer();
-#else
-    return &__acc[0];
-#endif
-}
 
 //A contract for future class: <sycl::event or other event, a value, sycl::buffers..., or __usm_host_or_buffer_storage>
 //Impl details: inheritance (private) instead of aggregation for enabling the empty base optimization.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -82,12 +82,12 @@
 #    define _ONEDPL_SYCL_REQD_SUB_GROUP_SIZE_IF_SUPPORTED(SIZE)
 #endif
 
-// The unified future supporting USM host memory and buffers is only supported after DPCPP 2023.1
+// The unified future supporting USM memory and buffers is only supported after DPCPP 2023.1
 // but not by 2023.2.
 #if (_ONEDPL_LIBSYCL_VERSION >= 60100 && _ONEDPL_LIBSYCL_VERSION != 60200)
-#    define _ONEDPL_SYCL_USM_HOST_PRESENT 1
+#    define _ONEDPL_SYCL_UNIFIED_USM_BUFFER_PRESENT 1
 #else
-#    define _ONEDPL_SYCL_USM_HOST_PRESENT 0
+#    define _ONEDPL_SYCL_UNIFIED_USM_BUFFER_PRESENT 0
 #endif
 
 namespace __dpl_sycl


### PR DESCRIPTION
The existing unified USM or buffer storage used in the family of reduce algorithms uses the default constructor of SYCL accessors. This is a SYCL 2020 feature that was implemented here: https://github.com/intel/llvm/pull/7815. This limits the supported DPCPP compilers to 2023.1 and newer. This PR extends the compiler support by using a SYCL accessor with the `get_multi_ptr` routine on older (2023.0 and older) compilers instead of the `__usm_host_or_buffer_accessor` class. The `_ONEDPL_SYCL_USM_HOST_PRESENT` macro is further renamed to `_ONEDPL_SYCL_UNIFIED_USM_BUFFER_PRESENT` to highlight whether the compiler supports the unified USM and buffer implementation.

This issue was detected by @AidanBeltonS during the testing of https://github.com/oneapi-src/oneDPL/pull/1354. The proposed fix was tested with DPCPP 2022.0 through 2024.0.