### PR TITLE
[oneDPL][hetero] A blocking behavior fix for some algo patterns (sync API)

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1031,7 +1031,7 @@ __pattern_remove_if(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
     //TODO: To optimize copy back depending on Iterator, i.e. set_final_data for host iterator/pointer
     // __pattern_copy_if above may be async due to there is implicit synchronization on sycl::buffer and the accessors
 
-    // The temporary buffer is constructed from a range, therefore it's destructor will not block, therefore 
+    // The temporary buffer is constructed from a range, therefore it's destructor will not block, therefore
     // we must call __pattern_walk2 in a way which provides blocking synchronization for this pattern.
     return __pattern_walk2(
         __tag, __par_backend_hetero::make_wrapped_policy<copy_back_wrapper>(::std::forward<_ExecutionPolicy>(__exec)),
@@ -1054,7 +1054,7 @@ __pattern_unique(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _It
 
     //TODO: optimize copy back depending on Iterator, i.e. set_final_data for host iterator/pointer
 
-    // The temporary buffer is constructed from a range, therefore it's destructor will not block, therefore 
+    // The temporary buffer is constructed from a range, therefore it's destructor will not block, therefore
     // we must call __pattern_walk2 in a way which provides blocking synchronization for this pattern.
     return __pattern_walk2</*_IsSync=*/std::true_type, __par_backend_hetero::access_mode::read_write,
                            __par_backend_hetero::access_mode::read_write>(
@@ -1238,7 +1238,7 @@ __pattern_inplace_merge(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __ex
 
     //TODO: optimize copy back depending on Iterator, i.e. set_final_data for host iterator/pointer
 
-    // The temporary buffer is constructed from a range, therefore it's destructor will not block, therefore 
+    // The temporary buffer is constructed from a range, therefore it's destructor will not block, therefore
     // we must call __pattern_walk2 in a way which provides blocking synchronization for this pattern.
     __pattern_walk2(
         __tag, __par_backend_hetero::make_wrapped_policy<copy_back_wrapper>(::std::forward<_ExecutionPolicy>(__exec)),
@@ -1325,9 +1325,8 @@ __pattern_stable_partition(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& _
     auto true_count = copy_result.first - __true_result;
 
     //TODO: optimize copy back if possible (inplace, decrease number of submits)
-    __pattern_walk2(
-        __tag, __par_backend_hetero::make_wrapped_policy<copy_back_wrapper>(__exec), __true_result, copy_result.first,
-        __first, __brick_move<__hetero_tag<_BackendTag>, _ExecutionPolicy>{});
+    __pattern_walk2(__tag, __par_backend_hetero::make_wrapped_policy<copy_back_wrapper>(__exec), __true_result,
+                    copy_result.first, __first, __brick_move<__hetero_tag<_BackendTag>, _ExecutionPolicy>{});
 
     __pattern_walk2(
         __tag, __par_backend_hetero::make_wrapped_policy<copy_back_wrapper2>(::std::forward<_ExecutionPolicy>(__exec)),
@@ -1549,7 +1548,7 @@ __pattern_partial_sort_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
             __tag, __par_backend_hetero::make_wrapped_policy<__copy_back>(::std::forward<_ExecutionPolicy>(__exec)),
             __buf_first, __buf_mid, __out_first, __brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>{});
 
-        // The temporary buffer is constructed from a range, therefore it's destructor will not block, therefore 
+        // The temporary buffer is constructed from a range, therefore it's destructor will not block, therefore
         // we must call __pattern_walk2 in a way which provides blocking synchronization for this pattern.
     }
 }
@@ -1669,7 +1668,7 @@ __pattern_rotate(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator
     oneapi::dpl::__par_backend_hetero::__parallel_for(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __brick,
                                                       __n, __temp_rng_rw, __buf.all_view()).wait();
 
-    // The temporary buffer is constructed from a range, therefore it's destructor will not block, therefore 
+    // The temporary buffer is constructed from a range, therefore it's destructor will not block, therefore
     // we must call __parallel_for with wait() to provide the blocking synchronization for this pattern.
 
     return __first + (__last - __new_first);


### PR DESCRIPTION
[oneDPL][hetero] + a blocking behavior fix for some algo patterns (sync API)

According to 4.7.2.3. Buffer synchronization rules, rule number (1), a destructor of such buffer does not need to block. So, RAII instance of such buffer doesn't guarantee implicit wait. The PR fixes the behavior for oneDPL sync API.

(https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:buf-sync-rules)