### PR TITLE
[Doc] Additional details for USM allocators with std::vector

### DIFF
--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -88,10 +88,10 @@ on details of the C++ standard library implementation and what information about
 allocator is included in the ``std::vector::iterator`` type definition. If USM allocated
 vector iterators are not detectable with your C++ standard library, they will still function
 as inputs to oneDPL, but they will be treated as if they were host-side
-``std::vector::iterator`` as described in the section below. To guarantee no additional
-host-side copies, you can use ``std::vector::data()`` in combination with ``std::vector::size()``
-with USM allocated vectors to obtain a USM pointers. This will avoid extra host-side copies
-regardless of the C++ standard library implementation.
+``std::vector::iterator`` as described in the `Use Host-Side std::vector`_ section. To guarantee
+no additional host-side copies, you can use ``std::vector::data()`` in combination with
+``std::vector::size()`` with USM allocated vectors to obtain a USM pointer. This will avoid
+extra host-side copies regardless of the C++ standard library implementation.
 
 An example of ``std::vector`` with a USM allocator:
 

--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -81,7 +81,19 @@ the buffer were created for the same queue. For example:
     return 0;
   }
 
-Alternatively, use ``std::vector`` with a USM allocator. For example:
+Alternatively, use ``std::vector`` with a USM allocator.
+
+Note: The ability to appropriately detect USM allocated ``std::vector::iterator`` depends
+on details of the C++ standard library implementation and what information about the
+allocator is included in the ``std::vector::iterator`` type definition. If USM allocated
+vector iterators are not detectable with your C++ standard library, they will still function
+as inputs to oneDPL, but they will be treated as if they were host-side
+``std::vector::iterator`` as described in the section below. To guarantee no additional
+host-side copies, you can use ``std::vector::data()`` in combination with ``std::vector::size()``
+with USM allocated vectors to obtain a USM pointers. This will avoid extra host-side copies
+regardless of the C++ standard library implementation.
+
+An example of ``std::vector`` with a USM allocator:
 
 .. code:: cpp
 
@@ -95,6 +107,9 @@ Alternatively, use ``std::vector`` with a USM allocator. For example:
     std::vector<int, decltype(alloc)> vec(n, alloc);
 
     std::fill(policy, vec.begin(), vec.end(), 42);
+
+    //alternative to use USM pointers:
+    // std::fill(policy, vec.data(), vec.data() + vec.size(), 42);
 
     return 0;
   }

--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -44,10 +44,19 @@ To use the functions, add ``#include <oneapi/dpl/iterator>`` to your code. For e
   #include <oneapi/dpl/iterator>
   #include <sycl/sycl.hpp>
   int main(){
-    sycl::buffer<int> buf { 1000 };
+    std::vector<int> vec(1000);
+    // generate random data on host for simplicity
+    std::random_device r;
+    std::default_random_engine e1(r());
+    std::uniform_int_distribution<int> uniform_dist(-2000, 2000);
+    std::generate(vec.begin(), vec.end(), [&](){ return uniform_dist(e1); });
+
+    //create a buffer from host memory
+    sycl::buffer<int> buf { vec.data(), vec.size() };
     auto buf_begin = oneapi::dpl::begin(buf);
     auto buf_end   = oneapi::dpl::end(buf);
-    std::fill(oneapi::dpl::execution::dpcpp_default, buf_begin, buf_end, 42);
+
+    std::sort(oneapi::dpl::execution::dpcpp_default, buf_begin, buf_end);
     return 0;
   }
 
@@ -69,8 +78,13 @@ the USM-allocated memory were created for the same queue. For example:
     sycl::queue q;
     const int n = 1000;
     int* d_head = sycl::malloc_shared<int>(n, q);
+    // generate random data on host for simplicity
+    std::random_device r;
+    std::default_random_engine e1(r());
+    std::uniform_int_distribution<int> uniform_dist(-2000, 2000);
+    std::generate(d_head, d_head + n, [&](){ return uniform_dist(e1); });
 
-    std::fill(oneapi::dpl::execution::make_device_policy(q), d_head, d_head + n, 42);
+    std::sort(oneapi::dpl::execution::make_device_policy(q), d_head, d_head + n);
 
     sycl::free(d_head, q);
     return 0;
