### PR TITLE
Tune vectorized binary_search, lower_bound, and upper_bound algorithms

### DIFF
--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -230,7 +230,7 @@ binary_search_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, Input
     auto keep_result = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read_write, OutputIterator>();
     auto result_buf = keep_result(result, result + value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
-    auto run_binary_search = [&comp, &value_size, &zip_vw](auto&& policy, auto size) {
+    auto run_binary_search = [comp, value_size, zip_vw](auto&& policy, auto size) {
         __bknd::__parallel_for(
             _BackendTag{}, ::std::forward<decltype(policy)>(policy),
             custom_brick<StrictWeakOrdering, decltype(size), search_algorithm::binary_search>{comp, size}, value_size,

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -76,7 +76,7 @@ struct custom_brick
         if (use_32bit_indexing)
             search_impl<std::uint32_t>(idx, acc);
         else
-            search_impl<std::size_t>(idx, acc);
+            search_impl<std::uint64_t>(idx, acc);
     }
 };
 

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -51,18 +51,18 @@ struct custom_brick
         using ::std::get;
         if constexpr (func == search_algorithm::lower_bound)
         {
-            get<2>(acc[idx]) = oneapi::dpl::internal::lower_bound_fun(get<0>(acc.tuple()), start_orig, end_orig,
-                                                                      get<1>(acc[idx]), comp);
+            get<2>(acc[idx]) = oneapi::dpl::__internal::__pstl_lower_bound(get<0>(acc.tuple()), start_orig, end_orig,
+                                                                           get<1>(acc[idx]), comp);
         }
-        else if (func == search_algorithm::upper_bound)
+        else if constexpr (func == search_algorithm::upper_bound)
         {
-            get<2>(acc[idx]) = oneapi::dpl::internal::upper_bound_fun(get<0>(acc.tuple()), start_orig, end_orig,
-                                                                      get<1>(acc[idx]), comp);
+            get<2>(acc[idx]) = oneapi::dpl::__internal::__pstl_upper_bound(get<0>(acc.tuple()), start_orig, end_orig,
+                                                                           get<1>(acc[idx]), comp);
         }
         else
         {
-            auto value = oneapi::dpl::internal::lower_bound_fun(get<0>(acc.tuple()), start_orig, end_orig,
-                                                                get<1>(acc[idx]), comp);
+            auto value = oneapi::dpl::__internal::__pstl_lower_bound(get<0>(acc.tuple()), start_orig, end_orig,
+                                                                     get<1>(acc[idx]), comp);
             get<2>(acc[idx]) = (value != end_orig) && (get<1>(acc[idx]) == get<0>(acc[value]));
         }
     }

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -149,8 +149,8 @@ lower_bound_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIt
     const bool use_32bit_indexing = size <= std::numeric_limits<std::uint32_t>::max();
     __bknd::__parallel_for(
         _BackendTag{}, ::std::forward<decltype(policy)>(policy),
-        custom_brick<StrictWeakOrdering, decltype(size), search_algorithm::lower_bound>{comp, size, use_32bit_indexing}, value_size,
-        zip_vw)
+        custom_brick<StrictWeakOrdering, decltype(size), search_algorithm::lower_bound>{comp, size, use_32bit_indexing},
+        value_size, zip_vw)
         .wait();
     return result + value_size;
 }
@@ -181,8 +181,8 @@ upper_bound_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIt
     const bool use_32bit_indexing = size <= std::numeric_limits<std::uint32_t>::max();
     __bknd::__parallel_for(
         _BackendTag{}, std::forward<decltype(policy)>(policy),
-        custom_brick<StrictWeakOrdering, decltype(size), search_algorithm::upper_bound>{comp, size, use_32bit_indexing}, value_size,
-        zip_vw)
+        custom_brick<StrictWeakOrdering, decltype(size), search_algorithm::upper_bound>{comp, size, use_32bit_indexing},
+        value_size, zip_vw)
         .wait();
     return result + value_size;
 }
@@ -211,10 +211,10 @@ binary_search_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, Input
     auto result_buf = keep_result(result, result + value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
     const bool use_32bit_indexing = size <= std::numeric_limits<std::uint32_t>::max();
-    __bknd::__parallel_for(
-        _BackendTag{}, std::forward<decltype(policy)>(policy),
-        custom_brick<StrictWeakOrdering, decltype(size), search_algorithm::binary_search>{comp, size, use_32bit_indexing}, value_size,
-        zip_vw)
+    __bknd::__parallel_for(_BackendTag{}, std::forward<decltype(policy)>(policy),
+                           custom_brick<StrictWeakOrdering, decltype(size), search_algorithm::binary_search>{
+                               comp, size, use_32bit_indexing},
+                           value_size, zip_vw)
         .wait();
     return result + value_size;
 }

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -137,20 +137,22 @@ lower_bound_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIt
     auto keep_result = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read_write, OutputIterator>();
     auto result_buf = keep_result(result, result + value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
-    // Enable index calculation to proceed with uint32_t if input range is small enough. 
+    // Enable index calculation to proceed with uint32_t if input range is small enough.
     if (size <= ::std::numeric_limits<::std::uint32_t>::max())
     {
         __bknd::__parallel_for(_BackendTag{}, ::std::forward<Policy>(policy),
-                               custom_brick<StrictWeakOrdering, ::std::uint32_t, search_algorithm::lower_bound>{comp, static_cast<::std::uint32_t>(size)}, value_size,
-                               zip_vw)
+                               custom_brick<StrictWeakOrdering, ::std::uint32_t, search_algorithm::lower_bound>{
+                                   comp, static_cast<::std::uint32_t>(size)},
+                               value_size, zip_vw)
             .wait();
     }
     else
     {
         auto fallback_policy = __bknd::make_wrapped_policy<lower_bound_fallback>(::std::forward<Policy>(policy));
         __bknd::__parallel_for(_BackendTag{}, ::std::move(fallback_policy),
-                               custom_brick<StrictWeakOrdering, ::std::size_t, search_algorithm::lower_bound>{comp, static_cast<::std::size_t>(size)}, value_size,
-                               zip_vw)
+                               custom_brick<StrictWeakOrdering, ::std::size_t, search_algorithm::lower_bound>{
+                                   comp, static_cast<::std::size_t>(size)},
+                               value_size, zip_vw)
             .wait();
     }
     return result + value_size;
