### PR TITLE
requiring fmt no longer for distributed-ranges tests

### DIFF
--- a/test/distributed-ranges/include/common-tests.hpp
+++ b/test/distributed-ranges/include/common-tests.hpp
@@ -137,9 +137,9 @@ bool is_equal(std::forward_iterator auto it, rng::range auto &&r) {
 auto equal_message(rng::range auto &&ref, rng::range auto &&actual,
                    std::string title = " ") {
   if (is_equal(ref, actual)) {
-    return fmt::format("");
+    return drfmt::format("");
   }
-  return fmt::format("\n{}"
+  return drfmt::format("\n{}"
                      "    ref:    {}\n"
                      "    actual: {}\n  ",
                      title == "" ? "" : "    " + title + "\n",
@@ -151,7 +151,7 @@ std::string unary_check_message(rng::range auto &&in, rng::range auto &&ref,
   if (is_equal(ref, tst)) {
     return "";
   } else {
-    return fmt::format("\n{}"
+    return drfmt::format("\n{}"
                        "    in:     {}\n"
                        "    ref:    {}\n"
                        "    actual: {}\n  ",
@@ -177,7 +177,7 @@ std::string check_segments_message(auto &&r) {
   auto segments = dr::ranges::segments(r);
   auto flat = rng::views::join(segments);
   if (contains_empty(segments) || !is_equal(r, flat)) {
-    return fmt::format("\n"
+    return drfmt::format("\n"
                        "    Segment error\n"
                        "      range:    {}\n"
                        "      segments: {}\n  ",
@@ -247,7 +247,7 @@ auto check_binary_check_op(rng::range auto &&a, rng::range auto &&b,
     return testing::AssertionSuccess();
   } else {
     return testing::AssertionFailure()
-           << fmt::format("\n        a: {}\n        b: {}\n      ref: {}\n    "
+           << drfmt::format("\n        a: {}\n        b: {}\n      ref: {}\n    "
                           "actual: {}\n  ",
                           a, b, ref, actual);
   }
@@ -258,7 +258,7 @@ auto check_segments(std::forward_iterator auto di) {
   auto flat = rng::join_view(segments);
   if (contains_empty(segments) || !is_equal(di, flat)) {
     return testing::AssertionFailure()
-           << fmt::format("\n    segments: {}\n  ", segments);
+           << drfmt::format("\n    segments: {}\n  ", segments);
   } else {
     return testing::AssertionSuccess();
   }
@@ -336,14 +336,14 @@ template <rng::range R1, rng::range R2> bool operator==(R1 &&r1, R2 &&r2) {
 template <typename... Ts>
 inline std::ostream &operator<<(std::ostream &os,
                                 const rng::common_tuple<Ts...> &obj) {
-  os << fmt::format("{}", obj);
+  os << drfmt::format("{}", obj);
   return os;
 }
 
 template <typename T1, typename T2>
 inline std::ostream &operator<<(std::ostream &os,
                                 const rng::common_pair<T1, T2> &obj) {
-  os << fmt::format("{}", obj);
+  os << drfmt::format("{}", obj);
   return os;
 }
 
@@ -354,14 +354,14 @@ namespace std {
 template <typename... Ts>
 inline std::ostream &operator<<(std::ostream &os,
                                 const std::tuple<Ts...> &obj) {
-  os << fmt::format("{}", obj);
+  os << drfmt::format("{}", obj);
   return os;
 }
 
 template <typename T1, typename T2>
 inline std::ostream &operator<<(std::ostream &os,
                                 const std::pair<T1, T2> &obj) {
-  os << fmt::format("{}", obj);
+  os << drfmt::format("{}", obj);
   return os;
 }
 

--- a/test/distributed-ranges/shp/CMakeLists.txt
+++ b/test/distributed-ranges/shp/CMakeLists.txt
@@ -1,6 +1,18 @@
 # SPDX-FileCopyrightText: Intel Corporation
 #
 # SPDX-License-Identifier: BSD-3-Clause
+
+include(CheckIncludeFileCXX)
+check_include_file_cxx("format" CXX_FORMAT_SUPPORT)
+if (NOT CXX_FORMAT_SUPPORT)
+  find_package(fmt QUIET)
+endif()
+
+if (NOT CXX_FORMAT_SUPPORT AND NOT fmt_FOUND)
+  message(WARNING "disabled distributed ranges tests, install fmt library or g++>=13 or clang>=17")
+  return()
+endif ()
+
 include(FetchContent)
 
 FetchContent_Declare(
@@ -14,12 +26,6 @@ FetchContent_Declare(
   GIT_REPOSITORY https://github.com/BenBrock/range-v3.git
   GIT_TAG 5300fe3)
 FetchContent_MakeAvailable(range-v3)
-
-FetchContent_Declare(
-  cpp-format
-  GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-  GIT_TAG 0b0f7cf)
-FetchContent_MakeAvailable(cpp-format)
 
 FetchContent_Declare(
     cxxopts
@@ -37,12 +43,16 @@ add_library(DR::shp ALIAS dr_shp)
 target_include_directories(dr_shp INTERFACE . vendor ../../../include)
 target_compile_definitions(dr_shp INTERFACE USE_MKL
                                             _GLIBCXX_USE_TBB_PAR_BACKEND=0)
-target_link_libraries(dr_shp INTERFACE range-v3 fmt::fmt MKL::MKL_DPCPP)
+target_link_libraries(dr_shp INTERFACE range-v3 MKL::MKL_DPCPP)
+if (NOT CXX_FORMAT_SUPPORT)
+  target_link_libraries(dr_shp INTERFACE fmt::fmt)
+  target_compile_definitions(dr_shp INTERFACE USE_FMT)
+  message(VERBOSE "using fmt library for logging in distributed-ranges tests")
+endif()
 
 if (DEFINED ONEDPL_USE_DR)
   target_compile_options(dr_shp INTERFACE "-DONEDPL_USE_DISTRIBUTED_RANGES")
 endif()
-
 
 # For use, see:
 # https://github.com/illuhad/hipSYCL/blob/develop/doc/using-hipsycl.md#using-the-cmake-integration
@@ -55,9 +65,6 @@ if($(HIPSYCL_TARGETS))
 endif()
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-
-
-
 
 add_executable(
   shp-tests
@@ -73,7 +80,11 @@ add_executable(
 add_executable(shp-tests-3 shp-tests.cpp containers-3.cpp copy-3.cpp)
 
 foreach(test-exec IN ITEMS shp-tests shp-tests-3)
-  target_link_libraries(${test-exec} GTest::gtest_main DR::shp fmt::fmt cxxopts)
+  target_link_libraries(${test-exec} GTest::gtest_main DR::shp cxxopts)
+  if (NOT CXX_FORMAT_SUPPORT AND fmt_FOUND)
+    target_link_libraries(${test-exec} fmt::fmt)
+    target_compile_definitions(${test-exec} PRIVATE USE_FMT)
+  endif()
 endforeach()
 
 add_custom_target(shp-all-tests)

--- a/test/distributed-ranges/shp/shp-tests.cpp
+++ b/test/distributed-ranges/shp/shp-tests.cpp
@@ -19,12 +19,12 @@ int main(int argc, char *argv[]) {
   try {
     options = options_spec.parse(argc, argv);
   } catch (const cxxopts::OptionParseException &e) {
-    fmt::print("{}\n", options_spec.help());
+    std::cout << options_spec.help() << "\n";
     exit(1);
   }
 
   if (options.count("drhelp")) {
-    fmt::print("{}\n", options_spec.help());
+    std::cout << options_spec.help() << "\n";
     exit(0);
   }
 

--- a/test/distributed-ranges/shp/xhp-tests.hpp
+++ b/test/distributed-ranges/shp/xhp-tests.hpp
@@ -4,13 +4,24 @@
 #pragma once
 
 #include "cxxopts.hpp"
-#include <fmt/core.h>
-#include <fmt/ranges.h>
+
 #include <gtest/gtest.h>
 #include <oneapi/dpl/distributed-ranges>
 
-#define TEST_SHP
+#ifdef __cpp_lib_format
+#include <format>
+namespace drfmt {
+  using std::format;
+}
+#else
+#include <fmt/core.h>
+#include <fmt/ranges.h>
+namespace drfmt {
+  using fmt::format;
+}
+#endif
 
+#define TEST_SHP
 // To share tests with MHP
 const std::size_t comm_rank = 0;
 const std::size_t comm_size = 1;


### PR DESCRIPTION
but if they are not found and they are not present in stdlib, then distributed-ranges tests aren't build