### PR TITLE
Remove duplicated host buffer implementations from oneDPL code

### DIFF
--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -46,6 +46,8 @@ pattern_exclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1, 
 {
     static_assert(__internal::__is_host_dispatch_tag_v<_Tag>);
 
+    using __buffer_backend_tag = typename __internal::__buffer_backend_tag_type<_Tag>::type;
+
     const auto n = ::std::distance(first1, last1);
 
     // Check for empty and single element ranges
@@ -64,7 +66,7 @@ pattern_exclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1, 
     InputIterator2 last2 = first2 + n;
 
     // compute head flags
-    oneapi::dpl::__par_backend::__buffer<Policy, FlagType> _flags(policy, n);
+    oneapi::dpl::__par_backend::__buffer<__buffer_backend_tag, Policy, FlagType> _flags(policy, n);
     auto flags = _flags.get();
     flags[0] = 1;
 
@@ -72,7 +74,7 @@ pattern_exclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1, 
               oneapi::dpl::__internal::__not_pred<BinaryPredicate>(binary_pred));
 
     // shift input one to the right and initialize segments with init
-    oneapi::dpl::__par_backend::__buffer<Policy, OutputType> _temp(policy, n);
+    oneapi::dpl::__par_backend::__buffer<__buffer_backend_tag, Policy, OutputType> _temp(policy, n);
     auto temp = _temp.get();
 
     temp[0] = init;
@@ -123,7 +125,7 @@ exclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag>, Policy&& p
     InputIterator2 last2 = first2 + n;
 
     // compute head flags
-    oneapi::dpl::__par_backend_hetero::__buffer<Policy, FlagType> _flags(policy, n);
+    oneapi::dpl::__par_backend_hetero::__buffer<_BackendTag, Policy, FlagType> _flags(policy, n);
     {
         auto flag_buf = _flags.get_buffer();
         auto flags = flag_buf.get_host_access(sycl::read_write);
@@ -134,7 +136,7 @@ exclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag>, Policy&& p
               oneapi::dpl::__internal::__not_pred<BinaryPredicate>(binary_pred));
 
     // shift input one to the right and initialize segments with init
