### PR TITLE
Constrict index size types in lower_bound call in __find_start_point

### DIFF
--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -131,20 +131,22 @@ lower_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, Inpu
     auto keep_result = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read_write, OutputIterator>();
     auto result_buf = keep_result(result, result + value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
-    // Enable index calculation to proceed with uint32_t if input range is small enough. 
+    // Enable index calculation to proceed with uint32_t if input range is small enough.
     if (size <= ::std::numeric_limits<::std::uint32_t>::max())
     {
         __bknd::__parallel_for(::std::forward<Policy>(policy),
-                               custom_brick<StrictWeakOrdering, ::std::uint32_t, search_algorithm::lower_bound>{comp, static_cast<::std::uint32_t>(size)}, value_size,
-                               zip_vw)
+                               custom_brick<StrictWeakOrdering, ::std::uint32_t, search_algorithm::lower_bound>{
+                                   comp, static_cast<::std::uint32_t>(size)},
+                               value_size, zip_vw)
             .wait();
     }
     else
     {
         auto fallback_policy = __bknd::make_wrapped_policy<lower_bound_fallback>(::std::forward<Policy>(policy));
         __bknd::__parallel_for(::std::move(fallback_policy),
-                               custom_brick<StrictWeakOrdering, ::std::size_t, search_algorithm::lower_bound>{comp, static_cast<::std::size_t>(size)}, value_size,
-                               zip_vw)
+                               custom_brick<StrictWeakOrdering, ::std::size_t, search_algorithm::lower_bound>{
+                                   comp, static_cast<::std::size_t>(size)},
+                               value_size, zip_vw)
             .wait();
     }
     return result + value_size;
@@ -176,20 +178,22 @@ upper_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, Inpu
     auto keep_result = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read_write, OutputIterator>();
     auto result_buf = keep_result(result, result + value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
-    // Enable index calculation to proceed with uint32_t if input range is small enough. 
+    // Enable index calculation to proceed with uint32_t if input range is small enough.
     if (size <= ::std::numeric_limits<::std::uint32_t>::max())
     {
         __bknd::__parallel_for(::std::forward<Policy>(policy),
-                               custom_brick<StrictWeakOrdering, ::std::uint32_t, search_algorithm::upper_bound>{comp, static_cast<::std::uint32_t>(size)}, value_size,
-                               zip_vw)
+                               custom_brick<StrictWeakOrdering, ::std::uint32_t, search_algorithm::upper_bound>{
+                                   comp, static_cast<::std::uint32_t>(size)},
+                               value_size, zip_vw)
             .wait();
     }
     else
     {
         auto fallback_policy = __bknd::make_wrapped_policy<upper_bound_fallback>(::std::forward<Policy>(policy));
         __bknd::__parallel_for(::std::move(fallback_policy),
-                               custom_brick<StrictWeakOrdering, ::std::size_t, search_algorithm::upper_bound>{comp, static_cast<::std::size_t>(size)}, value_size,
-                               zip_vw)
+                               custom_brick<StrictWeakOrdering, ::std::size_t, search_algorithm::upper_bound>{
+                                   comp, static_cast<::std::size_t>(size)},
+                               value_size, zip_vw)
             .wait();
     }
     return result + value_size;
@@ -222,20 +226,22 @@ binary_search_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, In
     auto result_buf = keep_result(result, result + value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
 
-    // Enable index calculation to proceed with uint32_t if input range is small enough. 
+    // Enable index calculation to proceed with uint32_t if input range is small enough.
     if (size <= ::std::numeric_limits<::std::uint32_t>::max())
     {
         __bknd::__parallel_for(::std::forward<Policy>(policy),
-                               custom_brick<StrictWeakOrdering, ::std::uint32_t, search_algorithm::binary_search>{comp, static_cast<::std::uint32_t>(size)}, value_size,
-                               zip_vw)
+                               custom_brick<StrictWeakOrdering, ::std::uint32_t, search_algorithm::binary_search>{
+                                   comp, static_cast<::std::uint32_t>(size)},
+                               value_size, zip_vw)
             .wait();
     }
     else
     {
         auto fallback_policy = __bknd::make_wrapped_policy<binary_search_fallback>(::std::forward<Policy>(policy));
         __bknd::__parallel_for(::std::move(fallback_policy),
-                               custom_brick<StrictWeakOrdering, ::std::size_t, search_algorithm::binary_search>{comp, static_cast<::std::size_t>(size)}, value_size,
-                               zip_vw)
+                               custom_brick<StrictWeakOrdering, ::std::size_t, search_algorithm::binary_search>{
+                                   comp, static_cast<::std::size_t>(size)},
+                               value_size, zip_vw)
             .wait();
     }
     return result + value_size;

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -51,18 +51,18 @@ struct custom_brick
         using ::std::get;
         if constexpr (func == search_algorithm::lower_bound)
         {
-            get<2>(acc[idx]) = oneapi::dpl::internal::lower_bound_fun(get<0>(acc.tuple()), start_orig, end_orig,
-                                                                      get<1>(acc[idx]), comp);
+            get<2>(acc[idx]) = oneapi::dpl::__internal::__pstl_lower_bound(get<0>(acc.tuple()), start_orig, end_orig,
+                                                                           get<1>(acc[idx]), comp);
         }