@@ -181,20 +183,22 @@ upper_bound_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIt
     auto keep_result = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read_write, OutputIterator>();
     auto result_buf = keep_result(result, result + value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
-    // Enable index calculation to proceed with uint32_t if input range is small enough. 
+    // Enable index calculation to proceed with uint32_t if input range is small enough.
     if (size <= ::std::numeric_limits<::std::uint32_t>::max())
     {
         __bknd::__parallel_for(_BackendTag{}, ::std::forward<Policy>(policy),
-                               custom_brick<StrictWeakOrdering, ::std::uint32_t, search_algorithm::upper_bound>{comp, static_cast<::std::uint32_t>(size)}, value_size,
-                               zip_vw)
+                               custom_brick<StrictWeakOrdering, ::std::uint32_t, search_algorithm::upper_bound>{
+                                   comp, static_cast<::std::uint32_t>(size)},
+                               value_size, zip_vw)
             .wait();
     }
     else
     {
         auto fallback_policy = __bknd::make_wrapped_policy<upper_bound_fallback>(::std::forward<Policy>(policy));
         __bknd::__parallel_for(_BackendTag{}, ::std::move(fallback_policy),
-                               custom_brick<StrictWeakOrdering, ::std::size_t, search_algorithm::upper_bound>{comp, static_cast<::std::size_t>(size)}, value_size,
-                               zip_vw)
+                               custom_brick<StrictWeakOrdering, ::std::size_t, search_algorithm::upper_bound>{
+                                   comp, static_cast<::std::size_t>(size)},
+                               value_size, zip_vw)
             .wait();
     }
     return result + value_size;
@@ -227,20 +231,22 @@ binary_search_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, Input
     auto result_buf = keep_result(result, result + value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
 
-    // Enable index calculation to proceed with uint32_t if input range is small enough. 
+    // Enable index calculation to proceed with uint32_t if input range is small enough.
     if (size <= ::std::numeric_limits<::std::uint32_t>::max())
     {
         __bknd::__parallel_for(_BackendTag{}, ::std::forward<Policy>(policy),
-                               custom_brick<StrictWeakOrdering, ::std::uint32_t, search_algorithm::binary_search>{comp, static_cast<::std::uint32_t>(size)}, value_size,
-                               zip_vw)
+                               custom_brick<StrictWeakOrdering, ::std::uint32_t, search_algorithm::binary_search>{
+                                   comp, static_cast<::std::uint32_t>(size)},
+                               value_size, zip_vw)
             .wait();
     }
     else
     {
         auto fallback_policy = __bknd::make_wrapped_policy<binary_search_fallback>(::std::forward<Policy>(policy));
         __bknd::__parallel_for(_BackendTag{}, ::std::move(fallback_policy),
-                               custom_brick<StrictWeakOrdering, ::std::size_t, search_algorithm::binary_search>{comp, static_cast<::std::size_t>(size)}, value_size,
-                               zip_vw)
+                               custom_brick<StrictWeakOrdering, ::std::size_t, search_algorithm::binary_search>{
+                                   comp, static_cast<::std::size_t>(size)},
+                               value_size, zip_vw)
             .wait();
     }
     return result + value_size;

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -49,21 +49,22 @@ struct custom_brick
         T start_orig = 0;
         auto end_orig = size;
         using ::std::get;
-        switch (func)
+        if constexpr (func == 0)
         {
-        case search_algorithm::lower_bound:
-            get<2>(acc[idx]) = oneapi::dpl::__internal::__pstl_lower_bound(get<0>(acc.tuple()), start_orig, end_orig,
-                                                                           get<1>(acc[idx]), comp);
-            break;
-        case search_algorithm::upper_bound:
-            get<2>(acc[idx]) = oneapi::dpl::__internal::__pstl_upper_bound(get<0>(acc.tuple()), start_orig, end_orig,
-                                                                           get<1>(acc[idx]), comp);
-            break;
-        case search_algorithm::binary_search:
-            auto value = oneapi::dpl::__internal::__pstl_lower_bound(get<0>(acc.tuple()), start_orig, end_orig,
-                                                                     get<1>(acc[idx]), comp);
+            get<2>(acc[idx]) = oneapi::dpl::internal::branchless_lower_bound(get<0>(acc.tuple()), start_orig, end_orig,
+                                                                             get<1>(acc[idx]), comp);
+        }
+        else if (func == 1)
+        {
+            get<2>(acc[idx]) = oneapi::dpl::internal::branchless_lower_bound(get<0>(acc.tuple()), start_orig, end_orig,
+                                                                             get<1>(acc[idx]), comp);
+
+        }
+        else
+        {
+            auto value = oneapi::dpl::internal::branchless_lower_bound(get<0>(acc.tuple()), start_orig, end_orig,
+                                                                       get<1>(acc[idx]), comp);
             get<2>(acc[idx]) = (value != end_orig) && (get<1>(acc[idx]) == get<0>(acc[value]));
-            break;
         }
     }
 };
@@ -134,10 +135,20 @@ lower_bound_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIt
     auto keep_result = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read_write, OutputIterator>();
     auto result_buf = keep_result(result, result + value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
-    __bknd::__parallel_for(_BackendTag{}, ::std::forward<Policy>(policy),
-                           custom_brick<StrictWeakOrdering, decltype(size), search_algorithm::lower_bound>{comp, size},
-                           value_size, zip_vw)
-        .wait();
+    if (size <= ::std::numeric_limits<::std::uint32_t>::max())
+    {
+        __bknd::__parallel_for(_BackendTag{}, ::std::forward<Policy>(policy),
+                               custom_brick<StrictWeakOrdering, ::std::uint32_t, lower_bound>{comp, size}, value_size,
+                               zip_vw)
+            .wait();
+    }
+    else
+    {
+        __bknd::__parallel_for(_BackendTag{}, ::std::forward<Policy>(policy),
+                               custom_brick<StrictWeakOrdering, decltype(size), lower_bound>{comp, size}, value_size,
+                               zip_vw)
+            .wait();
+    }
     return result + value_size;
 }
 
@@ -164,10 +175,22 @@ upper_bound_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIt
     auto keep_result = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read_write, OutputIterator>();
     auto result_buf = keep_result(result, result + value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
-    __bknd::__parallel_for(_BackendTag{}, ::std::forward<Policy>(policy),
-                           custom_brick<StrictWeakOrdering, decltype(size), search_algorithm::upper_bound>{comp, size},
-                           value_size, zip_vw)
-        .wait();
+
+    // Enable index calculation to proceed with uint32_t if input range is small enough. 
+    if (size <= ::std::numeric_limits<::std::uint32_t>::max())
+    {
+        __bknd::__parallel_for(_BackendTag{}, ::std::forward<Policy>(policy),
+                               custom_brick<StrictWeakOrdering, ::std::uint32_t, upper_bound>{comp, size}, value_size,
+                               zip_vw)
+            .wait();
+    }
+    else
+    {
+        __bknd::__parallel_for(_BackendTag{}, ::std::forward<Policy>(policy),
+                               custom_brick<StrictWeakOrdering, decltype(size), upper_bound>{comp, size}, value_size,
+                               zip_vw)
+            .wait();
+    }
     return result + value_size;
 }
 
