### PR TITLE
[Doc] Adding note for std::vector<bool>

### DIFF
--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -148,7 +148,6 @@ Known Limitations
   ``uninitialized_move_n``, ``uninitialized_default_construct``, ``uninitialized_default_construct_n``, ``uninitialized_value_construct``, ``uninitialized_value_construct_n``
   should be called with a device policy when using device data and should be called with a host policy when using host data. Otherwise, the result is undefined.
 * The algorithms that destroy data: ``destroy`` and ``destroy_n`` should be called with a host policy when using host data that was initialized on the host, and should be called with a device policy when using device data that was initialized on the device. Otherwise, the result is undefined.
-* Iterators of ``std::vector`` with ``bool`` value type and any allocator result in undefined behavior when used as input to oneDPL algorithms.
 
 
 Build Your Code with |onedpl_short|

--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -148,6 +148,7 @@ Known Limitations
   ``uninitialized_move_n``, ``uninitialized_default_construct``, ``uninitialized_default_construct_n``, ``uninitialized_value_construct``, ``uninitialized_value_construct_n``
   should be called with a device policy when using device data and should be called with a host policy when using host data. Otherwise, the result is undefined.
 * The algorithms that destroy data: ``destroy`` and ``destroy_n`` should be called with a host policy when using host data that was initialized on the host, and should be called with a device policy when using device data that was initialized on the device. Otherwise, the result is undefined.
+* Iterators of ``std::vector`` with ``bool`` value type and any allocator result in undefined behavior when used as input to oneDPL algorithms.
 
 
 Build Your Code with |onedpl_short|

--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -1,15 +1,14 @@
 Pass Data to Algorithms
 #######################
 
-When using C++ Standard Execution Policies, oneDPL supports data being passed to its algorithms as specified in the
-ISO/IEC 14882:2017 standard (commonly called C++17). According to this standard, it is the user's responsibility to
-avoid data races when using these parallel execution policies.
+When using the C++ standard execution policies, oneDPL supports data being passed to its algorithms as specified
+in the ISO/IEC 14882:2017 standard (commonly called C++17). According to the standard, the calling code
+must prevent data races when using algorithms with parallel execution policies.
 
-Note: ``std::vector<bool>`` implementations are not required to avoid data races when the contents of the contained
-object in different elements in the same sequence are modified concurrently. Some implementations of
-``std::vector<bool>`` may optimize multiple ``bool`` elements into a bitfield, causing data races with parallel
-execution policies. For this reason, it is recommended to avoid ``std::vector<bool>`` for anything but a read-only
-input with C++ Standard Execution Policies.
+Note: Implementations of ``std::vector<bool>`` are not required to avoid data races for concurrent modifications
+of vector elements. Some implementations may optimize multiple ``bool`` elements into a bitfield, making it unsafe
+for multithreading. For this reason, it is recommended to avoid ``std::vector<bool>`` for anything but a read-only
+input with the C++ standard execution policies.
 
 When using a device execution policy, you can use one of the following ways to pass data to an algorithm:
 

--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -1,7 +1,17 @@
 Pass Data to Algorithms
 #######################
 
-You can use one of the following ways to pass data to an algorithm executed with a device policy:
+When using C++ Standard Execution Policies, oneDPL supports data being passed to its algorithms as specified in the
+ISO/IEC 14882:2017 standard (commonly called C++17). According to this standard, it is the user's responsibility to
+avoid data races when using these parallel execution policies.
+
+Note: ``std::vector<bool>`` implementations are not required to avoid data races when the contents of the contained
+object in different elements in the same sequence are modified concurrently. Some implementations of
+``std::vector<bool>`` may optimize multiple ``bool`` elements into a bitfield, causing data races with parallel
+execution policies. For this reason, it is recommended to avoid ``std::vector<bool>`` for anything but a read-only
+input with C++ Standard Execution Policies.
+
+When using a device execution policy, you can use one of the following ways to pass data to an algorithm:
 
 * ``oneapi:dpl::begin`` and ``oneapi::dpl::end`` functions
 * Unified shared memory (USM) pointers and ``std::vector`` with USM allocators


### PR DESCRIPTION
`std::vector<bool>` has an optimization to a bitfield rather than individual booleans.  For host policies, this will simply not work for parallel algorithms (without some extra processing step / copy, which will kill performance).

On `icpx` and with device policies it works:
- With the default allocator, `std::vector<bool>::iterator` works as input to algorithms using a device policy, but only because of the copy to initialize the `sycl::buffer`. 
- With `usm_allocator`, `std::vector<bool>::iterator` also works, but only because it is treated as if it were a host_iterator, and copied into a `sycl::buffer`.  After #1438, this should still work by treating it as a host_iterator and copying to a `sycl::buffer`, because the implementation does not distinguish iterator types based on allocator.  

Since this depends on the implementation details of `std::vector<bool>`, it is safest to just label it undefined behavior, even if it happens to currently work for device policies.