### PR TITLE
[tests] Fix path for utils_sycl_defs.h

### DIFF
--- a/test/support/sycl_alloc_utils.h
+++ b/test/support/sycl_alloc_utils.h
@@ -21,7 +21,7 @@
 #include <list>
 #include <memory>
 
-#include "support/utils_sycl_defs.h"
+#include "utils_sycl_defs.h"
 
 namespace TestUtils
 {


### PR DESCRIPTION
Fixing path for `utils_sycl_defs.h` include, It is a sibling, not part of child directory.
