### PR TITLE
Common implementation of hosts backends buffer

### DIFF
--- a/include/oneapi/dpl/pstl/omp/util.h
+++ b/include/oneapi/dpl/pstl/omp/util.h
@@ -58,33 +58,7 @@ __cancel_execution(oneapi::dpl::__internal::__omp_backend_tag)
 //------------------------------------------------------------------------
 
 template <typename _ExecutionPolicy, typename _Tp>
-class __buffer_impl
-{
-    std::allocator<_Tp> __allocator_;
-    _Tp* __ptr_;
-    const std::size_t __buf_size_;
-    __buffer_impl(const __buffer_impl&) = delete;
-    void
-    operator=(const __buffer_impl&) = delete;
-
-  public:
-    __buffer_impl(_ExecutionPolicy /*__exec*/, std::size_t __n)
-        : __allocator_(), __ptr_(__allocator_.allocate(__n)), __buf_size_(__n)
-    {
-    }
-
-    operator bool() const { return __ptr_ != nullptr; }
-
-    _Tp*
-    get() const
-    {
-        return __ptr_;
-    }
-    ~__buffer_impl() { __allocator_.deallocate(__ptr_, __buf_size_); }
-};
-
-template <typename _ExecutionPolicy, typename _Tp>
-using __buffer = __buffer_impl<::std::decay_t<_ExecutionPolicy>, _Tp>;
+using __buffer = oneapi::dpl::__utils::__buffer_impl<::std::decay_t<_ExecutionPolicy>, _Tp, std::allocator>;
 
 // Preliminary size of each chunk: requires further discussion
 constexpr std::size_t __default_chunk_size = 2048;

--- a/include/oneapi/dpl/pstl/omp/util.h
+++ b/include/oneapi/dpl/pstl/omp/util.h
@@ -58,7 +58,7 @@ __cancel_execution(oneapi::dpl::__internal::__omp_backend_tag)
 //------------------------------------------------------------------------
 
 template <typename _ExecutionPolicy, typename _Tp>
-using __buffer = oneapi::dpl::__utils::__buffer_impl<::std::decay_t<_ExecutionPolicy>, _Tp, std::allocator>;
+using __buffer = oneapi::dpl::__utils::__buffer_impl<std::decay_t<_ExecutionPolicy>, _Tp, std::allocator>;
 
 // Preliminary size of each chunk: requires further discussion
 constexpr std::size_t __default_chunk_size = 2048;

--- a/include/oneapi/dpl/pstl/parallel_backend_serial.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_serial.h
@@ -25,6 +25,8 @@
 #include <utility>
 #include <type_traits>
 
