### PR TITLE
Inconsecutive implementation of  `__select_backend`

### DIFF
--- a/include/oneapi/dpl/pstl/iterator_defs.h
+++ b/include/oneapi/dpl/pstl/iterator_defs.h
@@ -40,9 +40,7 @@ auto
 __is_iterator_of(...) -> ::std::false_type;
 
 template <typename... _IteratorTypes>
-struct __is_random_access_iterator : decltype(__is_iterator_of<::std::random_access_iterator_tag, _IteratorTypes...>(0))
-{
-};
+using __is_random_access_iterator = decltype(__is_iterator_of<::std::random_access_iterator_tag, _IteratorTypes...>(0));
 
 template <typename... _IteratorTypes>
 struct __is_forward_iterator : decltype(__is_iterator_of<::std::forward_iterator_tag, _IteratorTypes...>(0))

--- a/include/oneapi/dpl/pstl/iterator_defs.h
+++ b/include/oneapi/dpl/pstl/iterator_defs.h
@@ -43,9 +43,7 @@ template <typename... _IteratorTypes>
 using __is_random_access_iterator = decltype(__is_iterator_of<::std::random_access_iterator_tag, _IteratorTypes...>(0));
 
 template <typename... _IteratorTypes>
-struct __is_forward_iterator : decltype(__is_iterator_of<::std::forward_iterator_tag, _IteratorTypes...>(0))
-{
-};
+using __is_forward_iterator = decltype(__is_iterator_of<::std::forward_iterator_tag, _IteratorTypes...>(0));
 
 template <typename... _IteratorTypes>
 inline constexpr bool __is_random_access_iterator_v = __is_random_access_iterator<_IteratorTypes...>::value;

--- a/include/oneapi/dpl/pstl/iterator_defs.h
+++ b/include/oneapi/dpl/pstl/iterator_defs.h
@@ -31,9 +31,8 @@ namespace __internal
 // SFINAE with a non-iterator type by providing a default value.
 template <typename _IteratorTag, typename... _IteratorTypes>
 auto
-__is_iterator_of(int) -> decltype(
-    ::std::conjunction<::std::is_base_of<
-        _IteratorTag, typename ::std::iterator_traits<::std::decay_t<_IteratorTypes>>::iterator_category>...>{});
+__is_iterator_of(int) -> typename ::std::conjunction<::std::is_base_of<
+    _IteratorTag, typename ::std::iterator_traits<::std::decay_t<_IteratorTypes>>::iterator_category>...>::type;
 
 template <typename... _IteratorTypes>
 auto


### PR DESCRIPTION
The yet another implementation of this task is in https://github.com/oneapi-src/oneDPL/pull/1456

Looks like we have incontinent implementation of `__select_backend`.
Sometimes we parametrize our dispatch tags with `std::true_type` or `std::false_type` types.
But in some cases we parametrize our dispatch tags with some another types like `_internal::__is_random_access_iterator<_IteratorTypes...>`
In this case it's not the same as `std::true_type` or `std::false_type` types.

For example let's analyze the next example of code:
```C++
void do_something_for(__serial_tag<std::false_type>) // overload (1)
{
    // use this overload for  __serial_tag<std::false_type>
}

template <typename __Tag>
void do_something_for(__Tag)
{
    // use this overload for  __serial_tag<std::true_type> and for tags of all other types
}
```

With our previous implementation `overload (1)` wouldn't work for `oneapi::dpl::execution::unsequenced_policy` due error in the code :
```C++
template <class... _IteratorTypes>
__serial_tag<__internal::__is_random_access_iterator<_IteratorTypes...>>
__select_backend(oneapi::dpl::execution::unsequenced_policy, _IteratorTypes&&...)
{
    return {};
}
```

because `__serial_tag` has been specialized here with some another type like `__is_random_access_iterator`.


This issue has been found by @MikeDvorskiy during works with tag dispatching.

# Another example - some code like `__pattern_for_loop_n`
Let's take a loot at our code :
```C++
template <typename _ExecutionPolicy, typename _Ip, typename _Size, typename _Function, typename... _Rest>
void
__pattern_for_loop_n(_ExecutionPolicy&&, _Ip __first, _Size __n, _Function __f, __single_stride_type,
                     /*vector=*/::std::false_type, /*parallel=*/::std::false_type, _Rest&&... __rest) noexcept
{
     // ...
}
```

The straightforward path too rewrite this function on tags is :
```C++
template <typename _ExecutionPolicy, typename _Ip, typename _Size, typename _Function, typename... _Rest>
void
__pattern_for_loop_n(__serial_tag<::std::false_type>,_ExecutionPolicy&&, _Ip __first, _Size __n, _Function __f, __single_stride_type, _Rest&&... __rest) noexcept
{
     // ...
}
```
But here we have some problem in this param type `__serial_tag<::std::false_type>` : not always the real type of `_IsVector` inside `__serial_tag` is `std::true_type` or `std::false_type`.
So we have the question - what is correct way to write overload of this concrete function on tags?

In this PR I am trying to resolve this point.