### PR TITLE
Fix compile errors in `ranges` tests

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -148,8 +148,8 @@ __pattern_find_end(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _
 
     if (__rng1.size() == __rng2.size())
     {
-        const bool __res = __pattern_equal(__tag, ::std::forward<_ExecutionPolicy>(__exec), __rng1,
-                                           ::std::forward<_Range2>(__rng2), __pred);
+        const bool __res = __ranges::__pattern_equal(__tag, ::std::forward<_ExecutionPolicy>(__exec), __rng1,
+                                                     ::std::forward<_Range2>(__rng2), __pred);
         return __res ? 0 : __rng1.size();
     }
 
@@ -228,7 +228,7 @@ __pattern_search(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ra
 
     if (__rng1.size() == __rng2.size())
     {
-        const bool __res = __pattern_equal(
+        const bool __res = __ranges::__pattern_equal(
             __tag, __par_backend_hetero::make_wrapped_policy<equal_wrapper>(::std::forward<_ExecutionPolicy>(__exec)),
             __rng1, ::std::forward<_Range2>(__rng2), __pred);
         return __res ? 0 : __rng1.size();
@@ -416,8 +416,8 @@ __pattern_remove_if(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
     oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec, __rng.size());
     auto __copy_rng = oneapi::dpl::__ranges::views::all(__buf.get_buffer());
 
-    auto __copy_last_id = __pattern_copy_if(__tag, __exec, __rng, __copy_rng, __not_pred<_Predicate>{__pred},
-                                            oneapi::dpl::__internal::__pstl_assign());
+    auto __copy_last_id = __ranges::__pattern_copy_if(__tag, __exec, __rng, __copy_rng, __not_pred<_Predicate>{__pred},
+                                                      oneapi::dpl::__internal::__pstl_assign());
     auto __copy_rng_truncated = __copy_rng | oneapi::dpl::experimental::ranges::views::take(__copy_last_id);
 
     oneapi::dpl::__internal::__ranges::__pattern_walk_n(
@@ -463,7 +463,8 @@ __pattern_unique(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ra
 
     oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec, __rng.size());
     auto res_rng = oneapi::dpl::__ranges::views::all(__buf.get_buffer());
-    auto res = __pattern_unique_copy(__tag, __exec, __rng, res_rng, __pred, oneapi::dpl::__internal::__pstl_assign());
+    auto res = __ranges::__pattern_unique_copy(__tag, __exec, __rng, res_rng, __pred,
+                                               oneapi::dpl::__internal::__pstl_assign());
 
     __pattern_walk_n(__tag, ::std::forward<_ExecutionPolicy>(__exec),
                      __brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>{}, res_rng,
@@ -739,7 +740,7 @@ __pattern_reduce_by_segment(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
     // evenly divisible by wg size (ensures segments are not long), or has a key not equal to the
     // adjacent element (marks end of real segments)
     // TODO: replace wgroup size with segment size based on platform specifics.
-    auto __intermediate_result_end = __pattern_copy_if(
+    auto __intermediate_result_end = __ranges::__pattern_copy_if(
         __tag, oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__assign_key1_wrapper>(__exec), __view1, __view2,
         [__n, __binary_pred, __wgroup_size](const auto& __a) {
             // The size of key range for the (i-1) view is one less, so for the 0th index we do not check the keys
@@ -782,7 +783,7 @@ __pattern_reduce_by_segment(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
 
     // element is copied if it is the 0th element (marks beginning of first segment), or has a key not equal to
     // the adjacent element (end of a segment). Artificial segments based on wg size are not created.
-    auto __result_end = __pattern_copy_if(
+    auto __result_end = __ranges::__pattern_copy_if(
         __tag, oneapi::dpl::__par_backend_hetero::make_wrapped_policy<__assign_key2_wrapper>(__exec), __view3, __view4,
         [__binary_pred](const auto& __a) {
             // The size of key range for the (i-1) view is one less, so for the 0th index we do not check the keys

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -259,8 +259,8 @@ __pattern_search_n(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _
     auto __s_rng = oneapi::dpl::experimental::ranges::views::iota(0, __count) |
                    oneapi::dpl::experimental::ranges::views::transform([__value](auto) { return __value; });
 
-    return __pattern_search(__tag, ::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range>(__rng), __s_rng,
-                            __pred);
+    return __ranges::__pattern_search(__tag, ::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range>(__rng),
+                                      __s_rng, __pred);
 }
 
 template <typename _Size>
@@ -396,8 +396,9 @@ __pattern_copy_if(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _R
     unseq_backend::__create_mask<_Predicate, _SizeType> __create_mask_op{__pred};
     unseq_backend::__copy_by_mask<_ReduceOp, _Assign, /*inclusive*/ ::std::true_type, 1> __copy_by_mask_op;
 
-    return __pattern_scan_copy(__tag, ::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range1>(__rng1),
-                               ::std::forward<_Range2>(__rng2), __create_mask_op, __copy_by_mask_op);
+    return __ranges::__pattern_scan_copy(__tag, ::std::forward<_ExecutionPolicy>(__exec),
+                                         ::std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2),
+                                         __create_mask_op, __copy_by_mask_op);
 }
 
 //------------------------------------------------------------------------
@@ -444,8 +445,9 @@ __pattern_unique_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec
     __create_mask_unique_copy<__not_pred<_BinaryPredicate>, _It1DifferenceType> __create_mask_op{
         __not_pred<_BinaryPredicate>{__pred}};
 
-    return __pattern_scan_copy(__tag, ::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range1>(__rng),
-                               ::std::forward<_Range2>(__result), __create_mask_op, __copy_by_mask_op);
+    return __ranges::__pattern_scan_copy(__tag, ::std::forward<_ExecutionPolicy>(__exec),
+                                         ::std::forward<_Range1>(__rng), ::std::forward<_Range2>(__result),
+                                         __create_mask_op, __copy_by_mask_op);
 }
 
 //------------------------------------------------------------------------
@@ -466,9 +468,9 @@ __pattern_unique(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ra
     auto res = __ranges::__pattern_unique_copy(__tag, __exec, __rng, res_rng, __pred,
                                                oneapi::dpl::__internal::__pstl_assign());
 
-    __pattern_walk_n(__tag, ::std::forward<_ExecutionPolicy>(__exec),
-                     __brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>{}, res_rng,
-                     ::std::forward<_Range>(__rng));
+    __ranges::__pattern_walk_n(__tag, ::std::forward<_ExecutionPolicy>(__exec),
+                               __brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>{}, res_rng,
+                               ::std::forward<_Range>(__rng));
     return res;
 }
 


### PR DESCRIPTION
In this PR we fix compile errors in two ranges tests:
- `remove_if_ranges_sycl.pass`;
- `unique_ranges_sycl.pass`.

How we fixing this errors: by adding `__ranges` namespace before range pattern calls in the code.

The errors:
```C++
oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h:471:12: error: no viable conversion from returned value of type 'oneapi::dpl::__internal::__pstl_equal' to function return type 'oneapi::dpl::__internal::__difference_t<all_view<int, sycl::access::mode::read_write, sycl::access::target::global_buffer, sycl::access::placeholder::true_t>>' (aka 'long')
  471 |     return res;
      |            ^~~
oneapi/dpl/pstl/glue_algorithm_ranges_impl.h:369:47: note: in instantiation of function template specialization 'oneapi::dpl::__internal::__ranges::__pattern_unique<oneapi::dpl::__internal::__device_backend_tag, oneapi::dpl::execution::device_policy<TestUtils::unique_kernel_name<oneapi::dpl::execution::device_policy<>, 0>> &, oneapi::dpl::__ranges::all_view<int, sycl::access::mode::read_write>, oneapi::dpl::__internal::__pstl_equal>' requested here
  369 |     return oneapi::dpl::__internal::__ranges::__pattern_unique(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
      |                                               ^
oneapi/dpl/pstl/glue_algorithm_ranges_impl.h:377:12: note: in instantiation of function template specialization 'oneapi::dpl::experimental::ranges::unique<oneapi::dpl::execution::device_policy<TestUtils::unique_kernel_name<oneapi::dpl::execution::device_policy<>, 0>> &, oneapi::dpl::__ranges::all_view<int, sycl::access::mode::read_write>, oneapi::dpl::__internal::__pstl_equal>' requested here
  377 |     return unique(::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range>(__rng),
      |            ^
/test/parallel_api/ranges/unique_ranges_sycl.pass.cpp:53:17: note: in instantiation of function template specialization 'oneapi::dpl::experimental::ranges::unique<oneapi::dpl::execution::device_policy<TestUtils::unique_kernel_name<oneapi::dpl::execution::device_policy<>, 0>> &, oneapi::dpl::__ranges::all_view<int, sycl::access::mode::read_write>>' requested here
   53 |     auto res1 = unique(exec1, views::all(A));
      |                 ^
In file included from /test/parallel_api/ranges/unique_ranges_sycl.pass.cpp:16:
In file included from oneapi/dpl/execution:66:
In file included from oneapi/dpl/pstl/algorithm_impl.h:36:
oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h:994:77: error: no type named 'difference_type' in 'std::iterator_traits<oneapi::dpl::__ranges::all_view<int, sycl::access::mode::read_write>>'
  994 |     using _It1DifferenceType = typename ::std::iterator_traits<_Iterator1>::difference_type;
      |                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~
oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h:466:16: note: in instantiation of function template specialization 'oneapi::dpl::__internal::__pattern_unique_copy<oneapi::dpl::__internal::__device_backend_tag, oneapi::dpl::execution::device_policy<TestUtils::unique_kernel_name<oneapi::dpl::execution::device_policy<>, 0>> &, oneapi::dpl::__ranges::all_view<int, sycl::access::mode::read_write>, oneapi::dpl::__internal::__pstl_equal, oneapi::dpl::__internal::__pstl_assign>' requested here
  466 |     auto res = __pattern_unique_copy(__tag, __exec, __rng, res_rng, __pred, oneapi::dpl::__internal::__pstl_assign());
      |                ^
oneapi/dpl/pstl/glue_algorithm_ranges_impl.h:369:47: note: in instantiation of function template specialization 'oneapi::dpl::__internal::__ranges::__pattern_unique<oneapi::dpl::__internal::__device_backend_tag, oneapi::dpl::execution::device_policy<TestUtils::unique_kernel_name<oneapi::dpl::execution::device_policy<>, 0>> &, oneapi::dpl::__ranges::all_view<int, sycl::access::mode::read_write>, oneapi::dpl::__internal::__pstl_equal>' requested here
  369 |     return oneapi::dpl::__internal::__ranges::__pattern_unique(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
      |                                               ^
oneapi/dpl/pstl/glue_algorithm_ranges_impl.h:377:12: note: in instantiation of function template specialization 'oneapi::dpl::experimental::ranges::unique<oneapi::dpl::execution::device_policy<TestUtils::unique_kernel_name<oneapi::dpl::execution::device_policy<>, 0>> &, oneapi::dpl::__ranges::all_view<int, sycl::access::mode::read_write>, oneapi::dpl::__internal::__pstl_equal>' requested here
  377 |     return unique(::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range>(__rng),
      |            ^
/test/parallel_api/ranges/unique_ranges_sycl.pass.cpp:53:17: note: in instantiation of function template specialization 'oneapi::dpl::experimental::ranges::unique<oneapi::dpl::execution::device_policy<TestUtils::unique_kernel_name<oneapi::dpl::execution::device_policy<>, 0>> &, oneapi::dpl::__ranges::all_view<int, sycl::access::mode::read_write>>' requested here
   53 |     auto res1 = unique(exec1, views::all(A));
      |                 ^
In file included from /test/parallel_api/ranges/unique_ranges_sycl.pass.cpp:16:
In file included from oneapi/dpl/execution:66:
In file included from oneapi/dpl/pstl/algorithm_impl.h:36:
oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h:1001:21: error: no matching function for call to '__pattern_scan_copy'
 1001 |     auto __result = __pattern_scan_copy(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
      |                     ^~~~~~~~~~~~~~~~~~~
oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h:906:1: note: candidate template ignored: substitution failure [with _BackendTag = oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy = oneapi::dpl::execution::device_policy<TestUtils::unique_kernel_name<oneapi::dpl::execution::device_policy<>, 0>> &, _Iterator1 = oneapi::dpl::__ranges::all_view<int, sycl::access::mode::read_write>, _IteratorOrTuple = oneapi::dpl::__internal::__pstl_equal, _CreateMaskOp = __create_mask_unique_copy<__not_pred<__pstl_assign>, _It1DifferenceType>, _CopyByMaskOp = unseq_backend::__copy_by_mask< ::std::plus<_It1DifferenceType>, oneapi::dpl::__internal::__pstl_assign, ::std::true_type, 1>]: no type named 'difference_type' in 'std::iterator_traits<oneapi::dpl::__ranges::all_view<int, sycl::access::mode::read_write>>'
  905 | ::std::pair<_IteratorOrTuple, typename ::std::iterator_traits<_Iterator1>::difference_type>
      |                                                                            ~~~~~~~~~~~~~~~
  906 | __pattern_scan_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator1 __first, _Iterator1 __last,
      | ^
```
