### PR TITLE
Change zip_iterator to always use oneDPL's tuple

### DIFF
--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -80,17 +80,17 @@ template <typename... _Types>
 class zip_forward_iterator
 {
     static const ::std::size_t __num_types = sizeof...(_Types);
-    typedef typename ::std::tuple<_Types...> __it_types;
+    typedef typename oneapi::dpl::__internal::tuple<_Types...> __it_types;
 
   public:
     typedef ::std::make_signed_t<::std::size_t> difference_type;
-    typedef ::std::tuple<typename ::std::iterator_traits<_Types>::value_type...> value_type;
-    typedef ::std::tuple<typename ::std::iterator_traits<_Types>::reference...> reference;
-    typedef ::std::tuple<typename ::std::iterator_traits<_Types>::pointer...> pointer;
+    typedef oneapi::dpl::__internal::tuple<typename ::std::iterator_traits<_Types>::value_type...> value_type;
+    typedef oneapi::dpl::__internal::tuple<typename ::std::iterator_traits<_Types>::reference...> reference;
+    typedef oneapi::dpl::__internal::tuple<typename ::std::iterator_traits<_Types>::pointer...> pointer;
     typedef ::std::forward_iterator_tag iterator_category;
 
     zip_forward_iterator() : __my_it_() {}
-    explicit zip_forward_iterator(_Types... __args) : __my_it_(::std::make_tuple(__args...)) {}
+    explicit zip_forward_iterator(_Types... __args) : __my_it_(oneapi::dpl::__internal::make_tuple(__args...)) {}
 
     reference operator*() const
     {
@@ -264,12 +264,12 @@ class zip_iterator
     typedef ::std::make_signed_t<::std::size_t> difference_type;
     typedef oneapi::dpl::__internal::tuple<typename ::std::iterator_traits<_Types>::value_type...> value_type;
     typedef oneapi::dpl::__internal::tuple<typename ::std::iterator_traits<_Types>::reference...> reference;
-    typedef ::std::tuple<typename ::std::iterator_traits<_Types>::pointer...> pointer;
+    typedef oneapi::dpl::__internal::tuple<typename ::std::iterator_traits<_Types>::pointer...> pointer;
     typedef ::std::random_access_iterator_tag iterator_category;
     using is_zip = ::std::true_type;
 
     zip_iterator() : __my_it_() {}
-    explicit zip_iterator(_Types... __args) : __my_it_(::std::make_tuple(__args...)) {}
+    explicit zip_iterator(_Types... __args) : __my_it_(oneapi::dpl::__internal::make_tuple(__args...)) {}
     explicit zip_iterator(std::tuple<_Types...> __arg) : __my_it_(__arg) {}
 
     reference operator*() const

--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -80,17 +80,17 @@ template <typename... _Types>
 class zip_forward_iterator
 {
     static const ::std::size_t __num_types = sizeof...(_Types);
-    typedef typename oneapi::dpl::__internal::tuple<_Types...> __it_types;
+    typedef typename std::tuple<_Types...> __it_types;
 
   public:
     typedef ::std::make_signed_t<::std::size_t> difference_type;
-    typedef oneapi::dpl::__internal::tuple<typename ::std::iterator_traits<_Types>::value_type...> value_type;
-    typedef oneapi::dpl::__internal::tuple<typename ::std::iterator_traits<_Types>::reference...> reference;
-    typedef oneapi::dpl::__internal::tuple<typename ::std::iterator_traits<_Types>::pointer...> pointer;
+    typedef std::tuple<typename ::std::iterator_traits<_Types>::value_type...> value_type;
+    typedef std::tuple<typename ::std::iterator_traits<_Types>::reference...> reference;
+    typedef std::tuple<typename ::std::iterator_traits<_Types>::pointer...> pointer;
     typedef ::std::forward_iterator_tag iterator_category;
 
     zip_forward_iterator() : __my_it_() {}
-    explicit zip_forward_iterator(_Types... __args) : __my_it_(oneapi::dpl::__internal::make_tuple(__args...)) {}
+    explicit zip_forward_iterator(_Types... __args) : __my_it_(std::make_tuple(__args...)) {}
 
     reference operator*() const
     {

--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -90,11 +90,7 @@ class zip_forward_iterator
     typedef ::std::forward_iterator_tag iterator_category;
 
     zip_forward_iterator() : __my_it_() {}
-    explicit
-    zip_forward_iterator(_Types... __args)
-        : __my_it_(oneapi::dpl::__internal::make_tuple(__args...))
-    {
-    }
+    explicit zip_forward_iterator(_Types... __args) : __my_it_(oneapi::dpl::__internal::make_tuple(__args...)) {}
 
     reference operator*() const
     {
@@ -273,11 +269,7 @@ class zip_iterator
     using is_zip = ::std::true_type;
 
     zip_iterator() : __my_it_() {}
-    explicit
-    zip_iterator(_Types... __args)
-        : __my_it_(oneapi::dpl::__internal::make_tuple(__args...))
-    {
-    }
+    explicit zip_iterator(_Types... __args) : __my_it_(oneapi::dpl::__internal::make_tuple(__args...)) {}
     explicit zip_iterator(std::tuple<_Types...> __arg) : __my_it_(__arg) {}
 
     reference operator*() const

--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -80,17 +80,17 @@ template <typename... _Types>
 class zip_forward_iterator
 {
     static const ::std::size_t __num_types = sizeof...(_Types);
-    typedef typename std::tuple<_Types...> __it_types;
+    typedef typename ::std::tuple<_Types...> __it_types;
 
   public:
     typedef ::std::make_signed_t<::std::size_t> difference_type;
-    typedef std::tuple<typename ::std::iterator_traits<_Types>::value_type...> value_type;
-    typedef std::tuple<typename ::std::iterator_traits<_Types>::reference...> reference;
-    typedef std::tuple<typename ::std::iterator_traits<_Types>::pointer...> pointer;
+    typedef ::std::tuple<typename ::std::iterator_traits<_Types>::value_type...> value_type;
+    typedef ::std::tuple<typename ::std::iterator_traits<_Types>::reference...> reference;
+    typedef ::std::tuple<typename ::std::iterator_traits<_Types>::pointer...> pointer;
     typedef ::std::forward_iterator_tag iterator_category;
 
     zip_forward_iterator() : __my_it_() {}
-    explicit zip_forward_iterator(_Types... __args) : __my_it_(std::make_tuple(__args...)) {}
+    explicit zip_forward_iterator(_Types... __args) : __my_it_(::std::make_tuple(__args...)) {}
 
     reference operator*() const
     {

--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -278,11 +278,7 @@ class zip_iterator
         : __my_it_(oneapi::dpl::__internal::make_tuple(__args...))
     {
     }
-    explicit
-    zip_iterator(std::tuple<_Types...> __arg)
-        : __my_it_(__arg)
-    {
-    }
+    explicit zip_iterator(std::tuple<_Types...> __arg) : __my_it_(__arg) {}
 
     reference operator*() const
     {

--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -90,7 +90,11 @@ class zip_forward_iterator
     typedef ::std::forward_iterator_tag iterator_category;
 
     zip_forward_iterator() : __my_it_() {}
-    explicit zip_forward_iterator(_Types... __args) : __my_it_(oneapi::dpl::__internal::make_tuple(__args...)) {}
+    explicit
+    zip_forward_iterator(_Types... __args)
+        : __my_it_(oneapi::dpl::__internal::make_tuple(__args...))
+    {
+    }
 
     reference operator*() const
     {
@@ -269,8 +273,16 @@ class zip_iterator
     using is_zip = ::std::true_type;
 
     zip_iterator() : __my_it_() {}
-    explicit zip_iterator(_Types... __args) : __my_it_(oneapi::dpl::__internal::make_tuple(__args...)) {}
-    explicit zip_iterator(std::tuple<_Types...> __arg) : __my_it_(__arg) {}
+    explicit
+    zip_iterator(_Types... __args)
+        : __my_it_(oneapi::dpl::__internal::make_tuple(__args...))
+    {
+    }
+    explicit
+    zip_iterator(std::tuple<_Types...> __arg)
+        : __my_it_(__arg)
+    {
+    }
 
     reference operator*() const
     {


### PR DESCRIPTION
`zip_iterator` had some mixed use of `std::tuple` and oneDPL's internal `tuple` internally.  Specifically we use of `std::make_tuple` in the constructor for `zip_iterator` we currently use the constructors from `std::tuple` on input types for `zip_iterator`, then use implicit conversion to our internal tuple type.   We also use the internal tuple type for `reference` and `value_type`, but use `std::tuple` for `pointer`.  It makes sense to standardize what we use internally for `zip_iterator` to be oneDPL's tuple. 

---
Details:
This was originally motivated by an error when we have a `zip_iterator` of two iterators where one is a `transform_iterator<it, lambda>`.  Due to the way `transfom_iterator` is written, this results in a build error for some std library implementations when calling `std::make_tuple`.  It turns out that a more direct fix is #1445 (look there for more details).  I still believe this PR is a good change, however it may not outweigh the momentum of keeping the code the same.