### PR TITLE
[CI] Fix for main CI getting cancelled post-merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ env:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+  cancel-in-progress: ${{ !contains(github.ref, 'refs/heads/main') }}
 
 jobs:
   clang-format:

--- a/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
@@ -63,6 +63,7 @@ class ParanoidKey
     //! Special value used to mark destroyed objects.
     static const std::int32_t Dead = -2;
     // True if key object has comparable value
+
     bool
     isLive() const
     {

--- a/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
@@ -63,7 +63,6 @@ class ParanoidKey
     //! Special value used to mark destroyed objects.
     static const std::int32_t Dead = -2;
     // True if key object has comparable value
-
     bool
     isLive() const
     {


### PR DESCRIPTION
This PR should prevent the post-merge CI from getting cancelled.
-

Recently, I've had a couple post-merge CI runs cancelled due to other merges. 
This should not happen, and we tried to protect against this when writing the CI cancel change in #1271 .

It seems what we had did not work  (see this example: https://github.com/oneapi-src/oneDPL/actions/runs/8707524513)

Following the guide [here](https://docs.github.com/en/enterprise-cloud@latest/actions/using-jobs/using-concurrency#example-only-cancel-in-progress-jobs-on-specific-branches), I'm loosening the check from an (in-)equality to a (not) contains.  From the example above, it seems that more may be embedded in the `github.ref` than I realized.