### PR TITLE
Adding public utility for users to check if usm_allocators are supported

### DIFF
--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -88,10 +88,10 @@ on details of the C++ standard library implementation and what information about
 allocator is included in the ``std::vector::iterator`` type definition. If USM allocated
 vector iterators are not detectable with your C++ standard library, they will still function
 as inputs to oneDPL, but they will be treated as if they were host-side
-``std::vector::iterator`` as described in the section below. To guarantee no additional
-host-side copies, you can use ``std::vector::data()`` in combination with ``std::vector::size()``
-with USM allocated vectors to obtain a USM pointers. This will avoid extra host-side copies
-regardless of the C++ standard library implementation.
+``std::vector::iterator`` as described in the `Use Host-Side std::vector`_ section. To guarantee
+no additional host-side copies, you can use ``std::vector::data()`` in combination with
+``std::vector::size()`` with USM allocated vectors to obtain a USM pointer. This will avoid
+extra host-side copies regardless of the C++ standard library implementation.
 
 An example of ``std::vector`` with a USM allocator:
 

--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -81,7 +81,19 @@ the buffer were created for the same queue. For example:
     return 0;
   }
 
-Alternatively, use ``std::vector`` with a USM allocator. For example:
+Alternatively, use ``std::vector`` with a USM allocator.
+
+Note: The ability to appropriately detect USM allocated ``std::vector::iterator`` depends
+on details of the C++ standard library implementation and what information about the
+allocator is included in the ``std::vector::iterator`` type definition. If USM allocated
+vector iterators are not detectable with your C++ standard library, they will still function
+as inputs to oneDPL, but they will be treated as if they were host-side
+``std::vector::iterator`` as described in the section below. To guarantee no additional
+host-side copies, you can use ``std::vector::data()`` in combination with ``std::vector::size()``
+with USM allocated vectors to obtain a USM pointers. This will avoid extra host-side copies
+regardless of the C++ standard library implementation.
+
+An example of ``std::vector`` with a USM allocator:
 
 .. code:: cpp
 
@@ -95,6 +107,9 @@ Alternatively, use ``std::vector`` with a USM allocator. For example:
     std::vector<int, decltype(alloc)> vec(n, alloc);
 
     std::fill(policy, vec.begin(), vec.end(), 42);
+
+    //alternative to use USM pointers:
+    // std::fill(policy, vec.data(), vec.data() + vec.size(), 42);
 
     return 0;
   }

--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -90,8 +90,9 @@ vector iterators are not detectable with your C++ standard library, they will st
 as inputs to oneDPL, but they will be treated as if they were host-side
 ``std::vector::iterator`` as described in the `Use Host-Side std::vector`_ section. To guarantee
 no additional host-side copies, you can use ``std::vector::data()`` in combination with
-``std::vector::size()`` with USM allocated vectors to obtain a USM pointer. This will avoid
-extra host-side copies regardless of the C++ standard library implementation.
+``std::vector::size()`` with USM allocated vectors to obtain USM pointers which can be used as
+substitutes for ``std::vector::begin()`` and ``std::vector::end()``. This will avoid extra
+host-side copies regardless of the C++ standard library implementation.
 
 An example of ``std::vector`` with a USM allocator:
 

--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -85,17 +85,21 @@ Alternatively, use ``std::vector`` with a USM allocator.
 
 Note: The ability to appropriately detect USM allocated ``std::vector::iterator`` depends
 on details of the C++ standard library implementation and what information about the
-allocator is included in the ``std::vector::iterator`` type definition. You can check
-if your C++ standard library implementation provides enough information by checking the
-value of ``oneapi::dpl::usm_allocated_vector_iterators_supported_v<ValueType>``. This will
-evaluate to ``true`` for C++ standard library implementations which allow oneDPL to support
-USM allocators with this ValueType and ``false`` otherwise. If usm_allocators are not
-supported with your C++ standard library, they will still function as inputs to oneDPL, but
-they will be treated as if they were host-side ``std::vector::iterator`` as described in
-the section below. To guarantee no additional host-side copies, you can use
-``std::vector::data()`` in combination with ``std::vector::size()`` with USM allocated
-vectors to obtain a USM pointers. This will avoid extra host-side copies regardless of the
-C++ standard library implementation.
+allocator is included in the ``std::vector::iterator`` type definition. If USM allocated
+vector iterators are not detectable with your C++ standard library, they will still function
+as inputs to oneDPL, but they will be treated as if they were host-side
+``std::vector::iterator`` as described in the `Use Host-Side std::vector`_ section. To guarantee
+no additional host-side copies, you can use ``std::vector::data()`` in combination with
+``std::vector::size()`` with USM allocated vectors to obtain USM pointers which can be used as
+substitutes for ``std::vector::begin()`` and ``std::vector::end()``. This will avoid extra
+host-side copies regardless of the C++ standard library implementation.  You can check if your
+C++ standard library implementation provides enough information by checking the value of
+``oneapi::dpl::usm_allocated_vector_iterators_supported_v<ValueType>``. This will evaluate to
+``true`` when using a C++ standard library implementation which allows oneDPL to detect and
+therefore support USM allocators for this ``ValueType`` and ``false`` otherwise. When
+``oneapi::dpl::usm_allocated_vector_iterators_supported_v<ValueType>`` evaluates to ``false``,
+it is best to instead rely upon USM pointers directly instead of iterators to vectors with 
+USM allocators.
 
 An example of ``std::vector`` with a USM allocator:
 

