### PR TITLE
Fix potential compile error in for_loop_impl.h

### DIFF
--- a/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
@@ -480,11 +480,19 @@ struct __use_par_vec_helper
 {
     template <typename _ExecutionPolicy>
     static constexpr auto
-    __use_vector(_ExecutionPolicy&& __exec, _Ip __it)
+    __get_tag_type(_ExecutionPolicy&& __exec, _Ip __it)
     {
         using __tag_type = std::conditional_t<std::is_integral_v<_Ip>,
                                               decltype(oneapi::dpl::__internal::__select_backend(__exec),
                                               decltype(oneapi::dpl::__internal::__select_backend(__exec, it)>;
+        return __tag_type{};
+    }
+
+    template <typename _ExecutionPolicy>
+    static constexpr auto
+    __use_vector(_ExecutionPolicy&& __exec, _Ip __it)
+    {
+        using __tag_type = decltype(__get_tag_type(__exec, __it));
         return typename __tag_type::__is_vector{};
     }
 
@@ -492,9 +500,7 @@ struct __use_par_vec_helper
     static constexpr auto
     __use_parallel(_ExecutionPolicy&& __exec, _Ip __it)
     {
-        using __tag_type = std::conditional_t<std::is_integral_v<_Ip>,
-                                              decltype(oneapi::dpl::__internal::__select_backend(__exec),
-                                              decltype(oneapi::dpl::__internal::__select_backend(__exec, it)>;
+        using __tag_type = decltype(__get_tag_type(__exec, __it));
         using __is_parallel_tag =
             std::disjunction<std::is_same<oneapi::dpl::__internal::__parallel_tag<std::true_type>, __tag_type>,
                                 std::is_same<oneapi::dpl::__internal::__parallel_tag<std::false_type>, __tag_type>>;

--- a/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
@@ -501,11 +501,7 @@ struct __use_par_vec_helper
     __use_parallel(_ExecutionPolicy&& __exec, _Ip __it)
     {
         using __tag_type = decltype(__get_tag_type(__exec, __it));
-        using __is_parallel_tag =
-            std::disjunction<std::is_same<oneapi::dpl::__internal::__parallel_tag<std::true_type>, __tag_type>,
-                                std::is_same<oneapi::dpl::__internal::__parallel_tag<std::false_type>, __tag_type>>;
-
-        return __is_parallel_tag{};
+        return oneapi::dpl::__internal::__is_parallel_tag<__tag_type>();
     }
 };
 

--- a/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
@@ -483,8 +483,8 @@ struct __use_par_vec_helper
     __get_tag_type(_ExecutionPolicy&& __exec, _Ip __it)
     {
         using __tag_type = std::conditional_t<std::is_integral_v<_Ip>,
-                                              decltype(oneapi::dpl::__internal::__select_backend(__exec),
-                                              decltype(oneapi::dpl::__internal::__select_backend(__exec, it)>;
+                                              decltype(oneapi::dpl::__internal::__select_backend(__exec)),
+                                              decltype(oneapi::dpl::__internal::__select_backend(__exec, __it))>;
         return __tag_type{};
     }
 

--- a/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
@@ -480,27 +480,27 @@ struct __use_par_vec_helper
 {
     template <typename _ExecutionPolicy>
     static constexpr auto
-    __get_tag_type(_ExecutionPolicy&& __exec, _Ip __it)
+    __get_tag_type(_ExecutionPolicy&& __exec)
     {
         using __tag_type = std::conditional_t<std::is_integral_v<_Ip>,
                                               decltype(oneapi::dpl::__internal::__select_backend(__exec)),
-                                              decltype(oneapi::dpl::__internal::__select_backend(__exec, __it))>;
+                                              decltype(oneapi::dpl::__internal::__select_backend(__exec, declval<_Ip>()))>;
         return __tag_type{};
     }
 
     template <typename _ExecutionPolicy>
     static constexpr auto
-    __use_vector(_ExecutionPolicy&& __exec, _Ip __it)
+    __use_vector(_ExecutionPolicy&& __exec)
     {
-        using __tag_type = decltype(__get_tag_type(__exec, __it));
+        using __tag_type = decltype(__get_tag_type(__exec));
         return typename __tag_type::__is_vector{};
     }
 
     template <typename _ExecutionPolicy>
     static constexpr auto
-    __use_parallel(_ExecutionPolicy&& __exec, _Ip __it)
+    __use_parallel(_ExecutionPolicy&& __exec)
     {
-        using __tag_type = decltype(__get_tag_type(__exec, __it));
+        using __tag_type = decltype(__get_tag_type(__exec));
         return oneapi::dpl::__internal::__is_parallel_tag<__tag_type>();
     }
 };
@@ -508,16 +508,16 @@ struct __use_par_vec_helper
 // Special versions for for_loop: handles both iterators and integral types(treated as random access iterators)
 template <typename _ExecutionPolicy, typename _Ip>
 auto
-__use_vectorization(_ExecutionPolicy&& __exec, _Ip __it)
+__use_vectorization(_ExecutionPolicy&& __exec)
 {
-    return __use_par_vec_helper<_Ip>::__use_vector(::std::forward<_ExecutionPolicy>(__exec), __it);
+    return __use_par_vec_helper<_Ip>::__use_vector(::std::forward<_ExecutionPolicy>(__exec));
 }
 
 template <typename _ExecutionPolicy, typename _Ip>
 auto
-__use_parallelization(_ExecutionPolicy&& __exec, _Ip __it)
+__use_parallelization(_ExecutionPolicy&& __exec)
 {
-    return __use_par_vec_helper<_Ip>::__use_parallel(::std::forward<_ExecutionPolicy>(__exec), __it);
+    return __use_par_vec_helper<_Ip>::__use_parallel(::std::forward<_ExecutionPolicy>(__exec));
 }
 
 // Helper functions to extract to separate a Callable object from the pack of reductions and inductions
@@ -528,8 +528,8 @@ __for_loop_impl(_ExecutionPolicy&& __exec, _Ip __start, _Ip __finish, _Fp&& __f,
 {
     oneapi::dpl::__internal::__pattern_for_loop(
         ::std::forward<_ExecutionPolicy>(__exec), __start, __finish, __f, __stride,
-        oneapi::dpl::__internal::__use_vectorization(__exec, __start),
-        oneapi::dpl::__internal::__use_parallelization(__exec, __start),
+        oneapi::dpl::__internal::__use_vectorization<_ExecutionPolicy, _Ip>(__exec),
+        oneapi::dpl::__internal::__use_parallelization<_ExecutionPolicy, _Ip>(__exec),
         ::std::get<_Is>(::std::move(__t))...);
 }
 
@@ -541,8 +541,8 @@ __for_loop_n_impl(_ExecutionPolicy&& __exec, _Ip __start, _Size __n, _Fp&& __f, 
 {
     oneapi::dpl::__internal::__pattern_for_loop_n(
         ::std::forward<_ExecutionPolicy>(__exec), __start, __n, __f, __stride,
-        oneapi::dpl::__internal::__use_vectorization(__exec, __start),
-        oneapi::dpl::__internal::__use_parallelization(__exec, __start),
+        oneapi::dpl::__internal::__use_vectorization<_ExecutionPolicy, _Ip>(__exec),
+        oneapi::dpl::__internal::__use_parallelization<_ExecutionPolicy, _Ip>(__exec),
         ::std::get<_Is>(::std::move(__t))...);
 }
 

--- a/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
@@ -482,40 +482,24 @@ struct __use_par_vec_helper
     static constexpr auto
     __use_vector(_ExecutionPolicy&& __exec, _Ip __it)
     {
-        if constexpr (::std::is_integral_v<_Ip>)
-        {
-            using __tag_type = decltype(oneapi::dpl::__internal::__select_backend(__exec));
-            return typename __tag_type::__is_vector{};
-        }
-        else
-        {
-            using __tag_type = decltype(oneapi::dpl::__internal::__select_backend(__exec, __it));
-            return typename __tag_type::__is_vector{};
-        }
+        using __tag_type = std::conditional_t<std::is_integral_v<_Ip>,
+                                              decltype(oneapi::dpl::__internal::__select_backend(__exec),
+                                              decltype(oneapi::dpl::__internal::__select_backend(__exec, it)>;
+        return typename __tag_type::__is_vector{};
     }
 
     template <typename _ExecutionPolicy>
     static constexpr auto
     __use_parallel(_ExecutionPolicy&& __exec, _Ip __it)
     {
-        if constexpr (::std::is_integral_v<_Ip>)
-        {
-            using __tag_type = decltype(oneapi::dpl::__internal::__select_backend(__exec));
-            using __is_parallel_tag =
-                std::disjunction<std::is_same<oneapi::dpl::__internal::__parallel_tag<std::true_type>, __tag_type>,
-                                 std::is_same<oneapi::dpl::__internal::__parallel_tag<std::false_type>, __tag_type>>;
+        using __tag_type = std::conditional_t<std::is_integral_v<_Ip>,
+                                              decltype(oneapi::dpl::__internal::__select_backend(__exec),
+                                              decltype(oneapi::dpl::__internal::__select_backend(__exec, it)>;
+        using __is_parallel_tag =
+            std::disjunction<std::is_same<oneapi::dpl::__internal::__parallel_tag<std::true_type>, __tag_type>,
+                                std::is_same<oneapi::dpl::__internal::__parallel_tag<std::false_type>, __tag_type>>;
 
-            return __is_parallel_tag{};
-        }
-        else
-        {
-            using __tag_type = decltype(oneapi::dpl::__internal::__select_backend(__exec, __it));
-            using __is_parallel_tag =
-                std::disjunction<std::is_same<oneapi::dpl::__internal::__parallel_tag<std::true_type>, __tag_type>,
-                                 std::is_same<oneapi::dpl::__internal::__parallel_tag<std::false_type>, __tag_type>>;
-
-            return __is_parallel_tag{};
-        }
+        return __is_parallel_tag{};
     }
 };
 


### PR DESCRIPTION
Avoid error when we trying to create fancy iterator without params in constructor.