### PR TITLE
Lazy `sycl::queue` creation in oneDPL hetero policies

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -177,6 +177,13 @@ inline fpga_policy<> dpcpp_fpga{};
 #endif // _ONEDPL_PREDEFINED_POLICIES
 
 // make_policy functions
+template <typename KernelNameOther>
+auto
+make_device_policy(const device_policy<KernelNameOther>& other)
+{
+    return device_policy<DefaultKernelName>(other);
+}
+
 template <typename KernelName = DefaultKernelName>
 device_policy<KernelName>
 make_device_policy(sycl::queue q)
@@ -191,7 +198,7 @@ make_device_policy(sycl::device d)
     return device_policy<KernelName>(d);
 }
 
-template <typename NewKernelName, typename OldKernelName = DefaultKernelName>
+template <typename NewKernelName, typename OldKernelName>
 device_policy<NewKernelName>
 make_device_policy(const device_policy<OldKernelName>& policy
 #if _ONEDPL_PREDEFINED_POLICIES
@@ -202,7 +209,7 @@ make_device_policy(const device_policy<OldKernelName>& policy
     return device_policy<NewKernelName>(policy);
 }
 
-template <typename NewKernelName, typename OldKernelName = DefaultKernelName>
+template <typename NewKernelName, typename OldKernelName>
 device_policy<NewKernelName>
 make_hetero_policy(const device_policy<OldKernelName>& policy)
 {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -43,7 +43,6 @@ template <class TSYCLQueueFactory>
 class sycl_queue_container
 {
   public:
-
     template <typename... Args>
     sycl::queue
     get_queue(Args&&... args)
@@ -87,26 +86,15 @@ class device_policy
   public:
     using kernel_name = KernelName;
 
-    device_policy()
-        : q_container(::std::make_shared<sycl_queue_container<TSyclQueueFactory>>())
-    {
-    }
+    device_policy() : q_container(::std::make_shared<sycl_queue_container<TSyclQueueFactory>>()) {}
 
     template <typename OtherName>
     device_policy(const device_policy<OtherName, TSyclQueueFactory>& other)
         : q_container(other.get_sycl_queue_container())
     {
     }
-    explicit device_policy(sycl::queue q_)
-        : device_policy()
-    {
-        q_container->get_queue(::std::move(q_));
-    }
-    explicit device_policy(sycl::device d_)
-        : device_policy()
-    {
-        q_container->get_queue(::std::move(d_));
-    }
+    explicit device_policy(sycl::queue q_) : device_policy() { q_container->get_queue(::std::move(q_)); }
+    explicit device_policy(sycl::device d_) : device_policy() { q_container->get_queue(::std::move(d_)); }
     operator sycl::queue() const { return queue(); }
     sycl::queue
     queue() const
@@ -114,13 +102,13 @@ class device_policy
         return q_container->get_queue();
     }
 
-    auto get_sycl_queue_container() const
+    auto
+    get_sycl_queue_container() const
     {
         return q_container;
     }
 
   private:
-
     mutable sycl_queue_container_ptr<TSyclQueueFactory> q_container;
 };
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -64,8 +64,8 @@ template <typename TFactory>
 using sycl_queue_container_ptr = ::std::shared_ptr<sycl_queue_container<TFactory>>;
 
 ////////////////////////////////////////////////////////////////////////////////
-// TDefaultSYCLQueueFactory - default sycl::queue factory
-struct TDefaultSYCLQueueFactory
+// sycl_queue_factory_device - default sycl::queue factory for device policy
+struct sycl_queue_factory_device
 {
     template <typename... Args>
     sycl::queue
@@ -80,7 +80,7 @@ struct TDefaultSYCLQueueFactory
 // 2. from sycl::device_selector (implicitly through sycl::queue)
 // 3. from sycl::device
 // 4. from other device_policy encapsulating the same queue type
-template <typename KernelName = DefaultKernelName, class TSyclQueueFactory = TDefaultSYCLQueueFactory>
+template <typename KernelName = DefaultKernelName, class TSyclQueueFactory = sycl_queue_factory_device>
 class device_policy
 {
   public:

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -152,27 +152,19 @@ struct TDefaultSYCLQueueFactoryFPGA
 };
 
 struct DefaultKernelNameFPGA;
-template <unsigned int factor = 1, typename KernelName = DefaultKernelNameFPGA>
-class fpga_policy : public device_policy<KernelName>
+template <unsigned int factor = 1, typename KernelName = DefaultKernelNameFPGA,
+          class TSYCLQueueFactory = TDefaultSYCLQueueFactoryFPGA>
+class fpga_policy : public device_policy<KernelName, TSYCLQueueFactory>
 {
-    using base = device_policy<KernelName>;
+    using base = device_policy<KernelName, TSYCLQueueFactory>;
 
   public:
     static constexpr unsigned int unroll_factor = factor;
 
-    fpga_policy()
-        : base(sycl::queue(
-#    if _ONEDPL_FPGA_EMU
-              __dpl_sycl::__fpga_emulator_selector()
-#    else
-              __dpl_sycl::__fpga_selector()
-#    endif // _ONEDPL_FPGA_EMU
-                  ))
-    {
-    }
+    fpga_policy() = default;
 
     template <unsigned int other_factor, typename OtherName>
-    fpga_policy(const fpga_policy<other_factor, OtherName>& other) : base(other.queue()){};
+    fpga_policy(const fpga_policy<other_factor, OtherName, TSYCLQueueFactory>& other) : base(other){};
     explicit fpga_policy(sycl::queue q) : base(q) {}
     explicit fpga_policy(sycl::device d) : base(d) {}
 };

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -115,8 +115,8 @@ class device_policy
 #if _ONEDPL_FPGA_DEVICE
 
 ////////////////////////////////////////////////////////////////////////////////
-// TDefaultSYCLQueueFactoryFPGA - default sycl::queue FPGA factory
-struct TDefaultSYCLQueueFactoryFPGA
+// sycl_queue_factory_fpga - default sycl::queue FPGA factory
+struct sycl_queue_factory_fpga
 {
     template <class... Args>
     sycl::queue
@@ -141,7 +141,7 @@ struct TDefaultSYCLQueueFactoryFPGA
 
 struct DefaultKernelNameFPGA;
 template <unsigned int factor = 1, typename KernelName = DefaultKernelNameFPGA,
-          class TSYCLQueueFactory = TDefaultSYCLQueueFactoryFPGA>
+          class TSYCLQueueFactory = sycl_queue_factory_fpga>
 class fpga_policy : public device_policy<KernelName, TSYCLQueueFactory>
 {
     using base = device_policy<KernelName, TSYCLQueueFactory>;

--- a/test/general/header_order_ranges_0.pass.cpp
+++ b/test/general/header_order_ranges_0.pass.cpp
@@ -27,7 +27,7 @@ main()
 {
 #if _ENABLE_RANGES_TESTING
     using namespace oneapi::dpl::experimental::ranges;
-    all_of(TestUtils::default_dpcpp_policy, views::fill(-1, 10), [](auto i) { return i == -1;});
+    all_of(TestUtils::get_default_dpcpp_policy(), views::fill(-1, 10), [](auto i) { return i == -1; });
 #endif
 
     return TestUtils::done(_ENABLE_RANGES_TESTING);

--- a/test/general/header_order_ranges_1.pass.cpp
+++ b/test/general/header_order_ranges_1.pass.cpp
@@ -27,7 +27,7 @@ main()
 {
 #if _ENABLE_RANGES_TESTING
     using namespace oneapi::dpl::experimental::ranges;
-    all_of(TestUtils::default_dpcpp_policy, views::fill(-1, 10), [](auto i) { return i == -1;});
+    all_of(TestUtils::get_default_dpcpp_policy(), views::fill(-1, 10), [](auto i) { return i == -1; });
 #endif
 
     return TestUtils::done(_ENABLE_RANGES_TESTING);

--- a/test/general/lambda_naming.pass.cpp
+++ b/test/general/lambda_naming.pass.cpp
@@ -33,7 +33,7 @@ int main() {
     auto buf_begin = oneapi::dpl::begin(buf);
     auto buf_end = buf_begin + n;
 
-    const auto policy = TestUtils::default_dpcpp_policy;
+    const auto policy = TestUtils::get_default_dpcpp_policy();
     auto buf_begin_discard_write = oneapi::dpl::begin(buf, sycl::write_only, sycl::property::no_init{});
 
     ::std::fill(policy, buf_begin_discard_write, buf_begin_discard_write + n, 1);

--- a/test/general/test_policies.pass.cpp
+++ b/test/general/test_policies.pass.cpp
@@ -59,7 +59,7 @@ main()
     static_assert(is_execution_policy_v<parallel_unsequenced_policy>, "wrong result for is_execution_policy_v<parallel_unsequenced_policy>");
 
 #if TEST_DPCPP_BACKEND_PRESENT
-    auto q = sycl::queue{TestUtils::default_selector};
+    auto q = sycl::queue{TestUtils::get_default_selector()};
 
     static_assert(is_execution_policy<device_policy<class Kernel_0>>::value, "wrong result for is_execution_policy<device_policy>");
     static_assert(is_execution_policy_v<device_policy<class Kernel_0>>, "wrong result for is_execution_policy_v<device_policy>");
@@ -73,10 +73,10 @@ main()
     // Currently, there is no implicit conversion (implicit syc::queue constructor by a device selector)
     // from a device selector to a queue.
     // The same test call with explicit queue creation we have below in line 78.
-    test_policy_instance(TestUtils::make_device_policy<class Kernel_12>(TestUtils::default_selector));
+    test_policy_instance(TestUtils::make_device_policy<class Kernel_12>(TestUtils::get_default_selector()));
 #endif
-    test_policy_instance(TestUtils::make_device_policy<class Kernel_13>(sycl::device{TestUtils::default_selector}));
-    test_policy_instance(TestUtils::make_device_policy<class Kernel_14>(sycl::queue{TestUtils::default_selector, sycl::property::queue::in_order()}));
+    test_policy_instance(TestUtils::make_device_policy<class Kernel_13>(sycl::device{TestUtils::get_default_selector()}));
+    test_policy_instance(TestUtils::make_device_policy<class Kernel_14>(sycl::queue{TestUtils::get_default_selector(), sycl::property::queue::in_order()}));
     test_policy_instance(TestUtils::make_device_policy<class Kernel_15>(dpcpp_default));
     // Special case: required to call make_device_policy directly from oneapi::dpl::execution namespace
     test_policy_instance(oneapi::dpl::execution::make_device_policy<class Kernel_16>());
@@ -84,7 +84,7 @@ main()
     // device_policy
     EXPECT_TRUE(device_policy<class Kernel_1>(q).queue() == q, "wrong result for queue()");
     test_policy_instance(device_policy<class Kernel_21>(q));
-    test_policy_instance(device_policy<class Kernel_22>(sycl::device{TestUtils::default_selector}));
+    test_policy_instance(device_policy<class Kernel_22>(sycl::device{TestUtils::get_default_selector()}));
     test_policy_instance(device_policy<class Kernel_23>(dpcpp_default));
     test_policy_instance(device_policy<class Kernel_24>(sycl::queue(dpcpp_default))); // conversion to sycl::queue
     test_policy_instance(device_policy<>{});
@@ -97,16 +97,16 @@ main()
     test_policy_instance(dpcpp_fpga);
 
     // make_fpga_policy
-    test_policy_instance(TestUtils::make_fpga_policy</*unroll_factor =*/ 1, class Kernel_31>(sycl::queue{TestUtils::default_selector}));
-    test_policy_instance(TestUtils::make_fpga_policy</*unroll_factor =*/ 2, class Kernel_32>(sycl::device{TestUtils::default_selector}));
+    test_policy_instance(TestUtils::make_fpga_policy</*unroll_factor =*/ 1, class Kernel_31>(sycl::queue{TestUtils::get_default_selector()}));
+    test_policy_instance(TestUtils::make_fpga_policy</*unroll_factor =*/ 2, class Kernel_32>(sycl::device{TestUtils::get_default_selector()}));
     test_policy_instance(TestUtils::make_fpga_policy</*unroll_factor =*/ 4, class Kernel_33>(dpcpp_fpga));
     // Special case: required to call make_fpga_policy directly from oneapi::dpl::execution namespace
     test_policy_instance(oneapi::dpl::execution::make_fpga_policy</*unroll_factor =*/ 8, class Kernel_34>());
-    test_policy_instance(TestUtils::make_fpga_policy</*unroll_factor =*/ 16, class Kernel_35>(sycl::queue{TestUtils::default_selector}));
+    test_policy_instance(TestUtils::make_fpga_policy</*unroll_factor =*/ 16, class Kernel_35>(sycl::queue{TestUtils::get_default_selector()}));
 
     // fpga_policy
-    test_policy_instance(fpga_policy</*unroll_factor =*/ 1, class Kernel_41>(sycl::queue{TestUtils::default_selector}));
-    test_policy_instance(fpga_policy</*unroll_factor =*/ 2, class Kernel_42>(sycl::device{TestUtils::default_selector}));
+    test_policy_instance(fpga_policy</*unroll_factor =*/ 1, class Kernel_41>(sycl::queue{TestUtils::get_default_selector()}));
+    test_policy_instance(fpga_policy</*unroll_factor =*/ 2, class Kernel_42>(sycl::device{TestUtils::get_default_selector()}));
     test_policy_instance(fpga_policy</*unroll_factor =*/ 4, class Kernel_43>(dpcpp_fpga));
     test_policy_instance(fpga_policy</*unroll_factor =*/ 8, class Kernel_44>{});
     static_assert(std::is_same_v<fpga_policy</*unroll_factor =*/ 8, Kernel_25>::kernel_name, Kernel_25>, "wrong result for kernel_name (fpga_policy)");

--- a/test/parallel_api/iterator/permutation_iterator.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator.pass.cpp
@@ -17,12 +17,6 @@
 
 #include "permutation_iterator_common.h"
 
-#if TEST_DPCPP_BACKEND_PRESENT
-#    include "support/utils_device_copyable.h"
-#endif
-
-using namespace TestUtils;
-
 int
 main()
 {
@@ -42,40 +36,23 @@ main()
     auto permItBegin = dpl::make_permutation_iterator(countingItBegin, kDefaultIndexStepOp);
     auto permItEnd = permItBegin + perm_size_expected;
 
-    static_assert(sycl::is_device_copyable_v<decltype(permItBegin)>,
-                  "permutation_iterator (counting_iterator) is not device copyable");
-
-    static_assert(
-        sycl::is_device_copyable_v<
-            oneapi::dpl::permutation_iterator<constant_iterator_device_copyable, constant_iterator_device_copyable>>,
-        "permutation_iterator is not device copyable with device copyable types");
-
-    static_assert(sycl::is_device_copyable_v<
-                      oneapi::dpl::permutation_iterator<constant_iterator_device_copyable, noop_device_copyable>>,
-                  "permutation_iterator is not device copyable with device copyable types");
-
-    static_assert(!sycl::is_device_copyable_v<
-                      oneapi::dpl::permutation_iterator<constant_iterator_non_device_copyable, noop_device_copyable>>,
-                  "permutation_iterator is device copyable with non device copyable types");
-
-    static_assert(!sycl::is_device_copyable_v<oneapi::dpl::permutation_iterator<int*, noop_non_device_copyable>>,
-                  "permutation_iterator is device copyable with non device copyable types");
-
-    static_assert(
-        !sycl::is_device_copyable_v<oneapi::dpl::permutation_iterator<int*, constant_iterator_non_device_copyable>>,
-        "permutation_iterator is device copyable with non device copyable types");
+    //transform_iterator is not trivially_copyable, as it defines a copy assignment operator which does not copy
+    // its unary functor.  permutation_iterator is based on transform_iterator and therefore is also not
+    // trivially_copyable.  This makes permutation_iterator's device_copyable trait deprecated with sycl 2020.
+    EXPECT_TRUE(check_if_device_copyable_by_sycl2020_or_by_old_definition <decltype(permItBegin)>,
+                "permutation_iterator (counting_iterator) is not properly copyable");
 
     const std::size_t perm_size_result = std::distance(permItBegin, permItEnd);
     EXPECT_EQ(perm_size_expected, perm_size_result,
               "Wrong result of std::distance<permutationIterator1, permutationIterator2)");
 
     std::vector<int> resultCopy(perm_size_result);
-    auto itCopiedDataEnd = dpl::copy(default_dpcpp_policy, permItBegin, permItEnd, resultCopy.begin());
+    auto itCopiedDataEnd = dpl::copy(TestUtils::default_dpcpp_policy, permItBegin, permItEnd, resultCopy.begin());
     EXPECT_EQ(true, resultCopy.end() == itCopiedDataEnd, "Wrong result of dpl::copy");
 
     const std::vector<int> expectedCopy = {0, 2, 4, 6, 8, 10, 12, 14, 16, 18};
     EXPECT_EQ_N(expectedCopy.begin(), resultCopy.begin(), perm_size_result, "Wrong state of dpl::copy data");
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-    return done(TEST_DPCPP_BACKEND_PRESENT);
+    return TestUtils::done(TEST_DPCPP_BACKEND_PRESENT);
 }

--- a/test/parallel_api/ranges/adjacent_find_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/adjacent_find_ranges_sycl.pass.cpp
@@ -40,7 +40,7 @@ main()
     {
         sycl::buffer<int> A(data, sycl::range<1>(n));
 
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::get_default_dpcpp_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/all_any_none_of_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/all_any_none_of_ranges_sycl.pass.cpp
@@ -41,7 +41,7 @@ main()
         sycl::buffer<int> A(data1, sycl::range<1>(max_n));
         sycl::buffer<int> B(data2, sycl::range<1>(max_n));
 
-        auto exec1 = TestUtils::default_dpcpp_policy;
+        auto exec1 = TestUtils::get_default_dpcpp_policy();
         using Policy = decltype(exec1);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec1);
         auto exec3 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec1);

--- a/test/parallel_api/ranges/copy_if_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/copy_if_ranges_sycl.pass.cpp
@@ -41,7 +41,7 @@ main()
 
     auto src = views::iota(0, max_n);
 
-    auto exec1 = TestUtils::default_dpcpp_policy;
+    auto exec1 = TestUtils::get_default_dpcpp_policy();
     using Policy = decltype(exec1);
     auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec1);
     auto exec3 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec1);

--- a/test/parallel_api/ranges/copy_ranges_factory_sycl.pass.cpp
+++ b/test/parallel_api/ranges/copy_ranges_factory_sycl.pass.cpp
@@ -44,7 +44,7 @@ main()
         auto view = iota_view(0, max_n) | views::transform(lambda1);
         auto range_res = all_view<int, sycl::access::mode::write>(B);
 
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::get_default_dpcpp_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/copy_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/copy_ranges_sycl.pass.cpp
@@ -46,7 +46,7 @@ main()
         auto view = views::reverse(sv) | views::transform(lambda1);
         auto range_res = all_view<int, sycl::access::mode::write>(B);
 
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::get_default_dpcpp_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/count_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/count_ranges_sycl.pass.cpp
@@ -41,7 +41,7 @@ main()
 
         auto view = views::all(A);
 
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::get_default_dpcpp_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/equal_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/equal_ranges_sycl.pass.cpp
@@ -43,7 +43,7 @@ main()
 
         auto view = views::all(A);
                           
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::get_default_dpcpp_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/exclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/exclusive_scan_ranges_sycl.pass.cpp
@@ -45,8 +45,8 @@ main()
         auto view = ranges::all_view<int, sycl::access::mode::read>(A);
         auto view_res1 = ranges::all_view<int, sycl::access::mode::write>(B1);
 
-        auto exec = TestUtils::default_dpcpp_policy;
-        using Policy = decltype(TestUtils::default_dpcpp_policy);
+        auto exec = TestUtils::get_default_dpcpp_policy();
+        using Policy = decltype(exec);
 
         ranges::exclusive_scan(exec, A, view_res1, 100);
         ranges::exclusive_scan(make_new_policy<new_kernel_name<Policy, 0>>(exec), view, B2, 100, ::std::plus<int>());

--- a/test/parallel_api/ranges/fill_generate_factory.pass.cpp
+++ b/test/parallel_api/ranges/fill_generate_factory.pass.cpp
@@ -52,7 +52,7 @@ main()
         sycl::buffer<int> A(expected1, sycl::range<1>(max_n));
         sycl::buffer<int> B(expected2, sycl::range<1>(max_n));
 
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::get_default_dpcpp_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/find_end_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/find_end_ranges_sycl.pass.cpp
@@ -48,7 +48,7 @@ main()
         auto view_a = all_view(A);
         auto view_b = all_view(B);
 
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::get_default_dpcpp_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/find_first_of_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/find_first_of_ranges_sycl.pass.cpp
@@ -48,7 +48,7 @@ main()
         auto view_a = all_view(A);
         auto view_b = all_view(B);
 
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::get_default_dpcpp_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/find_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/find_ranges_sycl.pass.cpp
@@ -45,8 +45,8 @@ main()
 
         auto view = all_view(A);
 
-        auto exec = TestUtils::default_dpcpp_policy;
-        using Policy = decltype(TestUtils::default_dpcpp_policy);
+        auto exec = TestUtils::get_default_dpcpp_policy();
+        using Policy = decltype(exec);
 
         res1 = find(make_new_policy<new_kernel_name<Policy, 0>>(exec), view, val); //check passing all_view
         res1 = find(make_new_policy<new_kernel_name<Policy, 1>>(exec), A, val);    //check passing sycl::buffer directly

--- a/test/parallel_api/ranges/for_each_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/for_each_ranges_sycl.pass.cpp
@@ -40,7 +40,7 @@ main()
     {
         sycl::buffer<int> A(data, sycl::range<1>(max_n));
 
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::get_default_dpcpp_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/inclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/inclusive_scan_ranges_sycl.pass.cpp
@@ -48,8 +48,8 @@ main()
         auto view_res2 = ranges::all_view<int, sycl::access::mode::write>(B2);
         auto view_res3 = ranges::all_view<int, sycl::access::mode::write>(B3);
 
-        auto exec = TestUtils::default_dpcpp_policy;
-        using Policy = decltype(TestUtils::default_dpcpp_policy);
+        auto exec = TestUtils::get_default_dpcpp_policy();
+        using Policy = decltype(exec);
 
         ranges::inclusive_scan(exec, A, view_res1);
         ranges::inclusive_scan(make_new_policy<new_kernel_name<Policy, 0>>(exec), view, B2, ::std::plus<int>());

--- a/test/parallel_api/ranges/is_sorted_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/is_sorted_ranges_sycl.pass.cpp
@@ -42,8 +42,8 @@ main()
         sycl::buffer<int> A(data1, sycl::range<1>(max_n));
         sycl::buffer<int> B(data2, sycl::range<1>(max_n));
 
-        auto exec = TestUtils::default_dpcpp_policy;
-        using Policy = decltype(TestUtils::default_dpcpp_policy);
+        auto exec = TestUtils::get_default_dpcpp_policy();
+        using Policy = decltype(exec);
 
         res1 = is_sorted(exec, all_view(A));
         res2 = is_sorted(make_new_policy<new_kernel_name<Policy, 0>>(exec), B);

--- a/test/parallel_api/ranges/is_sorted_until_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/is_sorted_until_ranges_sycl.pass.cpp
@@ -43,8 +43,8 @@ main()
 
         auto view  = all_view(A);
 
-        auto exec = TestUtils::default_dpcpp_policy;
-        using Policy = decltype(TestUtils::default_dpcpp_policy);
+        auto exec = TestUtils::get_default_dpcpp_policy();
+        using Policy = decltype(exec);
 
         res1 = is_sorted_until(exec, view);
         res2 = is_sorted_until(make_new_policy<new_kernel_name<Policy, 0>>(exec), A, [](auto a, auto b) { return a < b; });

--- a/test/parallel_api/ranges/merge_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/merge_ranges_sycl.pass.cpp
@@ -47,7 +47,7 @@ main()
         sycl::buffer<T> D(out1, sycl::range<1>(out_n));
         sycl::buffer<T> E(out2, sycl::range<1>(out_n));
 
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::get_default_dpcpp_policy();
 
         merge(exec, all_view(A), all_view(B), all_view<T, sycl::access::mode::write>(D));
         merge(TestUtils::make_device_policy<class merge_2>(exec), A, B, E, ::std::less<T>()); //check passing sycl buffers directly

--- a/test/parallel_api/ranges/minmax_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/minmax_ranges_sycl.pass.cpp
@@ -47,8 +47,8 @@ main()
 
         auto view = all_view(A);
 
-        auto exec = TestUtils::default_dpcpp_policy;
-        using Policy = decltype(TestUtils::default_dpcpp_policy);
+        auto exec = TestUtils::get_default_dpcpp_policy();
+        using Policy = decltype(exec);
 
         //min element
         res1 = min_element(exec, A);

--- a/test/parallel_api/ranges/move_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/move_ranges_sycl.pass.cpp
@@ -48,7 +48,7 @@ main()
 
         auto range_res = all_view<int, sycl::access::mode::write>(B);
 
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::get_default_dpcpp_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/reduce_by_key_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/reduce_by_key_ranges_sycl.pass.cpp
@@ -44,7 +44,7 @@ main()
     using namespace TestUtils;
     using namespace oneapi::dpl::experimental::ranges;
 
-    auto exec = TestUtils::default_dpcpp_policy;
+    auto exec = TestUtils::get_default_dpcpp_policy();
 
     auto res = reduce_by_segment(exec, views::all_read(A), views::all_read(B), views::all_write(C), views::all_write(D));
 

--- a/test/parallel_api/ranges/reduce_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/reduce_ranges_sycl.pass.cpp
@@ -40,8 +40,8 @@ main()
 
         auto view = all_view<int, sycl::access::mode::read>(A);
 
-        auto exec = TestUtils::default_dpcpp_policy;
-        using Policy = decltype(TestUtils::default_dpcpp_policy);
+        auto exec = TestUtils::get_default_dpcpp_policy();
+        using Policy = decltype(exec);
 
         res1 = reduce(exec, A);
         res2 = reduce(make_new_policy<new_kernel_name<Policy, 0>>(exec), view, 100);

--- a/test/parallel_api/ranges/remove_if_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/remove_if_ranges_sycl.pass.cpp
@@ -43,7 +43,7 @@ main()
     {
         sycl::buffer<T> A(in.data(), sycl::range<1>(in.size()));
 
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::get_default_dpcpp_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/remove_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/remove_ranges_sycl.pass.cpp
@@ -43,7 +43,7 @@ main()
     {
         sycl::buffer<T> A(in.data(), sycl::range<1>(in.size()));
 
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::get_default_dpcpp_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/replace_copy_if_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/replace_copy_if_ranges_sycl.pass.cpp
@@ -39,7 +39,7 @@ main()
     sycl::buffer<int> A(max_n);
 
     auto src = views::iota(0, max_n);
-    auto res = replace_copy_if(TestUtils::default_dpcpp_policy, src, A, pred, new_val);
+    auto res = replace_copy_if(TestUtils::get_default_dpcpp_policy(), src, A, pred, new_val);
 
     //check result
     int expected[max_n];

--- a/test/parallel_api/ranges/replace_copy_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/replace_copy_ranges_sycl.pass.cpp
@@ -39,7 +39,7 @@ main()
     sycl::buffer<int> A(max_n);
 
     auto src = views::fill(old_val, max_n);
-    auto res = replace_copy(TestUtils::default_dpcpp_policy, src, A, old_val, new_val);
+    auto res = replace_copy(TestUtils::get_default_dpcpp_policy(), src, A, old_val, new_val);
 
     //check result
     EXPECT_TRUE(res == max_n, "wrong result from replace_copy");

--- a/test/parallel_api/ranges/replace_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/replace_ranges_sycl.pass.cpp
@@ -43,7 +43,7 @@ main()
 
         auto view = views::all(A);
 
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::get_default_dpcpp_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/reverse_copy_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/reverse_copy_ranges_sycl.pass.cpp
@@ -37,7 +37,7 @@ main()
     sycl::buffer<int> A(max_n);
 
     auto src = views::iota(0, max_n);
-    auto res = reverse_copy(TestUtils::default_dpcpp_policy, src, A);
+    auto res = reverse_copy(TestUtils::get_default_dpcpp_policy(), src, A);
 
     //check result
     EXPECT_TRUE(res == max_n, "wrong result from reverse_copy");

--- a/test/parallel_api/ranges/reverse_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/reverse_ranges_sycl.pass.cpp
@@ -39,7 +39,7 @@ main()
     auto iota = views::iota(0, max_n);
     //the name nano::ranges::copy is not injected into oneapi::dpl::experimental::ranges namespace
     __nanorange::nano::ranges::copy(iota, views::host_all(A).begin());
-    reverse(TestUtils::default_dpcpp_policy, A);
+    reverse(TestUtils::get_default_dpcpp_policy(), A);
 
     for(auto v: views::host_all(A))
         ::std::cout << v << " ";

--- a/test/parallel_api/ranges/rotate_copy_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/rotate_copy_ranges_sycl.pass.cpp
@@ -38,7 +38,7 @@ main()
     sycl::buffer<int> A(max_n);
 
     auto src = views::iota(0, max_n);
-    auto res = rotate_copy(TestUtils::default_dpcpp_policy, src, rotate_val, A);
+    auto res = rotate_copy(TestUtils::get_default_dpcpp_policy(), src, rotate_val, A);
 
     //check result
     EXPECT_TRUE(res == max_n, "wrong result from rotate_copy");

--- a/test/parallel_api/ranges/rotate_view_sycl.pass.cpp
+++ b/test/parallel_api/ranges/rotate_view_sycl.pass.cpp
@@ -39,7 +39,7 @@ main()
     {
         sycl::buffer<int> A(data, sycl::range<1>(max_n));
         sycl::buffer<int> B(expected, sycl::range<1>(max_n));
-        ranges::copy(TestUtils::default_dpcpp_policy, 
+        ranges::copy(TestUtils::get_default_dpcpp_policy(),
                      ranges::views::all_read(A) | ranges::views::rotate(rotate_val), ranges::views::all_write(B));
     }
 

--- a/test/parallel_api/ranges/search_n_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/search_n_ranges_sycl.pass.cpp
@@ -43,7 +43,7 @@ main()
 
         auto view_a = all_view(A);
 
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::get_default_dpcpp_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/search_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/search_ranges_sycl.pass.cpp
@@ -47,8 +47,8 @@ main()
         auto view_a = all_view(A);
         auto view_b = all_view(B);
 
-        auto exec = TestUtils::default_dpcpp_policy;
-        using Policy = decltype(TestUtils::default_dpcpp_policy);
+        auto exec = TestUtils::get_default_dpcpp_policy();
+        using Policy = decltype(exec);
 
         res1 = search(exec, A, view_b);
         res2 = search(make_new_policy<new_kernel_name<Policy, 0>>(exec), view_a, B, [](auto a, auto b) { return a == b; });

--- a/test/parallel_api/ranges/sort_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/sort_ranges_sycl.pass.cpp
@@ -40,8 +40,8 @@ main()
     using namespace TestUtils;
     using namespace oneapi::dpl::experimental::ranges;
 
-    auto exec = TestUtils::default_dpcpp_policy;
-    using Policy = decltype(TestUtils::default_dpcpp_policy);
+    auto exec = TestUtils::get_default_dpcpp_policy();
+    using Policy = decltype(exec);
     {
         sycl::buffer<int> A(data1, sycl::range<1>(max_n));
         sycl::buffer<int> B(data2, sycl::range<1>(max_n));

--- a/test/parallel_api/ranges/stable_sort_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/stable_sort_ranges_sycl.pass.cpp
@@ -39,8 +39,8 @@ main()
         sycl::buffer<int> A(data1, sycl::range<1>(max_n));
         sycl::buffer<int> B(data2, sycl::range<1>(max_n));
 
-        auto exec = TestUtils::default_dpcpp_policy;
-        using Policy = decltype(TestUtils::default_dpcpp_policy);
+        auto exec = TestUtils::get_default_dpcpp_policy();
+        using Policy = decltype(exec);
 
         stable_sort(exec, A); //check passing sycl buffer directly
         stable_sort(make_new_policy<new_kernel_name<Policy, 0>>(exec), all_view<int, sycl::access::mode::read_write>(B),

--- a/test/parallel_api/ranges/swap_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/swap_ranges_sycl.pass.cpp
@@ -43,7 +43,7 @@ main()
         sycl::buffer<int> C(data3, sycl::range<1>(max_n_2));
         sycl::buffer<int> D(data4, sycl::range<1>(max_n));
                           
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::get_default_dpcpp_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/transform2_ranges_factory_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform2_ranges_factory_sycl.pass.cpp
@@ -45,7 +45,7 @@ main()
         auto view = oneapi::dpl::experimental::ranges::iota_view(0, max_n) | oneapi::dpl::experimental::ranges::views::transform(lambda1);
         auto range_res = oneapi::dpl::experimental::ranges::all_view<int, sycl::access::mode::write>(B);
 
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::get_default_dpcpp_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/transform_exclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_exclusive_scan_ranges_sycl.pass.cpp
@@ -46,7 +46,7 @@ main()
         auto view = ranges::all_view<int, sycl::access::mode::read>(A);
         auto view_res = ranges::all_view<int, sycl::access::mode::write>(B);
 
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::get_default_dpcpp_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/transform_inclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_inclusive_scan_ranges_sycl.pass.cpp
@@ -47,8 +47,8 @@ main()
         auto view = ranges::all_view<int, sycl::access::mode::read>(A);
         auto view_res1 = ranges::all_view<int, sycl::access::mode::write>(B1);
 
-        auto exec = TestUtils::default_dpcpp_policy;
-        using Policy = decltype(TestUtils::default_dpcpp_policy);
+        auto exec = TestUtils::get_default_dpcpp_policy();
+        using Policy = decltype(exec);
 
         ranges::transform_inclusive_scan(exec, A, view_res1, ::std::plus<int>(), lambda);
         ranges::transform_inclusive_scan(make_new_policy<new_kernel_name<Policy, 0>>(exec), view, B2, ::std::plus<int>(), lambda, init);

--- a/test/parallel_api/ranges/transform_ranges_factory_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_ranges_factory_sycl.pass.cpp
@@ -46,7 +46,7 @@ main()
         auto view = iota_view(0, max_n) | views::transform(lambda1);
         auto range_res = all_view<int, sycl::access::mode::write>(B);
 
-        auto exec = TestUtils::default_dpcpp_policy;
+        auto exec = TestUtils::get_default_dpcpp_policy();
         using Policy = decltype(exec);
         auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
         auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/transform_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_ranges_sycl.pass.cpp
@@ -46,7 +46,7 @@ main()
         auto view = views::reverse(sv) | views::transform(lambda1);
 
         auto range_res = all_view<int, sycl::access::mode::write>(B);
-        transform(TestUtils::default_dpcpp_policy, view, range_res, lambda2);
+        transform(TestUtils::get_default_dpcpp_policy(), view, range_res, lambda2);
     }
 
     //check result

--- a/test/parallel_api/ranges/transform_reduce_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_reduce_ranges_sycl.pass.cpp
@@ -42,8 +42,8 @@ main()
 
         auto view = oneapi::dpl::experimental::ranges::all_view<int, sycl::access::mode::read>(A);
 
-        auto exec = TestUtils::default_dpcpp_policy;
-        using Policy = decltype(TestUtils::default_dpcpp_policy);
+        auto exec = TestUtils::get_default_dpcpp_policy();
+        using Policy = decltype(exec);
 
         res1 = oneapi::dpl::experimental::ranges::transform_reduce(exec, A, view, 0);
         res2 = oneapi::dpl::experimental::ranges::transform_reduce(make_new_policy<new_kernel_name<Policy, 0>>(exec), view, A, 0, ::std::plus<int>(), ::std::multiplies<int>());

--- a/test/parallel_api/ranges/unique_copy_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/unique_copy_ranges_sycl.pass.cpp
@@ -35,7 +35,7 @@ main()
 
     auto is_equal = [](auto i, auto j) { return i == j; };
 
-    auto exec = TestUtils::default_dpcpp_policy;
+    auto exec = TestUtils::get_default_dpcpp_policy();
     using Policy = decltype(exec);
     auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
     auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/parallel_api/ranges/unique_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/unique_ranges_sycl.pass.cpp
@@ -35,7 +35,7 @@ main()
 
     auto is_equal = [](auto i, auto j) { return i == j; };
 
-    auto exec = TestUtils::default_dpcpp_policy;
+    auto exec = TestUtils::get_default_dpcpp_policy();
     using Policy = decltype(exec);
     auto exec1 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 0>>(exec);
     auto exec2 = TestUtils::make_new_policy<TestUtils::new_kernel_name<Policy, 1>>(exec);

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -75,31 +75,40 @@ auto async_handler = [](sycl::exception_list ex_list) {
 };
 
 #if ONEDPL_FPGA_DEVICE
-inline auto default_selector =
+auto
+get_default_selector()
+{
+    return
 #    if ONEDPL_FPGA_EMULATOR
         sycl::ext::intel::fpga_emulator_selector_v;
 #    else
         sycl::ext::intel::fpga_selector{};
 #    endif // ONEDPL_FPGA_EMULATOR
+}
 
 inline auto&& default_dpcpp_policy =
 #    if ONEDPL_USE_PREDEFINED_POLICIES
         oneapi::dpl::execution::dpcpp_fpga;
 #    else
-        TestUtils::make_fpga_policy(sycl::queue{default_selector});
+        TestUtils::make_fpga_policy(sycl::queue{get_default_selector()});
 #    endif // ONEDPL_USE_PREDEFINED_POLICIES
 #else
-inline auto default_selector =
+auto
+get_default_selector()
+{
+    return
 #    if TEST_LIBSYCL_VERSION >= 60000
         sycl::default_selector_v;
 #    else
         sycl::default_selector{};
 #    endif
+}
+
 inline auto&& default_dpcpp_policy =
 #    if ONEDPL_USE_PREDEFINED_POLICIES
         oneapi::dpl::execution::dpcpp_default;
 #    else
-        oneapi::dpl::execution::make_device_policy(sycl::queue{default_selector});
+        oneapi::dpl::execution::make_device_policy(sycl::queue{get_default_selector()});
 #    endif // ONEDPL_USE_PREDEFINED_POLICIES
 #endif     // ONEDPL_FPGA_DEVICE
 
@@ -107,7 +116,7 @@ inline
 sycl::queue get_test_queue()
 {
     // create the queue with custom asynchronous exceptions handler
-    static sycl::queue my_queue(default_selector, async_handler);
+    static sycl::queue my_queue(get_default_selector(), async_handler);
     return my_queue;
 }
 

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -86,12 +86,16 @@ get_default_selector()
 #    endif // ONEDPL_FPGA_EMULATOR
 }
 
-inline auto&& default_dpcpp_policy =
+auto
+get_default_dpcpp_policy()
+{
+    return
 #    if ONEDPL_USE_PREDEFINED_POLICIES
         oneapi::dpl::execution::dpcpp_fpga;
 #    else
         TestUtils::make_fpga_policy(sycl::queue{get_default_selector()});
 #    endif // ONEDPL_USE_PREDEFINED_POLICIES
+}
 #else
 auto
 get_default_selector()
@@ -104,12 +108,16 @@ get_default_selector()
 #    endif
 }
 
-inline auto&& default_dpcpp_policy =
+auto
+get_default_dpcpp_policy()
+{
+    return
 #    if ONEDPL_USE_PREDEFINED_POLICIES
         oneapi::dpl::execution::dpcpp_default;
 #    else
         oneapi::dpl::execution::make_device_policy(sycl::queue{get_default_selector()});
 #    endif // ONEDPL_USE_PREDEFINED_POLICIES
+}
 #endif     // ONEDPL_FPGA_DEVICE
 
 inline


### PR DESCRIPTION
# Attention: ABI breaking change.

Yet another approach to lazy `sycl::queue` creation in oneDPL hetero policies:
- the source issue described at https://github.com/oneapi-src/oneDPL/issues/1060
- the previous approach has been implemented by @adamfidel in the PR https://github.com/oneapi-src/oneDPL/pull/1154

The main implementation detail is `std::once_flag` and `::std::call_once` usage packed into separate container
```C++
template <class TSYCLQueueFactory>
class sycl_queue_container
{
  public:
    template <typename... Args>
    sycl::queue
    get_queue(Args&&... args)
    {
        ::std::call_once(__is_created, [&]() {
            TSYCLQueueFactory factory;
            __queue.emplace(factory(::std::forward<Args>(args)...));
        });

        assert(__queue.has_value());
        return __queue.value();
    }

  private:
    ::std::once_flag __is_created;
    ::std::optional<sycl::queue> __queue;
};
```

This container shares between hetero policies instances:
```C++
template <typename TFactory>
using sycl_queue_container_ptr = ::std::shared_ptr<sycl_queue_container<TFactory>>;


// ...


template <typename KernelName = DefaultKernelName, class TSyclQueueFactory = TDefaultSYCLQueueFactory>
class device_policy
{
  public:
    // ...

  private:
    mutable sycl_queue_container_ptr<TSyclQueueFactory> q_container;       // <<<<<<-- shared sycl::queue container
};
```

From my point of view this approach is correct because it's simple repeat something like `sycl::queue` implementation ([pimpl-implementation](https://www.google.com/search?q=pimpl+implementation&rlz=1C1GCEA_en__1012__1012&oq=pimpl+implementation&gs_lcrp=EgZjaHJvbWUyBggAEEUYOTIJCAEQABgTGIAE0gEJNTAzOWowajE1qAIAsAIA&sourceid=chrome&ie=UTF-8)) and we don't introduce any new synchronization errors here.