### PR TITLE
Avoid `__brick_reverse` and `__brick_reverse_copy` calls for empty source data

### DIFF
--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1691,9 +1691,6 @@ __pattern_reverse(_ExecutionPolicy&&, _BidirectionalIterator __first, _Bidirecti
                   _IsVector _is_vector,
                   /*is_parallel=*/::std::false_type) noexcept
 {
-    if (__first == __last)
-        return;
-
     __internal::__brick_reverse(__first, __last, _is_vector);
 }
 
@@ -1741,9 +1738,6 @@ oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy, _Ou
 __pattern_reverse_copy(_ExecutionPolicy&&, _BidirectionalIterator __first, _BidirectionalIterator __last,
                        _OutputIterator __d_first, _IsVector __is_vector, /*is_parallel=*/::std::false_type) noexcept
 {
-    if (__first == __last)
-        return __d_first;
-
     return __internal::__brick_reverse_copy(__first, __last, __d_first, __is_vector);
 }
 

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1758,13 +1758,12 @@ __pattern_reverse_copy(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __first
         return __d_first;
 
     __par_backend::__parallel_for(::std::forward<_ExecutionPolicy>(__exec), __first, __last,
-                                    [__is_vector, __first, __len, __d_first](_RandomAccessIterator1 __inner_first,
-                                                                            _RandomAccessIterator1 __inner_last) {
-                                        __internal::__brick_reverse_copy(
-                                            __inner_first, __inner_last,
-                                            __d_first + (__len - (__inner_last - __first)), __is_vector);
-                                    });
-
+                                  [__is_vector, __first, __len, __d_first](_RandomAccessIterator1 __inner_first,
+                                                                           _RandomAccessIterator1 __inner_last) {
+                                      __internal::__brick_reverse_copy(__inner_first, __inner_last,
+                                                                       __d_first + (__len - (__inner_last - __first)),
+                                                                       __is_vector);
+                                  });
     return __d_first + __len;
 }
 

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1691,7 +1691,10 @@ __pattern_reverse(_ExecutionPolicy&&, _BidirectionalIterator __first, _Bidirecti
                   _IsVector _is_vector,
                   /*is_parallel=*/::std::false_type) noexcept
 {
+    if (__first != __last)
+    {
     __internal::__brick_reverse(__first, __last, _is_vector);
+    }
 }
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _IsVector>

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1663,10 +1663,10 @@ void
 __brick_reverse(_BidirectionalIterator __first, _BidirectionalIterator __last, _BidirectionalIterator __d_last,
                 /*is_vector=*/::std::false_type) noexcept
 {
-    for (--__d_last; __first != __last; ++__first, --__d_last)
+    for (__first != __last; ++__first)
     {
         using ::std::iter_swap;
-        iter_swap(__first, __d_last);
+        iter_swap(__first, --__d_last);
     }
 }
 

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1699,11 +1699,14 @@ oneapi::dpl::__internal::__enable_if_host_execution_policy<_ExecutionPolicy>
 __pattern_reverse(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last,
                   _IsVector __is_vector, /*is_parallel=*/::std::true_type)
 {
+    if (__first != __last)
+    {
     __par_backend::__parallel_for(
         ::std::forward<_ExecutionPolicy>(__exec), __first, __first + (__last - __first) / 2,
         [__is_vector, __first, __last](_RandomAccessIterator __inner_first, _RandomAccessIterator __inner_last) {
             __internal::__brick_reverse(__inner_first, __inner_last, __last - (__inner_first - __first), __is_vector);
         });
+    }
 }
 
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1732,8 +1732,8 @@ __brick_reverse_copy(_RandomAccessIterator1 __first, _RandomAccessIterator1 __la
     typedef typename ::std::iterator_traits<_RandomAccessIterator1>::reference _ReferenceType1;
     typedef typename ::std::iterator_traits<_RandomAccessIterator2>::reference _ReferenceType2;
 
-        return __unseq_backend::__simd_walk_2(::std::reverse_iterator<_RandomAccessIterator1>(__last), __last - __first,
-                                              __d_first, [](_ReferenceType1 __x, _ReferenceType2 __y) { __y = __x; });
+    return __unseq_backend::__simd_walk_2(::std::reverse_iterator<_RandomAccessIterator1>(__last), __last - __first,
+                                            __d_first, [](_ReferenceType1 __x, _ReferenceType2 __y) { __y = __x; });
 }
 
 template <class _ExecutionPolicy, class _BidirectionalIterator, class _OutputIterator, class _IsVector>

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1663,7 +1663,7 @@ void
 __brick_reverse(_BidirectionalIterator __first, _BidirectionalIterator __last, _BidirectionalIterator __d_last,
                 /*is_vector=*/::std::false_type) noexcept
 {
-    for (__first != __last; ++__first)
+    for (; __first != __last; ++__first)
     {
         using ::std::iter_swap;
         iter_swap(__first, --__d_last);

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1733,7 +1733,7 @@ __brick_reverse_copy(_RandomAccessIterator1 __first, _RandomAccessIterator1 __la
     typedef typename ::std::iterator_traits<_RandomAccessIterator2>::reference _ReferenceType2;
 
     return __unseq_backend::__simd_walk_2(::std::reverse_iterator<_RandomAccessIterator1>(__last), __last - __first,
-                                            __d_first, [](_ReferenceType1 __x, _ReferenceType2 __y) { __y = __x; });
+                                          __d_first, [](_ReferenceType1 __x, _ReferenceType2 __y) { __y = __x; });
 }
 
 template <class _ExecutionPolicy, class _BidirectionalIterator, class _OutputIterator, class _IsVector>

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1707,7 +1707,8 @@ __pattern_reverse(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _Ran
         __par_backend::__parallel_for(
             ::std::forward<_ExecutionPolicy>(__exec), __first, __first + (__last - __first) / 2,
             [__is_vector, __first, __last](_RandomAccessIterator __inner_first, _RandomAccessIterator __inner_last) {
-                __internal::__brick_reverse(__inner_first, __inner_last, __last - (__inner_first - __first), __is_vector);
+                __internal::__brick_reverse(__inner_first, __inner_last, __last - (__inner_first - __first),
+                                            __is_vector);
             });
     }
 }


### PR DESCRIPTION
Assertion happens in the `reverse.pass` test.

It's reproduced on any C++ compiler on Windows
for CMake line `-DCMAKE_CXX_COMPILER=dpcpp-cl -DCMAKE_BUILD_TYPE=debug -DONEDPL_BACKEND=serial`

The root cause is that we call `__brick_reverse` and `__brick_reverse_copy` for empty source data in the parallel implementations for serial backend.