### PR TITLE
Improvements of `__pattern_stable_partition` and `__pattern_walk2`

### DIFF
--- a/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
+++ b/include/oneapi/dpl/internal/async_impl/async_impl_hetero.h
@@ -48,8 +48,7 @@ __pattern_walk1_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _For
     return __future_obj;
 }
 
-template <typename _IsSync = ::std::false_type,
-          __par_backend_hetero::access_mode __acc_mode1 = __par_backend_hetero::access_mode::read,
+template <__par_backend_hetero::access_mode __acc_mode1 = __par_backend_hetero::access_mode::read,
           __par_backend_hetero::access_mode __acc_mode2 = __par_backend_hetero::access_mode::write,
           typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator1, typename _ForwardIterator2,
           typename _Function>
@@ -69,9 +68,6 @@ __pattern_walk2_async(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _For
     auto __future = oneapi::dpl::__par_backend_hetero::__parallel_for(
         _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
         unseq_backend::walk_n<_ExecutionPolicy, _Function>{__f}, __n, __buf1.all_view(), __buf2.all_view());
-
-    if constexpr (_IsSync::value)
-        __future.wait();
 
     return __future.__make_future(__first2 + __n);
 }

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -28,6 +28,12 @@
 #    include "dpcpp/unseq_backend_sycl.h"
 #endif
 
+template <typename _Name>
+struct __walk2_brick_wrapper;
+
+template <typename _SourceT>
+struct fill_functor;
+
 #include "../../internal/async_impl/async_impl_hetero.h"
 
 namespace oneapi

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1322,7 +1322,7 @@ __pattern_stable_partition(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& _
     const auto __n_walk2 = copy_result.first - __true_result;
     if (__n_walk2 > 0)
     {
-        auto __future1 = __pattern_walk2_async(__tag, __par_backend_hetero::make_wrapped_policy<copy_back_wrapper>(__exec),
+        auto __future = __pattern_walk2_async(__tag, __par_backend_hetero::make_wrapped_policy<copy_back_wrapper>(__exec),
                                              __true_result, copy_result.first, __first,
                                              __brick_move<__hetero_tag<_BackendTag>, _ExecutionPolicy>{});
         __pattern_walk2(
@@ -1330,7 +1330,7 @@ __pattern_stable_partition(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& _
             __false_result, copy_result.second, __first + true_count,
             __brick_move<__hetero_tag<_BackendTag>, _ExecutionPolicy>{});
 
-        __future1.wait();
+        __future.wait();
     }
     else
     {

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1513,10 +1513,11 @@ __pattern_partial_sort_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
 
         auto __buf_first = __buf.get();
 
-        auto __buf_last = __pattern_walk2</*_IsSync=*/::std::false_type>(
+        auto __future = __pattern_walk2_async(
             __tag, __par_backend_hetero::make_wrapped_policy<__initial_copy_2>(__exec), __first, __last, __buf_first,
             __brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>{});
 
+        auto __buf_last = __future.get();
         auto __buf_mid = __buf_first + __out_size;
 
         // The wait() call on result of __parallel_partial_sort isn't required here

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -84,7 +84,7 @@ __pattern_walk1_n(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _F
 //------------------------------------------------------------------------
 
 // TODO: A tag _IsSync is used for provide a patterns call pipeline, where the last one should be synchronous
-// Probably it should be re-designed by a pipeline approach, when a pattern returns some sync obejects
+// Probably it should be re-designed by a pipeline approach, when a pattern returns some sync objects
 // and ones are combined into a "pipeline" (probably like Range pipeline)
 template <__par_backend_hetero::access_mode __acc_mode1 = __par_backend_hetero::access_mode::read,
           __par_backend_hetero::access_mode __acc_mode2 = __par_backend_hetero::access_mode::write,


### PR DESCRIPTION
The goals of this PR:
1. Optimize `__pattern_stable_partition` hetero implementation: as far as two calls of `__pattern_walk2` working on independent data we able to run them in parallel.
2. Remove first template param `typename _IsSync = ::std::false_type` from `__pattern_walk2` as not required: we are able to implement all our functional without it.
3. Remove first template param `typename _IsSync = ::std::false_type` from `__pattern_walk2_async` as not required: we are able to implement all our functional without it.