-        else if (func == search_algorithm::upper_bound)
+        else if constexpr (func == search_algorithm::upper_bound)
         {
-            get<2>(acc[idx]) = oneapi::dpl::internal::upper_bound_fun(get<0>(acc.tuple()), start_orig, end_orig,
-                                                                      get<1>(acc[idx]), comp);
+            get<2>(acc[idx]) = oneapi::dpl::__internal::__pstl_upper_bound(get<0>(acc.tuple()), start_orig, end_orig,
+                                                                           get<1>(acc[idx]), comp);
         }
         else
         {
-            auto value = oneapi::dpl::internal::lower_bound_fun(get<0>(acc.tuple()), start_orig, end_orig,
-                                                                get<1>(acc[idx]), comp);
+            auto value = oneapi::dpl::__internal::__pstl_lower_bound(get<0>(acc.tuple()), start_orig, end_orig,
+                                                                     get<1>(acc[idx]), comp);
             get<2>(acc[idx]) = (value != end_orig) && (get<1>(acc[idx]) == get<0>(acc[value]));
         }
     }

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -139,7 +139,7 @@ lower_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, Inpu
     else
     {
         __bknd::__parallel_for(::std::forward<Policy>(policy),
-                               custom_brick<StrictWeakOrdering, decltype(size), lower_bound>{comp, size}, value_size,
+                               custom_brick<StrictWeakOrdering, ::std::size_t, lower_bound>{comp, static_cast<::std::size_t>(size)}, value_size,
                                zip_vw)
             .wait();
     }
@@ -180,7 +180,7 @@ upper_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, Inpu
     else
     {
         __bknd::__parallel_for(::std::forward<Policy>(policy),
-                               custom_brick<StrictWeakOrdering, decltype(size), upper_bound>{comp, size}, value_size,
+                               custom_brick<StrictWeakOrdering, ::std::size_t, upper_bound>{comp, static_cast<::std::size_t>(size)}, value_size,
                                zip_vw)
             .wait();
     }
