### PR TITLE
Bugfix for reverse_iterators as oneDPL input with device policy

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -481,7 +481,7 @@ struct __get_sycl_range
     {
         assert(__first < __last);
 
-        auto __res = __process_input_iter<_LocalAccMode>(__first.base(), __last.base());
+        auto __res = __process_input_iter<_LocalAccMode>(__last.base(), __first.base());
         auto __rng = oneapi::dpl::__ranges::reverse_view_simple<decltype(__res.all_view())>{__res.all_view()};
 
         return __range_holder<decltype(__rng)>{__rng};


### PR DESCRIPTION
This PR switches the order of the iterators when processing the base iterator range for reverse_iterators.
If we do not do this, the next layer of handling for the input iterator will have incorrect ordering, and it will fail the assertion that `__first < __last` for the base.
This is a regression as of #1254, where a specialization was added specifically for reverse_iterators (However prior to that PR, it reverse_iterators may have been handled in a inefficient way).