--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -85,14 +85,17 @@ Alternatively, use ``std::vector`` with a USM allocator.
 
 Note: The ability to appropriately detect USM allocated ``std::vector::iterator`` depends
 on details of the C++ standard library implementation and what information about the
-allocator is included in the ``std::vector::iterator`` type definition. If USM allocated
-vector iterators are not detectable with your C++ standard library, they will still function
-as inputs to oneDPL, but they will be treated as if they were host-side
-``std::vector::iterator`` as described in the `Use Host-Side std::vector`_ section. To guarantee
-no additional host-side copies, you can use ``std::vector::data()`` in combination with
-``std::vector::size()`` with USM allocated vectors to obtain USM pointers which can be used as
-substitutes for ``std::vector::begin()`` and ``std::vector::end()``. This will avoid extra
-host-side copies regardless of the C++ standard library implementation.
+allocator is included in the ``std::vector::iterator`` type definition. You can check
+if your C++ standard library implementation provides enough information by checking the
+value of ``oneapi::dpl::usm_allocated_vector_iterators_supported_v<ValueType>``. This will
+evaluate to ``true`` for C++ standard library implementations which allow oneDPL to support
+USM allocators with this ValueType and ``false`` otherwise. If usm_allocators are not
+supported with your C++ standard library, they will still function as inputs to oneDPL, but
+they will be treated as if they were host-side ``std::vector::iterator`` as described in
+the section below. To guarantee no additional host-side copies, you can use
+``std::vector::data()`` in combination with ``std::vector::size()`` with USM allocated
+vectors to obtain a USM pointers. This will avoid extra host-side copies regardless of the
+C++ standard library implementation.
 
 An example of ``std::vector`` with a USM allocator:
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -159,7 +159,6 @@ using __usm_shared_alloc_vec_iter =
 template <typename Iter, typename ValueType = typename std::iterator_traits<Iter>::value_type>
 using __usm_host_alloc_vec_iter =
     typename std::vector<ValueType, typename sycl::usm_allocator<ValueType, sycl::usm::alloc::host>>::iterator;
-
 // Evaluates to true if the provided type is an iterator with a value_type and if the implementation of a
 // std::vector<value_type, Alloc>::iterator can be distinguished between three different allocators, the
 // default, usm_shared, and usm_host. If all are distinct, it is very unlikely any non-usm based allocator
@@ -234,6 +233,11 @@ __internal::sycl_iterator<access_mode::discard_read_write, T, Allocator> end(syc
     return __internal::sycl_iterator<access_mode::discard_read_write, T, Allocator>{buf,
                                                                                     __dpl_sycl::__get_buffer_size(buf)};
 }
+
+template <typename ValueType>
+constexpr static bool usm_allocated_vector_iterators_supported_v =
+    oneapi::dpl::__internal::__vector_iter_distinguishes_by_allocator<ValueType*>::value;
+
 } // namespace dpl
 } // namespace oneapi
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -159,6 +159,7 @@ using __usm_shared_alloc_vec_iter =
 template <typename Iter, typename ValueType = typename std::iterator_traits<Iter>::value_type>
 using __usm_host_alloc_vec_iter =
     typename std::vector<ValueType, typename sycl::usm_allocator<ValueType, sycl::usm::alloc::host>>::iterator;
+
 // Evaluates to true if the provided type is an iterator with a value_type and if the implementation of a
 // std::vector<value_type, Alloc>::iterator can be distinguished between three different allocators, the
 // default, usm_shared, and usm_host. If all are distinct, it is very unlikely any non-usm based allocator


### PR DESCRIPTION
Support for USM allocators depends on the implementation details of the C++ standard library used after #1438, and after doc changes of #1477.

This PR adds a public utility (`usm_allocated_vector_iterators_supported_v<ValueType>`) which users can use at compile time to check if usm_allocators are available to them as efficient input to oneDPL algorithms.  

- If `usm_allocated_vector_iterators_supported_v<ValueType>` evaluates to `true`, `std::vector<ValueType, usm_allocator>::iterator` input types are passed directly to sycl kernels, and are an efficient way of using oneDPL.  

- If `usm_allocated_vector_iterators_supported_v<ValueType>` evaluates to `false`, `std::vector<ValueType, usm_allocator>::iterator` input types are treated as if they were host-side iterators, and wrapped in `sycl::buffer` before use in sycl kernels.  This includes all that comes with that, an extra host-side copy in and out.  Also these cannot then be used as the source iterator for `permutation_iterator`.