@@ -194,11 +217,22 @@ binary_search_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, Input
     auto keep_result = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read_write, OutputIterator>();
     auto result_buf = keep_result(result, result + value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
-    __bknd::__parallel_for(
-        _BackendTag{}, ::std::forward<Policy>(policy),
-        custom_brick<StrictWeakOrdering, decltype(size), search_algorithm::binary_search>{comp, size}, value_size,
-        zip_vw)
-        .wait();
+
+    // Enable index calculation to proceed with uint32_t if input range is small enough. 
+    if (size <= ::std::numeric_limits<::std::uint32_t>::max())
+    {
+        __bknd::__parallel_for(_BackendTag{}, ::std::forward<Policy>(policy),
+                               custom_brick<StrictWeakOrdering, ::std::uint32_t, binary_search>{comp, size}, value_size,
+                               zip_vw)
+            .wait();
+    }
+    else
+    {
+        __bknd::__parallel_for(_BackendTag{}, ::std::forward<Policy>(policy),
+                               custom_brick<StrictWeakOrdering, decltype(size), binary_search>{comp, size}, value_size,
+                               zip_vw)
+            .wait();
+    }
     return result + value_size;
 }
 

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -49,12 +49,12 @@ struct custom_brick
         T start_orig = 0;
         auto end_orig = size;
         using ::std::get;
-        if constexpr (func == 0)
+        if constexpr (func == search_algorithm::lower_bound)
         {
             get<2>(acc[idx]) = oneapi::dpl::internal::lower_bound_fun(get<0>(acc.tuple()), start_orig, end_orig,
                                                                       get<1>(acc[idx]), comp);
         }
