### PR TITLE
Fix review comments for tag dispatching

### DIFF
--- a/include/oneapi/dpl/pstl/algorithm_fwd.h
+++ b/include/oneapi/dpl/pstl/algorithm_fwd.h
@@ -71,9 +71,9 @@ template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _Fun
 void
 __pattern_walk1(_Tag, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _Function) noexcept;
 
-template <class _ExecutionPolicy, class _RandomAccessIterator, class _Function>
+template <class _ExecutionPolicy, class _ForwardIterator, class _Function>
 void
-__pattern_walk1(__parallel_forward_tag, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _Function);
+__pattern_walk1(__parallel_forward_tag, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _Function);
 
 template <class _IsVector, class _ExecutionPolicy, class _ForwardIterator, class _Function>
 void

--- a/include/oneapi/dpl/pstl/algorithm_fwd.h
+++ b/include/oneapi/dpl/pstl/algorithm_fwd.h
@@ -75,9 +75,9 @@ template <class _ExecutionPolicy, class _ForwardIterator, class _Function>
 void
 __pattern_walk1(__parallel_forward_tag, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _Function);
 
-template <class _IsVector, class _ExecutionPolicy, class _ForwardIterator, class _Function>
+template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Function>
 void
-__pattern_walk1(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _Function);
+__pattern_walk1(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _Function);
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _Brick>
 void
@@ -298,9 +298,10 @@ template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _Pre
 _ForwardIterator
 __pattern_find_if(_Tag, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _Predicate) noexcept;
 
-template <class _IsVector, class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
-_ForwardIterator
-__pattern_find_if(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _Predicate);
+template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Predicate>
+_RandomAccessIterator
+__pattern_find_if(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator,
+                  _Predicate);
 
 //------------------------------------------------------------------------
 // find_end
@@ -346,11 +347,11 @@ _ForwardIterator1
 __pattern_find_first_of(_Tag, _ExecutionPolicy&&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2,
                         _ForwardIterator2, _BinaryPredicate) noexcept;
 
-template <class _IsVector, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2,
+template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
           class _BinaryPredicate>
-_ForwardIterator1
-__pattern_find_first_of(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _ForwardIterator1, _ForwardIterator1,
-                        _ForwardIterator2, _ForwardIterator2, _BinaryPredicate);
+_RandomAccessIterator1
+__pattern_find_first_of(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator1, _RandomAccessIterator1,
+                        _RandomAccessIterator2, _RandomAccessIterator2, _BinaryPredicate);
 
 //------------------------------------------------------------------------
 // search
@@ -1231,10 +1232,12 @@ bool
 __pattern_lexicographical_compare(_Tag, _ExecutionPolicy&&, _ForwardIterator1, _ForwardIterator1, _ForwardIterator2,
                                   _ForwardIterator2, _Compare) noexcept;
 
-template <class _IsVector, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Compare>
+template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
+          class _Compare>
 bool
-__pattern_lexicographical_compare(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _ForwardIterator1, _ForwardIterator1,
-                                  _ForwardIterator2, _ForwardIterator2, _Compare) noexcept;
+__pattern_lexicographical_compare(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator1,
+                                  _RandomAccessIterator1, _RandomAccessIterator2, _RandomAccessIterator2,
+                                  _Compare) noexcept;
 
 template <class _Tag, class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Function>
 _ForwardIterator2
@@ -1259,10 +1262,10 @@ _ForwardIterator
 __pattern_shift_left(_Tag, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator,
                      typename ::std::iterator_traits<_ForwardIterator>::difference_type) noexcept;
 
-template <class _IsVector, class _ExecutionPolicy, class _ForwardIterator>
-_ForwardIterator
-__pattern_shift_left(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator,
-                     typename ::std::iterator_traits<_ForwardIterator>::difference_type);
+template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator>
+_RandomAccessIterator
+__pattern_shift_left(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator,
+                     typename ::std::iterator_traits<_RandomAccessIterator>::difference_type);
 
 //------------------------------------------------------------------------
 // shift_right

--- a/include/oneapi/dpl/pstl/execution_impl.h
+++ b/include/oneapi/dpl/pstl/execution_impl.h
@@ -73,7 +73,7 @@ using __parallel_policy_tag_selector_t = ::std::conditional_t<
     ::std::conditional_t<__is_forward_iterator_v<_IteratorTypes...>, __parallel_forward_tag, __serial_tag<_IsVector>>>;
 
 template <class... _IteratorTypes>
-__serial_tag<std::false_type>
+__serial_tag<::std::false_type>
 __select_backend(oneapi::dpl::execution::sequenced_policy, _IteratorTypes&&...)
 {
     return {};
@@ -87,7 +87,7 @@ __select_backend(oneapi::dpl::execution::unsequenced_policy, _IteratorTypes&&...
 }
 
 template <class... _IteratorTypes>
-__parallel_policy_tag_selector_t<std::false_type, _IteratorTypes...>
+__parallel_policy_tag_selector_t<::std::false_type, _IteratorTypes...>
 __select_backend(oneapi::dpl::execution::parallel_policy, _IteratorTypes&&...)
 {
     return {};

--- a/include/oneapi/dpl/pstl/execution_impl.h
+++ b/include/oneapi/dpl/pstl/execution_impl.h
@@ -73,7 +73,7 @@ using __parallel_policy_tag_selector_t = ::std::conditional_t<
     ::std::conditional_t<__is_forward_iterator_v<_IteratorTypes...>, __parallel_forward_tag, __serial_tag<_IsVector>>>;
 
 template <class... _IteratorTypes>
-__serial_tag<::std::false_type>
+__serial_tag<std::false_type>
 __select_backend(oneapi::dpl::execution::sequenced_policy, _IteratorTypes&&...)
 {
     return {};
@@ -87,7 +87,7 @@ __select_backend(oneapi::dpl::execution::unsequenced_policy, _IteratorTypes&&...
 }
 
 template <class... _IteratorTypes>
-__parallel_policy_tag_selector_t<::std::false_type, _IteratorTypes...>
+__parallel_policy_tag_selector_t<std::false_type, _IteratorTypes...>
 __select_backend(oneapi::dpl::execution::parallel_policy, _IteratorTypes&&...)
 {
     return {};


### PR DESCRIPTION
Fixed some review comments from @danhoeflinger :

1) `_ForwardIterator` template params type with `__parallel_tag<_IsVector>` renamed to `_RandomAccessIterator`

2) `_RandomAccessIterator` template params type with `__parallel_forward_tag` renamed to `_ForwardIterator`

This change has been made to align these template param type names with `__parallel_policy_tag_selector_t` implementation:
```C++
template <class _IsVector, class... _IteratorTypes>
using __parallel_policy_tag_selector_t = ::std::conditional_t<
    __internal::__is_random_access_iterator_v<_IteratorTypes...>, __parallel_tag<_IsVector>,
    ::std::conditional_t<__is_forward_iterator_v<_IteratorTypes...>, __parallel_forward_tag, __serial_tag<_IsVector>>>;
```
