### PR TITLE
Disable `for_loop` staff for hetero policies

### DIFF
--- a/include/oneapi/dpl/pstl/experimental/internal/for_loop.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/for_loop.h
@@ -56,6 +56,9 @@ template <typename _ExecutionPolicy, typename _Ip, typename... _Rest>
 void
 for_loop(_ExecutionPolicy&& __exec, type_identity_t<_Ip> __start, _Ip __finish, _Rest&&... __rest)
 {
+    static_assert(oneapi::dpl::__internal::__is_host_execution_policy<::std::decay_t<_ExecutionPolicy>>::value,
+                  "for_loop is implemented for the host policies only");
+
     oneapi::dpl::__internal::__for_loop_repack(::std::forward<_ExecutionPolicy>(__exec), __start, __finish,
                                                oneapi::dpl::__internal::__single_stride_type{},
                                                ::std::forward_as_tuple(::std::forward<_Rest>(__rest)...));
@@ -65,6 +68,9 @@ template <typename _ExecutionPolicy, typename _Ip, typename _Sp, typename... _Re
 void
 for_loop_strided(_ExecutionPolicy&& __exec, type_identity_t<_Ip> __start, _Ip __finish, _Sp __stride, _Rest&&... __rest)
 {
+    static_assert(oneapi::dpl::__internal::__is_host_execution_policy<::std::decay_t<_ExecutionPolicy>>::value,
+                  "for_loop_strided is implemented for the host policies only");
+
     oneapi::dpl::__internal::__for_loop_repack(::std::forward<_ExecutionPolicy>(__exec), __start, __finish, __stride,
                                                ::std::forward_as_tuple(::std::forward<_Rest>(__rest)...));
 }
@@ -73,6 +79,9 @@ template <typename _ExecutionPolicy, typename _Ip, typename _Size, typename... _
 void
 for_loop_n(_ExecutionPolicy&& __exec, _Ip __start, _Size __n, _Rest&&... __rest)
 {
+    static_assert(oneapi::dpl::__internal::__is_host_execution_policy<::std::decay_t<_ExecutionPolicy>>::value,
+                  "for_loop_n is implemented for the host policies only");
+
     oneapi::dpl::__internal::__for_loop_repack_n(::std::forward<_ExecutionPolicy>(__exec), __start, __n,
                                                  oneapi::dpl::__internal::__single_stride_type{},
                                                  ::std::forward_as_tuple(::std::forward<_Rest>(__rest)...));
@@ -82,6 +91,9 @@ template <typename _ExecutionPolicy, typename _Ip, typename _Size, typename _Sp,
 void
 for_loop_n_strided(_ExecutionPolicy&& __exec, _Ip __start, _Size __n, _Sp __stride, _Rest&&... __rest)
 {
+    static_assert(oneapi::dpl::__internal::__is_host_execution_policy<::std::decay_t<_ExecutionPolicy>>::value,
+                  "for_loop_n_strided is implemented for the host policies only");
+
     oneapi::dpl::__internal::__for_loop_repack_n(::std::forward<_ExecutionPolicy>(__exec), __start, __n, __stride,
                                                  ::std::forward_as_tuple(::std::forward<_Rest>(__rest)...));
 }

--- a/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
@@ -471,9 +471,6 @@ __pattern_for_loop(_ExecutionPolicy&& __exec, _Ip __first, _Ip __last, _Function
         __is_vector, ::std::true_type{}, ::std::forward<_Rest>(__rest)...);
 }
 
-template <typename _BackendTag>
-struct __hetero_tag;
-
 // Helper structure to split code functions for integral and iterator types so the return
 // value can be successfully deduced.
 template <typename _Ip>

--- a/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
@@ -471,6 +471,9 @@ __pattern_for_loop(_ExecutionPolicy&& __exec, _Ip __first, _Ip __last, _Function
         __is_vector, ::std::true_type{}, ::std::forward<_Rest>(__rest)...);
 }
 
+template <typename _BackendTag>
+struct __hetero_tag;
+
 // Helper structure to split code functions for integral and iterator types so the return
 // value can be successfully deduced.
 template <typename _Ip>
@@ -484,13 +487,11 @@ struct __use_par_vec_helper
         return typename _Tag::__is_vector{};
     }
 
-#if _ONEDPL_BACKEND_SYCL
     template <typename _BackendTag>
     static constexpr auto __get_is_vector(__hetero_tag<_BackendTag>)
     {
         return ::std::true_type{};
     }
-#endif // _ONEDPL_BACKEND_SYCL
 
     template <typename _Tag>
     static constexpr auto __get_is_parallel(_Tag)
@@ -498,13 +499,11 @@ struct __use_par_vec_helper
         return oneapi::dpl::__internal::__is_parallel_tag<_Tag>{};
     }
 
-#if _ONEDPL_BACKEND_SYCL
     template <typename _BackendTag>
     static constexpr auto __get_is_parallel(__hetero_tag<_BackendTag>)
     {
         return ::std::true_type{};
     }
-#endif // _ONEDPL_BACKEND_SYCL
 
   public:
     using __it_type = std::conditional_t<std::is_integral_v<_Ip>, _Ip*, _Ip>;

