### PR TITLE
[Dynamic Selection] Skipping auto_tune and dynamic load tests when device=FPGA_EMU

### DIFF
--- a/test/parallel_api/dynamic_selection/sycl/test_auto_tune_policy_sycl.pass.cpp
+++ b/test/parallel_api/dynamic_selection/sycl/test_auto_tune_policy_sycl.pass.cpp
@@ -164,7 +164,7 @@ test_auto_submit_wait_on_event(UniverseContainer u, int best_resource)
         }
 
         int count = ecount.load();
-        EXPECT_EQ(i * (i + 1) / 2, count, "ERROR: scheduler did not execute all tasks exactly once\n");
+        //EXPECT_EQ(i * (i + 1) / 2, count, "ERROR: scheduler did not execute all tasks exactly once\n");
     }
     EXPECT_TRUE(pass, "ERROR: did not select expected resources\n");
     if constexpr (call_select_before_submit)
@@ -492,6 +492,7 @@ main()
     bool bProcessed = false;
 
 #if TEST_DYNAMIC_SELECTION_AVAILABLE
+#if ONEDPL_CPU_DEVICE || ONEDPL_GPU_DEVICE
     using policy_t = oneapi::dpl::experimental::auto_tune_policy<oneapi::dpl::experimental::sycl_backend>;
     std::vector<sycl::queue> u;
     build_auto_tune_universe(u);
@@ -542,6 +543,7 @@ main()
 
         bProcessed = true;
     }
+#endif // Devices available are CPU and GPU
 #endif // TEST_DYNAMIC_SELECTION_AVAILABLE
 
     return TestUtils::done(bProcessed);

--- a/test/parallel_api/dynamic_selection/sycl/test_auto_tune_policy_sycl.pass.cpp
+++ b/test/parallel_api/dynamic_selection/sycl/test_auto_tune_policy_sycl.pass.cpp
@@ -164,7 +164,7 @@ test_auto_submit_wait_on_event(UniverseContainer u, int best_resource)
         }
 
         int count = ecount.load();
-        //EXPECT_EQ(i * (i + 1) / 2, count, "ERROR: scheduler did not execute all tasks exactly once\n");
+        EXPECT_EQ(i * (i + 1) / 2, count, "ERROR: scheduler did not execute all tasks exactly once\n");
     }
     EXPECT_TRUE(pass, "ERROR: did not select expected resources\n");
     if constexpr (call_select_before_submit)

--- a/test/parallel_api/dynamic_selection/sycl/test_auto_tune_policy_sycl.pass.cpp
+++ b/test/parallel_api/dynamic_selection/sycl/test_auto_tune_policy_sycl.pass.cpp
@@ -492,7 +492,7 @@ main()
     bool bProcessed = false;
 
 #if TEST_DYNAMIC_SELECTION_AVAILABLE
-#if ONEDPL_CPU_DEVICE || ONEDPL_GPU_DEVICE
+#if !ONEDPL_FPGA_DEVICE || !ONEDPL_FPGA_EMULATOR
     using policy_t = oneapi::dpl::experimental::auto_tune_policy<oneapi::dpl::experimental::sycl_backend>;
     std::vector<sycl::queue> u;
     build_auto_tune_universe(u);

--- a/test/parallel_api/dynamic_selection/sycl/test_dynamic_load_policy_sycl.pass.cpp
+++ b/test/parallel_api/dynamic_selection/sycl/test_dynamic_load_policy_sycl.pass.cpp
@@ -47,6 +47,7 @@ main()
     bool bProcessed = false;
 
 #if TEST_DYNAMIC_SELECTION_AVAILABLE
+#if !ONEDPL_FPGA_DEVICE || !ONEDPL_FPGA_EMULATOR
     using policy_t = oneapi::dpl::experimental::dynamic_load_policy<oneapi::dpl::experimental::sycl_backend>;
     std::vector<sycl::queue> u;
     build_dl_universe(u);
@@ -76,6 +77,7 @@ main()
 
         bProcessed = true;
     }
+#endif // Devices available are CPU and GPU
 #endif // TEST_DYNAMIC_SELECTION_AVAILABLE
 
     return TestUtils::done(bProcessed);

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -106,7 +106,7 @@ make_new_policy(_Policy&& __policy)
 #if ONEDPL_FPGA_DEVICE
 inline auto default_selector =
 #    if ONEDPL_FPGA_EMULATOR
-        sycl::ext::intel::fpga_emulator_selector{};
+        sycl::ext::intel::fpga_emulator_selector_v;
 #    else
         sycl::ext::intel::fpga_selector{};
 #    endif // ONEDPL_FPGA_EMULATOR


### PR DESCRIPTION
Tests with default device as FPGA_EMU have a runtime error of - terminate called after throwing an instance of 'sycl::_V1::runtime_error'.
Skipping since we do not use default device in our tests. 