### PR TITLE
Fix issues in USM result and scratch memory (PR #1354)

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -558,9 +558,12 @@ struct __result_and_scratch_storage
         if (__use_USM_host && __supports_USM_device)
         {
             // Separate scratch (device) and result (host) allocations on performant backends (i.e. L0)
-            __scratch_buf = ::std::shared_ptr<_T>(
-                __internal::__sycl_usm_alloc<_ExecutionPolicy, _T, sycl::usm::alloc::device>{__exec}(__scratch_n),
-                __internal::__sycl_usm_free<_ExecutionPolicy, _T>{__exec});
+            if (__scratch_n > 0)
+            {
+                __scratch_buf = ::std::shared_ptr<_T>(
+                    __internal::__sycl_usm_alloc<_ExecutionPolicy, _T, sycl::usm::alloc::device>{__exec}(__scratch_n),
+                    __internal::__sycl_usm_free<_ExecutionPolicy, _T>{__exec});
+            }
             __result_buf = ::std::shared_ptr<_T>(
                 __internal::__sycl_usm_alloc<_ExecutionPolicy, _T, sycl::usm::alloc::host>{__exec}(1),
                 __internal::__sycl_usm_free<_ExecutionPolicy, _T>{__exec});

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -543,7 +543,7 @@ struct __result_and_scratch_storage
     inline bool
     __use_USM_allocations(sycl::queue __queue)
     {
-#if _ONEDPL_SYCL_USM_HOST_PRESENT
+#if _ONEDPL_SYCL_UNIFIED_USM_BUFFER_PRESENT
         return __queue.get_device().has(sycl::aspect::usm_device_allocations);
 #else
         return false;


### PR DESCRIPTION
This PR addresses several issues found in #1354:

1. `ONEDPL_SYCL_USM_HOST_PRESENT` was renamed to `_ONEDPL_SYCL_UNIFIED_USM_BUFFER_PRESENT` in #1410
2. Empty scratch space allocation is unguarded when using USM host memory. This leads to runtime issues or `bad_alloc`.
3. The guards to support older compilers (#1410) are missing.
4. `__get_usm_host_or_buffer_accessor_ptr` should be used based on @MikeDvorskiy's comment here: https://github.com/oneapi-src/oneDPL/pull/1410#discussion_r1504499285

This includes the changes to address the first issue proposed by @mmichel11 in #1502.