### PR TITLE
[tests] Fix for permutation_iterator tests with transform_iterator index

### DIFF
--- a/test/parallel_api/iterator/permutation_iterator.h
+++ b/test/parallel_api/iterator/permutation_iterator.h
@@ -197,22 +197,22 @@ struct test_through_permutation_iterator<TSourceIterator, TSourceDataSize, perm_
     {
     }
 
+    using ValueType = typename ::std::iterator_traits<TSourceIterator>::value_type;
+
+    // Using callable object instead of lambda here to ensure transform iterator would be
+    // default constructible, that is part of the Forward Iterator requirements in the C++ standard.
+    struct NoTransform
+    {
+        ValueType operator()(const ValueType& val) const
+        {
+            return val;
+        }
+    };
+
     template <typename Operand>
     void
     operator()(Operand op)
     {
-        using ValueType = typename ::std::iterator_traits<TSourceIterator>::value_type;
-
-        // Using callable object instead of lambda here to ensure transform iterator would be
-        // default constructible, that is part of the Forward Iterator requirements in the C++ standard.
-        struct NoTransform
-        {
-            ValueType operator()(const ValueType& val) const
-            {
-                return val;
-            }
-        };
-
         auto indexes_begin = dpl::counting_iterator<TSourceDataSize>(0);
         auto itTransformBegin = dpl::make_transform_iterator(indexes_begin, NoTransform{});
         auto permItBegin = dpl::make_permutation_iterator(data.itSource, itTransformBegin);


### PR DESCRIPTION
This PR should fix the `permutation_iterator` tests with `transform_iterator` as index.  In practice, without this PR, errors only appear on Windows platforms, however it may not be limited to windows.

The SYCL spec requires that template arguments (captures) to lambda functions submitted as sycl kernels must be included in the kernel name and must be "forward declarable at namespace scope".
https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:interfaces.kernels.as.lambdas

When we use a functor in a `transform_iterator` which is then used as index for a `permutation_iterator`, the type of the resulting range must be forward declarable at namespace scope as it is used in the reduce kernel as an input capture to the lambda sycl kernel.   When we define the functor within a function's scope, rather than within the structure's scope, we lose this, and end up with an invalid kernel name.  This PR simply moves the functor definition to a scope which makes it forward declarable at namespace scope.

On windows, it seems that this results in an exception when attempting to call the kernel:
"No kernel named  was found -46 (PI_ERROR_INVALID_KERNEL_NAME)"