@@ -98,8 +112,12 @@ as shown in the following example:
   #include <vector>
   int main(){
     std::vector<int> vec( 1000 );
-    std::fill(oneapi::dpl::execution::dpcpp_default, vec.begin(), vec.end(), 42);
-    // each element of vec equals to 42
+    std::random_device r;
+    std::default_random_engine e1(r());
+    std::uniform_int_distribution<int> uniform_dist(-2000, 2000);
+    std::generate(vec.begin(), vec.end(), [&](){ return uniform_dist(e1); });
+
+    std::sort(oneapi::dpl::execution::dpcpp_default, vec.begin(), vec.end();
     return 0;
   }
 
@@ -122,12 +140,16 @@ You can also use ``std::vector`` with a USM allocator, as shown in the following
     sycl::usm_allocator<int, sycl::usm::alloc::shared> alloc(policy.queue());
     std::vector<int, decltype(alloc)> vec(n, alloc);
 
+    std::random_device r;
+    std::default_random_engine e1(r());
+    std::uniform_int_distribution<int> uniform_dist(-2000, 2000);
+    std::generate(vec.begin(), vec.end(), [&](){ return uniform_dist(e1); });
+
     // Recommended to use USM pointers:
-    std::fill(policy, vec.data(), vec.data() + vec.size(), 42);
+    std::sort(policy, vec.data(), vec.data() + vec.size());
 
     // Iterators for USM allocators might require extra copying - not recommended method
-    // std::fill(policy, vec.begin(), vec.end(), 42);
-
+    // std::sort(policy, vec.begin(), vec.end());
     return 0;
   }
 

--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -42,14 +42,11 @@ To use the functions, add ``#include <oneapi/dpl/iterator>`` to your code. For e
   #include <oneapi/dpl/execution>
   #include <oneapi/dpl/algorithm>
   #include <oneapi/dpl/iterator>