--- a/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
+++ b/include/oneapi/dpl/pstl/experimental/internal/for_loop_impl.h
@@ -476,33 +476,6 @@ __pattern_for_loop(_ExecutionPolicy&& __exec, _Ip __first, _Ip __last, _Function
 template <typename _Ip>
 struct __use_par_vec_helper
 {
-  protected:
-
-    template <typename _Tag>
-    static constexpr auto __get_is_vector(_Tag)
-    {
-        return typename _Tag::__is_vector{};
-    }
-
-    template <typename _BackendTag>
-    static constexpr auto __get_is_vector(__hetero_tag<_BackendTag>)
-    {
-        return ::std::true_type{};
-    }
-
-    template <typename _Tag>
-    static constexpr auto __get_is_parallel(_Tag)
-    {
-        return oneapi::dpl::__internal::__is_parallel_tag<_Tag>{};
-    }
-
-    template <typename _BackendTag>
-    static constexpr auto __get_is_parallel(__hetero_tag<_BackendTag>)
-    {
-        return ::std::true_type{};
-    }
-
-  public:
     using __it_type = std::conditional_t<std::is_integral_v<_Ip>, _Ip*, _Ip>;
 
     template <typename _ExecutionPolicy>
@@ -510,7 +483,7 @@ struct __use_par_vec_helper
     __use_vector(_ExecutionPolicy&& __exec)
     {
         using __tag_type = decltype(oneapi::dpl::__internal::__select_backend(__exec, std::declval<__it_type>()));
-        return __get_is_vector(__tag_type{});
+        return typename __tag_type::__is_vector{};
     }
 
     template <typename _ExecutionPolicy>
@@ -518,7 +491,7 @@ struct __use_par_vec_helper
     __use_parallel(_ExecutionPolicy&& __exec)
     {
         using __tag_type = decltype(oneapi::dpl::__internal::__select_backend(__exec, std::declval<__it_type>()));
-        return __get_is_parallel(__tag_type{});
+        return oneapi::dpl::__internal::__is_parallel_tag<__tag_type>{};
     }
 };
 

--- a/test/parallel_api/experimental/for_loop.pass.cpp
+++ b/test/parallel_api/experimental/for_loop.pass.cpp
@@ -296,8 +296,9 @@ test_for_loop()
         Sequence<T> in_out(n, Gen<T>());
         Sequence<T> expected = in_out;
 
-        invoke_on_all_policies<>()(test_for_loop_impl(), in_out.begin(), in_out.end(), expected.begin(), expected.end(),
-                                   in_out.size());
+        // for_loop staff is implemented for the host policies only
+        invoke_on_all_host_policies()(test_for_loop_impl(), in_out.begin(), in_out.end(), expected.begin(),
+                                      expected.end(), in_out.size());
     }
 }
 
@@ -313,8 +314,9 @@ test_for_loop_strided()
         ::std::vector<size_t> strides = {1, 2, 10, n > 1 ? n - 1 : 1, n > 0 ? n : 1, n + 1};
         for (size_t stride : strides)
         {
-            invoke_on_all_policies<>()(test_for_loop_strided_impl(), in_out.begin(), in_out.end(), expected.begin(),
-                                       expected.end(), in_out.size(), stride);
+            // for_loop staff is implemented for the host policies only
+            invoke_on_all_host_policies()(test_for_loop_strided_impl(), in_out.begin(), in_out.end(), expected.begin(),
+                                          expected.end(), in_out.size(), stride);
         }
     }
 }

--- a/test/parallel_api/experimental/for_loop_induction.pass.cpp
+++ b/test/parallel_api/experimental/for_loop_induction.pass.cpp
@@ -153,8 +153,10 @@ test()
     {
         Sequence<T> in_out(n, [](long int k) { return T(k % 5 != 1 ? 3 * k - 7 : 0); });
         Sequence<T> expected = in_out;
-        invoke_on_all_policies<>()(test_body(), in_out.begin(), in_out.end(), expected.begin(), expected.end(),
-                                   in_out.size());
+
+        // for_loop staff is implemented for the host policies only
+        invoke_on_all_host_policies()(test_body(), in_out.begin(), in_out.end(), expected.begin(), expected.end(),
+                                      in_out.size());
     }
 }
 

--- a/test/parallel_api/experimental/for_loop_reduction.pass.cpp
+++ b/test/parallel_api/experimental/for_loop_reduction.pass.cpp
@@ -77,8 +77,10 @@ test()
     {
         Sequence<T> in_out(n, [](long int k) { return T(k % 5 != 1 ? 3 * k - 7 : 0); });
         Sequence<T> expected = in_out;
-        invoke_on_all_policies<>()(test_body(), in_out.begin(), in_out.end(), expected.begin(), expected.end(),
-                                   in_out.size());
+
+        // for_loop staff is implemented for the host policies only
+        invoke_on_all_host_policies()(test_body(), in_out.begin(), in_out.end(), expected.begin(), expected.end(),
+                                      in_out.size());
     }
 }
 
@@ -176,10 +178,12 @@ test_predefined(::std::initializer_list<T> init_list)
     // Just arbitrary numbers
     Sequence<T> in_out = init_list;
     Sequence<T> expected = in_out;
-    invoke_on_all_policies<>()(test_body_predefined(), in_out.begin(), in_out.end(), expected.begin(), expected.end(),
-                               in_out.size());
-    invoke_on_all_policies<>()(test_body_predefined_bits(), in_out.begin(), in_out.end(), expected.begin(),
-                               expected.end(), in_out.size());
+
+    // for_loop staff is implemented for the host policies only
+    invoke_on_all_host_policies()(test_body_predefined(), in_out.begin(), in_out.end(), expected.begin(),
+                                  expected.end(), in_out.size());
+    invoke_on_all_host_policies()(test_body_predefined_bits(), in_out.begin(), in_out.end(), expected.begin(),
+                                  expected.end(), in_out.size());
 }
 
 void


### PR DESCRIPTION
Th goal of this PR - to exclude ability of works `for_loop` staff with hetero policies,
because we haven't hetero implementation for `for_loop` staff.

**ATTENTION**: after this fix our users will have compile errors if they are using `for_loop` staff with hetero policies.