-        else if (func == 1)
+        else if (func == search_algorithm::upper_bound)
         {
             get<2>(acc[idx]) = oneapi::dpl::internal::upper_bound_fun(get<0>(acc.tuple()), start_orig, end_orig,
                                                                       get<1>(acc[idx]), comp);
@@ -141,7 +141,7 @@ lower_bound_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIt
     if (size <= ::std::numeric_limits<::std::uint32_t>::max())
     {
         __bknd::__parallel_for(_BackendTag{}, ::std::forward<Policy>(policy),
-                               custom_brick<StrictWeakOrdering, ::std::uint32_t, lower_bound>{comp, static_cast<::std::uint32_t>(size)}, value_size,
+                               custom_brick<StrictWeakOrdering, ::std::uint32_t, search_algorithm::lower_bound>{comp, static_cast<::std::uint32_t>(size)}, value_size,
                                zip_vw)
             .wait();
     }
@@ -149,7 +149,7 @@ lower_bound_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIt
     {
         auto fallback_policy = __bknd::make_wrapped_policy<lower_bound_fallback>(::std::forward<Policy>(policy));
         __bknd::__parallel_for(_BackendTag{}, ::std::move(fallback_policy),
-                               custom_brick<StrictWeakOrdering, ::std::size_t, lower_bound>{comp, static_cast<::std::size_t>(size)}, value_size,
+                               custom_brick<StrictWeakOrdering, ::std::size_t, search_algorithm::lower_bound>{comp, static_cast<::std::size_t>(size)}, value_size,
                                zip_vw)
             .wait();
     }
@@ -185,7 +185,7 @@ upper_bound_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIt
     if (size <= ::std::numeric_limits<::std::uint32_t>::max())
     {
         __bknd::__parallel_for(_BackendTag{}, ::std::forward<Policy>(policy),
-                               custom_brick<StrictWeakOrdering, ::std::uint32_t, upper_bound>{comp, static_cast<::std::uint32_t>(size)}, value_size,
+                               custom_brick<StrictWeakOrdering, ::std::uint32_t, search_algorithm::upper_bound>{comp, static_cast<::std::uint32_t>(size)}, value_size,
                                zip_vw)
             .wait();
     }
@@ -193,7 +193,7 @@ upper_bound_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIt
     {
         auto fallback_policy = __bknd::make_wrapped_policy<upper_bound_fallback>(::std::forward<Policy>(policy));
         __bknd::__parallel_for(_BackendTag{}, ::std::move(fallback_policy),
-                               custom_brick<StrictWeakOrdering, ::std::size_t, upper_bound>{comp, static_cast<::std::size_t>(size)}, value_size,
+                               custom_brick<StrictWeakOrdering, ::std::size_t, search_algorithm::upper_bound>{comp, static_cast<::std::size_t>(size)}, value_size,
                                zip_vw)
             .wait();
     }
@@ -231,7 +231,7 @@ binary_search_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, Input
     if (size <= ::std::numeric_limits<::std::uint32_t>::max())
     {
         __bknd::__parallel_for(_BackendTag{}, ::std::forward<Policy>(policy),
-                               custom_brick<StrictWeakOrdering, ::std::uint32_t, binary_search>{comp, static_cast<::std::uint32_t>(size)}, value_size,
+                               custom_brick<StrictWeakOrdering, ::std::uint32_t, search_algorithm::binary_search>{comp, static_cast<::std::uint32_t>(size)}, value_size,
                                zip_vw)
             .wait();
     }
@@ -239,7 +239,7 @@ binary_search_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, Input
     {
         auto fallback_policy = __bknd::make_wrapped_policy<binary_search_fallback>(::std::forward<Policy>(policy));
         __bknd::__parallel_for(_BackendTag{}, ::std::move(fallback_policy),
-                               custom_brick<StrictWeakOrdering, ::std::size_t, binary_search>{comp, static_cast<::std::size_t>(size)}, value_size,
+                               custom_brick<StrictWeakOrdering, ::std::size_t, search_algorithm::binary_search>{comp, static_cast<::std::size_t>(size)}, value_size,
                                zip_vw)
             .wait();
     }

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -56,7 +56,7 @@ struct custom_brick
         }
         else if (func == 1)
         {
-            get<2>(acc[idx]) = oneapi::dpl::internal::branchless_lower_bound(get<0>(acc.tuple()), start_orig, end_orig,
+            get<2>(acc[idx]) = oneapi::dpl::internal::branchless_upper_bound(get<0>(acc.tuple()), start_orig, end_orig,
                                                                              get<1>(acc[idx]), comp);
         }
         else

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -58,7 +58,6 @@ struct custom_brick
         {
             get<2>(acc[idx]) = oneapi::dpl::internal::branchless_lower_bound(get<0>(acc.tuple()), start_orig, end_orig,
                                                                              get<1>(acc[idx]), comp);
-
         }
         else
         {
@@ -135,10 +134,11 @@ lower_bound_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIt
     auto keep_result = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read_write, OutputIterator>();
     auto result_buf = keep_result(result, result + value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
+    // Enable index calculation to proceed with uint32_t if input range is small enough. 
     if (size <= ::std::numeric_limits<::std::uint32_t>::max())
     {
         __bknd::__parallel_for(_BackendTag{}, ::std::forward<Policy>(policy),
-                               custom_brick<StrictWeakOrdering, ::std::uint32_t, lower_bound>{comp, size}, value_size,
+                               custom_brick<StrictWeakOrdering, ::std::uint32_t, lower_bound>{comp, static_cast<::std::uint32_t>(size)}, value_size,
                                zip_vw)
             .wait();
     }
@@ -175,12 +175,11 @@ upper_bound_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIt
     auto keep_result = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read_write, OutputIterator>();
     auto result_buf = keep_result(result, result + value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
-
     // Enable index calculation to proceed with uint32_t if input range is small enough. 
     if (size <= ::std::numeric_limits<::std::uint32_t>::max())
     {
         __bknd::__parallel_for(_BackendTag{}, ::std::forward<Policy>(policy),
-                               custom_brick<StrictWeakOrdering, ::std::uint32_t, upper_bound>{comp, size}, value_size,
+                               custom_brick<StrictWeakOrdering, ::std::uint32_t, upper_bound>{comp, static_cast<::std::uint32_t>(size)}, value_size,
                                zip_vw)
             .wait();
     }
@@ -217,12 +216,11 @@ binary_search_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, Input
     auto keep_result = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read_write, OutputIterator>();
     auto result_buf = keep_result(result, result + value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
-
     // Enable index calculation to proceed with uint32_t if input range is small enough. 
     if (size <= ::std::numeric_limits<::std::uint32_t>::max())
     {
         __bknd::__parallel_for(_BackendTag{}, ::std::forward<Policy>(policy),
-                               custom_brick<StrictWeakOrdering, ::std::uint32_t, binary_search>{comp, size}, value_size,
+                               custom_brick<StrictWeakOrdering, ::std::uint32_t, binary_search>{comp, static_cast<::std::uint32_t>(size)}, value_size,
                                zip_vw)
             .wait();
     }

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -20,6 +20,7 @@
 #include "function.h"
 #include "binary_search_extension_defs.h"
 #include "../pstl/iterator_impl.h"
+#include "../pstl/utils.h"
 
 namespace oneapi
 {
@@ -51,18 +52,18 @@ struct custom_brick
         using ::std::get;
         if constexpr (func == search_algorithm::lower_bound)
         {
-            get<2>(acc[idx]) = oneapi::dpl::__internal::__pstl_lower_bound(get<0>(acc.tuple()), start_orig, end_orig,
-                                                                           get<1>(acc[idx]), comp);
+            get<2>(acc[idx]) = oneapi::dpl::__internal::__shars_lower_bound(get<0>(acc.tuple()), start_orig, end_orig,
+                                                                            get<1>(acc[idx]), comp);
         }
         else if constexpr (func == search_algorithm::upper_bound)
         {
-            get<2>(acc[idx]) = oneapi::dpl::__internal::__pstl_upper_bound(get<0>(acc.tuple()), start_orig, end_orig,
-                                                                           get<1>(acc[idx]), comp);
+            get<2>(acc[idx]) = oneapi::dpl::__internal::__shars_upper_bound(get<0>(acc.tuple()), start_orig, end_orig,
+                                                                            get<1>(acc[idx]), comp);
         }
         else
         {
-            auto value = oneapi::dpl::__internal::__pstl_lower_bound(get<0>(acc.tuple()), start_orig, end_orig,
-                                                                     get<1>(acc[idx]), comp);
+            auto value = oneapi::dpl::__internal::__shars_lower_bound(get<0>(acc.tuple()), start_orig, end_orig,
+                                                                      get<1>(acc[idx]), comp);
             get<2>(acc[idx]) = (value != end_orig) && (get<1>(acc[idx]) == get<0>(acc[value]));
         }
     }

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -42,14 +42,15 @@ struct custom_brick
 {
     Comp comp;
     T size;
+    bool use_32bit_indexing;
 
-    template <typename _ItemId, typename _Acc1>
+    template <typename _Size, typename _ItemId, typename _Acc>
     void
-    operator()(_ItemId idx, _Acc1 acc) const
+    search_impl(_ItemId idx, _Acc acc) const
     {
-        T start_orig = 0;
-        auto end_orig = size;
-        using ::std::get;
+        _Size start_orig = 0;
+        _Size end_orig = size;
+        using std::get;
         if constexpr (func == search_algorithm::lower_bound)
         {
             get<2>(acc[idx]) = oneapi::dpl::__internal::__shars_lower_bound(get<0>(acc.tuple()), start_orig, end_orig,
@@ -66,6 +67,16 @@ struct custom_brick
                                                                       get<1>(acc[idx]), comp);
             get<2>(acc[idx]) = (value != end_orig) && (get<1>(acc[idx]) == get<0>(acc[value]));
         }
+    }
+
+    template <typename _ItemId, typename _Acc>
+    void
+    operator()(_ItemId idx, _Acc acc) const
+    {
+        if (use_32bit_indexing)
+            search_impl<std::uint32_t>(idx, acc);
+        else
+            search_impl<std::size_t>(idx, acc);
     }
 };
 
@@ -112,9 +123,6 @@ binary_search_impl(_Tag, Policy&& policy, InputIterator1 start, InputIterator1 e
 }
 
 #if _ONEDPL_BACKEND_SYCL
-template <typename T>
-class lower_bound_fallback;
-
 template <typename _BackendTag, typename Policy, typename InputIterator1, typename InputIterator2,
           typename OutputIterator, typename StrictWeakOrdering>
 OutputIterator
@@ -127,7 +135,7 @@ lower_bound_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIt
     if (size <= 0)
         return result;
 
-    const auto value_size = ::std::distance(value_start, value_end);
+    const auto value_size = std::distance(value_start, value_end);
 
     auto keep_input = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read, InputIterator1>();
     auto input_buf = keep_input(start, end);
@@ -138,28 +146,14 @@ lower_bound_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIt
     auto keep_result = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read_write, OutputIterator>();
     auto result_buf = keep_result(result, result + value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
-    auto run_lower_bound = [comp, value_size, zip_vw](auto&& policy, auto size) {
-        __bknd::__parallel_for(
-            _BackendTag{}, ::std::forward<decltype(policy)>(policy),
-            custom_brick<StrictWeakOrdering, decltype(size), search_algorithm::lower_bound>{comp, size}, value_size,
-            zip_vw)
-            .wait();
-    };
-    // Enable index calculation to proceed with uint32_t if input range is small enough.
-    if (size <= ::std::numeric_limits<::std::uint32_t>::max())
-    {
-        run_lower_bound(::std::forward<Policy>(policy), static_cast<::std::uint32_t>(size));
-    }
-    else
-    {
-        run_lower_bound(__bknd::make_wrapped_policy<lower_bound_fallback>(::std::forward<Policy>(policy)),
-                        static_cast<::std::size_t>(size));
-    }
+    const bool use_32bit_indexing = size <= std::numeric_limits<std::uint32_t>::max();
+    __bknd::__parallel_for(
+        _BackendTag{}, ::std::forward<decltype(policy)>(policy),
+        custom_brick<StrictWeakOrdering, decltype(size), search_algorithm::lower_bound>{comp, size, use_32bit_indexing}, value_size,
+        zip_vw)
+        .wait();
     return result + value_size;
 }
-
-template <typename T>
-class upper_bound_fallback;
 
 template <typename _BackendTag, typename Policy, typename InputIterator1, typename InputIterator2,
           typename OutputIterator, typename StrictWeakOrdering>
@@ -168,12 +162,12 @@ upper_bound_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIt
                  InputIterator2 value_start, InputIterator2 value_end, OutputIterator result, StrictWeakOrdering comp)
 {
     namespace __bknd = __par_backend_hetero;
-    const auto size = ::std::distance(start, end);
+    const auto size = std::distance(start, end);
 
     if (size <= 0)
         return result;
 
-    const auto value_size = ::std::distance(value_start, value_end);
+    const auto value_size = std::distance(value_start, value_end);
 
     auto keep_input = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read, InputIterator1>();
     auto input_buf = keep_input(start, end);
@@ -184,28 +178,14 @@ upper_bound_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, InputIt
     auto keep_result = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read_write, OutputIterator>();
     auto result_buf = keep_result(result, result + value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
-    auto run_upper_bound = [comp, value_size, zip_vw](auto&& policy, auto size) {
-        __bknd::__parallel_for(
-            _BackendTag{}, ::std::forward<decltype(policy)>(policy),
-            custom_brick<StrictWeakOrdering, decltype(size), search_algorithm::upper_bound>{comp, size}, value_size,
-            zip_vw)
-            .wait();
-    };
-    // Enable index calculation to proceed with uint32_t if input range is small enough.
-    if (size <= ::std::numeric_limits<::std::uint32_t>::max())
-    {
-        run_upper_bound(::std::forward<Policy>(policy), static_cast<::std::uint32_t>(size));
-    }
-    else
-    {
-        run_upper_bound(__bknd::make_wrapped_policy<upper_bound_fallback>(::std::forward<Policy>(policy)),
-                        static_cast<::std::size_t>(size));
-    }
+    const bool use_32bit_indexing = size <= std::numeric_limits<std::uint32_t>::max();
+    __bknd::__parallel_for(
+        _BackendTag{}, std::forward<decltype(policy)>(policy),
+        custom_brick<StrictWeakOrdering, decltype(size), search_algorithm::upper_bound>{comp, size, use_32bit_indexing}, value_size,
+        zip_vw)
+        .wait();
     return result + value_size;
 }
-
-template <typename T>
-class binary_search_fallback;
 
 template <typename _BackendTag, typename Policy, typename InputIterator1, typename InputIterator2,
           typename OutputIterator, typename StrictWeakOrdering>
@@ -219,7 +199,7 @@ binary_search_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, Input
     if (size <= 0)
         return result;
 
-    const auto value_size = ::std::distance(value_start, value_end);
+    const auto value_size = std::distance(value_start, value_end);
 
     auto keep_input = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read, InputIterator1>();
     auto input_buf = keep_input(start, end);
@@ -230,23 +210,12 @@ binary_search_impl(__internal::__hetero_tag<_BackendTag>, Policy&& policy, Input
     auto keep_result = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read_write, OutputIterator>();
     auto result_buf = keep_result(result, result + value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
-    auto run_binary_search = [comp, value_size, zip_vw](auto&& policy, auto size) {
-        __bknd::__parallel_for(
-            _BackendTag{}, ::std::forward<decltype(policy)>(policy),
-            custom_brick<StrictWeakOrdering, decltype(size), search_algorithm::binary_search>{comp, size}, value_size,
-            zip_vw)
-            .wait();
-    };
-    // Enable index calculation to proceed with uint32_t if input range is small enough.
-    if (size <= ::std::numeric_limits<::std::uint32_t>::max())
-    {
-        run_binary_search(::std::forward<Policy>(policy), static_cast<::std::uint32_t>(size));
-    }
-    else
-    {
-        run_binary_search(__bknd::make_wrapped_policy<binary_search_fallback>(::std::forward<Policy>(policy)),
-                          static_cast<::std::size_t>(size));
-    }
+    const bool use_32bit_indexing = size <= std::numeric_limits<std::uint32_t>::max();
+    __bknd::__parallel_for(
+        _BackendTag{}, std::forward<decltype(policy)>(policy),
+        custom_brick<StrictWeakOrdering, decltype(size), search_algorithm::binary_search>{comp, size, use_32bit_indexing}, value_size,
+        zip_vw)
+        .wait();
     return result + value_size;
 }
 

--- a/include/oneapi/dpl/internal/function.h
+++ b/include/oneapi/dpl/internal/function.h
@@ -165,27 +165,27 @@ branchless_lower_bound(Acc acc, IdxT first, IdxT last, const Value& value, Compa
     IdxT cur = n;
 #if 0
     IdxT it;
-    while (__n > 0)
+    while (n > 0)
     {
-        __it = __first;
-        __cur = __n / 2;
-        __it += __cur;
-        if (__comp(__acc[__it], __value))
+        it = first;
+        cur = n / 2;
+        it += cur;
+        if (comp(acc[it], value))
         {
-            __n -= __cur + 1, __first = ++__it;
+            n -= cur + 1, first = ++it;
         }
         else
-            __n = __cur;
+            n = cur;
     }
-    return __first;
+    return first;
 #else
     // TODO: Evaluate wider scale correctness 
     IdxT offset = 0;
     // TODO: Figure out a good way to check '<=' instead of just '<' which __comp defines. 
-    for (IdxT i = __n / 2; i >= 1; i >>= 1)
-        offset += std::min(__n - 1, IdxT((__comp(__acc[offset + i], __value) || __acc[offset + i] == __value) * i));
+    for (IdxT i = n / 2; i >= 1; i >>= 1)
+        offset += std::min(n - 1, IdxT((comp(acc[offset + i], value) || acc[offset + i] == value) * i));
 
-    return __first + offset;
+    return first + offset;
 #endif
 }
 } // namespace internal

--- a/include/oneapi/dpl/internal/function.h
+++ b/include/oneapi/dpl/internal/function.h
@@ -166,10 +166,15 @@ branchless_lower_bound(Acc acc, IdxT first, IdxT last, const Value& value, Compa
     IdxT offset = 0;
     IdxT start = oneapi::dpl::__internal::__dpl_bit_ceil(n) / 2;
     // TODO: Figure out a good way to check '<=' instead of just '<' which __comp defines. 
-    for (IdxT i = start; i >= 1; i /= 2)
+    for (IdxT i = start; i >= 2; i >>= 1)
     {
-        IdxT idx = ::std::min(n-1, offset + i);
-        offset += IdxT(comp(acc[idx], value) || acc[idx] == value) * i;
+        IdxT idx = offset + i;
+        offset += static_cast<IdxT>(comp(acc[idx], value) || acc[idx] == value) * i;
+    }
+    if (n > 1)
+    {
+        IdxT idx = ::std::min(n-1, offset + 1);
+        offset += static_cast<IdxT>(comp(acc[idx], value) || acc[idx] == value);
     }
     return first + offset;
 }

--- a/include/oneapi/dpl/internal/function.h
+++ b/include/oneapi/dpl/internal/function.h
@@ -163,21 +163,15 @@ IdxT
 lower_bound_fun(Acc acc, IdxT first, IdxT last, const Value& value, Compare comp)
 {
     IdxT n = last - first;
-    IdxT offset = 0;
+    IdxT offset = first;
     IdxT start = oneapi::dpl::__internal::__dpl_bit_ceil(n) / 2;
-    for (IdxT i = start; i >= 2; i >>= 1)
+    for (IdxT i = start; i >= 1; i >>= 1)
     {
-        IdxT idx = offset + i;
-        offset += static_cast<IdxT>(comp(acc[idx], value)) * i;
-    }
-    // Hoist the last case to special handle non-powers of two.
-    if (n > 1)
-    {
-        IdxT idx = ::std::min(n - 1, offset + 1);
-        offset += static_cast<IdxT>(comp(acc[idx], value));
+        IdxT idx = ::std::min(n - 1, offset + i);
+        offset = comp(acc[idx], value) ? idx : offset;
     }
     // Special handle the case where comp is never satisifed
-    if (offset == 0 && !comp(acc[0], value))
+    if (offset == first && !comp(acc[first], value))
     {
         return first;
     }

--- a/include/oneapi/dpl/internal/function.h
+++ b/include/oneapi/dpl/internal/function.h
@@ -155,12 +155,12 @@ class transform_if_stencil_fun
     UnaryOperation op;
 };
 
-// Lower bound functor more suitable to SIMD / SIMT style execution to minimize subgroup divergence.
+// Lower bound function for vectorized lower bound intended to minimize subgroup divergence.
 // Runs in Theta(log2(input size)) time.
 // Used by: binary_search and lower_bound.
 template <typename Acc, typename IdxT, typename Value, typename Compare>
 IdxT
-branchless_lower_bound(Acc acc, IdxT first, IdxT last, const Value& value, Compare comp)
+lower_bound_fun(Acc acc, IdxT first, IdxT last, const Value& value, Compare comp)
 {
     IdxT n = last - first;
     IdxT offset = 0;
@@ -188,11 +188,11 @@ branchless_lower_bound(Acc acc, IdxT first, IdxT last, const Value& value, Compa
 // Used by: upper_bound.
 template <typename Acc, typename IdxT, typename Value, typename Compare>
 IdxT
-branchless_upper_bound(Acc acc, IdxT first, IdxT last, const Value& value, Compare comp)
+upper_bound_fun(Acc acc, IdxT first, IdxT last, const Value& value, Compare comp)
 {
-    return branchless_lower_bound(acc, first, last, value,
-                                  oneapi::dpl::__internal::__not_pred<oneapi::dpl::__internal::__reorder_pred<Compare>>{
-                                      oneapi::dpl::__internal::__reorder_pred<Compare>{comp}});
+    return lower_bound_fun(acc, first, last, value,
+                           oneapi::dpl::__internal::__not_pred<oneapi::dpl::__internal::__reorder_pred<Compare>>{
+                               oneapi::dpl::__internal::__reorder_pred<Compare>{comp}});
 }
 } // namespace internal
 } // namespace dpl

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -718,11 +718,11 @@ struct __spirv_target_conditional :
 inline constexpr bool __is_spirv_target_v = __spirv_target_conditional<::std::true_type, ::std::false_type>::value;
 
 // Lower bound implementation based on Shar's algorithm for binary search.
-template <typename _Acc, typename _Size1, typename _Value, typename _Compare,
-          ::std::enable_if_t<::std::is_unsigned_v<_Size1>, int> = 0>
+template <typename _Acc, typename _Size1, typename _Value, typename _Compare>
 _Size1
 __shars_lower_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp)
 {
+    static_assert(::std::is_unsigned_v<_Size1>, "__shars_lower_bound requires an unsigned size type");
     _Size1 __n = __last - __first;
     if (__n == 0)
         return __first;

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -506,7 +506,7 @@ __pstl_lower_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __va
         _Size1 __idx = ::std::min(__n - 1, __offset + __i);
         __offset = __comp(__acc[__idx], __value) ? __idx : __offset;
     }
-    // Special handle the case where __comp is never satisifed
+    // Special handle the case where __comp is never satisfied.
     if (__offset == __first && (__n == 0 || !__comp(__acc[__first], __value)))
     {
         return __first;

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -507,7 +507,7 @@ __pstl_lower_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __va
         __offset = __comp(__acc[__idx], __value) ? __idx : __offset;
     }
     // Special handle the case where __comp is never satisifed
-    if (__offset == __first && !__comp(__acc[__first], __value))
+    if (__offset == __first && (n == 0 || !__comp(__acc[__first], __value)))
     {
         return __first;
     }

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -747,9 +747,9 @@ template <typename _Acc, typename _Size1, typename _Value, typename _Compare>
 _Size1
 __shars_upper_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp)
 {
-    return __pstl_lower_bound(__acc, __first, __last, __value,
-                              oneapi::dpl::__internal::__not_pred<oneapi::dpl::__internal::__reorder_pred<_Compare>>{
-                                  oneapi::dpl::__internal::__reorder_pred<_Compare>{__comp}});
+    return __shars_lower_bound(__acc, __first, __last, __value,
+                               oneapi::dpl::__internal::__not_pred<oneapi::dpl::__internal::__reorder_pred<_Compare>>{
+                                   oneapi::dpl::__internal::__reorder_pred<_Compare>{__comp}});
 }
 
 } // namespace __internal

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -723,14 +723,14 @@ _Size1
 __shars_lower_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp)
 {
     static_assert(::std::is_unsigned_v<_Size1>, "__shars_lower_bound requires an unsigned size type");
-    _Size1 __n = __last - __first;
+    const _Size1 __n = __last - __first;
     if (__n == 0)
         return __first;
     _Size1 __cur_pow2 = __dpl_bit_floor(__n);
-    _Size1 __midpoint = __n / 2;
+    const _Size1 __midpoint = __n / 2;
     // Check the middle element to determine if we should search the first or last
     // 2^(bit_floor(__n)) - 1 elements.
-    _Size1 __shifted_first = __comp(__acc[__midpoint], __value) ? __n + 1 - __cur_pow2 : __first;
+    const _Size1 __shifted_first = __comp(__acc[__midpoint], __value) ? __n + 1 - __cur_pow2 : __first;
     // Check descending powers of two. If __comp(__acc[__search_idx], __pow) holds for a __cur_pow2, then its
     // bit must be set in the result.
     _Size1 __search_offset{0};

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -507,7 +507,7 @@ __pstl_lower_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __va
         __offset = __comp(__acc[__idx], __value) ? __idx : __offset;
     }
     // Special handle the case where __comp is never satisifed
-    if (__offset == __first && (n == 0 || !__comp(__acc[__first], __value)))
+    if (__offset == __first && (__n == 0 || !__comp(__acc[__first], __value)))
     {
         return __first;
     }

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -688,7 +688,7 @@ __shars_lower_bound(_Acc __acc, _Size __first, _Size __last, const _Value& __val
     _Size __search_offset{0};
     for (__cur_pow2 /= 2; __cur_pow2 > 0; __cur_pow2 /= 2)
     {
-        _Size __search_idx = __shifted_first + (__search_offset | __cur_pow2) - 1;
+        const _Size __search_idx = __shifted_first + (__search_offset | __cur_pow2) - 1;
         if (__comp(__acc[__search_idx], __value))
             __search_offset |= __cur_pow2;
     }

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -718,25 +718,25 @@ struct __spirv_target_conditional :
 inline constexpr bool __is_spirv_target_v = __spirv_target_conditional<::std::true_type, ::std::false_type>::value;
 
 // Lower bound implementation based on Shar's algorithm for binary search.
-template <typename _Acc, typename _Size1, typename _Value, typename _Compare>
-_Size1
-__shars_lower_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp)
+template <typename _Acc, typename _Size, typename _Value, typename _Compare>
+_Size
+__shars_lower_bound(_Acc __acc, _Size __first, _Size __last, const _Value& __value, _Compare __comp)
 {
-    static_assert(::std::is_unsigned_v<_Size1>, "__shars_lower_bound requires an unsigned size type");
-    const _Size1 __n = __last - __first;
+    static_assert(::std::is_unsigned_v<_Size>, "__shars_lower_bound requires an unsigned size type");
+    const _Size __n = __last - __first;
     if (__n == 0)
         return __first;
-    _Size1 __cur_pow2 = __dpl_bit_floor(__n);
-    const _Size1 __midpoint = __n / 2;
+    _Size __cur_pow2 = __dpl_bit_floor(__n);
+    const _Size __midpoint = __n / 2;
     // Check the middle element to determine if we should search the first or last
     // 2^(bit_floor(__n)) - 1 elements.
-    const _Size1 __shifted_first = __comp(__acc[__midpoint], __value) ? __n + 1 - __cur_pow2 : __first;
+    const _Size __shifted_first = __comp(__acc[__midpoint], __value) ? __n + 1 - __cur_pow2 : __first;
     // Check descending powers of two. If __comp(__acc[__search_idx], __pow) holds for a __cur_pow2, then its
     // bit must be set in the result.
-    _Size1 __search_offset{0};
+    _Size __search_offset{0};
     for (__cur_pow2 /= 2; __cur_pow2 > 0; __cur_pow2 /= 2)
     {
-        _Size1 __search_idx = __shifted_first + (__search_offset | __cur_pow2) - 1;
+        _Size __search_idx = __shifted_first + (__search_offset | __cur_pow2) - 1;
         if (__comp(__acc[__search_idx], __value))
             __search_offset |= __cur_pow2;
     }

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -686,7 +686,7 @@ __shars_lower_bound(_Acc __acc, _Size __first, _Size __last, const _Value& __val
     // Check descending powers of two. If __comp(__acc[__search_idx], __pow) holds for a __cur_pow2, then its
     // bit must be set in the result.
     _Size __search_offset{0};
-    for (__cur_pow2 /= 2; __cur_pow2 > 0; __cur_pow2 /= 2)
+    for (__cur_pow2 >>= 1; __cur_pow2 > 0; __cur_pow2 >>= 1)
     {
         const _Size __search_idx = __shifted_first + (__search_offset | __cur_pow2) - 1;
         if (__comp(__acc[__search_idx], __value))

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -743,9 +743,9 @@ __shars_lower_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __v
     return __shifted_first + __search_offset;
 }
 
-template <typename _Acc, typename _Size1, typename _Value, typename _Compare>
-_Size1
-__shars_upper_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp)
+template <typename _Acc, typename _Size, typename _Value, typename _Compare>
+_Size
+__shars_upper_bound(_Acc __acc, _Size __first, _Size __last, const _Value& __value, _Compare __comp)
 {
     return __shars_lower_bound(__acc, __first, __last, __value,
                                oneapi::dpl::__internal::__not_pred<oneapi::dpl::__internal::__reorder_pred<_Compare>>{

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -406,7 +406,72 @@ __cmp_iterators_by_values(_ForwardIterator __a, _ForwardIterator __b, _Compare _
     }
 }
 
-template <typename _Acc, typename _Size1, typename _Value, typename _Compare>
+//-----------------------------------------------------------------------
+// Generic bit- and number-manipulation routines
+//-----------------------------------------------------------------------
+
+// Bitwise type casting, same as C++20 std::bit_cast
+template <typename _Dst, typename _Src>
+::std::enable_if_t<
+    sizeof(_Dst) == sizeof(_Src) && ::std::is_trivially_copyable_v<_Dst> && ::std::is_trivially_copyable_v<_Src>, _Dst>
+__dpl_bit_cast(const _Src& __src) noexcept
+{
+#if __cpp_lib_bit_cast >= 201806L
+    return ::std::bit_cast<_Dst>(__src);
+#elif _ONEDPL_BACKEND_SYCL && _ONEDPL_LIBSYCL_VERSION >= 50300
+    return sycl::bit_cast<_Dst>(__src);
+#elif __has_builtin(__builtin_bit_cast)
+    return __builtin_bit_cast(_Dst, __src);
+#else
+    _Dst __result;
+    ::std::memcpy(&__result, &__src, sizeof(_Dst));
+    return __result;
+#endif
+}
+
+// The max power of 2 not exceeding the given value, same as C++20 std::bit_floor
+template <typename _T>
+::std::enable_if_t<::std::is_integral_v<_T> && ::std::is_unsigned_v<_T>, _T>
+__dpl_bit_floor(_T __x) noexcept
+{
+    if (__x == 0)
+        return 0;
+#if __cpp_lib_int_pow2 >= 202002L
+    return ::std::bit_floor(__x);
+#elif _ONEDPL_BACKEND_SYCL
+    // Use the count-leading-zeros function
+    return _T{1} << (sizeof(_T) * CHAR_BIT - sycl::clz(__x) - 1);
+#else
+    // Fill all the lower bits with 1s
+    __x |= (__x >> 1);
+    __x |= (__x >> 2);
+    __x |= (__x >> 4);
+    if constexpr (sizeof(_T) > 1) __x |= (__x >> 8);
+    if constexpr (sizeof(_T) > 2) __x |= (__x >> 16);
+    if constexpr (sizeof(_T) > 4) __x |= (__x >> 32);
+    __x += 1; // Now it equals to the next greater power of 2, or 0 in case of wraparound
+    return (__x == 0) ? _T{1} << (sizeof(_T) * CHAR_BIT - 1) : __x >> 1;
+#endif
+}
+
+// The max power of 2 not smaller than the given value, same as C++20 std::bit_ceil
+template <typename _T>
+::std::enable_if_t<::std::is_integral_v<_T> && ::std::is_unsigned_v<_T>, _T>
+__dpl_bit_ceil(_T __x) noexcept
+{
+    return ((__x & (__x - 1)) != 0) ? __dpl_bit_floor(__x) << 1 : __x;
+}
+
+// rounded up result of (__number / __divisor)
+template <typename _T1, typename _T2>
+constexpr auto
+__dpl_ceiling_div(_T1 __number, _T2 __divisor)
+{
+    return (__number - 1) / __divisor + 1;
+}
+
+template <typename _Acc, typename _Size1, typename _Value, typename _Compare,
+          ::std::enable_if_t<!::std::is_unsigned_v<_Size1>, int> = 0>
 _Size1
 __pstl_lower_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp)
 {
@@ -426,6 +491,28 @@ __pstl_lower_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __va
             __n = __cur;
     }
     return __first;
+}
+
+template <typename _Acc, typename _Size1, typename _Value, typename _Compare,
+          ::std::enable_if_t<::std::is_unsigned_v<_Size1>, int> = 0>
+_Size1
+__pstl_lower_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp)
+{
+    _Size1 __n = __last - __first;
+    _Size1 __offset = __first;
+    _Size1 __start = __dpl_bit_ceil(__n) / 2;
+    for (_Size1 __i = __start; __i >= 1; __i >>= 1)
+    {
+        _Size1 __idx = ::std::min(__n - 1, __offset + __i);
+        __offset = __comp(__acc[__idx], __value) ? __idx : __offset;
+    }
+    // Special handle the case where __comp is never satisifed
+    if (__offset == __first && !__comp(__acc[__first], __value))
+    {
+        return __first;
+    }
+    // First + offset is the __last place where __comp is true, so we must return the next index.
+    return __first + __offset + 1;
 }
 
 template <typename _Acc, typename _Size1, typename _Value, typename _Compare>
@@ -604,70 +691,6 @@ struct __lifetime_keeper : public __lifetime_keeper_base
     ::std::tuple<Ts...> __my_tmps;
     __lifetime_keeper(Ts... __t) : __my_tmps(::std::make_tuple(__t...)) {}
 };