-    oneapi::dpl::__par_backend_hetero::__buffer<Policy, OutputType> _temp(policy, n);
+    oneapi::dpl::__par_backend_hetero::__buffer<_BackendTag, Policy, OutputType> _temp(policy, n);
     {
         auto temp_buf = _temp.get_buffer();
         auto temp = temp_buf.get_host_access(sycl::read_write);

--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -24,7 +24,6 @@
 #include "by_segment_extension_defs.h"
 #include "../pstl/utils.h"
 #include "scan_by_segment_impl.h"
-#include "../pstl/parallel_backend_utils.h"
 
 namespace oneapi
 {

--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -24,6 +24,7 @@
 #include "by_segment_extension_defs.h"
 #include "../pstl/utils.h"
 #include "scan_by_segment_impl.h"
+#include "../pstl/parallel_backend_utils.h"
 
 namespace oneapi
 {
@@ -46,8 +47,6 @@ pattern_exclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1, 
 {
     static_assert(__internal::__is_host_dispatch_tag_v<_Tag>);
 
-    using __buffer_backend_tag = typename __internal::__buffer_backend_tag_type<_Tag>::type;
-
     const auto n = ::std::distance(first1, last1);
 
     // Check for empty and single element ranges
@@ -66,7 +65,7 @@ pattern_exclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1, 
     InputIterator2 last2 = first2 + n;
 
     // compute head flags
-    oneapi::dpl::__par_backend::__buffer<__buffer_backend_tag, Policy, FlagType> _flags(policy, n);
+    oneapi::dpl::__par_backend::__buffer<_Tag, Policy, FlagType> _flags(policy, n);
     auto flags = _flags.get();
     flags[0] = 1;
 
@@ -74,7 +73,7 @@ pattern_exclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1, 
               oneapi::dpl::__internal::__not_pred<BinaryPredicate>(binary_pred));
 
     // shift input one to the right and initialize segments with init
-    oneapi::dpl::__par_backend::__buffer<__buffer_backend_tag, Policy, OutputType> _temp(policy, n);
+    oneapi::dpl::__par_backend::__buffer<_Tag, Policy, OutputType> _temp(policy, n);
     auto temp = _temp.get();
 
     temp[0] = init;

--- a/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
@@ -45,6 +45,8 @@ pattern_inclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1, 
 {
     static_assert(__internal::__is_host_dispatch_tag_v<_Tag>);
 
+    using __buffer_backend_tag = typename __internal::__buffer_backend_tag_type<_Tag>::type;
+
     const auto n = ::std::distance(first1, last1);
 
     // Check for empty and single element ranges
@@ -59,7 +61,7 @@ pattern_inclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1, 
     typedef unsigned int FlagType;
     typedef typename ::std::iterator_traits<InputIterator2>::value_type ValueType;
 
-    oneapi::dpl::__par_backend::__buffer<Policy, FlagType> _mask(policy, n);
+    oneapi::dpl::__par_backend::__buffer<__buffer_backend_tag, Policy, FlagType> _mask(policy, n);
     auto mask = _mask.get();
 
     mask[0] = 1;
@@ -109,7 +111,7 @@ inclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag>, Policy&& p
 
     FlagType initial_mask = 1;
 
-    oneapi::dpl::__par_backend_hetero::__buffer<Policy, FlagType> _mask(policy, n);
+    oneapi::dpl::__par_backend_hetero::__buffer<_BackendTag, Policy, FlagType> _mask(policy, n);
     {
         auto mask_buf = _mask.get_buffer();
         auto mask = mask_buf.get_host_access(sycl::read_write);

--- a/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
@@ -45,8 +45,6 @@ pattern_inclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1, 
 {
     static_assert(__internal::__is_host_dispatch_tag_v<_Tag>);
 
-    using __buffer_backend_tag = typename __internal::__buffer_backend_tag_type<_Tag>::type;
-
     const auto n = ::std::distance(first1, last1);
 
     // Check for empty and single element ranges
@@ -61,7 +59,7 @@ pattern_inclusive_scan_by_segment(_Tag, Policy&& policy, InputIterator1 first1, 
     typedef unsigned int FlagType;
     typedef typename ::std::iterator_traits<InputIterator2>::value_type ValueType;
 
-    oneapi::dpl::__par_backend::__buffer<__buffer_backend_tag, Policy, FlagType> _mask(policy, n);
+    oneapi::dpl::__par_backend::__buffer<_Tag, Policy, FlagType> _mask(policy, n);
     auto mask = _mask.get();
 
     mask[0] = 1;

--- a/include/oneapi/dpl/internal/reduce_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/reduce_by_segment_impl.h
@@ -88,8 +88,6 @@ reduce_by_segment_impl(_Tag, Policy&& policy, InputIterator1 first1, InputIterat
 {
     static_assert(__internal::__is_host_dispatch_tag_v<_Tag>);
 
-    using __buffer_backend_tag = typename __internal::__buffer_backend_tag_type<_Tag>::type;
-
     // The algorithm reduces values in [first2, first2 + (last1-first1)) where the associated
     // keys for the values are equal to the adjacent key. This function's implementation is a derivative work
     // and responsible for the second copyright notice in this header.
@@ -117,7 +115,7 @@ reduce_by_segment_impl(_Tag, Policy&& policy, InputIterator1 first1, InputIterat
 
     // buffer that is used to store a flag indicating if the associated key is not equal to
     // the next key, and thus its associated sum should be part of the final result
-    oneapi::dpl::__par_backend::__buffer<__buffer_backend_tag, Policy, FlagType> _mask(policy, n + 1);
+    oneapi::dpl::__par_backend::__buffer<_Tag, Policy, FlagType> _mask(policy, n + 1);
     auto mask = _mask.get();
     mask[0] = 1;
 
@@ -133,11 +131,11 @@ reduce_by_segment_impl(_Tag, Policy&& policy, InputIterator1 first1, InputIterat
     // buffer stores the sums of values associated with a given key. Sums are copied with
     // a shift into result2, and the shift is computed at the same time as the sums, so the
     // sums can't be written to result2 directly.
-    oneapi::dpl::__par_backend::__buffer<__buffer_backend_tag, Policy, ValueType> _scanned_values(policy, n);
+    oneapi::dpl::__par_backend::__buffer<_Tag, Policy, ValueType> _scanned_values(policy, n);
 
     // Buffer is used to store results of the scan of the mask. Values indicate which position
     // in result2 needs to be written with the scanned_values element.
-    oneapi::dpl::__par_backend::__buffer<__buffer_backend_tag, Policy, FlagType> _scanned_tail_flags(policy, n);
+    oneapi::dpl::__par_backend::__buffer<_Tag, Policy, FlagType> _scanned_tail_flags(policy, n);
 
     // Compute the sum of the segments. scanned_tail_flags values are not used.
     inclusive_scan(policy, make_zip_iterator(first2, _mask.get()), make_zip_iterator(first2, _mask.get()) + n,

--- a/include/oneapi/dpl/internal/reduce_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/reduce_by_segment_impl.h
@@ -88,6 +88,8 @@ reduce_by_segment_impl(_Tag, Policy&& policy, InputIterator1 first1, InputIterat
 {
     static_assert(__internal::__is_host_dispatch_tag_v<_Tag>);
 
+    using __buffer_backend_tag = typename __internal::__buffer_backend_tag_type<_Tag>::type;
+
     // The algorithm reduces values in [first2, first2 + (last1-first1)) where the associated
     // keys for the values are equal to the adjacent key. This function's implementation is a derivative work
     // and responsible for the second copyright notice in this header.
@@ -115,7 +117,7 @@ reduce_by_segment_impl(_Tag, Policy&& policy, InputIterator1 first1, InputIterat
 
     // buffer that is used to store a flag indicating if the associated key is not equal to
     // the next key, and thus its associated sum should be part of the final result
-    oneapi::dpl::__par_backend::__buffer<Policy, FlagType> _mask(policy, n + 1);
+    oneapi::dpl::__par_backend::__buffer<__buffer_backend_tag, Policy, FlagType> _mask(policy, n + 1);
     auto mask = _mask.get();
     mask[0] = 1;
 
@@ -131,11 +133,11 @@ reduce_by_segment_impl(_Tag, Policy&& policy, InputIterator1 first1, InputIterat
     // buffer stores the sums of values associated with a given key. Sums are copied with
     // a shift into result2, and the shift is computed at the same time as the sums, so the
     // sums can't be written to result2 directly.
-    oneapi::dpl::__par_backend::__buffer<Policy, ValueType> _scanned_values(policy, n);
+    oneapi::dpl::__par_backend::__buffer<__buffer_backend_tag, Policy, ValueType> _scanned_values(policy, n);
 
     // Buffer is used to store results of the scan of the mask. Values indicate which position
     // in result2 needs to be written with the scanned_values element.
-    oneapi::dpl::__par_backend::__buffer<Policy, FlagType> _scanned_tail_flags(policy, n);
+    oneapi::dpl::__par_backend::__buffer<__buffer_backend_tag, Policy, FlagType> _scanned_tail_flags(policy, n);
 
     // Compute the sum of the segments. scanned_tail_flags values are not used.
     inclusive_scan(policy, make_zip_iterator(first2, _mask.get()), make_zip_iterator(first2, _mask.get()) + n,
@@ -264,17 +266,21 @@ __sycl_reduce_by_segment(__internal::__hetero_tag<_BackendTag>, _ExecutionPolicy
 
     // intermediate reductions within a workgroup
     auto __partials =
-        oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, __val_type>(__exec, __n_groups).get_buffer();
+        oneapi::dpl::__par_backend_hetero::__buffer<_BackendTag, _ExecutionPolicy, __val_type>(__exec, __n_groups)
+            .get_buffer();
 
-    auto __end_idx = oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, __diff_type>(__exec, 1).get_buffer();
+    auto __end_idx =
+        oneapi::dpl::__par_backend_hetero::__buffer<_BackendTag, _ExecutionPolicy, __diff_type>(__exec, 1).get_buffer();
 
     // the number of segment ends found in each work group
     auto __seg_ends =
-        oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, __diff_type>(__exec, __n_groups).get_buffer();
+        oneapi::dpl::__par_backend_hetero::__buffer<_BackendTag, _ExecutionPolicy, __diff_type>(__exec, __n_groups)
+            .get_buffer();
 
     // buffer that stores an exclusive scan of the results
     auto __seg_ends_scanned =
-        oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, __diff_type>(__exec, __n_groups).get_buffer();
+        oneapi::dpl::__par_backend_hetero::__buffer<_BackendTag, _ExecutionPolicy, __diff_type>(__exec, __n_groups)
+            .get_buffer();
 
     // 1. Count the segment ends in each workgroup
     auto __seg_end_identification = __exec.queue().submit([&](sycl::handler& __cgh) {

--- a/include/oneapi/dpl/internal/scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/scan_by_segment_impl.h
@@ -147,11 +147,13 @@ struct __sycl_scan_by_segment_impl
         ::std::size_t __n_groups = __internal::__dpl_ceiling_div(__n, __wgroup_size * __vals_per_item);
 
         auto __partials =
-            oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, __val_type>(__exec, __n_groups).get_buffer();
+            oneapi::dpl::__par_backend_hetero::__buffer<_BackendTag, _ExecutionPolicy, __val_type>(__exec, __n_groups)
+                .get_buffer();
 
         // the number of segment ends found in each work group
         auto __seg_ends =
-            oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, bool>(__exec, __n_groups).get_buffer();
+            oneapi::dpl::__par_backend_hetero::__buffer<_BackendTag, _ExecutionPolicy, bool>(__exec, __n_groups)
+                .get_buffer();
 
         // 1. Work group reduction
         auto __wg_scan = __exec.queue().submit([&](sycl::handler& __cgh) {

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1323,7 +1323,7 @@ __pattern_copy_if(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
     const _DifferenceType __n = __last - __first;
     if (_DifferenceType(1) < __n)
     {
-        __par_backend::__buffer<_ExecutionPolicy, bool> __mask_buf(__exec, __n);
+        __par_backend::__buffer<__backend_tag, _ExecutionPolicy, bool> __mask_buf(__exec, __n);
         return __internal::__except_handler([&__exec, __n, __first, __result, __pred, &__mask_buf]() {
             bool* __mask = __mask_buf.get();
             _DifferenceType __m{};
@@ -1442,7 +1442,7 @@ __remove_elements(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
     typedef typename ::std::iterator_traits<_RandomAccessIterator>::difference_type _DifferenceType;
     typedef typename ::std::iterator_traits<_RandomAccessIterator>::value_type _Tp;
     _DifferenceType __n = __last - __first;
-    __par_backend::__buffer<_ExecutionPolicy, bool> __mask_buf(__exec, __n);
+    __par_backend::__buffer<__backend_tag, _ExecutionPolicy, bool> __mask_buf(__exec, __n);
     // 1. find a first iterator that should be removed
     return __internal::__except_handler([&]() {
         bool* __mask = __mask_buf.get();
@@ -1479,7 +1479,7 @@ __remove_elements(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
         __n -= __min;
         __first += __min;
 
-        __par_backend::__buffer<_ExecutionPolicy, _Tp> __buf(__exec, __n);
+        __par_backend::__buffer<__backend_tag, _ExecutionPolicy, _Tp> __buf(__exec, __n);
         _Tp* __result = __buf.get();
         __mask += __min;
         _DifferenceType __m{};
@@ -1607,7 +1607,7 @@ __pattern_unique_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Ran
     const _DifferenceType __n = __last - __first;
     if (_DifferenceType(2) < __n)
     {
-        __par_backend::__buffer<_ExecutionPolicy, bool> __mask_buf(__exec, __n);
+        __par_backend::__buffer<__backend_tag, _ExecutionPolicy, bool> __mask_buf(__exec, __n);
         if (_DifferenceType(2) < __n)
         {
             return __internal::__except_handler([&__exec, __n, __first, __result, __pred, &__mask_buf]() {
@@ -1860,7 +1860,7 @@ __pattern_rotate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAc
     auto __m = __middle - __first;
     if (__m <= __n / 2)
     {
-        __par_backend::__buffer<_ExecutionPolicy, _Tp> __buf(__exec, __n - __m);
+        __par_backend::__buffer<__backend_tag, _ExecutionPolicy, _Tp> __buf(__exec, __n - __m);
         return __internal::__except_handler([&__exec, __n, __m, __first, __middle, __last, &__buf]() {
             _Tp* __result = __buf.get();
             __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __middle, __last,
@@ -1886,7 +1886,7 @@ __pattern_rotate(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAc
     }
     else
     {
-        __par_backend::__buffer<_ExecutionPolicy, _Tp> __buf(__exec, __m);
+        __par_backend::__buffer<__backend_tag, _ExecutionPolicy, _Tp> __buf(__exec, __m);
         return __internal::__except_handler([&__exec, __n, __m, __first, __middle, __last, &__buf]() {
             _Tp* __result = __buf.get();
             __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __middle,
@@ -2366,7 +2366,7 @@ __pattern_partition_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _
     const _DifferenceType __n = __last - __first;
     if (_DifferenceType(1) < __n)
     {
-        __par_backend::__buffer<_ExecutionPolicy, bool> __mask_buf(__exec, __n);
+        __par_backend::__buffer<__backend_tag, _ExecutionPolicy, bool> __mask_buf(__exec, __n);
         return __internal::__except_handler([&__exec, __n, __first, __out_true, __out_false, __pred, &__mask_buf]() {
             bool* __mask = __mask_buf.get();
             _ReturnType __m{};
@@ -2592,7 +2592,7 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
         {
             typedef typename ::std::iterator_traits<_RandomAccessIterator1>::value_type _T1;
             typedef typename ::std::iterator_traits<_RandomAccessIterator2>::value_type _T2;
-            __par_backend::__buffer<_ExecutionPolicy, _T1> __buf(__exec, __n1);
+            __par_backend::__buffer<__backend_tag, _ExecutionPolicy, _T1> __buf(__exec, __n1);
             _T1* __r = __buf.get();
 
             __par_backend::__parallel_stable_sort(
@@ -3088,7 +3088,7 @@ __pattern_inplace_merge(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _R
 
     typedef typename ::std::iterator_traits<_RandomAccessIterator>::value_type _Tp;
     auto __n = __last - __first;
-    __par_backend::__buffer<_ExecutionPolicy, _Tp> __buf(__exec, __n);
+    __par_backend::__buffer<__backend_tag, _ExecutionPolicy, _Tp> __buf(__exec, __n);
     _Tp* __r = __buf.get();
     __internal::__except_handler([&]() {
         auto __move_values = [](_RandomAccessIterator __x, _Tp* __z) {
@@ -3222,7 +3222,7 @@ __parallel_set_op(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
     const _DifferenceType __n1 = __last1 - __first1;
     const _DifferenceType __n2 = __last2 - __first2;
 
-    __par_backend::__buffer<_ExecutionPolicy, _T> __buf(__exec, __size_func(__n1, __n2));
+    __par_backend::__buffer<__backend_tag, _ExecutionPolicy, _T> __buf(__exec, __size_func(__n1, __n2));
 
     return __internal::__except_handler([&__exec, __n1, __first1, __last1, __first2, __last2, __result, __comp,
                                          __size_func, __set_op, &__buf]() {

--- a/include/oneapi/dpl/pstl/execution_defs.h
+++ b/include/oneapi/dpl/pstl/execution_defs.h
@@ -169,9 +169,6 @@ struct __parallel_forward_tag;
 // Buffer allocator selectors
 //------------------------------------------------------------------------
 
-template <typename _T>
-constexpr decltype(auto) __get_buffer_allocator(oneapi::dpl::__internal::__serial_backend_tag);
-
 template <typename _T, typename _IsVector>
 constexpr decltype(auto) __get_buffer_allocator(oneapi::dpl::__internal::__serial_tag<_IsVector>);
 

--- a/include/oneapi/dpl/pstl/execution_defs.h
+++ b/include/oneapi/dpl/pstl/execution_defs.h
@@ -169,14 +169,8 @@ struct __parallel_forward_tag;
 // Buffer allocator selectors
 //------------------------------------------------------------------------
 
-template <typename _T, typename _IsVector>
-constexpr decltype(auto) __get_buffer_allocator(oneapi::dpl::__internal::__serial_tag<_IsVector>);
-
-template <typename _T, typename _IsVector>
-constexpr decltype(auto) __get_buffer_allocator(oneapi::dpl::__internal::__parallel_tag<_IsVector>);
-
-template <typename _T>
-constexpr decltype(auto) __get_buffer_allocator(oneapi::dpl::__internal::__parallel_forward_tag);
+template <typename _T, typename = void>
+struct __backend_buffer_allocator_selector;
 
 } // namespace __internal
 

--- a/include/oneapi/dpl/pstl/execution_defs.h
+++ b/include/oneapi/dpl/pstl/execution_defs.h
@@ -153,6 +153,34 @@ struct __omp_backend_tag
 {
 };
 
+//------------------------------------------------------------------------
+// dispatch tags
+//------------------------------------------------------------------------
+
+template <class _IsVector>
+struct __serial_tag;
+
+template <class _IsVector>
+struct __parallel_tag;
+
+struct __parallel_forward_tag;
+
+//------------------------------------------------------------------------
+// Buffer allocator selectors
+//------------------------------------------------------------------------
+
+template <typename _T>
+constexpr decltype(auto) __get_buffer_allocator(oneapi::dpl::__internal::__serial_backend_tag);
+
+template <typename _T, typename _IsVector>
+constexpr decltype(auto) __get_buffer_allocator(oneapi::dpl::__internal::__serial_tag<_IsVector>);
+
+template <typename _T, typename _IsVector>
+constexpr decltype(auto) __get_buffer_allocator(oneapi::dpl::__internal::__parallel_tag<_IsVector>);
+
+template <typename _T>
+constexpr decltype(auto) __get_buffer_allocator(oneapi::dpl::__internal::__parallel_forward_tag);
+
 } // namespace __internal
 
 } // namespace dpl

--- a/include/oneapi/dpl/pstl/execution_impl.h
+++ b/include/oneapi/dpl/pstl/execution_impl.h
@@ -164,29 +164,24 @@ inline constexpr bool __is_host_dispatch_tag_v =
 //------------------------------------------------------------------------
 
 template <typename _T, typename _IsVector>
-constexpr decltype(auto)
-__get_buffer_allocator(oneapi::dpl::__internal::__serial_tag<_IsVector>)
+struct __backend_buffer_allocator_selector<_T, oneapi::dpl::__internal::__serial_tag<_IsVector>>
 {
-    return ::std::allocator<_T>{};
-}
+    using allocator_type = ::std::allocator<_T>;
+};
 
 template <typename _T, typename _IsVector>
-constexpr decltype(auto)
-__get_buffer_allocator(oneapi::dpl::__internal::__parallel_tag<_IsVector>)
+struct __backend_buffer_allocator_selector<_T, oneapi::dpl::__internal::__parallel_tag<_IsVector>>
 {
-    using __backend_tag = typename oneapi::dpl::__internal::__parallel_tag<_IsVector>::__backend_tag;
-
-    return oneapi::dpl::__internal::__get_buffer_allocator<_T>(__backend_tag{});
-}
+    using allocator_type = typename __backend_buffer_allocator_selector<
+        _T, typename oneapi::dpl::__internal::__parallel_tag<_IsVector>::__backend_tag>::allocator_type;
+};
 
 template <typename _T>
-constexpr decltype(auto)
-__get_buffer_allocator(oneapi::dpl::__internal::__parallel_forward_tag)
+struct __backend_buffer_allocator_selector<_T, oneapi::dpl::__internal::__parallel_forward_tag>
 {
-    using __backend_tag = typename oneapi::dpl::__internal::__parallel_forward_tag::__backend_tag;
-
-    return oneapi::dpl::__internal::__get_buffer_allocator<_T>(__backend_tag{});
-}
+    using allocator_type = typename __backend_buffer_allocator_selector<
+        _T, typename oneapi::dpl::__internal::__parallel_forward_tag::__backend_tag>::allocator_type;
+};
 
 } // namespace __internal
 } // namespace dpl

--- a/include/oneapi/dpl/pstl/execution_impl.h
+++ b/include/oneapi/dpl/pstl/execution_impl.h
@@ -159,6 +159,38 @@ template <class _Tag>
 inline constexpr bool __is_host_dispatch_tag_v =
     __is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag> || __is_parallel_tag_v<_Tag>;
 
+//------------------------------------------------------------------------
+// Buffer allocator selectors
+//------------------------------------------------------------------------
+
+template <typename _T>
+constexpr decltype(auto) __get_buffer_allocator(oneapi::dpl::__internal::__serial_backend_tag)
+{
+    return ::std::allocator<_T>{};
+}
+
+template <typename _T, typename _IsVector>
+constexpr decltype(auto) __get_buffer_allocator(oneapi::dpl::__internal::__serial_tag<_IsVector>)
+{
+    return oneapi::dpl::__internal::__get_buffer_allocator<_T>(oneapi::dpl::__internal::__serial_backend_tag{});
+}
+
+template <typename _T, typename _IsVector>
+constexpr decltype(auto) __get_buffer_allocator(oneapi::dpl::__internal::__parallel_tag<_IsVector>)
+{
+    using __backend_tag = typename oneapi::dpl::__internal::__parallel_tag<_IsVector>::__backend_tag;
+
+    return oneapi::dpl::__internal::__get_buffer_allocator<_T>(__backend_tag{});
+}
+
+template <typename _T>
+constexpr decltype(auto) __get_buffer_allocator(oneapi::dpl::__internal::__parallel_forward_tag)
+{
+    using __backend_tag = typename oneapi::dpl::__internal::__parallel_forward_tag::__backend_tag;
+
+    return oneapi::dpl::__internal::__get_buffer_allocator<_T>(__backend_tag{});
+}
+
 } // namespace __internal
 } // namespace dpl
 } // namespace oneapi

--- a/include/oneapi/dpl/pstl/execution_impl.h
+++ b/include/oneapi/dpl/pstl/execution_impl.h
@@ -164,13 +164,15 @@ inline constexpr bool __is_host_dispatch_tag_v =
 //------------------------------------------------------------------------
 
 template <typename _T, typename _IsVector>
-constexpr decltype(auto) __get_buffer_allocator(oneapi::dpl::__internal::__serial_tag<_IsVector>)
+constexpr decltype(auto)
+__get_buffer_allocator(oneapi::dpl::__internal::__serial_tag<_IsVector>)
 {
     return ::std::allocator<_T>{};
 }
 
 template <typename _T, typename _IsVector>
-constexpr decltype(auto) __get_buffer_allocator(oneapi::dpl::__internal::__parallel_tag<_IsVector>)
+constexpr decltype(auto)
+__get_buffer_allocator(oneapi::dpl::__internal::__parallel_tag<_IsVector>)
 {
     using __backend_tag = typename oneapi::dpl::__internal::__parallel_tag<_IsVector>::__backend_tag;
 
@@ -178,7 +180,8 @@ constexpr decltype(auto) __get_buffer_allocator(oneapi::dpl::__internal::__paral
 }
 
 template <typename _T>
-constexpr decltype(auto) __get_buffer_allocator(oneapi::dpl::__internal::__parallel_forward_tag)
+constexpr decltype(auto)
+__get_buffer_allocator(oneapi::dpl::__internal::__parallel_forward_tag)
 {
     using __backend_tag = typename oneapi::dpl::__internal::__parallel_forward_tag::__backend_tag;
 

--- a/include/oneapi/dpl/pstl/execution_impl.h
+++ b/include/oneapi/dpl/pstl/execution_impl.h
@@ -163,10 +163,13 @@ inline constexpr bool __is_host_dispatch_tag_v =
 // Buffer allocator selectors
 //------------------------------------------------------------------------
 
+template <typename _T>
+using __serial_buffer_allocator = ::std::allocator<_T>;
+
 template <typename _T, typename _IsVector>
 constexpr decltype(auto) __get_buffer_allocator(oneapi::dpl::__internal::__serial_tag<_IsVector>)
 {
-    return oneapi::dpl::__internal::__get_buffer_allocator<_T>(oneapi::dpl::__internal::__serial_backend_tag{});
+    return __serial_buffer_allocator<_T>{};
 }
 
 template <typename _T, typename _IsVector>

--- a/include/oneapi/dpl/pstl/execution_impl.h
+++ b/include/oneapi/dpl/pstl/execution_impl.h
@@ -163,12 +163,6 @@ inline constexpr bool __is_host_dispatch_tag_v =
 // Buffer allocator selectors
 //------------------------------------------------------------------------
 
-template <typename _T>
-constexpr decltype(auto) __get_buffer_allocator(oneapi::dpl::__internal::__serial_backend_tag)
-{
-    return ::std::allocator<_T>{};
-}
-
 template <typename _T, typename _IsVector>
 constexpr decltype(auto) __get_buffer_allocator(oneapi::dpl::__internal::__serial_tag<_IsVector>)
 {

--- a/include/oneapi/dpl/pstl/execution_impl.h
+++ b/include/oneapi/dpl/pstl/execution_impl.h
@@ -163,13 +163,10 @@ inline constexpr bool __is_host_dispatch_tag_v =
 // Buffer allocator selectors
 //------------------------------------------------------------------------
 
-template <typename _T>
-using __serial_buffer_allocator = ::std::allocator<_T>;
-
 template <typename _T, typename _IsVector>
 constexpr decltype(auto) __get_buffer_allocator(oneapi::dpl::__internal::__serial_tag<_IsVector>)
 {
-    return __serial_buffer_allocator<_T>{};
+    return ::std::allocator<_T>{};
 }
 
 template <typename _T, typename _IsVector>

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1023,7 +1023,8 @@ __pattern_remove_if(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
 
     using _ValueType = typename ::std::iterator_traits<_Iterator>::value_type;
 
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec, __last - __first);
+    oneapi::dpl::__par_backend_hetero::__buffer<_BackendTag, _ExecutionPolicy, _ValueType> __buf(__exec,
+                                                                                                 __last - __first);
     auto __copy_first = __buf.get();
 
     auto __copy_last = __pattern_copy_if(__tag, __exec, __first, __last, __copy_first, __not_pred<_Predicate>{__pred});
@@ -1047,7 +1048,8 @@ __pattern_unique(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _It
 
     using _ValueType = typename ::std::iterator_traits<_Iterator>::value_type;
 
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec, __last - __first);
+    oneapi::dpl::__par_backend_hetero::__buffer<_BackendTag, _ExecutionPolicy, _ValueType> __buf(__exec,
+                                                                                                 __last - __first);
     auto __copy_first = __buf.get();
     auto __copy_last = __pattern_unique_copy(__tag, __exec, __first, __last, __copy_first, __pred);
 
@@ -1223,7 +1225,7 @@ __pattern_inplace_merge(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __ex
     assert(__first < __middle && __middle < __last);
 
     auto __n = __last - __first;
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec, __n);
+    oneapi::dpl::__par_backend_hetero::__buffer<_BackendTag, _ExecutionPolicy, _ValueType> __buf(__exec, __n);
     auto __copy_first = __buf.get();
     auto __copy_last = __copy_first + __n;
 
@@ -1313,8 +1315,8 @@ __pattern_stable_partition(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& _
 
     auto __n = __last - __first;
 
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __true_buf(__exec, __n);
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __false_buf(__exec, __n);
+    oneapi::dpl::__par_backend_hetero::__buffer<_BackendTag, _ExecutionPolicy, _ValueType> __true_buf(__exec, __n);
+    oneapi::dpl::__par_backend_hetero::__buffer<_BackendTag, _ExecutionPolicy, _ValueType> __false_buf(__exec, __n);
     auto __true_result = __true_buf.get();
     auto __false_result = __false_buf.get();
 
@@ -1521,7 +1523,7 @@ __pattern_partial_sort_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
         // - create a temporary buffer and copy all the elements from the input buffer there
         // - run partial sort on the temporary buffer
         // - copy k elements from the temporary buffer to the output buffer.
-        oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec, __in_size);
+        oneapi::dpl::__par_backend_hetero::__buffer<_BackendTag, _ExecutionPolicy, _ValueType> __buf(__exec, __in_size);
 
         auto __buf_first = __buf.get();
 
@@ -1642,7 +1644,7 @@ __pattern_rotate(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator
 
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read_write, _Iterator>();
     auto __buf = __keep(__first, __last);
-    auto __temp_buf = oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _Tp>(__exec, __n);
+    auto __temp_buf = oneapi::dpl::__par_backend_hetero::__buffer<_BackendTag, _ExecutionPolicy, _Tp>(__exec, __n);
 
     auto __temp_rng_w =
         oneapi::dpl::__ranges::all_view<_Tp, __par_backend_hetero::access_mode::write>(__temp_buf.get_buffer());
@@ -1731,7 +1733,7 @@ __pattern_hetero_set_op(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _F
         __comp, __n1, __n2};
 
     // temporary buffer to store boolean mask
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, int32_t> __mask_buf(__exec, __n1);
+    oneapi::dpl::__par_backend_hetero::__buffer<_BackendTag, _ExecutionPolicy, int32_t> __mask_buf(__exec, __n1);
 
     auto __keep1 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _ForwardIterator1>();
@@ -1860,7 +1862,7 @@ __pattern_set_union(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
 
     // temporary buffer to store intermediate result
     const auto __n2 = __last2 - __first2;
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __diff(__exec, __n2);
+    oneapi::dpl::__par_backend_hetero::__buffer<_BackendTag, _ExecutionPolicy, _ValueType> __diff(__exec, __n2);
     auto __buf = __diff.get();
 
     //1. Calc difference {2} \ {1}
@@ -1941,10 +1943,10 @@ __pattern_set_symmetric_difference(__hetero_tag<_BackendTag> __tag, _ExecutionPo
 
     // temporary buffers to store intermediate result
     const auto __n1 = __last1 - __first1;
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __diff_1(__exec, __n1);
+    oneapi::dpl::__par_backend_hetero::__buffer<_BackendTag, _ExecutionPolicy, _ValueType> __diff_1(__exec, __n1);
     auto __buf_1 = __diff_1.get();
     const auto __n2 = __last2 - __first2;
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __diff_2(__exec, __n2);
+    oneapi::dpl::__par_backend_hetero::__buffer<_BackendTag, _ExecutionPolicy, _ValueType> __diff_2(__exec, __n2);
     auto __buf_2 = __diff_2.get();
 
     //1. Calc difference {1} \ {2}

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -360,7 +360,8 @@ __pattern_scan_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range
     _DataAcc __get_data_op;
     _MaskAssigner __add_mask_op;
 
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, int32_t> __mask_buf(__exec, __rng1.size());
+    oneapi::dpl::__par_backend_hetero::__buffer<_BackendTag, _ExecutionPolicy, int32_t> __mask_buf(__exec,
+                                                                                                   __rng1.size());
 
     auto __res =
         __par_backend_hetero::__parallel_transform_scan_base(
@@ -414,7 +415,7 @@ __pattern_remove_if(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
 
     using _ValueType = oneapi::dpl::__internal::__value_t<_Range>;
 
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec, __rng.size());
+    oneapi::dpl::__par_backend_hetero::__buffer<_BackendTag, _ExecutionPolicy, _ValueType> __buf(__exec, __rng.size());
     auto __copy_rng = oneapi::dpl::__ranges::views::all(__buf.get_buffer());
 
     auto __copy_last_id = __ranges::__pattern_copy_if(__tag, __exec, __rng, __copy_rng, __not_pred<_Predicate>{__pred},
@@ -463,7 +464,7 @@ __pattern_unique(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ra
 
     using _ValueType = oneapi::dpl::__internal::__value_t<_Range>;
 
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec, __rng.size());
+    oneapi::dpl::__par_backend_hetero::__buffer<_BackendTag, _ExecutionPolicy, _ValueType> __buf(__exec, __rng.size());
     auto res_rng = oneapi::dpl::__ranges::views::all(__buf.get_buffer());
     auto res = __ranges::__pattern_unique_copy(__tag, __exec, __rng, res_rng, __pred,
                                                oneapi::dpl::__internal::__pstl_assign());
@@ -717,11 +718,14 @@ __pattern_reduce_by_segment(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
     // Round 1: reduce with extra indices added to avoid long segments
     // TODO: At threshold points check if the key is equal to the key at the previous threshold point, indicating a long sequence.
     // Skip a round of copy_if and reduces if there are none.
-    auto __idx = oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, __diff_type>(__exec, __n).get_buffer();
+    auto __idx = oneapi::dpl::__par_backend_hetero::__buffer<_BackendTag, _ExecutionPolicy, __diff_type>(__exec, __n)
+                     .get_buffer();
     auto __tmp_out_keys =
-        oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, __key_type>(__exec, __n).get_buffer();
+        oneapi::dpl::__par_backend_hetero::__buffer<_BackendTag, _ExecutionPolicy, __key_type>(__exec, __n)
+            .get_buffer();
     auto __tmp_out_values =
-        oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, __val_type>(__exec, __n).get_buffer();
+        oneapi::dpl::__par_backend_hetero::__buffer<_BackendTag, _ExecutionPolicy, __val_type>(__exec, __n)
+            .get_buffer();
 
     // Replicating first element of keys view to be able to compare (i-1)-th and (i)-th key with aligned sequences,
     //  dropping the last key for the i-1 sequence.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -873,7 +873,9 @@ __parallel_scan_copy(oneapi::dpl::__internal::__device_backend_tag __backend_tag
     _MaskAssigner __add_mask_op;
 
     // temporary buffer to store boolean mask
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, int32_t> __mask_buf(__exec, __n);
+    oneapi::dpl::__par_backend_hetero::__buffer<oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy,
+                                                int32_t>
+        __mask_buf(__exec, __n);
 
     return __parallel_transform_scan_base(
         __backend_tag, ::std::forward<_ExecutionPolicy>(__exec),
@@ -1578,7 +1580,7 @@ struct __parallel_sort_submitter<_IdType, __internal::__optional_kernel_name<_Le
         });
 
         // 2. Merge sorting
-        oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _Tp> __temp_buf(__exec, __n);
+        oneapi::dpl::__par_backend_hetero::__buffer<_BackendTag, _ExecutionPolicy, _Tp> __temp_buf(__exec, __n);
         auto __temp = __temp_buf.get_buffer();
         bool __data_in_temp = false;
         _IdType __n_sorted = __leaf;
@@ -1699,7 +1701,7 @@ struct __parallel_partial_sort_submitter<__internal::__optional_kernel_name<_Glo
         _Size __n = __rng.size();
         assert(__n > 1);
 
-        oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _Tp> __temp_buf(__exec, __n);
+        oneapi::dpl::__par_backend_hetero::__buffer<_BackendTag, _ExecutionPolicy, _Tp> __temp_buf(__exec, __n);
         auto __temp = __temp_buf.get_buffer();
         _PRINT_INFO_IN_DEBUG_MODE(__exec);
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -428,7 +428,8 @@ struct __histogram_general_private_global_atomics_submitter<__internal::__option
             oneapi::dpl::__internal::__dpl_ceiling_div(__n, __work_group_size * __iters_per_work_item);
 
         auto __private_histograms =
-            oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _bin_type>(__exec, __segments * __num_bins)
+            oneapi::dpl::__par_backend_hetero::__buffer<_BackendTag, _ExecutionPolicy, _bin_type>(
+                __exec, __segments * __num_bins)
                 .get_buffer();
 
         return __exec.queue().submit([&](auto& __h) {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -829,7 +829,9 @@ __parallel_radix_sort(oneapi::dpl::__internal::__device_backend_tag, _ExecutionP
         sycl::buffer<::std::uint32_t, 1> __tmp_buf{sycl::range<1>(__tmp_buf_size)};
 
         // memory for storing values sorted for an iteration
-        oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, _ValueT> __out_buffer_holder{__exec, __n};
+        oneapi::dpl::__par_backend_hetero::__buffer<oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy,
+                                                    _ValueT>
+            __out_buffer_holder{__exec, __n};
         auto __out_rng = oneapi::dpl::__ranges::all_view<_ValueT, __par_backend_hetero::access_mode::read_write>(
             __out_buffer_holder.get_buffer());
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -378,7 +378,7 @@ struct __local_buffer<sycl::buffer<::std::tuple<_T...>, __dim, _AllocT>>
 
 // impl for sycl::buffer<...>
 template <typename _BackendTag, typename _ExecutionPolicy, typename _T>
-class __buffer_impl
+class __buffer_impl_hetero
 {
   private:
     using __container_t = typename __local_buffer<sycl::buffer<_T>>::type;
@@ -386,7 +386,8 @@ class __buffer_impl
     __container_t __container;
 
   public:
-    __buffer_impl(_ExecutionPolicy /*__exec*/, ::std::size_t __n_elements) : __container{sycl::range<1>(__n_elements)}
+    __buffer_impl_hetero(_ExecutionPolicy /*__exec*/, ::std::size_t __n_elements)
+        : __container{sycl::range<1>(__n_elements)}
     {
     }
 
@@ -447,7 +448,7 @@ struct __memobj_traits<_T*>
 } // namespace __internal
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _T>
-using __buffer = __internal::__buffer_impl<_BackendTag, ::std::decay_t<_ExecutionPolicy>, _T>;
+using __buffer = __internal::__buffer_impl_hetero<_BackendTag, ::std::decay_t<_ExecutionPolicy>, _T>;
 
 template <typename T>
 struct __repacked_tuple

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -386,6 +386,8 @@ class __buffer_impl_hetero
     __container_t __container;
 
   public:
+    static_assert(::std::is_base_of_v<oneapi::dpl::__internal::__device_backend_tag, _BackendTag>);
+
     __buffer_impl_hetero(_ExecutionPolicy /*__exec*/, ::std::size_t __n_elements)
         : __container{sycl::range<1>(__n_elements)}
     {
@@ -447,8 +449,8 @@ struct __memobj_traits<_T*>
 
 } // namespace __internal
 
-template <typename _BackendOrDispatchTag, typename _ExecutionPolicy, typename _T>
-using __buffer = __internal::__buffer_impl_hetero<_BackendOrDispatchTag, ::std::decay_t<_ExecutionPolicy>, _T>;
+template <typename _BackendTag, typename _ExecutionPolicy, typename _T>
+using __buffer = __internal::__buffer_impl_hetero<_BackendTag, ::std::decay_t<_ExecutionPolicy>, _T>;
 
 template <typename T>
 struct __repacked_tuple

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -447,8 +447,8 @@ struct __memobj_traits<_T*>
 
 } // namespace __internal
 
-template <typename _BackendTag, typename _ExecutionPolicy, typename _T>
-using __buffer = __internal::__buffer_impl_hetero<_BackendTag, ::std::decay_t<_ExecutionPolicy>, _T>;
+template <typename _BackendOrDispatchTag, typename _ExecutionPolicy, typename _T>
+using __buffer = __internal::__buffer_impl_hetero<_BackendOrDispatchTag, ::std::decay_t<_ExecutionPolicy>, _T>;
 
 template <typename T>
 struct __repacked_tuple

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -377,7 +377,7 @@ struct __local_buffer<sycl::buffer<::std::tuple<_T...>, __dim, _AllocT>>
 };
 
 // impl for sycl::buffer<...>
-template <typename _ExecutionPolicy, typename _T>
+template <typename _BackendTag, typename _ExecutionPolicy, typename _T>
 class __buffer_impl
 {
   private:
@@ -446,8 +446,8 @@ struct __memobj_traits<_T*>
 
 } // namespace __internal
 
-template <typename _ExecutionPolicy, typename _T>
-using __buffer = __internal::__buffer_impl<::std::decay_t<_ExecutionPolicy>, _T>;
+template <typename _BackendTag, typename _ExecutionPolicy, typename _T>
+using __buffer = __internal::__buffer_impl<_BackendTag, ::std::decay_t<_ExecutionPolicy>, _T>;
 
 template <typename T>
 struct __repacked_tuple

--- a/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_impl_hetero.h
@@ -162,7 +162,7 @@ __pattern_transform_scan_base(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&
         using _NewExecutionPolicy = decltype(__policy);
 
         // Create temporary buffer
-        oneapi::dpl::__par_backend_hetero::__buffer<_NewExecutionPolicy, _Type> __tmp_buf(__policy, __n);
+        oneapi::dpl::__par_backend_hetero::__buffer<_BackendTag, _NewExecutionPolicy, _Type> __tmp_buf(__policy, __n);
         auto __first_tmp = __tmp_buf.get();
         auto __last_tmp = __first_tmp + __n;
         auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _Iterator2>();

--- a/include/oneapi/dpl/pstl/omp/parallel_scan.h
+++ b/include/oneapi/dpl/pstl/omp/parallel_scan.h
@@ -89,7 +89,8 @@ __parallel_strict_scan_body(_ExecutionPolicy&& __exec, _Index __n, _Tp __initial
     const _Index __slack = 4;
     _Index __tilesize = (__n - 1) / (__slack * __p) + 1;
     _Index __m = (__n - 1) / __tilesize;
-    __buffer<_ExecutionPolicy, _Tp> __buf(::std::forward<_ExecutionPolicy>(__exec), __m + 1);
+    __buffer<oneapi::dpl::__internal::__omp_backend_tag, _ExecutionPolicy, _Tp> __buf(
+        ::std::forward<_ExecutionPolicy>(__exec), __m + 1);
     _Tp* __r = __buf.get();
 
     oneapi::dpl::__omp_backend::__upsweep(_Index(0), _Index(__m + 1), __tilesize, __r, __n - __m * __tilesize, __reduce,

--- a/include/oneapi/dpl/pstl/omp/util.h
+++ b/include/oneapi/dpl/pstl/omp/util.h
@@ -46,12 +46,13 @@ namespace __internal
 //------------------------------------------------------------------------
 // Buffer allocators
 //------------------------------------------------------------------------
+
 template <typename _T>
-constexpr decltype(auto)
-__get_buffer_allocator(oneapi::dpl::__internal::__omp_backend_tag)
+struct __backend_buffer_allocator_selector<_T, oneapi::dpl::__internal::__omp_backend_tag>
 {
-    return ::std::allocator<_T>{};
-}
+    using allocator_type = ::std::allocator<_T>;
+};
+
 }; // namespace __internal
 
 namespace __omp_backend
@@ -71,8 +72,8 @@ __cancel_execution(oneapi::dpl::__internal::__omp_backend_tag)
 //------------------------------------------------------------------------
 
 template <typename _BackendOrDispatchTag, typename _ExecutionPolicy, typename _Tp,
-          typename _TAllocator =
-              decltype(oneapi::dpl::__internal::__get_buffer_allocator<_Tp>(::std::declval<_BackendOrDispatchTag>()))>
+          typename _TAllocator = typename oneapi::dpl::__internal::__backend_buffer_allocator_selector<
+              _Tp, _BackendOrDispatchTag>::allocator_type>
 using __buffer = oneapi::dpl::__utils::__buffer_impl_host<::std::decay_t<_ExecutionPolicy>, _Tp, _TAllocator>;
 
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/omp/util.h
+++ b/include/oneapi/dpl/pstl/omp/util.h
@@ -47,7 +47,8 @@ namespace __internal
 // Buffer allocators
 //------------------------------------------------------------------------
 template <typename _T>
-constexpr decltype(auto) __get_buffer_allocator(oneapi::dpl::__internal::__omp_backend_tag)
+constexpr decltype(auto)
+__get_buffer_allocator(oneapi::dpl::__internal::__omp_backend_tag)
 {
     return ::std::allocator<_T>{};
 }

--- a/include/oneapi/dpl/pstl/omp/util.h
+++ b/include/oneapi/dpl/pstl/omp/util.h
@@ -58,32 +58,6 @@ __cancel_execution(oneapi::dpl::__internal::__omp_backend_tag)
 //------------------------------------------------------------------------
 
 template <typename _ExecutionPolicy, typename _Tp>
-class __buffer_impl
-{
-    std::allocator<_Tp> __allocator_;
-    _Tp* __ptr_;
-    const std::size_t __buf_size_;
-    __buffer_impl(const __buffer_impl&) = delete;
-    void
-    operator=(const __buffer_impl&) = delete;
-
-  public:
-    __buffer_impl(_ExecutionPolicy /*__exec*/, std::size_t __n)
-        : __allocator_(), __ptr_(__allocator_.allocate(__n)), __buf_size_(__n)
-    {
-    }
-
-    operator bool() const { return __ptr_ != nullptr; }
-
-    _Tp*
-    get() const
-    {
-        return __ptr_;
-    }
-    ~__buffer_impl() { __allocator_.deallocate(__ptr_, __buf_size_); }
-};
-
-template <typename _ExecutionPolicy, typename _Tp>
 using __buffer = __buffer_impl<::std::decay_t<_ExecutionPolicy>, _Tp>;
 
 // Preliminary size of each chunk: requires further discussion

--- a/include/oneapi/dpl/pstl/omp/util.h
+++ b/include/oneapi/dpl/pstl/omp/util.h
@@ -57,8 +57,8 @@ __cancel_execution(oneapi::dpl::__internal::__omp_backend_tag)
 // raw buffer
 //------------------------------------------------------------------------
 
-template <typename _ExecutionPolicy, typename _Tp>
-using __buffer = __buffer_impl<::std::decay_t<_ExecutionPolicy>, _Tp>;
+template <typename _BackendTag, typename _ExecutionPolicy, typename _Tp>
+using __buffer = __buffer_impl<typename _BackendTag, ::std::decay_t<_ExecutionPolicy>, _Tp>;
 
 // Preliminary size of each chunk: requires further discussion
 constexpr std::size_t __default_chunk_size = 2048;

--- a/include/oneapi/dpl/pstl/omp/util.h
+++ b/include/oneapi/dpl/pstl/omp/util.h
@@ -58,7 +58,7 @@ __cancel_execution(oneapi::dpl::__internal::__omp_backend_tag)
 //------------------------------------------------------------------------
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Tp>
-using __buffer = __buffer_impl<typename _BackendTag, ::std::decay_t<_ExecutionPolicy>, _Tp>;
+using __buffer = __buffer_impl_host<typename _BackendTag, ::std::decay_t<_ExecutionPolicy>, _Tp>;
 
 // Preliminary size of each chunk: requires further discussion
 constexpr std::size_t __default_chunk_size = 2048;

--- a/include/oneapi/dpl/pstl/omp/util.h
+++ b/include/oneapi/dpl/pstl/omp/util.h
@@ -41,6 +41,18 @@ namespace oneapi
 {
 namespace dpl
 {
+namespace __internal
+{
+//------------------------------------------------------------------------
+// Buffer allocators
+//------------------------------------------------------------------------
+template <typename _T>
+constexpr decltype(auto) __get_buffer_allocator(oneapi::dpl::__internal::__omp_backend_tag)
+{
+    return ::std::allocator<_T>{};
+}
+}; // namespace __internal
+
 namespace __omp_backend
 {
 
@@ -57,8 +69,12 @@ __cancel_execution(oneapi::dpl::__internal::__omp_backend_tag)
 // raw buffer
 //------------------------------------------------------------------------
 
-template <typename _BackendTag, typename _ExecutionPolicy, typename _Tp>
-using __buffer = __buffer_impl_host<typename _BackendTag, ::std::decay_t<_ExecutionPolicy>, _Tp>;
+template <typename _BackendOrDispatchTag, typename _ExecutionPolicy, typename _Tp,
+          typename _TAllocator =
+              decltype(oneapi::dpl::__internal::__get_buffer_allocator<_Tp>(::std::declval<_BackendOrDispatchTag>()))>
+using __buffer = oneapi::dpl::__utils::__buffer_impl_host<::std::decay_t<_ExecutionPolicy>, _Tp, _TAllocator>;
+
+//------------------------------------------------------------------------
 
 // Preliminary size of each chunk: requires further discussion
 constexpr std::size_t __default_chunk_size = 2048;

--- a/include/oneapi/dpl/pstl/parallel_backend_serial.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_serial.h
@@ -32,8 +32,8 @@ namespace dpl
 namespace __serial_backend
 {
 
-template <typename _ExecutionPolicy, typename _Tp>
-using __buffer = __buffer_impl<::std::decay_t<_ExecutionPolicy>, _Tp>;
+template <typename _BackendTag, typename _ExecutionPolicy, typename _Tp>
+using __buffer = __buffer_impl<_BackendTag, ::std::decay_t<_ExecutionPolicy>, _Tp>;
 
 inline void
 __cancel_execution(oneapi::dpl::__internal::__serial_backend_tag)

--- a/include/oneapi/dpl/pstl/parallel_backend_serial.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_serial.h
@@ -34,11 +34,10 @@ namespace dpl
 namespace __internal
 {
 template <typename _T>
-constexpr decltype(auto)
-__get_buffer_allocator(oneapi::dpl::__internal::__serial_backend_tag)
+struct __backend_buffer_allocator_selector<_T, oneapi::dpl::__internal::__serial_backend_tag>
 {
-    return ::std::allocator<_T>{};
-}
+    using allocator_type = ::std::allocator<_T>;
+};
 }; // namespace __internal
 
 namespace __serial_backend
@@ -48,8 +47,8 @@ namespace __serial_backend
 //------------------------------------------------------------------------
 
 template <typename _BackendOrDispatchTag, typename _ExecutionPolicy, typename _Tp,
-          typename _TAllocator =
-              decltype(oneapi::dpl::__internal::__get_buffer_allocator<_Tp>(::std::declval<_BackendOrDispatchTag>()))>
+          typename _TAllocator = typename oneapi::dpl::__internal::__backend_buffer_allocator_selector<
+              _Tp, _BackendOrDispatchTag>::allocator_type>
 using __buffer = oneapi::dpl::__utils::__buffer_impl_host<::std::decay_t<_ExecutionPolicy>, _Tp, _TAllocator>;
 
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/parallel_backend_serial.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_serial.h
@@ -33,31 +33,6 @@ namespace __serial_backend
 {
 
 template <typename _ExecutionPolicy, typename _Tp>
-class __buffer_impl
-{
-    ::std::allocator<_Tp> __allocator_;
-    _Tp* __ptr_;
-    const ::std::size_t __buf_size_;
-    __buffer_impl(const __buffer_impl&) = delete;
-    void
-    operator=(const __buffer_impl&) = delete;
-
-  public:
-    __buffer_impl(_ExecutionPolicy /*__exec*/, ::std::size_t __n)
-        : __allocator_(), __ptr_(__allocator_.allocate(__n)), __buf_size_(__n)
-    {
-    }
-
-    operator bool() const { return __ptr_ != nullptr; }
-    _Tp*
-    get() const
-    {
-        return __ptr_;
-    }
-    ~__buffer_impl() { __allocator_.deallocate(__ptr_, __buf_size_); }
-};
-
-template <typename _ExecutionPolicy, typename _Tp>
 using __buffer = __buffer_impl<::std::decay_t<_ExecutionPolicy>, _Tp>;
 
 inline void

--- a/include/oneapi/dpl/pstl/parallel_backend_serial.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_serial.h
@@ -33,7 +33,7 @@ namespace __serial_backend
 {
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Tp>
-using __buffer = __buffer_impl<_BackendTag, ::std::decay_t<_ExecutionPolicy>, _Tp>;
+using __buffer = __buffer_impl_host<_BackendTag, ::std::decay_t<_ExecutionPolicy>, _Tp>;
 
 inline void
 __cancel_execution(oneapi::dpl::__internal::__serial_backend_tag)

--- a/include/oneapi/dpl/pstl/parallel_backend_serial.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_serial.h
@@ -25,15 +25,24 @@
 #include <utility>
 #include <type_traits>
 
+#include "parallel_backend_utils.h"
+
 namespace oneapi
 {
 namespace dpl
 {
 namespace __serial_backend
 {
+//------------------------------------------------------------------------
+// raw buffer
+//------------------------------------------------------------------------
 
-template <typename _BackendTag, typename _ExecutionPolicy, typename _Tp>
-using __buffer = __buffer_impl_host<_BackendTag, ::std::decay_t<_ExecutionPolicy>, _Tp>;
+template <typename _BackendOrDispatchTag, typename _ExecutionPolicy, typename _Tp,
+          typename _TAllocator =
+              decltype(oneapi::dpl::__internal::__get_buffer_allocator<_Tp>(::std::declval<_BackendOrDispatchTag>()))>
+using __buffer = oneapi::dpl::__utils::__buffer_impl_host<::std::decay_t<_ExecutionPolicy>, _Tp, _TAllocator>;
+
+//------------------------------------------------------------------------
 
 inline void
 __cancel_execution(oneapi::dpl::__internal::__serial_backend_tag)

--- a/include/oneapi/dpl/pstl/parallel_backend_serial.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_serial.h
@@ -36,7 +36,7 @@ namespace __internal
 template <typename _T>
 constexpr decltype(auto) __get_buffer_allocator(oneapi::dpl::__internal::__serial_backend_tag)
 {
-    return ::std::allocator<_T>{};
+    return oneapi::dpl::__internal::__serial_buffer_allocator<_T>{};
 }
 };
 

--- a/include/oneapi/dpl/pstl/parallel_backend_serial.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_serial.h
@@ -31,6 +31,15 @@ namespace oneapi
 {
 namespace dpl
 {
+namespace __internal
+{
+template <typename _T>
+constexpr decltype(auto) __get_buffer_allocator(oneapi::dpl::__internal::__serial_backend_tag)
+{
+    return ::std::allocator<_T>{};
+}
+};
+
 namespace __serial_backend
 {
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/parallel_backend_serial.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_serial.h
@@ -36,7 +36,7 @@ namespace __internal
 template <typename _T>
 constexpr decltype(auto) __get_buffer_allocator(oneapi::dpl::__internal::__serial_backend_tag)
 {
-    return oneapi::dpl::__internal::__serial_buffer_allocator<_T>{};
+    return ::std::allocator<_T>{};
 }
 };
 

--- a/include/oneapi/dpl/pstl/parallel_backend_serial.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_serial.h
@@ -34,11 +34,12 @@ namespace dpl
 namespace __internal
 {
 template <typename _T>
-constexpr decltype(auto) __get_buffer_allocator(oneapi::dpl::__internal::__serial_backend_tag)
+constexpr decltype(auto)
+__get_buffer_allocator(oneapi::dpl::__internal::__serial_backend_tag)
 {
     return ::std::allocator<_T>{};
 }
-};
+}; // namespace __internal
 
 namespace __serial_backend
 {

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -364,7 +364,8 @@ __parallel_strict_scan(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPol
             const _Index __slack = 4;
             _Index __tilesize = (__n - 1) / (__slack * __p) + 1;
             _Index __m = (__n - 1) / __tilesize;
-            __tbb_backend::__buffer<_ExecutionPolicy, _Tp> __buf(__exec, __m + 1);
+            __tbb_backend::__buffer<oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPolicy, _Tp> __buf(__exec,
+                                                                                                             __m + 1);
             _Tp* __r = __buf.get();
             __tbb_backend::__upsweep(_Index(0), _Index(__m + 1), __tilesize, __r, __n - __m * __tilesize, __reduce,
                                      __combine);
@@ -1170,7 +1171,8 @@ __parallel_stable_sort(oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPol
         const _DifferenceType __sort_cut_off = _ONEDPL_STABLE_SORT_CUT_OFF;
         if (__n > __sort_cut_off)
         {
-            __tbb_backend::__buffer<_ExecutionPolicy, _ValueType> __buf(__exec, __n);
+            __tbb_backend::__buffer<oneapi::dpl::__internal::__tbb_backend_tag, _ExecutionPolicy, _ValueType> __buf(
+                __exec, __n);
             __root_task<__stable_sort_func<_RandomAccessIterator, _ValueType*, _Compare, _LeafSort>> __root{
                 __xs, __xe, __buf.get(), true, __comp, __leaf_sort, __nsort, __xs, __buf.get()};
             __task::spawn_root_and_wait(__root);

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -54,9 +54,9 @@ namespace __tbb_backend
 not an initialize array, because initialization/destruction
 would make the span be at least O(N). */
 // tbb::allocator can improve performance in some cases.
-template <typename _ExecutionPolicy, typename _Tp,
+template <typename _BackendTag, typename _ExecutionPolicy, typename _Tp,
           template <typename _Tp> typename _TAllocator = tbb::tbb_allocator<_Tp>>
-using __buffer = __buffer_impl<::std::decay_t<_ExecutionPolicy>, _Tp, _TAllocator>;
+using __buffer = __buffer_impl<_BackendTag, ::std::decay_t<_ExecutionPolicy>, _Tp, _TAllocator>;
 
 // Wrapper for tbb::task
 inline void

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -51,7 +51,8 @@ namespace __internal
 // Buffer allocators
 //------------------------------------------------------------------------
 template <typename _T>
-constexpr decltype(auto) __get_buffer_allocator(oneapi::dpl::__internal::__tbb_backend_tag)
+constexpr decltype(auto)
+__get_buffer_allocator(oneapi::dpl::__internal::__tbb_backend_tag)
 {
     // Some of our algorithms need to start with raw memory buffer,
     // not an initialize array, because initialization/destruction

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -56,7 +56,7 @@ would make the span be at least O(N). */
 // tbb::allocator can improve performance in some cases.
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Tp,
           template <typename _Tp> typename _TAllocator = tbb::tbb_allocator<_Tp>>
-using __buffer = __buffer_impl<_BackendTag, ::std::decay_t<_ExecutionPolicy>, _Tp, _TAllocator>;
+using __buffer = __buffer_impl_host<_BackendTag, ::std::decay_t<_ExecutionPolicy>, _Tp, _TAllocator>;
 
 // Wrapper for tbb::task
 inline void

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -51,8 +51,7 @@ namespace __internal
 // Buffer allocators
 //------------------------------------------------------------------------
 template <typename _T>
-constexpr decltype(auto)
-__get_buffer_allocator(oneapi::dpl::__internal::__tbb_backend_tag)
+struct __backend_buffer_allocator_selector<_T, oneapi::dpl::__internal::__tbb_backend_tag>
 {
     // Some of our algorithms need to start with raw memory buffer,
     // not an initialize array, because initialization/destruction
@@ -60,8 +59,8 @@ __get_buffer_allocator(oneapi::dpl::__internal::__tbb_backend_tag)
     //
     // tbb::allocator can improve performance in some cases.
     //
-    return tbb::tbb_allocator<_T>{};
-}
+    using allocator_type = tbb::tbb_allocator<_T>;
+};
 }; // namespace __internal
 
 namespace __tbb_backend
@@ -69,8 +68,8 @@ namespace __tbb_backend
 
 //! Raw memory buffer with automatic freeing and no exceptions.
 template <typename _BackendOrDispatchTag, typename _ExecutionPolicy, typename _Tp,
-          typename _TAllocator =
-              decltype(oneapi::dpl::__internal::__get_buffer_allocator<_Tp>(::std::declval<_BackendOrDispatchTag>()))>
+          typename _TAllocator = typename oneapi::dpl::__internal::__backend_buffer_allocator_selector<
+              _Tp, _BackendOrDispatchTag>::allocator_type>
 using __buffer = oneapi::dpl::__utils::__buffer_impl_host<::std::decay_t<_ExecutionPolicy>, _Tp, _TAllocator>;
 
 // Wrapper for tbb::task

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -54,36 +54,9 @@ namespace __tbb_backend
 not an initialize array, because initialization/destruction
 would make the span be at least O(N). */
 // tbb::allocator can improve performance in some cases.
-template <typename _ExecutionPolicy, typename _Tp>
-class __buffer_impl
-{
-    tbb::tbb_allocator<_Tp> _M_allocator;
-    _Tp* _M_ptr;
-    const ::std::size_t _M_buf_size;
-    __buffer_impl(const __buffer_impl&) = delete;
-    void
-    operator=(const __buffer_impl&) = delete;
-
-  public:
-    //! Try to obtain buffer of given size to store objects of _Tp type
-    __buffer_impl(_ExecutionPolicy /*__exec*/, const ::std::size_t __n)
-        : _M_allocator(), _M_ptr(_M_allocator.allocate(__n)), _M_buf_size(__n)
-    {
-    }
-    //! True if buffer was successfully obtained, zero otherwise.
-    operator bool() const { return _M_ptr != nullptr; }
-    //! Return pointer to buffer, or nullptr if buffer could not be obtained.
-    _Tp*
-    get() const
-    {
-        return _M_ptr;
-    }
-    //! Destroy buffer
-    ~__buffer_impl() { _M_allocator.deallocate(_M_ptr, _M_buf_size); }
-};
-
-template <typename _ExecutionPolicy, typename _Tp>
-using __buffer = __buffer_impl<::std::decay_t<_ExecutionPolicy>, _Tp>;
+template <typename _ExecutionPolicy, typename _Tp,
+          template <typename _Tp> typename _TAllocator = tbb::tbb_allocator<_Tp>>
+using __buffer = __buffer_impl<::std::decay_t<_ExecutionPolicy>, _Tp, _TAllocator>;
 
 // Wrapper for tbb::task
 inline void

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -33,19 +33,19 @@ namespace __utils
 //------------------------------------------------------------------------
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Tp, template <typename _T> typename _TAllocator>
-class __buffer_impl
+class __buffer_impl_host
 {
     _TAllocator<_Tp> _M_allocator;
     _Tp* _M_ptr = nullptr;
     const ::std::size_t _M_buf_size = 0;
 
-    __buffer_impl(const __buffer_impl&) = delete;
+    __buffer_impl_host(const __buffer_impl_host&) = delete;
     void
-    operator=(const __buffer_impl&) = delete;
+    operator=(const __buffer_impl_host&) = delete;
 
   public:
     //! Try to obtain buffer of given size to store objects of _Tp type
-    __buffer_impl(_ExecutionPolicy /*__exec*/, const ::std::size_t __n)
+    __buffer_impl_host(_ExecutionPolicy /*__exec*/, const ::std::size_t __n)
         : _M_allocator(), _M_ptr(_M_allocator.allocate(__n)), _M_buf_size(__n)
     {
     }
@@ -58,7 +58,7 @@ class __buffer_impl
         return _M_ptr;
     }
     //! Destroy buffer
-    ~__buffer_impl() { _M_allocator.deallocate(_M_ptr, _M_buf_size); }
+    ~__buffer_impl_host() { _M_allocator.deallocate(_M_ptr, _M_buf_size); }
 };
 
 //! Destroy sequence [xs,xe)

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -32,7 +32,7 @@ namespace __utils
 // raw buffer (with specified _TAllocator)
 //------------------------------------------------------------------------
 
-template <typename _ExecutionPolicy, typename _Tp, template <typename _T> typename _TAllocator>
+template <typename _BackendTag, typename _ExecutionPolicy, typename _Tp, template <typename _T> typename _TAllocator>
 class __buffer_impl
 {
     _TAllocator<_Tp> _M_allocator;

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -25,9 +25,41 @@ namespace oneapi
 {
 namespace dpl
 {
-
 namespace __utils
 {
+
+//------------------------------------------------------------------------
+// raw buffer (with specified _TAllocator)
+//------------------------------------------------------------------------
+
+template <typename _ExecutionPolicy, typename _Tp, template <typename _T> typename _TAllocator>
+class __buffer_impl
+{
+    _TAllocator<_Tp> _M_allocator;
+    _Tp* _M_ptr = nullptr;
+    const ::std::size_t _M_buf_size = 0;
+
+    __buffer_impl(const __buffer_impl&) = delete;
+    void
+    operator=(const __buffer_impl&) = delete;
+
+  public:
+    //! Try to obtain buffer of given size to store objects of _Tp type
+    __buffer_impl(_ExecutionPolicy /*__exec*/, const ::std::size_t __n)
+        : _M_allocator(), _M_ptr(_M_allocator.allocate(__n)), _M_buf_size(__n)
+    {
+    }
+    //! True if buffer was successfully obtained, zero otherwise.
+    operator bool() const { return _M_ptr != nullptr; }
+    //! Return pointer to buffer, or nullptr if buffer could not be obtained.
+    _Tp*
+    get() const
+    {
+        return _M_ptr;
+    }
+    //! Destroy buffer
+    ~__buffer_impl() { _M_allocator.deallocate(_M_ptr, _M_buf_size); }
+};
 
 //! Destroy sequence [xs,xe)
 struct __serial_destroy

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -20,11 +20,13 @@
 #include <utility>
 #include <cassert>
 #include "utils.h"
+#include "execution_impl.h"
 
 namespace oneapi
 {
 namespace dpl
 {
+
 namespace __utils
 {
 
@@ -32,10 +34,10 @@ namespace __utils
 // raw buffer (with specified _TAllocator)
 //------------------------------------------------------------------------
 
-template <typename _BackendTag, typename _ExecutionPolicy, typename _Tp, template <typename _T> typename _TAllocator>
+template <typename _ExecutionPolicy, typename _Tp, typename _TAllocator>
 class __buffer_impl_host
 {
-    _TAllocator<_Tp> _M_allocator;
+    _TAllocator _M_allocator;
     _Tp* _M_ptr = nullptr;
     const ::std::size_t _M_buf_size = 0;
 
@@ -77,6 +79,7 @@ struct __serial_destroy
     }
 };
 
+//------------------------------------------------------------------------
 //! Merge sequences [__xs,__xe) and [__ys,__ye) to output sequence [__zs,(__xe-__xs)+(__ye-__ys)), using ::std::move
 struct __serial_move_merge
 {


### PR DESCRIPTION
The goals of this PR:
- to have only one implementation of host `__buffer` for all backend (`serial`, `tbb` and `omp`) due avoid code duplications.

At this moment our three implementations of host `__buffer` is absolutly the same excepting the allocators, which they are using:
- `serial` backend implementation - using `std::allocator`;
- `tbb` backend implementation - using `tbb::tbb_allocator`;
- `omp` backend implementation - using `std::allocator`.

In this PR we are not going to break these rules, but will specify using allocator by additional template param of `__buffer' implementation class.

# Implementation details

Now we have only one `class __buffer_impl` in oneDPL code and it's renamed to `class __buffer_impl_host`:
```C++
template <typename _ExecutionPolicy, typename _Tp, typename _TAllocator>
class __buffer_impl_host
{
    // ...
};
```

The definition of `__buffer` template alias inside each of host backends looks like
```C++
template <typename _BackendOrDispatchTag, typename _ExecutionPolicy, typename _Tp,
          typename _TAllocator = typename oneapi::dpl::__internal::__backend_buffer_allocator_selector<
              _Tp, _BackendOrDispatchTag>::allocator_type>
using __buffer = oneapi::dpl::__utils::__buffer_impl_host<::std::decay_t<_ExecutionPolicy>, _Tp, _TAllocator>;
```
One important detail here - in the template param `_BackendOrDispatchTag` we are ready to receive:
- our host backend tags: `__serial_backend_tag`, `__tbb_backend_tag` and `__omp_backend_tag`;
- our host dispatch tags: `__serial_tag`, `__parallel_tag` and `__parallel_forward_tag`.

Also now we can specify which allocator we will use in this buffer through template param `_TAllocator` :
- for `serial` and `omp` backends it's `::std::allocator`;
- for `tbb` backend it's `tbb::tbb_allocator`.

For support tag dispatching and use different allocators the the host buffer now we using the type `allocator_type` from  `__backend_buffer_allocator_selector` structure specializations :
```C++
template <typename _T>
struct __backend_buffer_allocator_selector<_T, oneapi::dpl::__internal::__serial_backend_tag>
{
    using allocator_type = ::std::allocator<_T>;
};

template <typename _T>
struct __backend_buffer_allocator_selector<_T, oneapi::dpl::__internal::__omp_backend_tag>
{
    using allocator_type = ::std::allocator<_T>;
};

template <typename _T>
struct __backend_buffer_allocator_selector<_T, oneapi::dpl::__internal::__tbb_backend_tag>
{
    using allocator_type = tbb::tbb_allocator<_T>;
};
```

This structure `__backend_buffer_allocator_selector` also has specializations for resolve dispatching tags into buffer allocators:
```C++
template <typename _T, typename _IsVector>
struct __backend_buffer_allocator_selector<_T, oneapi::dpl::__internal::__serial_tag<_IsVector>>
{
    using allocator_type = ::std::allocator<_T>;
};

template <typename _T, typename _IsVector>
struct __backend_buffer_allocator_selector<_T, oneapi::dpl::__internal::__parallel_tag<_IsVector>>
{
    using allocator_type = typename __backend_buffer_allocator_selector<
        _T, typename oneapi::dpl::__internal::__parallel_tag<_IsVector>::__backend_tag>::allocator_type;
};

template <typename _T>
struct __backend_buffer_allocator_selector<_T, oneapi::dpl::__internal::__parallel_forward_tag>
{
    using allocator_type = typename __backend_buffer_allocator_selector<
        _T, typename oneapi::dpl::__internal::__parallel_forward_tag::__backend_tag>::allocator_type;
};
```

As result now we have only one implementation of host `__buffer` with different using allocators which depends on <backend tags> or <dispatch tags>.