### PR TITLE
Handle potential sycl::malloc issues

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -424,7 +424,11 @@ struct __sycl_usm_alloc
     operator()(::std::size_t __elements) const
     {
         const auto& __queue = __exec.queue();
-        return (_T*)sycl::malloc(sizeof(_T) * __elements, __queue.get_device(), __queue.get_context(), __alloc_t);
+        auto __buf = static_cast<_T*>(
+            sycl::malloc(sizeof(_T) * __elements, __queue.get_device(), __queue.get_context(), __alloc_t));
+        if (!__buf)
+            throw std::bad_alloc();
+        return __buf;
     }
 };
 


### PR DESCRIPTION
The SYCL spec on `sycl::malloc` reads: " If there are not enough resources to allocate the requested memory, these functions return nullptr." This patch handles the null pointer case by throwing `std::bad_alloc`.