### PR TITLE
Adding std::vector<T, usm_allocator>::iterator to is_passed_directly types

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -78,11 +78,7 @@ class all_view
     {
         return begin() + size();
     }
-    __return_t&
-    operator[](__diff_type i) const
-    {
-        return begin()[i];
-    }
+    __return_t& operator[](__diff_type i) const { return begin()[i]; }
 
     __diff_type
     size() const

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -206,6 +206,7 @@ struct is_passed_directly<Iter, ::std::enable_if_t<Iter::is_passed_directly::val
 {
 };
 
+//support std::vector::iterator with usm shared allocator as passed directly
 template <class Iter>
 struct is_passed_directly<
     Iter,
@@ -213,6 +214,18 @@ struct is_passed_directly<
         Iter, typename ::std::vector<typename ::std::iterator_traits<Iter>::value_type,
                                      typename sycl::usm_allocator<typename ::std::iterator_traits<Iter>::value_type,
                                                                   sycl::usm::alloc::shared>::iterator>>>>
+    : ::std::true_type
+{
+};
+
+//support std::vector::iterator with usm host allocator as passed directly
+template <class Iter>
+struct is_passed_directly<
+    Iter,
+    ::std::enable_if_t<::std::is_same_v<
+        Iter, typename ::std::vector<typename ::std::iterator_traits<Iter>::value_type,
+                                     typename sycl::usm_allocator<typename ::std::iterator_traits<Iter>::value_type,
+                                                                  sycl::usm::alloc::host>::iterator>>>>
     : ::std::true_type
 {
 };

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -213,7 +213,7 @@ struct is_passed_directly<
     ::std::enable_if_t<::std::is_same_v<
         Iter, typename ::std::vector<typename ::std::iterator_traits<Iter>::value_type,
                                      typename sycl::usm_allocator<typename ::std::iterator_traits<Iter>::value_type,
-                                                                  sycl::usm::alloc::shared>::iterator>>>>
+                                                                  sycl::usm::alloc::shared>>::iterator>>>
     : ::std::true_type
 {
 };
@@ -225,7 +225,7 @@ struct is_passed_directly<
     ::std::enable_if_t<::std::is_same_v<
         Iter, typename ::std::vector<typename ::std::iterator_traits<Iter>::value_type,
                                      typename sycl::usm_allocator<typename ::std::iterator_traits<Iter>::value_type,
-                                                                  sycl::usm::alloc::host>::iterator>>>>
+                                                                  sycl::usm::alloc::host>>::iterator>>>
     : ::std::true_type
 {
 };

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -78,7 +78,11 @@ class all_view
     {
         return begin() + size();
     }
-    __return_t& operator[](__diff_type i) const { return begin()[i]; }
+    __return_t&
+    operator[](__diff_type i) const
+    {
+        return begin()[i];
+    }
 
     __diff_type
     size() const
@@ -206,26 +210,19 @@ struct is_passed_directly<Iter, ::std::enable_if_t<Iter::is_passed_directly::val
 {
 };
 
-//support std::vector::iterator with usm shared allocator as passed directly
+//support std::vector::iterator with usm host / shared allocator as passed directly
 template <class Iter>
 struct is_passed_directly<
     Iter,
-    ::std::enable_if_t<::std::is_same_v<
-        Iter, typename ::std::vector<typename ::std::iterator_traits<Iter>::value_type,
-                                     typename sycl::usm_allocator<typename ::std::iterator_traits<Iter>::value_type,
-                                                                  sycl::usm::alloc::shared>>::iterator>>>
-    : ::std::true_type
-{
-};
-
-//support std::vector::iterator with usm host allocator as passed directly
-template <class Iter>
-struct is_passed_directly<
-    Iter,
-    ::std::enable_if_t<::std::is_same_v<
-        Iter, typename ::std::vector<typename ::std::iterator_traits<Iter>::value_type,
-                                     typename sycl::usm_allocator<typename ::std::iterator_traits<Iter>::value_type,
-                                                                  sycl::usm::alloc::host>>::iterator>>>
+    ::std::enable_if_t<
+        ::std::is_same_v<
+            Iter, typename ::std::vector<typename ::std::iterator_traits<Iter>::value_type,
+                                         typename sycl::usm_allocator<typename ::std::iterator_traits<Iter>::value_type,
+                                                                      sycl::usm::alloc::shared>>::iterator> ||
+        ::std::is_same_v<
+            Iter, typename ::std::vector<typename ::std::iterator_traits<Iter>::value_type,
+                                         typename sycl::usm_allocator<typename ::std::iterator_traits<Iter>::value_type,
+                                                                      sycl::usm::alloc::host>>::iterator>>>
     : ::std::true_type
 {
 };

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -206,6 +206,17 @@ struct is_passed_directly<Iter, ::std::enable_if_t<Iter::is_passed_directly::val
 {
 };
 
+template <class Iter>
+struct is_passed_directly<
+    Iter,
+    ::std::enable_if_t<::std::is_same_v<
+        Iter, typename ::std::vector<typename ::std::iterator_traits<Iter>::value_type,
+                                     typename sycl::usm_allocator<typename ::std::iterator_traits<Iter>::value_type,
+                                                                  sycl::usm::alloc::shared>::iterator>>>>
+    : ::std::true_type
+{
+};
+
 template <typename Ip>
 struct is_passed_directly<oneapi::dpl::counting_iterator<Ip>> : ::std::true_type
 {


### PR DESCRIPTION
It seems that `std::vector` with `usm_allocator` with `sycl::usm::alloc::shared` data were being processed as if they were host_iterators when being passed to oneDPL with device policy and dpcpp backend.  

This means that they were being used to initialize a `sycl::buffer` which includes an extra copy to intermediate host memory.  This is unnecessary because iterators to such data should be passed directly, and directly usable within a kernel.  

This PR adds a specialization for the is_passed_directly trait, which enables such iterators to be properly passed directly.  This avoids the extra copy.  

This was uncovered in investigation #1429, and will be tested by those tests, after a suggestion from @mmichel11 .