+#include "parallel_backend_utils.h"
+
 namespace oneapi
 {
 namespace dpl
@@ -33,32 +35,7 @@ namespace __serial_backend
 {
 
 template <typename _ExecutionPolicy, typename _Tp>
-class __buffer_impl
-{
-    ::std::allocator<_Tp> __allocator_;
-    _Tp* __ptr_;
-    const ::std::size_t __buf_size_;
-    __buffer_impl(const __buffer_impl&) = delete;
-    void
-    operator=(const __buffer_impl&) = delete;
-
-  public:
-    __buffer_impl(_ExecutionPolicy /*__exec*/, ::std::size_t __n)
-        : __allocator_(), __ptr_(__allocator_.allocate(__n)), __buf_size_(__n)
-    {
-    }
-
-    operator bool() const { return __ptr_ != nullptr; }
-    _Tp*
-    get() const
-    {
-        return __ptr_;
-    }
-    ~__buffer_impl() { __allocator_.deallocate(__ptr_, __buf_size_); }
-};
-
-template <typename _ExecutionPolicy, typename _Tp>
-using __buffer = __buffer_impl<::std::decay_t<_ExecutionPolicy>, _Tp>;
+using __buffer = oneapi::dpl::__utils::__buffer_impl<::std::decay_t<_ExecutionPolicy>, _Tp, std::allocator>;
 
 inline void
 __cancel_execution(oneapi::dpl::__internal::__serial_backend_tag)

--- a/include/oneapi/dpl/pstl/parallel_backend_serial.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_serial.h
@@ -35,7 +35,7 @@ namespace __serial_backend
 {
 
 template <typename _ExecutionPolicy, typename _Tp>
-using __buffer = oneapi::dpl::__utils::__buffer_impl<::std::decay_t<_ExecutionPolicy>, _Tp, std::allocator>;
+using __buffer = oneapi::dpl::__utils::__buffer_impl<std::decay_t<_ExecutionPolicy>, _Tp, std::allocator>;
 
 inline void
 __cancel_execution(oneapi::dpl::__internal::__serial_backend_tag)

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -55,35 +55,7 @@ not an initialize array, because initialization/destruction
 would make the span be at least O(N). */
 // tbb::allocator can improve performance in some cases.
 template <typename _ExecutionPolicy, typename _Tp>
-class __buffer_impl
-{
-    tbb::tbb_allocator<_Tp> _M_allocator;
-    _Tp* _M_ptr;
-    const ::std::size_t _M_buf_size;
-    __buffer_impl(const __buffer_impl&) = delete;
-    void
-    operator=(const __buffer_impl&) = delete;
-
-  public:
-    //! Try to obtain buffer of given size to store objects of _Tp type
-    __buffer_impl(_ExecutionPolicy /*__exec*/, const ::std::size_t __n)
-        : _M_allocator(), _M_ptr(_M_allocator.allocate(__n)), _M_buf_size(__n)
-    {
-    }
-    //! True if buffer was successfully obtained, zero otherwise.
-    operator bool() const { return _M_ptr != nullptr; }
-    //! Return pointer to buffer, or nullptr if buffer could not be obtained.
-    _Tp*
-    get() const
-    {
-        return _M_ptr;
-    }
-    //! Destroy buffer
-    ~__buffer_impl() { _M_allocator.deallocate(_M_ptr, _M_buf_size); }
-};
-
-template <typename _ExecutionPolicy, typename _Tp>
-using __buffer = __buffer_impl<::std::decay_t<_ExecutionPolicy>, _Tp>;
+using __buffer = oneapi::dpl::__utils::__buffer_impl<::std::decay_t<_ExecutionPolicy>, _Tp, tbb::tbb_allocator>;
 
 // Wrapper for tbb::task
 inline void

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -55,7 +55,7 @@ not an initialize array, because initialization/destruction
 would make the span be at least O(N). */
 // tbb::allocator can improve performance in some cases.
 template <typename _ExecutionPolicy, typename _Tp>
-using __buffer = oneapi::dpl::__utils::__buffer_impl<::std::decay_t<_ExecutionPolicy>, _Tp, tbb::tbb_allocator>;
+using __buffer = oneapi::dpl::__utils::__buffer_impl<std::decay_t<_ExecutionPolicy>, _Tp, tbb::tbb_allocator>;
 
 // Wrapper for tbb::task
 inline void

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -25,9 +25,41 @@ namespace oneapi
 {
 namespace dpl
 {
-
 namespace __utils
 {
+
+//------------------------------------------------------------------------
+// raw buffer (with specified _TAllocator)
+//------------------------------------------------------------------------
+
+template <typename _ExecutionPolicy, typename _Tp, template <typename _T> typename _TAllocator>
+class __buffer_impl
+{
+    _TAllocator<_Tp> _M_allocator;
+    _Tp* _M_ptr = nullptr;
+    const ::std::size_t _M_buf_size = 0;
+
+    __buffer_impl(const __buffer_impl&) = delete;
+    void
+    operator=(const __buffer_impl&) = delete;
+
+  public:
+    //! Try to obtain buffer of given size to store objects of _Tp type
+    __buffer_impl(_ExecutionPolicy /*__exec*/, const ::std::size_t __n)
+        : _M_allocator(), _M_ptr(_M_allocator.allocate(__n)), _M_buf_size(__n)
+    {
+    }
+    //! True if buffer was successfully obtained, zero otherwise.
+    operator bool() const { return _M_ptr != nullptr; }
+    //! Return pointer to buffer, or nullptr if buffer could not be obtained.
+    _Tp*
+    get() const
+    {
+        return _M_ptr;
+    }
+    //! Destroy buffer
+    ~__buffer_impl() { _M_allocator.deallocate(_M_ptr, _M_buf_size); }
+};
 
 //! Destroy sequence [xs,xe)
 struct __serial_destroy


### PR DESCRIPTION
The goal of this PR - to reduce the amount of duplicated code in our host backends implementations.

In this PR we implement and use the common implementation of host backends buffer, specialized by different memory allocators.
Previously we had three different implementations of hosts backends buffer: they were absolutely the same but have used different memory allocators.