+  #include <random>
   #include <sycl/sycl.hpp>
   int main(){
     std::vector<int> vec(1000);
-
-    std::random_device r;
-    std::default_random_engine e1(r());
-    std::uniform_int_distribution<int> uniform_dist(-2000, 2000);
-    std::generate(vec.begin(), vec.end(), [&](){ return uniform_dist(e1); });
+    std::generate(vec.begin(), vec.end(), std::minstd_rand{});
 
     //create a buffer from host memory
     sycl::buffer<int> buf { vec.data(), vec.size() };
@@ -73,16 +70,13 @@ the USM-allocated memory were created for the same queue. For example:
 
   #include <oneapi/dpl/execution>
   #include <oneapi/dpl/algorithm>
+  #include <random>
   #include <sycl/sycl.hpp>
   int main(){
     sycl::queue q;
     const int n = 1000;
     int* d_head = sycl::malloc_shared<int>(n, q);
-
-    std::random_device r;
-    std::default_random_engine e1(r());
-    std::uniform_int_distribution<int> uniform_dist(-2000, 2000);
-    std::generate(d_head, d_head + n, [&](){ return uniform_dist(e1); });
+    std::generate(d_head, d_head + n, std::minstd_rand{});
 
     std::sort(oneapi::dpl::execution::make_device_policy(q), d_head, d_head + n);
 
@@ -109,13 +103,11 @@ as shown in the following example:
 
   #include <oneapi/dpl/execution>
   #include <oneapi/dpl/algorithm>
+  #include <random>
   #include <vector>
   int main(){
     std::vector<int> vec( 1000 );
-    std::random_device r;
-    std::default_random_engine e1(r());
-    std::uniform_int_distribution<int> uniform_dist(-2000, 2000);
-    std::generate(vec.begin(), vec.end(), [&](){ return uniform_dist(e1); });
+    std::generate(vec.begin(), vec.end(), std::minstd_rand{});
 
     std::sort(oneapi::dpl::execution::dpcpp_default, vec.begin(), vec.end());
     return 0;
@@ -133,17 +125,14 @@ You can also use ``std::vector`` with a USM allocator, as shown in the following
 
   #include <oneapi/dpl/execution>
   #include <oneapi/dpl/algorithm>
+  #include <random>
   #include <sycl/sycl.hpp>
   int main(){
     const int n = 1000;
     auto policy = oneapi::dpl::execution::dpcpp_default;
     sycl::usm_allocator<int, sycl::usm::alloc::shared> alloc(policy.queue());
     std::vector<int, decltype(alloc)> vec(n, alloc);
-
-    std::random_device r;
-    std::default_random_engine e1(r());
-    std::uniform_int_distribution<int> uniform_dist(-2000, 2000);
-    std::generate(vec.begin(), vec.end(), [&](){ return uniform_dist(e1); });
+    std::generate(vec.begin(), vec.end(), std::minstd_rand{});
 
     // Recommended to use USM pointers:
     std::sort(policy, vec.data(), vec.data() + vec.size());

--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -45,7 +45,7 @@ To use the functions, add ``#include <oneapi/dpl/iterator>`` to your code. For e
   #include <sycl/sycl.hpp>
   int main(){
     std::vector<int> vec(1000);
-    // generate random data on host for simplicity
+
     std::random_device r;
     std::default_random_engine e1(r());
     std::uniform_int_distribution<int> uniform_dist(-2000, 2000);
@@ -78,7 +78,7 @@ the USM-allocated memory were created for the same queue. For example:
     sycl::queue q;
     const int n = 1000;
     int* d_head = sycl::malloc_shared<int>(n, q);
-    // generate random data on host for simplicity
+
     std::random_device r;
     std::default_random_engine e1(r());
     std::uniform_int_distribution<int> uniform_dist(-2000, 2000);
@@ -117,7 +117,7 @@ as shown in the following example:
     std::uniform_int_distribution<int> uniform_dist(-2000, 2000);
     std::generate(vec.begin(), vec.end(), [&](){ return uniform_dist(e1); });
 
-    std::sort(oneapi::dpl::execution::dpcpp_default, vec.begin(), vec.end();
+    std::sort(oneapi::dpl::execution::dpcpp_default, vec.begin(), vec.end());
     return 0;
   }
 

--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -84,7 +84,7 @@ the USM-allocated memory were created for the same queue. For example:
     return 0;
   }
 
-When using device USM, such as allocated by malloc_device, you are responsible for data
+When using device USM, such as allocated by ``malloc_device``, you are responsible for data
 transfers to and from the device to ensure that input data is device accessible during oneDPL
 algorithm execution and that the result is available to the operations.
 

--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -76,8 +76,9 @@ the USM-allocated memory were created for the same queue. For example:
     return 0;
   }
 
-When using device USM, such as allocated by ``malloc_device``, manually copy data to this memory
-before calling oneDPL algorithms, and copy it back once the algorithms have finished execution.
+When using device USM, such as allocated by malloc_device, the user is responsible for data
+transfers to and from the device to ensure that input data is device accessible during oneDPL
+algorithm execution and that the result is available to the operation which follows.
 
 Use std::vector
 -----------------------------
@@ -124,7 +125,7 @@ You can also use ``std::vector`` with a USM allocator, as shown in the following
     // Recommended to use USM pointers:
     std::fill(policy, vec.data(), vec.data() + vec.size(), 42);
 
-    // Iterators for USM allocators might require extra copying
+    // Iterators for USM allocators might require extra copying - not recommended method
     // std::fill(policy, vec.begin(), vec.end(), 42);
 
     return 0;

--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -90,8 +90,9 @@ vector iterators are not detectable with your C++ standard library, they will st
 as inputs to oneDPL, but they will be treated as if they were host-side
 ``std::vector::iterator`` as described in the `Use Host-Side std::vector`_ section. To guarantee
 no additional host-side copies, you can use ``std::vector::data()`` in combination with
-``std::vector::size()`` with USM allocated vectors to obtain a USM pointer. This will avoid
-extra host-side copies regardless of the C++ standard library implementation.
+``std::vector::size()`` with USM allocated vectors to obtain USM pointers which can be used as
+substitutes for ``std::vector::begin()`` and ``std::vector::end()``. This will avoid extra
+host-side copies regardless of the C++ standard library implementation.
 
 An example of ``std::vector`` with a USM allocator:
 

--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -84,16 +84,16 @@ the USM-allocated memory were created for the same queue. For example:
     return 0;
   }
 
-When using device USM, such as allocated by malloc_device, the user is responsible for data
+When using device USM, such as allocated by malloc_device, you are responsible for data
 transfers to and from the device to ensure that input data is device accessible during oneDPL
-algorithm execution and that the result is available to the operation which follows.
+algorithm execution and that the result is available to the operations.
 
 Use std::vector
 -----------------------------
 
 The following examples demonstrate two ways to use the parallel algorithms with ``std::vector``:
 
-* host allocators
+* Host allocators
 * USM allocators
 
 You can use iterators to host allocated ``std::vector`` data

--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -131,11 +131,10 @@ You can also use ``std::vector`` with a USM allocator, as shown in the following
   }
 
 Make sure that the execution policy and the USM-allocated memory were created for the same queue.
-When using USM allocators with ``std::vector``, it is recommended to use USM pointers as shown in
-the example above, rather than with iterators to ``std::vector``. In some implementations of the C++
-Standard Library, it is not possible to detect that iterators are pointing to USM-allocated data.
-In those cases, data will be treated as if it were host-side data, and will require extra copying
-between host and device. |onedpl_short| will avoid copies whenever it is possible with the C++
-Standard Library implementation.  However, to guarantee no unintended copying, use
-``std::vector::data()`` in combination with ``std::vector::size()`` when using USM-allocated data
-to retrieve USM pointers for the sequence as shown.
+
+For ``std::vector`` with a USM allocator we recommend to use ``std::vector::data()`` in
+combination with ``std::vector::size()`` as shown in the example above, rather than iterators to
+``std::vector``. That is because for some implementations of the C++ Standard Library it might not
+be possible for |onedpl_short| to detect that iterators are pointing to USM-allocated data. In that
+case the data will be treated as if it were host-allocated, with an extra copy made to a SYCL buffer.
+Retrieving USM pointers from ``std::vector`` as shown guarantees no unintended copying.

--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -86,7 +86,7 @@ the USM-allocated memory were created for the same queue. For example:
 
 When using device USM, such as allocated by ``malloc_device``, you are responsible for data
 transfers to and from the device to ensure that input data is device accessible during oneDPL
-algorithm execution and that the result is available to the operations.
+algorithm execution and that the result is available to the subsequent operations.
 
 Use std::vector
 -----------------------------

--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -5,7 +5,7 @@ You can use one of the following ways to pass data to an algorithm executed with
 
 * ``oneapi:dpl::begin`` and ``oneapi::dpl::end`` functions
 * Unified shared memory (USM) pointers
-* Iterators or USM pointers to ``std::vector`` data
+* ``std::vector`` with or without a USM allocator
 
 .. _use-buffer-wrappers:
 

--- a/documentation/library_guide/parallel_api/pass_data_algorithms.rst
+++ b/documentation/library_guide/parallel_api/pass_data_algorithms.rst
@@ -90,7 +90,7 @@ vector iterators are not detectable with your C++ standard library, they will st
 as inputs to oneDPL, but they will be treated as if they were host-side
 ``std::vector::iterator`` as described in the `Use Host-Side std::vector`_ section. To guarantee
 no additional host-side copies, you can use ``std::vector::data()`` in combination with
-``std::vector::size()`` with USM allocated vectors to obtain USM pointers which can be used as
+``std::vector::size()`` with USM allocated vectors to obtain USM pointers, which can be used as
 substitutes for ``std::vector::begin()`` and ``std::vector::end()``. This will avoid extra
 host-side copies regardless of the C++ standard library implementation.
 


### PR DESCRIPTION
Separated out from #1438.  
Documentation changes to describe the details of usm allocators after that PR is merged.  
It also describes a more guaranteed way for proper handling of USM allocated data by directly obtaining USM pointers from a `std::vector`, as this does not rely on any implementation details of the C++ standard library implementation.
