### PR TITLE
Fix incorrect _ONEDPL_SYCL_USM_HOST_PRESENT usage in USM allocation helpers

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -567,7 +567,6 @@ struct __result_and_scratch_storage
         }
         else if (__supports_USM_device)
         {
-            std::cout << "device" << std::endl;
             // If we don't use host memory, malloc only a single unified device allocation
             __scratch_buf = ::std::shared_ptr<_T>(
                 __internal::__sycl_usm_alloc<_ExecutionPolicy, _T, sycl::usm::alloc::device>{__exec}(__scratch_n + 1),
@@ -575,7 +574,6 @@ struct __result_and_scratch_storage
         }
         else
         {
-            std::cout << "buffer" << std::endl;
             // If we don't have USM support allocate memory here
             __sycl_buf = ::std::make_shared<__sycl_buffer_t>(__sycl_buffer_t(__scratch_n + 1));
         }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -543,7 +543,7 @@ struct __result_and_scratch_storage
     inline bool
     __use_USM_allocations(sycl::queue __queue)
     {
-#if _ONEDPL_SYCL_USM_HOST_PRESENT
+#if _ONEDPL_SYCL_UNIFIED_USM_BUFFER_PRESENT
         return __queue.get_device().has(sycl::aspect::usm_device_allocations);
 #else
         return false;
@@ -567,6 +567,7 @@ struct __result_and_scratch_storage
         }
         else if (__supports_USM_device)
         {
+            std::cout << "device" << std::endl;
             // If we don't use host memory, malloc only a single unified device allocation
             __scratch_buf = ::std::shared_ptr<_T>(
                 __internal::__sycl_usm_alloc<_ExecutionPolicy, _T, sycl::usm::alloc::device>{__exec}(__scratch_n + 1),
@@ -574,6 +575,7 @@ struct __result_and_scratch_storage
         }
         else
         {
+            std::cout << "buffer" << std::endl;
             // If we don't have USM support allocate memory here
             __sycl_buf = ::std::make_shared<__sycl_buffer_t>(__sycl_buffer_t(__scratch_n + 1));
         }


### PR DESCRIPTION
`__use_USM_allocations` introduced in PR #1354 uses `_ONEDPL_SYCL_USM_HOST_PRESENT` to check if host memory support is present. However, this macro was renamed to `_ONEDPL_SYCL_UNIFIED_USM_BUFFER_PRESENT` in PR #1410, so the function always returns false. This causes incompatible scratch and result buffer paths to be taken in the code causing incorrect results and hangs.

This PR switches to use the correct macro here.