@@ -221,7 +221,7 @@ binary_search_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, In
     else
     {
         __bknd::__parallel_for(::std::forward<Policy>(policy),
-                               custom_brick<StrictWeakOrdering, decltype(size), binary_search>{comp, size}, value_size,
+                               custom_brick<StrictWeakOrdering, ::std::size_t, binary_search>{comp, static_cast<::std::size_t>(size)}, value_size,
                                zip_vw)
             .wait();
     }

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -58,7 +58,6 @@ struct custom_brick
         {
             get<2>(acc[idx]) = oneapi::dpl::internal::branchless_lower_bound(get<0>(acc.tuple()), start_orig, end_orig,
                                                                              get<1>(acc[idx]), comp);
-
         }
         else
         {
@@ -129,10 +128,11 @@ lower_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, Inpu
     auto keep_result = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read_write, OutputIterator>();
     auto result_buf = keep_result(result, result + value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
+    // Enable index calculation to proceed with uint32_t if input range is small enough. 
     if (size <= ::std::numeric_limits<::std::uint32_t>::max())
     {
         __bknd::__parallel_for(::std::forward<Policy>(policy),
-                               custom_brick<StrictWeakOrdering, ::std::uint32_t, lower_bound>{comp, size}, value_size,
+                               custom_brick<StrictWeakOrdering, ::std::uint32_t, lower_bound>{comp, static_cast<::std::uint32_t>(size)}, value_size,
                                zip_vw)
             .wait();
     }
@@ -169,12 +169,11 @@ upper_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, Inpu
     auto keep_result = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read_write, OutputIterator>();
     auto result_buf = keep_result(result, result + value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
-
     // Enable index calculation to proceed with uint32_t if input range is small enough. 
     if (size <= ::std::numeric_limits<::std::uint32_t>::max())
     {
         __bknd::__parallel_for(::std::forward<Policy>(policy),
-                               custom_brick<StrictWeakOrdering, ::std::uint32_t, upper_bound>{comp, size}, value_size,
+                               custom_brick<StrictWeakOrdering, ::std::uint32_t, upper_bound>{comp, static_cast<::std::uint32_t>(size)}, value_size,
                                zip_vw)
             .wait();
     }
@@ -211,12 +210,11 @@ binary_search_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, In
     auto keep_result = oneapi::dpl::__ranges::__get_sycl_range<__bknd::access_mode::read_write, OutputIterator>();
     auto result_buf = keep_result(result, result + value_size);
     auto zip_vw = make_zip_view(input_buf.all_view(), value_buf.all_view(), result_buf.all_view());
-
     // Enable index calculation to proceed with uint32_t if input range is small enough. 
     if (size <= ::std::numeric_limits<::std::uint32_t>::max())
     {
         __bknd::__parallel_for(::std::forward<Policy>(policy),
-                               custom_brick<StrictWeakOrdering, ::std::uint32_t, binary_search>{comp, size}, value_size,
+                               custom_brick<StrictWeakOrdering, ::std::uint32_t, binary_search>{comp, static_cast<::std::uint32_t>(size)}, value_size,
                                zip_vw)
             .wait();
     }

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -56,7 +56,7 @@ struct custom_brick
         }
         else if (func == 1)
         {
-            get<2>(acc[idx]) = oneapi::dpl::internal::branchless_lower_bound(get<0>(acc.tuple()), start_orig, end_orig,
+            get<2>(acc[idx]) = oneapi::dpl::internal::branchless_upper_bound(get<0>(acc.tuple()), start_orig, end_orig,
                                                                              get<1>(acc[idx]), comp);
         }
         else

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -29,14 +29,14 @@ namespace dpl
 namespace internal
 {
 
-enum search_algorithm
+enum class search_algorithm
 {
     lower_bound,
     upper_bound,
     binary_search
 };
 
-template <typename Comp, typename T, int func>
+template <typename Comp, typename T, search_algorithm func>
 struct custom_brick
 {
     Comp comp;
@@ -49,12 +49,12 @@ struct custom_brick
         T start_orig = 0;
         auto end_orig = size;
         using ::std::get;
-        if constexpr (func == 0)
+        if constexpr (func == search_algorithm::lower_bound)
         {
             get<2>(acc[idx]) = oneapi::dpl::internal::lower_bound_fun(get<0>(acc.tuple()), start_orig, end_orig,
                                                                       get<1>(acc[idx]), comp);
         }
-        else if (func == 1)
+        else if (func == search_algorithm::upper_bound)
         {
             get<2>(acc[idx]) = oneapi::dpl::internal::upper_bound_fun(get<0>(acc.tuple()), start_orig, end_orig,
                                                                       get<1>(acc[idx]), comp);
@@ -135,7 +135,7 @@ lower_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, Inpu
     if (size <= ::std::numeric_limits<::std::uint32_t>::max())
     {
         __bknd::__parallel_for(::std::forward<Policy>(policy),
-                               custom_brick<StrictWeakOrdering, ::std::uint32_t, lower_bound>{comp, static_cast<::std::uint32_t>(size)}, value_size,
+                               custom_brick<StrictWeakOrdering, ::std::uint32_t, search_algorithm::lower_bound>{comp, static_cast<::std::uint32_t>(size)}, value_size,
                                zip_vw)
             .wait();
     }
@@ -143,7 +143,7 @@ lower_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, Inpu
     {
         auto fallback_policy = __bknd::make_wrapped_policy<lower_bound_fallback>(::std::forward<Policy>(policy));
         __bknd::__parallel_for(::std::move(fallback_policy),
-                               custom_brick<StrictWeakOrdering, ::std::size_t, lower_bound>{comp, static_cast<::std::size_t>(size)}, value_size,
+                               custom_brick<StrictWeakOrdering, ::std::size_t, search_algorithm::lower_bound>{comp, static_cast<::std::size_t>(size)}, value_size,
                                zip_vw)
             .wait();
     }
@@ -180,7 +180,7 @@ upper_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, Inpu
     if (size <= ::std::numeric_limits<::std::uint32_t>::max())
     {
         __bknd::__parallel_for(::std::forward<Policy>(policy),
-                               custom_brick<StrictWeakOrdering, ::std::uint32_t, upper_bound>{comp, static_cast<::std::uint32_t>(size)}, value_size,
+                               custom_brick<StrictWeakOrdering, ::std::uint32_t, search_algorithm::upper_bound>{comp, static_cast<::std::uint32_t>(size)}, value_size,
                                zip_vw)
             .wait();
     }
@@ -188,7 +188,7 @@ upper_bound_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, Inpu
     {
         auto fallback_policy = __bknd::make_wrapped_policy<upper_bound_fallback>(::std::forward<Policy>(policy));
         __bknd::__parallel_for(::std::move(fallback_policy),
-                               custom_brick<StrictWeakOrdering, ::std::size_t, upper_bound>{comp, static_cast<::std::size_t>(size)}, value_size,
+                               custom_brick<StrictWeakOrdering, ::std::size_t, search_algorithm::upper_bound>{comp, static_cast<::std::size_t>(size)}, value_size,
                                zip_vw)
             .wait();
     }
@@ -226,7 +226,7 @@ binary_search_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, In
     if (size <= ::std::numeric_limits<::std::uint32_t>::max())
     {
         __bknd::__parallel_for(::std::forward<Policy>(policy),
-                               custom_brick<StrictWeakOrdering, ::std::uint32_t, binary_search>{comp, static_cast<::std::uint32_t>(size)}, value_size,
+                               custom_brick<StrictWeakOrdering, ::std::uint32_t, search_algorithm::binary_search>{comp, static_cast<::std::uint32_t>(size)}, value_size,
                                zip_vw)
             .wait();
     }
@@ -234,7 +234,7 @@ binary_search_impl(Policy&& policy, InputIterator1 start, InputIterator1 end, In
     {
         auto fallback_policy = __bknd::make_wrapped_policy<binary_search_fallback>(::std::forward<Policy>(policy));
         __bknd::__parallel_for(::std::move(fallback_policy),
-                               custom_brick<StrictWeakOrdering, ::std::size_t, binary_search>{comp, static_cast<::std::size_t>(size)}, value_size,
+                               custom_brick<StrictWeakOrdering, ::std::size_t, search_algorithm::binary_search>{comp, static_cast<::std::size_t>(size)}, value_size,
                                zip_vw)
             .wait();
     }

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -20,6 +20,7 @@
 #include "function.h"
 #include "binary_search_extension_defs.h"
 #include "../pstl/iterator_impl.h"
+#include "../pstl/utils.h"
 
 namespace oneapi
 {
@@ -51,18 +52,18 @@ struct custom_brick
         using ::std::get;
         if constexpr (func == search_algorithm::lower_bound)
         {
-            get<2>(acc[idx]) = oneapi::dpl::__internal::__pstl_lower_bound(get<0>(acc.tuple()), start_orig, end_orig,
-                                                                           get<1>(acc[idx]), comp);
+            get<2>(acc[idx]) = oneapi::dpl::__internal::__shars_lower_bound(get<0>(acc.tuple()), start_orig, end_orig,
+                                                                            get<1>(acc[idx]), comp);
         }
         else if constexpr (func == search_algorithm::upper_bound)
         {
-            get<2>(acc[idx]) = oneapi::dpl::__internal::__pstl_upper_bound(get<0>(acc.tuple()), start_orig, end_orig,
-                                                                           get<1>(acc[idx]), comp);
+            get<2>(acc[idx]) = oneapi::dpl::__internal::__shars_upper_bound(get<0>(acc.tuple()), start_orig, end_orig,
+                                                                            get<1>(acc[idx]), comp);
         }
         else
         {
-            auto value = oneapi::dpl::__internal::__pstl_lower_bound(get<0>(acc.tuple()), start_orig, end_orig,
-                                                                     get<1>(acc[idx]), comp);
+            auto value = oneapi::dpl::__internal::__shars_lower_bound(get<0>(acc.tuple()), start_orig, end_orig,
+                                                                      get<1>(acc[idx]), comp);
             get<2>(acc[idx]) = (value != end_orig) && (get<1>(acc[idx]) == get<0>(acc[value]));
         }
     }

--- a/include/oneapi/dpl/internal/function.h
+++ b/include/oneapi/dpl/internal/function.h
@@ -165,27 +165,27 @@ branchless_lower_bound(Acc acc, IdxT first, IdxT last, const Value& value, Compa
     IdxT cur = n;
 #if 0
     IdxT it;
-    while (__n > 0)
+    while (n > 0)
     {
-        __it = __first;
-        __cur = __n / 2;
-        __it += __cur;
-        if (__comp(__acc[__it], __value))
+        it = first;
+        cur = n / 2;
+        it += cur;
+        if (comp(acc[it], value))
         {
-            __n -= __cur + 1, __first = ++__it;
+            n -= cur + 1, first = ++it;
         }
         else
-            __n = __cur;
+            n = cur;
     }
-    return __first;
+    return first;
 #else
     // TODO: Evaluate wider scale correctness 
     IdxT offset = 0;
     // TODO: Figure out a good way to check '<=' instead of just '<' which __comp defines. 
-    for (IdxT i = __n / 2; i >= 1; i >>= 1)
-        offset += std::min(__n - 1, IdxT((__comp(__acc[offset + i], __value) || __acc[offset + i] == __value) * i));
+    for (IdxT i = n / 2; i >= 1; i >>= 1)
+        offset += std::min(n - 1, IdxT((comp(acc[offset + i], value) || acc[offset + i] == value) * i));
 
-    return __first + offset;
+    return first + offset;
 #endif
 }
 } // namespace internal

--- a/include/oneapi/dpl/internal/function.h
+++ b/include/oneapi/dpl/internal/function.h
@@ -166,10 +166,15 @@ branchless_lower_bound(Acc acc, IdxT first, IdxT last, const Value& value, Compa
     IdxT offset = 0;
     IdxT start = oneapi::dpl::__internal::__dpl_bit_ceil(n) / 2;
     // TODO: Figure out a good way to check '<=' instead of just '<' which __comp defines. 
-    for (IdxT i = start; i >= 1; i /= 2)
+    for (IdxT i = start; i >= 2; i >>= 1)
     {
-        IdxT idx = ::std::min(n-1, offset + i);
-        offset += IdxT(comp(acc[idx], value) || acc[idx] == value) * i;
+        IdxT idx = offset + i;
+        offset += static_cast<IdxT>(comp(acc[idx], value) || acc[idx] == value) * i;
+    }
+    if (n > 1)
+    {
+        IdxT idx = ::std::min(n-1, offset + 1);
+        offset += static_cast<IdxT>(comp(acc[idx], value) || acc[idx] == value);
     }
     return first + offset;
 }

--- a/include/oneapi/dpl/internal/function.h
+++ b/include/oneapi/dpl/internal/function.h
@@ -163,21 +163,15 @@ IdxT
 lower_bound_fun(Acc acc, IdxT first, IdxT last, const Value& value, Compare comp)
 {
     IdxT n = last - first;
-    IdxT offset = 0;
+    IdxT offset = first;
     IdxT start = oneapi::dpl::__internal::__dpl_bit_ceil(n) / 2;
-    for (IdxT i = start; i >= 2; i >>= 1)
+    for (IdxT i = start; i >= 1; i >>= 1)
     {
-        IdxT idx = offset + i;
-        offset += static_cast<IdxT>(comp(acc[idx], value)) * i;
-    }
-    // Hoist the last case to special handle non-powers of two.
-    if (n > 1)
-    {
-        IdxT idx = ::std::min(n - 1, offset + 1);
-        offset += static_cast<IdxT>(comp(acc[idx], value));
+        IdxT idx = ::std::min(n - 1, offset + i);
+        offset = comp(acc[idx], value) ? idx : offset;
     }
     // Special handle the case where comp is never satisifed
-    if (offset == 0 && !comp(acc[0], value))
+    if (offset == first && !comp(acc[first], value))
     {
         return first;
     }

--- a/include/oneapi/dpl/internal/function.h
+++ b/include/oneapi/dpl/internal/function.h
@@ -155,12 +155,12 @@ class transform_if_stencil_fun
     UnaryOperation op;
 };
 
-// Lower bound functor more suitable to SIMD / SIMT style execution to minimize subgroup divergence.
+// Lower bound function for vectorized lower bound intended to minimize subgroup divergence.
 // Runs in Theta(log2(input size)) time.
 // Used by: binary_search and lower_bound.
 template <typename Acc, typename IdxT, typename Value, typename Compare>
 IdxT
-branchless_lower_bound(Acc acc, IdxT first, IdxT last, const Value& value, Compare comp)
+lower_bound_fun(Acc acc, IdxT first, IdxT last, const Value& value, Compare comp)
 {
     IdxT n = last - first;
     IdxT offset = 0;
@@ -188,11 +188,11 @@ branchless_lower_bound(Acc acc, IdxT first, IdxT last, const Value& value, Compa
 // Used by: upper_bound.
 template <typename Acc, typename IdxT, typename Value, typename Compare>
 IdxT
-branchless_upper_bound(Acc acc, IdxT first, IdxT last, const Value& value, Compare comp)
+upper_bound_fun(Acc acc, IdxT first, IdxT last, const Value& value, Compare comp)
 {
-    return branchless_lower_bound(acc, first, last, value,
-                                  oneapi::dpl::__internal::__not_pred<oneapi::dpl::__internal::__reorder_pred<Compare>>{
-                                      oneapi::dpl::__internal::__reorder_pred<Compare>{comp}});
+    return lower_bound_fun(acc, first, last, value,
+                           oneapi::dpl::__internal::__not_pred<oneapi::dpl::__internal::__reorder_pred<Compare>>{
+                               oneapi::dpl::__internal::__reorder_pred<Compare>{comp}});
 }
 } // namespace internal
 } // namespace dpl

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1359,7 +1359,7 @@ __find_start_point(const _Rng1& __rng1, const _Rng2& __rng2, _Index __i_elem, _I
 
         //searching for the first '1', a lower bound for a diagonal [0, 0,..., 0, 1, 1,.... 1, 1]
         oneapi::dpl::counting_iterator<_Index> __diag_it(0);
-        auto __res = ::std::lower_bound(__diag_it, __diag_it + __n_diag, 1/*value to find*/,
+        auto __res = __diag_it + oneapi::dpl::__internal::__pstl_lower_bound(__diag_it, static_cast<_Index>(0), static_cast<_Index>(__n_diag), 1/*value to find*/,
             [&__rng2, &__rng1, __q, __comp](const auto& __i_diag, const auto& __value) mutable
             {
                 auto __zero_or_one = __comp(__rng2[__q - __i_diag - 1], __rng1[__i_diag]);
@@ -1375,7 +1375,7 @@ __find_start_point(const _Rng1& __rng1, const _Rng2& __rng2, _Index __i_elem, _I
 
         //searching for the first '1', a lower bound for a diagonal [0, 0,..., 0, 1, 1,.... 1, 1]
         oneapi::dpl::counting_iterator<_Index> __diag_it(0);
-        auto __res = ::std::lower_bound(__diag_it, __diag_it + __n_diag, 1/*value to find*/,
+        auto __res = __diag_it + oneapi::dpl::__internal::__pstl_lower_bound(__diag_it, static_cast<_Index>(0), static_cast<_Index>(__n_diag), 1/*value to find*/,
             [&__rng2, &__rng1, __n2, __q, __comp](const auto& __i_diag, const auto& __value) mutable
             {
                 auto __zero_or_one = __comp(__rng2[__n2 - __i_diag - 1], __rng1[__q + __i_diag]);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1359,7 +1359,7 @@ __find_start_point(const _Rng1& __rng1, const _Rng2& __rng2, _Index __i_elem, _I
 
         //searching for the first '1', a lower bound for a diagonal [0, 0,..., 0, 1, 1,.... 1, 1]
         oneapi::dpl::counting_iterator<_Index> __diag_it(0);
-        auto __res = __diag_it + oneapi::dpl::__internal::__pstl_lower_bound(__diag_it, static_cast<_Index>(0), static_cast<_Index>(__n_diag), 1/*value to find*/,
+        auto __res = __diag_it + oneapi::dpl::__internal::__shars_lower_bound(__diag_it, static_cast<_Index>(0), static_cast<_Index>(__n_diag), 1/*value to find*/,
             [&__rng2, &__rng1, __q, __comp](const auto& __i_diag, const auto& __value) mutable
             {
                 auto __zero_or_one = __comp(__rng2[__q - __i_diag - 1], __rng1[__i_diag]);
@@ -1375,7 +1375,7 @@ __find_start_point(const _Rng1& __rng1, const _Rng2& __rng2, _Index __i_elem, _I
 
         //searching for the first '1', a lower bound for a diagonal [0, 0,..., 0, 1, 1,.... 1, 1]
         oneapi::dpl::counting_iterator<_Index> __diag_it(0);
-        auto __res = __diag_it + oneapi::dpl::__internal::__pstl_lower_bound(__diag_it, static_cast<_Index>(0), static_cast<_Index>(__n_diag), 1/*value to find*/,
+        auto __res = __diag_it + oneapi::dpl::__internal::__shars_lower_bound(__diag_it, static_cast<_Index>(0), static_cast<_Index>(__n_diag), 1/*value to find*/,
             [&__rng2, &__rng1, __n2, __q, __comp](const auto& __i_diag, const auto& __value) mutable
             {
                 auto __zero_or_one = __comp(__rng2[__n2 - __i_diag - 1], __rng1[__q + __i_diag]);

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -718,11 +718,11 @@ struct __spirv_target_conditional :
 inline constexpr bool __is_spirv_target_v = __spirv_target_conditional<::std::true_type, ::std::false_type>::value;
 
 // Lower bound implementation based on Shar's algorithm for binary search.
-template <typename _Acc, typename _Size1, typename _Value, typename _Compare,
-          ::std::enable_if_t<::std::is_unsigned_v<_Size1>, int> = 0>
+template <typename _Acc, typename _Size1, typename _Value, typename _Compare>
 _Size1
 __shars_lower_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp)
 {
+    static_assert(::std::is_unsigned_v<_Size1>, "__shars_lower_bound requires an unsigned size type");
     _Size1 __n = __last - __first;
     if (__n == 0)
         return __first;

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -506,7 +506,7 @@ __pstl_lower_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __va
         _Size1 __idx = ::std::min(__n - 1, __offset + __i);
         __offset = __comp(__acc[__idx], __value) ? __idx : __offset;
     }
-    // Special handle the case where __comp is never satisifed
+    // Special handle the case where __comp is never satisfied.
     if (__offset == __first && (__n == 0 || !__comp(__acc[__first], __value)))
     {
         return __first;

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -507,7 +507,7 @@ __pstl_lower_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __va
         __offset = __comp(__acc[__idx], __value) ? __idx : __offset;
     }
     // Special handle the case where __comp is never satisifed
-    if (__offset == __first && !__comp(__acc[__first], __value))
+    if (__offset == __first && (n == 0 || !__comp(__acc[__first], __value)))
     {
         return __first;
     }

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -507,7 +507,7 @@ __pstl_lower_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __va
         __offset = __comp(__acc[__idx], __value) ? __idx : __offset;
     }
     // Special handle the case where __comp is never satisifed
-    if (__offset == __first && (n == 0 || !__comp(__acc[__first], __value)))
+    if (__offset == __first && (__n == 0 || !__comp(__acc[__first], __value)))
     {
         return __first;
     }

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -406,7 +406,72 @@ __cmp_iterators_by_values(_ForwardIterator __a, _ForwardIterator __b, _Compare _
     }
 }
 
-template <typename _Acc, typename _Size1, typename _Value, typename _Compare>
+//-----------------------------------------------------------------------
+// Generic bit- and number-manipulation routines
+//-----------------------------------------------------------------------
+
+// Bitwise type casting, same as C++20 std::bit_cast
+template <typename _Dst, typename _Src>
+::std::enable_if_t<
+    sizeof(_Dst) == sizeof(_Src) && ::std::is_trivially_copyable_v<_Dst> && ::std::is_trivially_copyable_v<_Src>, _Dst>
+__dpl_bit_cast(const _Src& __src) noexcept
+{
+#if __cpp_lib_bit_cast >= 201806L
+    return ::std::bit_cast<_Dst>(__src);
+#elif _ONEDPL_BACKEND_SYCL && _ONEDPL_LIBSYCL_VERSION >= 50300
+    return sycl::bit_cast<_Dst>(__src);
+#elif __has_builtin(__builtin_bit_cast)
+    return __builtin_bit_cast(_Dst, __src);
+#else
+    _Dst __result;
+    ::std::memcpy(&__result, &__src, sizeof(_Dst));
+    return __result;
+#endif
+}
+
+// The max power of 2 not exceeding the given value, same as C++20 std::bit_floor
+template <typename _T>
+::std::enable_if_t<::std::is_integral_v<_T> && ::std::is_unsigned_v<_T>, _T>
+__dpl_bit_floor(_T __x) noexcept
+{
+    if (__x == 0)
+        return 0;
+#if __cpp_lib_int_pow2 >= 202002L
+    return ::std::bit_floor(__x);
+#elif _ONEDPL_BACKEND_SYCL
+    // Use the count-leading-zeros function
+    return _T{1} << (sizeof(_T) * CHAR_BIT - sycl::clz(__x) - 1);
+#else
+    // Fill all the lower bits with 1s
+    __x |= (__x >> 1);
+    __x |= (__x >> 2);
+    __x |= (__x >> 4);
+    if constexpr (sizeof(_T) > 1) __x |= (__x >> 8);
+    if constexpr (sizeof(_T) > 2) __x |= (__x >> 16);
+    if constexpr (sizeof(_T) > 4) __x |= (__x >> 32);
+    __x += 1; // Now it equals to the next greater power of 2, or 0 in case of wraparound
+    return (__x == 0) ? _T{1} << (sizeof(_T) * CHAR_BIT - 1) : __x >> 1;
+#endif
+}
+
+// The max power of 2 not smaller than the given value, same as C++20 std::bit_ceil
+template <typename _T>
+::std::enable_if_t<::std::is_integral_v<_T> && ::std::is_unsigned_v<_T>, _T>
+__dpl_bit_ceil(_T __x) noexcept
+{
+    return ((__x & (__x - 1)) != 0) ? __dpl_bit_floor(__x) << 1 : __x;
+}
+
+// rounded up result of (__number / __divisor)
+template <typename _T1, typename _T2>
+constexpr auto
+__dpl_ceiling_div(_T1 __number, _T2 __divisor)
+{
+    return (__number - 1) / __divisor + 1;
+}
+
+template <typename _Acc, typename _Size1, typename _Value, typename _Compare,
+          ::std::enable_if_t<!::std::is_unsigned_v<_Size1>, int> = 0>
 _Size1
 __pstl_lower_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp)
 {
@@ -426,6 +491,28 @@ __pstl_lower_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __va
             __n = __cur;
     }
     return __first;
+}
+
+template <typename _Acc, typename _Size1, typename _Value, typename _Compare,
+          ::std::enable_if_t<::std::is_unsigned_v<_Size1>, int> = 0>
+_Size1
+__pstl_lower_bound(_Acc __acc, _Size1 __first, _Size1 __last, const _Value& __value, _Compare __comp)
+{
+    _Size1 __n = __last - __first;
+    _Size1 __offset = __first;
+    _Size1 __start = __dpl_bit_ceil(__n) / 2;
+    for (_Size1 __i = __start; __i >= 1; __i >>= 1)
+    {
+        _Size1 __idx = ::std::min(__n - 1, __offset + __i);
+        __offset = __comp(__acc[__idx], __value) ? __idx : __offset;
+    }
+    // Special handle the case where __comp is never satisifed
+    if (__offset == __first && !__comp(__acc[__first], __value))
+    {
+        return __first;
+    }
+    // First + offset is the __last place where __comp is true, so we must return the next index.
+    return __first + __offset + 1;
 }
 
 template <typename _Acc, typename _Size1, typename _Value, typename _Compare>
@@ -604,70 +691,6 @@ struct __lifetime_keeper : public __lifetime_keeper_base
     ::std::tuple<Ts...> __my_tmps;
     __lifetime_keeper(Ts... __t) : __my_tmps(::std::make_tuple(__t...)) {}
 };
-
-//-----------------------------------------------------------------------
-// Generic bit- and number-manipulation routines
-//-----------------------------------------------------------------------
-
-// Bitwise type casting, same as C++20 std::bit_cast
-template <typename _Dst, typename _Src>
-::std::enable_if_t<
-    sizeof(_Dst) == sizeof(_Src) && ::std::is_trivially_copyable_v<_Dst> && ::std::is_trivially_copyable_v<_Src>, _Dst>
-__dpl_bit_cast(const _Src& __src) noexcept
-{
-#if __cpp_lib_bit_cast >= 201806L
-    return ::std::bit_cast<_Dst>(__src);
-#elif _ONEDPL_BACKEND_SYCL && _ONEDPL_LIBSYCL_VERSION >= 50300
-    return sycl::bit_cast<_Dst>(__src);
-#elif __has_builtin(__builtin_bit_cast)
-    return __builtin_bit_cast(_Dst, __src);
-#else
-    _Dst __result;
-    ::std::memcpy(&__result, &__src, sizeof(_Dst));
-    return __result;
-#endif
-}
-
-// The max power of 2 not exceeding the given value, same as C++20 std::bit_floor
-template <typename _T>
-::std::enable_if_t<::std::is_integral_v<_T> && ::std::is_unsigned_v<_T>, _T>
-__dpl_bit_floor(_T __x) noexcept
-{
-    if (__x == 0)
-        return 0;
-#if __cpp_lib_int_pow2 >= 202002L
-    return ::std::bit_floor(__x);
-#elif _ONEDPL_BACKEND_SYCL
-    // Use the count-leading-zeros function
-    return _T{1} << (sizeof(_T) * CHAR_BIT - sycl::clz(__x) - 1);
-#else
-    // Fill all the lower bits with 1s
-    __x |= (__x >> 1);
-    __x |= (__x >> 2);
-    __x |= (__x >> 4);
-    if constexpr (sizeof(_T) > 1) __x |= (__x >> 8);
-    if constexpr (sizeof(_T) > 2) __x |= (__x >> 16);
-    if constexpr (sizeof(_T) > 4) __x |= (__x >> 32);
-    __x += 1; // Now it equals to the next greater power of 2, or 0 in case of wraparound
-    return (__x == 0) ? _T{1} << (sizeof(_T) * CHAR_BIT - 1) : __x >> 1;
-#endif
-}
-
-// The max power of 2 not smaller than the given value, same as C++20 std::bit_ceil
-template <typename _T>
-::std::enable_if_t<::std::is_integral_v<_T> && ::std::is_unsigned_v<_T>, _T>
-__dpl_bit_ceil(_T __x) noexcept
-{
-    return ((__x & (__x - 1)) != 0) ? __dpl_bit_floor(__x) << 1 : __x;
-}
-
-// rounded up result of (__number / __divisor)
-template <typename _T1, typename _T2>
-constexpr auto
-__dpl_ceiling_div(_T1 __number, _T2 __divisor)
-{
-    return (__number - 1) / __divisor + 1;
-}
 
 // TODO In C++20 we may try to use std::equality_comparable
 template <typename _Iterator1, typename _Iterator2, typename = void>


### PR DESCRIPTION
`__find_start_point` is the first step in the merge pattern prior to serial merging. One of the current optimizations employed in the merge pattern is to restrict the `_Index` size type used for index calculation based on if the some of the two buffer sizes can fit in a `uint32_t` variable. `__find_start_point` receives this index type as `_Index`.

By switching to using `__pstl_lower_bound` in `__find_start_point` instead of `std::lower_bound` we can use the same optimization in this call. Coupled with the changes in https://github.com/oneapi-src/oneDPL/pull/1446, I have observed a 1.25x improvement in merge performance for merging of two `2^28` float buffers on GPU Series Max 1550.

https://github.com/oneapi-src/oneDPL/pull/1446 should be merged prior to this PR as the `__shars_lower_bound` algorithm must be used to observe significant benefit.