-
-//-----------------------------------------------------------------------
-// Generic bit- and number-manipulation routines
-//-----------------------------------------------------------------------
-
-// Bitwise type casting, same as C++20 std::bit_cast
-template <typename _Dst, typename _Src>
-::std::enable_if_t<
-    sizeof(_Dst) == sizeof(_Src) && ::std::is_trivially_copyable_v<_Dst> && ::std::is_trivially_copyable_v<_Src>, _Dst>
-__dpl_bit_cast(const _Src& __src) noexcept
-{
-#if __cpp_lib_bit_cast >= 201806L
-    return ::std::bit_cast<_Dst>(__src);
-#elif _ONEDPL_BACKEND_SYCL && _ONEDPL_LIBSYCL_VERSION >= 50300
-    return sycl::bit_cast<_Dst>(__src);
-#elif __has_builtin(__builtin_bit_cast)
-    return __builtin_bit_cast(_Dst, __src);
-#else
-    _Dst __result;
-    ::std::memcpy(&__result, &__src, sizeof(_Dst));
-    return __result;
-#endif
-}
-
-// The max power of 2 not exceeding the given value, same as C++20 std::bit_floor
-template <typename _T>
-::std::enable_if_t<::std::is_integral_v<_T> && ::std::is_unsigned_v<_T>, _T>
-__dpl_bit_floor(_T __x) noexcept
-{
-    if (__x == 0)
-        return 0;
-#if __cpp_lib_int_pow2 >= 202002L
-    return ::std::bit_floor(__x);
-#elif _ONEDPL_BACKEND_SYCL
-    // Use the count-leading-zeros function
-    return _T{1} << (sizeof(_T) * CHAR_BIT - sycl::clz(__x) - 1);
-#else
-    // Fill all the lower bits with 1s
-    __x |= (__x >> 1);
-    __x |= (__x >> 2);
-    __x |= (__x >> 4);
-    if constexpr (sizeof(_T) > 1) __x |= (__x >> 8);
-    if constexpr (sizeof(_T) > 2) __x |= (__x >> 16);
-    if constexpr (sizeof(_T) > 4) __x |= (__x >> 32);
-    __x += 1; // Now it equals to the next greater power of 2, or 0 in case of wraparound
-    return (__x == 0) ? _T{1} << (sizeof(_T) * CHAR_BIT - 1) : __x >> 1;
-#endif
-}
-
-// The max power of 2 not smaller than the given value, same as C++20 std::bit_ceil
-template <typename _T>
-::std::enable_if_t<::std::is_integral_v<_T> && ::std::is_unsigned_v<_T>, _T>
-__dpl_bit_ceil(_T __x) noexcept
-{
-    return ((__x & (__x - 1)) != 0) ? __dpl_bit_floor(__x) << 1 : __x;
-}
-
-// rounded up result of (__number / __divisor)
-template <typename _T1, typename _T2>
-constexpr auto
-__dpl_ceiling_div(_T1 __number, _T2 __divisor)
-{
-    return (__number - 1) / __divisor + 1;
-}
 
 // TODO In C++20 we may try to use std::equality_comparable
 template <typename _Iterator1, typename _Iterator2, typename = void>


### PR DESCRIPTION
This PR introduces some additional tuning for the vectorized search algorithms (binary_search, lower_bound, and upper_bound) where a series of searches across a provided set of search keys are performed on a single input buffer.

The improvements are explained below:

1. In the current implementations, `__pstl_lower_bound`  / `__pstl_upper_bound` have been passed a 64-bit size type to compute indicies in its binary search. For inputs with a large number of search keys, this is a bottleneck in performance and rooflines have shown that this kernel is bound by 64-bit arithmetic. This PR introduces a 2-kernel solution where a 32-bit unsigned type is used for index calculation if there are less than ``2^32`` search keys with a fallback to 64-bit offset calculation otherwise. This results in a performance improvement across these algorithms of `~1.3x` on GPU Series Max 1550 for large inputs.
2. The second improvement is in the implementation of `__pstl_lower_bound`. Simplifying the loop body by checking descending powers-of-2 as opposed to continuously dividing the input size by `2` reduces the amount of total arithmetic in the compiled code and results in a performance improvement of `10-15%` for large inputs on top of the changes in `1`. This improvement requires the size type to be unsigned and is implemented as a new utility function: `__shars_lower_bound`.