### PR TITLE
Avoid extra constructor and destructor calls in oneDPL code

### DIFF
--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1497,7 +1497,7 @@ __remove_elements(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
                 __internal::__brick_copy_by_mask(
                     __first + __i, __first + __i + __len, __result + __initial, __mask + __i,
                     [](_RandomAccessIterator __x, _Tp* __z) {
-                        if constexpr (std::is_trivially_move_constructible_v<_Tp>)
+                        if constexpr (std::is_trivial_v<_Tp>)
                             *__z = std::move(*__x);
                         else
                             ::new (std::addressof(*__z)) _Tp(std::move(*__x));
@@ -2605,7 +2605,7 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
                     // 1. Copy elements from input to raw memory
                     for (_T1* __k = __i; __k != __j; ++__k, ++__it)
                     {
-                        if constexpr (std::is_trivially_copy_constructible_v<_T2>)
+                        if constexpr (std::is_trivial_v<_T2>)
                             *__k = *__it;
                         else
                             ::new (__k) _T2(*__it);
@@ -3097,7 +3097,7 @@ __pattern_inplace_merge(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _R
     _Tp* __r = __buf.get();
     __internal::__except_handler([&]() {
         auto __move_values = [](_RandomAccessIterator __x, _Tp* __z) {
-            if constexpr (std::is_trivially_move_constructible_v<_Tp>)
+            if constexpr (std::is_trivial_v<_Tp>)
                 *__z = std::move(*__x);
             else
                 ::new (std::addressof(*__z)) _Tp(std::move(*__x));

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1497,10 +1497,10 @@ __remove_elements(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
                 __internal::__brick_copy_by_mask(
                     __first + __i, __first + __i + __len, __result + __initial, __mask + __i,
                     [](_RandomAccessIterator __x, _Tp* __z) {
-                        if constexpr (::std::is_trivial_v<_Tp>)
-                            *__z = ::std::move(*__x);
+                        if constexpr (std::is_trivially_move_constructible_v<_Tp>)
+                            *__z = std::move(*__x);
                         else
-                            ::new (::std::addressof(*__z)) _Tp(::std::move(*__x));
+                            ::new (std::addressof(*__z)) _Tp(std::move(*__x));
                     },
                     _IsVector{});
             },
@@ -3094,10 +3094,10 @@ __pattern_inplace_merge(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _R
     _Tp* __r = __buf.get();
     __internal::__except_handler([&]() {
         auto __move_values = [](_RandomAccessIterator __x, _Tp* __z) {
-            if constexpr (::std::is_trivial_v<_Tp>)
-                *__z = ::std::move(*__x);
+            if constexpr (std::is_trivially_move_constructible_v<_Tp>)
+                *__z = std::move(*__x);
             else
-                ::new (::std::addressof(*__z)) _Tp(::std::move(*__x));
+                ::new (std::addressof(*__z)) _Tp(std::move(*__x));
         };
 
         auto __move_sequences = [](_RandomAccessIterator __first1, _RandomAccessIterator __last1, _Tp* __first2) {

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -2605,7 +2605,10 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
                     // 1. Copy elements from input to raw memory
                     for (_T1* __k = __i; __k != __j; ++__k, ++__it)
                     {
-                        ::new (__k) _T2(*__it);
+                        if constexpr (std::is_trivially_copy_constructible_v<_T2>)
+                            *__k = *__it;
+                        else
+                            ::new (__k) _T2(*__it);
                     }
 
                     // 2. Sort elements in temporary buffer

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1145,7 +1145,8 @@ struct __brick_move_destroy
         return __unseq_backend::__simd_assign(__first, __last - __first, __result,
                                               [](_RandomAccessIterator1 __first, _RandomAccessIterator2 __result) {
                                                   *__result = ::std::move(*__first);
-                                                  (*__first).~_IteratorValueType();
+                                                  if constexpr (!std::is_trivially_destructible_v<_IteratorValueType>)
+                                                      (*__first).~_IteratorValueType();
                                               });
     }
 
@@ -1158,7 +1159,8 @@ struct __brick_move_destroy
         for (; __first != __last; ++__first, ++__result)
         {
             *__result = ::std::move(*__first);
-            (*__first).~_IteratorValueType();
+            if constexpr (!std::is_trivially_destructible_v<_IteratorValueType>)
+                (*__first).~_IteratorValueType();
         }
         return __result;
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -600,7 +600,7 @@ __radix_sort_reorder_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments,
                     if (__self_lidx < __residual)
                     {
                         //initialize the storage via move constructor for _ValueT type
-                        if constexpr (std::is_trivially_move_constructible_v<_ValueT>)
+                        if constexpr (std::is_trivial_v<_ValueT>)
                             __in_val.__v = std::move(__input_rng[__seg_end + __self_lidx]);
                         else
                             new (&__in_val.__v) _ValueT(std::move(__input_rng[__seg_end + __self_lidx]));

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -616,7 +616,8 @@ __radix_sort_reorder_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments,
                     if (__self_lidx < __residual)
                     {
                         __output_rng[__new_offset_idx] = std::move(__in_val.__v);
-                        __in_val.__v.~_ValueT();
+                        if constexpr (!std::is_trivially_destructible_v<_ValueT>)
+                            __in_val.__v.~_ValueT();
                     }
                 }
             });

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -600,7 +600,10 @@ __radix_sort_reorder_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments,
                     if (__self_lidx < __residual)
                     {
                         //initialize the storage via move constructor for _ValueT type
-                        new (&__in_val.__v) _ValueT(std::move(__input_rng[__seg_end + __self_lidx]));
+                        if constexpr (std::is_trivially_move_constructible_v<_ValueT>)
+                            __in_val.__v = std::move(__input_rng[__seg_end + __self_lidx]);
+                        else
+                            new (&__in_val.__v) _ValueT(std::move(__input_rng[__seg_end + __self_lidx]));
 
                         __bucket = __get_bucket<(1 << __radix_bits) - 1>(
                             __order_preserving_cast<__is_ascending>(__proj(__in_val.__v)), __radix_offset);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
@@ -254,17 +254,21 @@ struct __subgroup_radix_sort
                                     {
                                         //move the values to source range and destroy the values
                                         __src[__r] = ::std::move(__values.__v[__i]);
-                                        __values.__v[__i].~_ValT();
+                                        if constexpr (!std::is_trivially_destructible_v<_ValT>)
+                                            __values.__v[__i].~_ValT();
                                     }
                                 }
 
                                 //destroy values in exchange buffer
-                                _ONEDPL_PRAGMA_UNROLL
-                                for (uint16_t __i = 0; __i < __block_size; ++__i)
+                                if constexpr (!std::is_trivially_destructible_v<_ValT>)
                                 {
-                                    const uint16_t __idx = __wi * __block_size + __i;
-                                    if (__idx < __n)
-                                        __exchange_lacc[__idx].~_ValT();
+                                    _ONEDPL_PRAGMA_UNROLL
+                                    for (uint16_t __i = 0; __i < __block_size; ++__i)
+                                    {
+                                        const uint16_t __idx = __wi * __block_size + __i;
+                                        if (__idx < __n)
+                                            __exchange_lacc[__idx].~_ValT();
+                                    }
                                 }
 
                                 return;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
@@ -106,7 +106,12 @@ struct __subgroup_radix_sort
         {
             const uint16_t __idx = __wi * __block_size + __i;
             if (__idx < __n)
-                new (&__values[__i]) _ValueT(::std::move(__src[__idx]));
+            {
+                if constexpr (std::is_trivially_move_constructible_v<_ValueT>)
+                    __values[__i] = std::move(__src[__idx]);
+                else
+                    new (&__values[__i]) _ValueT(std::move(__src[__idx]));
+            }
         }
     }
 
@@ -282,7 +287,12 @@ struct __subgroup_radix_sort
                                 {
                                     const uint16_t __r = __indices[__i];
                                     if (__r < __n)
-                                        new (&__exchange_lacc[__r]) _ValT(::std::move(__values.__v[__i]));
+                                    {
+                                        if constexpr (std::is_trivially_move_constructible_v<_ValT>)
+                                            __exchange_lacc[__r] = std::move(__values.__v[__i]);
+                                        else
+                                            new (&__exchange_lacc[__r]) _ValT(::std::move(__values.__v[__i]));
+                                    }
                                 }
                             }
                             else

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
@@ -107,7 +107,7 @@ struct __subgroup_radix_sort
             const uint16_t __idx = __wi * __block_size + __i;
             if (__idx < __n)
             {
-                if constexpr (std::is_trivially_move_constructible_v<_ValueT>)
+                if constexpr (std::is_trivial_v<_ValueT>)
                     __values[__i] = std::move(__src[__idx]);
                 else
                     new (&__values[__i]) _ValueT(std::move(__src[__idx]));
@@ -288,7 +288,7 @@ struct __subgroup_radix_sort
                                     const uint16_t __r = __indices[__i];
                                     if (__r < __n)
                                     {
-                                        if constexpr (std::is_trivially_move_constructible_v<_ValT>)
+                                        if constexpr (std::is_trivial_v<_ValT>)
                                             __exchange_lacc[__r] = std::move(__values.__v[__i]);
                                         else
                                             new (&__exchange_lacc[__r]) _ValT(::std::move(__values.__v[__i]));

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -72,7 +72,8 @@ __work_group_reduce_kernel(const _NDItemId __item_id, const _Size __n, _Transfor
         __reduce_pattern.apply_init(__init, __result.__v);
         __res_acc[0] = __result.__v;
     }
-    __result.__v.~_Tp();
+    if constexpr (!std::is_trivially_destructible_v<_Tp>)
+        __result.__v.~_Tp();
 }
 
 // Device kernel that transforms and reduces __n elements to the number of work groups preliminary results.
@@ -98,7 +99,8 @@ __device_reduce_kernel(const _NDItemId __item_id, const _Size __n, _TransformPat
     __result.__v = __reduce_pattern(__item_id, __n_items, __result.__v, __local_mem);
     if (__local_idx == 0)
         __temp_acc[__group_idx] = __result.__v;
-    __result.__v.~_Tp();
+    if constexpr (!std::is_trivially_destructible_v<_Tp>)
+        __result.__v.~_Tp();
 }
 
 //------------------------------------------------------------------------
@@ -421,7 +423,8 @@ struct __parallel_transform_reduce_impl
 
                             __temp_ptr[__offset_1 + __group_idx] = __result.__v;
                         }
-                        __result.__v.~_Tp();
+                        if constexpr (std::is_trivially_destructible_v<_Tp>)
+                            __result.__v.~_Tp();
                     });
             });
             __is_first = false;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -222,7 +222,7 @@ struct transform_reduce
         if (__adjusted_global_id + __iters_per_work_item < __adjusted_n)
         {
             // Keep these statements in the same scope to allow for better memory alignment
-            if constexpr (std::is_trivially_move_constructible_v<_Tp>)
+            if constexpr (std::is_trivially_copy_constructible_v<_Tp>)
                 __res.__v = __unary_op(__adjusted_global_id, __acc...);
             else
                 new (&__res.__v) _Tp(__unary_op(__adjusted_global_id, __acc...));
@@ -234,7 +234,7 @@ struct transform_reduce
         {
             const _Size __items_to_process = __adjusted_n - __adjusted_global_id;
             // Keep these statements in the same scope to allow for better memory alignment
-            if constexpr (std::is_trivially_move_constructible_v<_Tp>)
+            if constexpr (std::is_trivially_copy_constructible_v<_Tp>)
                 __res.__v = __unary_op(__adjusted_global_id, __acc...);
             else
                 new (&__res.__v) _Tp(__unary_op(__adjusted_global_id, __acc...));
@@ -259,7 +259,7 @@ struct transform_reduce
         // Coalesced load and reduce from global memory
         if (__adjusted_global_id + __stride * __iters_per_work_item < __adjusted_n)
         {
-            if constexpr (std::is_trivially_move_constructible_v<_Tp>)
+            if constexpr (std::is_trivially_copy_constructible_v<_Tp>)
                 __res.__v = __unary_op(__adjusted_global_id, __acc...);
             else
                 new (&__res.__v) _Tp(__unary_op(__adjusted_global_id, __acc...));
@@ -271,7 +271,7 @@ struct transform_reduce
         {
             const _Size __items_to_process =
                 std::max(((__adjusted_n - __adjusted_global_id - 1) / __stride) + 1, static_cast<_Size>(0));
-            if constexpr (std::is_trivially_move_constructible_v<_Tp>)
+            if constexpr (std::is_trivially_copy_constructible_v<_Tp>)
                 __res.__v = __unary_op(__adjusted_global_id, __acc...);
             else
                 new (&__res.__v) _Tp(__unary_op(__adjusted_global_id, __acc...));

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -222,7 +222,10 @@ struct transform_reduce
         if (__adjusted_global_id + __iters_per_work_item < __adjusted_n)
         {
             // Keep these statements in the same scope to allow for better memory alignment
-            new (&__res.__v) _Tp(__unary_op(__adjusted_global_id, __acc...));
+            if constexpr (std::is_trivially_move_constructible_v<_Tp>)
+                __res.__v = __unary_op(__adjusted_global_id, __acc...);
+            else
+                new (&__res.__v) _Tp(__unary_op(__adjusted_global_id, __acc...));
             _ONEDPL_PRAGMA_UNROLL
             for (_Size __i = 1; __i < __iters_per_work_item; ++__i)
                 __res.__v = __binary_op(__res.__v, __unary_op(__adjusted_global_id + __i, __acc...));
@@ -231,7 +234,10 @@ struct transform_reduce
         {
             const _Size __items_to_process = __adjusted_n - __adjusted_global_id;
             // Keep these statements in the same scope to allow for better memory alignment
-            new (&__res.__v) _Tp(__unary_op(__adjusted_global_id, __acc...));
+            if constexpr (std::is_trivially_move_constructible_v<_Tp>)
+                __res.__v = __unary_op(__adjusted_global_id, __acc...);
+            else
+                new (&__res.__v) _Tp(__unary_op(__adjusted_global_id, __acc...));
             for (_Size __i = 1; __i < __items_to_process; ++__i)
                 __res.__v = __binary_op(__res.__v, __unary_op(__adjusted_global_id + __i, __acc...));
         }
@@ -253,7 +259,10 @@ struct transform_reduce
         // Coalesced load and reduce from global memory
         if (__adjusted_global_id + __stride * __iters_per_work_item < __adjusted_n)
         {
-            new (&__res.__v) _Tp(__unary_op(__adjusted_global_id, __acc...));
+            if constexpr (std::is_trivially_move_constructible_v<_Tp>)
+                __res.__v = __unary_op(__adjusted_global_id, __acc...);
+            else
+                new (&__res.__v) _Tp(__unary_op(__adjusted_global_id, __acc...));
             _ONEDPL_PRAGMA_UNROLL
             for (_Size __i = 1; __i < __iters_per_work_item; ++__i)
                 __res.__v = __binary_op(__res.__v, __unary_op(__adjusted_global_id + __stride * __i, __acc...));
@@ -262,7 +271,10 @@ struct transform_reduce
         {
             const _Size __items_to_process =
                 std::max(((__adjusted_n - __adjusted_global_id - 1) / __stride) + 1, static_cast<_Size>(0));
-            new (&__res.__v) _Tp(__unary_op(__adjusted_global_id, __acc...));
+            if constexpr (std::is_trivially_move_constructible_v<_Tp>)
+                __res.__v = __unary_op(__adjusted_global_id, __acc...);
+            else
+                new (&__res.__v) _Tp(__unary_op(__adjusted_global_id, __acc...));
             for (_Size __i = 1; __i < __items_to_process; ++__i)
                 __res.__v = __binary_op(__res.__v, __unary_op(__adjusted_global_id + __stride * __i, __acc...));
         }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -222,7 +222,7 @@ struct transform_reduce
         if (__adjusted_global_id + __iters_per_work_item < __adjusted_n)
         {
             // Keep these statements in the same scope to allow for better memory alignment
-            if constexpr (std::is_trivially_copy_constructible_v<_Tp>)
+            if constexpr (std::is_trivial_v<_Tp>)
                 __res.__v = __unary_op(__adjusted_global_id, __acc...);
             else
                 new (&__res.__v) _Tp(__unary_op(__adjusted_global_id, __acc...));
@@ -234,7 +234,7 @@ struct transform_reduce
         {
             const _Size __items_to_process = __adjusted_n - __adjusted_global_id;
             // Keep these statements in the same scope to allow for better memory alignment
-            if constexpr (std::is_trivially_copy_constructible_v<_Tp>)
+            if constexpr (std::is_trivial_v<_Tp>)
                 __res.__v = __unary_op(__adjusted_global_id, __acc...);
             else
                 new (&__res.__v) _Tp(__unary_op(__adjusted_global_id, __acc...));
@@ -259,7 +259,7 @@ struct transform_reduce
         // Coalesced load and reduce from global memory
         if (__adjusted_global_id + __stride * __iters_per_work_item < __adjusted_n)
         {
-            if constexpr (std::is_trivially_copy_constructible_v<_Tp>)
+            if constexpr (std::is_trivial_v<_Tp>)
                 __res.__v = __unary_op(__adjusted_global_id, __acc...);
             else
                 new (&__res.__v) _Tp(__unary_op(__adjusted_global_id, __acc...));
@@ -271,7 +271,7 @@ struct transform_reduce
         {
             const _Size __items_to_process =
                 std::max(((__adjusted_n - __adjusted_global_id - 1) / __stride) + 1, static_cast<_Size>(0));
-            if constexpr (std::is_trivially_copy_constructible_v<_Tp>)
+            if constexpr (std::is_trivial_v<_Tp>)
                 __res.__v = __unary_op(__adjusted_global_id, __acc...);
             else
                 new (&__res.__v) _Tp(__unary_op(__adjusted_global_id, __acc...));

--- a/include/oneapi/dpl/pstl/memory_impl.h
+++ b/include/oneapi/dpl/pstl/memory_impl.h
@@ -217,7 +217,8 @@ struct __op_uninitialized_default_construct<_ExecutionPolicy>
     {
         using _TargetValueType = ::std::decay_t<_TargetT>;
 
-        ::new (::std::addressof(__target)) _TargetValueType;
+        static_assert(!std::is_trivial_v<_TargetValueType>);
+        ::new (std::addressof(__target)) _TargetValueType;
     }
 };
 

--- a/include/oneapi/dpl/pstl/memory_impl.h
+++ b/include/oneapi/dpl/pstl/memory_impl.h
@@ -66,6 +66,8 @@ __brick_destroy(_Iterator __first, _Iterator __last, /*vector*/ ::std::false_typ
 {
     using _ValueType = typename ::std::iterator_traits<_Iterator>::value_type;
 
+    static_assert(!std::is_trivially_destructible_v<_ValueType>);
+
     for (; __first != __last; ++__first)
         __first->~_ValueType();
 }
@@ -76,6 +78,8 @@ __brick_destroy(_RandomAccessIterator __first, _RandomAccessIterator __last, /*v
 {
     using _ValueType = typename ::std::iterator_traits<_RandomAccessIterator>::value_type;
     using _ReferenceType = typename ::std::iterator_traits<_RandomAccessIterator>::reference;
+
+    static_assert(!std::is_trivially_destructible_v<_ValueType>);
 
     __unseq_backend::__simd_walk_1(__first, __last - __first, [](_ReferenceType __x) { __x.~_ValueType(); });
 }
@@ -174,6 +178,8 @@ struct __op_destroy<_ExecutionPolicy>
     operator()(_TargetT& __target) const
     {
         using _TargetValueType = ::std::decay_t<_TargetT>;
+
+        static_assert(!std::is_trivially_destructible_v<_TargetValueType>);
         __target.~_TargetValueType();
     }
 };

--- a/include/oneapi/dpl/pstl/memory_impl.h
+++ b/include/oneapi/dpl/pstl/memory_impl.h
@@ -235,7 +235,8 @@ struct __op_uninitialized_value_construct<_ExecutionPolicy>
     {
         using _TargetValueType = ::std::decay_t<_TargetT>;
 
-        ::new (::std::addressof(__target)) _TargetValueType();
+        static_assert(!std::is_trivial_v<_TargetValueType>);
+        ::new (std::addressof(__target)) _TargetValueType();
     }
 };
 

--- a/include/oneapi/dpl/pstl/memory_impl.h
+++ b/include/oneapi/dpl/pstl/memory_impl.h
@@ -137,7 +137,7 @@ struct __op_uninitialized_copy<_ExecutionPolicy>
     operator()(_SourceT&& __source, _TargetT& __target) const
     {
         using _TargetValueType = std::decay_t<_TargetT>;
-        if constexpr (std::is_trivial_v<_TargetValueType>)
+        if constexpr (std::is_trivially_constructible_v<_TargetValueType>)
             __target = std::forward<_SourceT>(__source);
         else
             ::new (std::addressof(__target)) _TargetValueType(std::forward<_SourceT>(__source));

--- a/include/oneapi/dpl/pstl/memory_impl.h
+++ b/include/oneapi/dpl/pstl/memory_impl.h
@@ -41,7 +41,7 @@ __brick_uninitialized_move(_ForwardIterator __first, _ForwardIterator __last, _O
     using _ValueType = typename ::std::iterator_traits<_OutputIterator>::value_type;
     for (; __first != __last; ++__first, ++__result)
     {
-        if constexpr (std::is_trivially_move_constructible_v<_ValueType>)
+        if constexpr (std::is_trivial_v<_ValueType>)
             *__result = std::move(*__first);
         else
             ::new (std::addressof(*__result)) _ValueType(std::move(*__first));
@@ -60,7 +60,7 @@ __brick_uninitialized_move(_RandomAccessIterator __first, _RandomAccessIterator 
 
     return __unseq_backend::__simd_walk_2(__first, __last - __first, __result,
                                           [](_ReferenceType1 __x, _ReferenceType2 __y) {
-                                              if constexpr (std::is_trivially_move_constructible_v<__ValueType>)
+                                              if constexpr (std::is_trivial_v<__ValueType>)
                                                   __y = std::move(__x);
                                               else
                                                   ::new (std::addressof(__y)) __ValueType(std::move(__x));
@@ -103,7 +103,7 @@ __brick_uninitialized_copy(_ForwardIterator __first, _ForwardIterator __last, _O
     using _ValueType = typename ::std::iterator_traits<_OutputIterator>::value_type;
     for (; __first != __last; ++__first, ++__result)
     {
-        if constexpr (std::is_trivially_copy_constructible_v<_ValueType>)
+        if constexpr (std::is_trivial_v<_ValueType>)
             *__result = *__first;
         else
             ::new (std::addressof(*__result)) _ValueType(*__first);
@@ -122,7 +122,7 @@ __brick_uninitialized_copy(_RandomAccessIterator __first, _RandomAccessIterator 
 
     return __unseq_backend::__simd_walk_2(__first, __last - __first, __result,
                                           [](_ReferenceType1 __x, _ReferenceType2 __y) {
-                                              if constexpr (std::is_trivially_copy_constructible_v<__ValueType>)
+                                              if constexpr (std::is_trivial_v<__ValueType>)
                                                   __y = __x;
                                               else
                                                   ::new (std::addressof(__y)) __ValueType(__x);
@@ -157,7 +157,7 @@ struct __op_uninitialized_move<_ExecutionPolicy>
     {
         using _TargetValueType = ::std::decay_t<_TargetT>;
 
-        if constexpr (std::is_trivially_move_constructible_v<_TargetValueType>)
+        if constexpr (std::is_trivial_v<_TargetValueType>)
             __target = std::move(__source);
         else
             ::new (std::addressof(__target)) _TargetValueType(std::move(__source));
@@ -179,7 +179,7 @@ struct __op_uninitialized_fill<_SourceT, _ExecutionPolicy>
     {
         using _TargetValueType = ::std::decay_t<_TargetT>;
 
-        if constexpr (std::is_trivially_copy_constructible_v<_TargetValueType>)
+        if constexpr (std::is_trivial_v<_TargetValueType>)
             __target = __source;
         else
             ::new (std::addressof(__target)) _TargetValueType(__source);

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -153,8 +153,11 @@ struct __par_trans_red_body
     ~__par_trans_red_body()
     {
         // 17.6.5.12 tells us to not worry about catching exceptions from destructors.
-        if (_M_has_sum)
-            sum().~_Tp();
+        if constexpr (!std::is_trivially_destructible_v<_Tp>)
+        {
+            if (_M_has_sum)
+                sum().~_Tp();
+        }
     }
 
     void
@@ -223,8 +226,11 @@ class __trans_scan_body
     ~__trans_scan_body()
     {
         // 17.6.5.12 tells us to not worry about catching exceptions from destructors.
-        if (_M_has_sum)
-            sum().~_Tp();
+        if constexpr (!std::is_trivially_destructible_v<_Tp>)
+        {
+            if (_M_has_sum)
+                sum().~_Tp();
+        }
     }
 
     _Tp&

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -753,7 +753,7 @@ class __merge_func
         void
         operator()(Iterator1 __x, Iterator2 __z)
         {
-            if constexpr (std::is_trivially_move_constructible_v<_ValueType>)
+            if constexpr (std::is_trivial_v<_ValueType>)
                 *__z = std::move(*__x);
             else
                 ::new (std::addressof(*__z)) _ValueType(std::move(*__x));

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -753,7 +753,10 @@ class __merge_func
         void
         operator()(Iterator1 __x, Iterator2 __z)
         {
-            ::new (::std::addressof(*__z)) _ValueType(::std::move(*__x));
+            if constexpr (std::is_trivially_move_constructible_v<_ValueType>)
+                *__z = std::move(*__x);
+            else
+                ::new (std::addressof(*__z)) _ValueType(std::move(*__x));
         }
     };
 

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -191,7 +191,7 @@ __set_union_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _Fo
             return __cc_range(__first1, __last1, __result);
         if (__comp(*__first2, *__first1))
         {
-            if constexpr (std::is_trivially_copy_constructible_v<_Tp>)
+            if constexpr (std::is_trivial_v<_Tp>)
                 *__result = *__first2;
             else
                 ::new (std::addressof(*__result)) _Tp(*__first2);
@@ -199,7 +199,7 @@ __set_union_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _Fo
         }
         else
         {
-            if constexpr (std::is_trivially_copy_constructible_v<_Tp>)
+            if constexpr (std::is_trivial_v<_Tp>)
                 *__result = *__first1;
             else
                 ::new (std::addressof(*__result)) _Tp(*__first1);
@@ -261,7 +261,7 @@ __set_difference_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1
 
         if (__comp(*__first1, *__first2))
         {
-            if constexpr (std::is_trivially_copy_constructible_v<_Tp>)
+            if constexpr (std::is_trivial_v<_Tp>)
                 *__result = *__first1;
             else
                 ::new (std::addressof(*__result)) _Tp(*__first1);
@@ -293,7 +293,7 @@ __set_symmetric_difference_construct(_ForwardIterator1 __first1, _ForwardIterato
 
         if (__comp(*__first1, *__first2))
         {
-            if constexpr (std::is_trivially_copy_constructible_v<_Tp>)
+            if constexpr (std::is_trivial_v<_Tp>)
                 *__result = *__first1;
             else
                 ::new (std::addressof(*__result)) _Tp(*__first1);
@@ -304,7 +304,7 @@ __set_symmetric_difference_construct(_ForwardIterator1 __first1, _ForwardIterato
         {
             if (__comp(*__first2, *__first1))
             {
-                if constexpr (std::is_trivially_copy_constructible_v<_Tp>)
+                if constexpr (std::is_trivial_v<_Tp>)
                     *__result = *__first2;
                 else
                     ::new (std::addressof(*__result)) _Tp(*__first2);

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -70,6 +70,7 @@ struct __serial_destroy
     operator()(_RandomAccessIterator __zs, _RandomAccessIterator __ze)
     {
         typedef typename ::std::iterator_traits<_RandomAccessIterator>::value_type _ValueType;
+        static_assert(!std::is_trivially_destructible_v<_ValueType>);
         while (__zs != __ze)
         {
             --__ze;

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -191,12 +191,18 @@ __set_union_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _Fo
             return __cc_range(__first1, __last1, __result);
         if (__comp(*__first2, *__first1))
         {
-            ::new (::std::addressof(*__result)) _Tp(*__first2);
+            if constexpr (std::is_trivially_copy_constructible_v<_Tp>)
+                *__result = *__first2;
+            else
+                ::new (std::addressof(*__result)) _Tp(*__first2);
             ++__first2;
         }
         else
         {
-            ::new (::std::addressof(*__result)) _Tp(*__first1);
+            if constexpr (std::is_trivially_copy_constructible_v<_Tp>)
+                *__result = *__first1;
+            else
+                ::new (std::addressof(*__result)) _Tp(*__first1);
             if (!__comp(*__first1, *__first2))
                 ++__first2;
             ++__first1;
@@ -255,7 +261,10 @@ __set_difference_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1
 
         if (__comp(*__first1, *__first2))
         {
-            ::new (::std::addressof(*__result)) _Tp(*__first1);
+            if constexpr (std::is_trivially_copy_constructible_v<_Tp>)
+                *__result = *__first1;
+            else
+                ::new (std::addressof(*__result)) _Tp(*__first1);
             ++__result;
             ++__first1;
         }
@@ -284,7 +293,10 @@ __set_symmetric_difference_construct(_ForwardIterator1 __first1, _ForwardIterato
 
         if (__comp(*__first1, *__first2))
         {
-            ::new (::std::addressof(*__result)) _Tp(*__first1);
+            if constexpr (std::is_trivially_copy_constructible_v<_Tp>)
+                *__result = *__first1;
+            else
+                ::new (std::addressof(*__result)) _Tp(*__first1);
             ++__result;
             ++__first1;
         }
@@ -292,7 +304,10 @@ __set_symmetric_difference_construct(_ForwardIterator1 __first1, _ForwardIterato
         {
             if (__comp(*__first2, *__first1))
             {
-                ::new (::std::addressof(*__result)) _Tp(*__first2);
+                if constexpr (std::is_trivially_copy_constructible_v<_Tp>)
+                    *__result = *__first2;
+                else
+                    ::new (std::addressof(*__result)) _Tp(*__first2);
                 ++__result;
             }
             else

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -494,7 +494,7 @@ __simd_transform_reduce(_Size __n, _Tp __init, _BinaryOperation __binary_op, _Un
         _ONEDPL_PRAGMA_SIMD
         for (_Size __i = 0; __i < __block_size; ++__i)
         {
-            if constexpr (std::is_trivially_copy_constructible_v<_Tp>)
+            if constexpr (std::is_trivial_v<_Tp>)
                 *(__lane + __i) = __binary_op(__f(__i), __f(__block_size + __i));
             else
                 ::new (__lane + __i) _Tp(__binary_op(__f(__i), __f(__block_size + __i)));

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -519,10 +519,13 @@ __simd_transform_reduce(_Size __n, _Tp __init, _BinaryOperation __binary_op, _Un
             __init = __binary_op(__init, __lane[__i]);
         }
         // destroyer
-        _ONEDPL_PRAGMA_SIMD
-        for (_Size __i = 0; __i < __block_size; ++__i)
+        if constexpr (!std::is_trivially_destructible_v<_Tp>)
         {
-            __lane[__i].~_Tp();
+            _ONEDPL_PRAGMA_SIMD
+            for (_Size __i = 0; __i < __block_size; ++__i)
+            {
+                __lane[__i].~_Tp();
+            }
         }
     }
     else

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -494,7 +494,10 @@ __simd_transform_reduce(_Size __n, _Tp __init, _BinaryOperation __binary_op, _Un
         _ONEDPL_PRAGMA_SIMD
         for (_Size __i = 0; __i < __block_size; ++__i)
         {
-            ::new (__lane + __i) _Tp(__binary_op(__f(__i), __f(__block_size + __i)));
+            if constexpr (std::is_trivially_copy_constructible_v<_Tp>)
+                *(__lane + __i) = __binary_op(__f(__i), __f(__block_size + __i));
+            else
+                ::new (__lane + __i) _Tp(__binary_op(__f(__i), __f(__block_size + __i)));
         }
         // main loop
         _Size __i = 2 * __block_size;


### PR DESCRIPTION
The goal of this PR - to avoid extra constructor and destructor calls in oneDPL code.
For that we using the next additional compile-time checks:
- [std::is_trivial_v](https://en.cppreference.com/w/cpp/types/is_trivial) check to avoid extra **constructor** calls;
- [std::is_trivially_destructible_v](https://en.cppreference.com/w/cpp/types/is_destructible) check to avoid extra **destructor** calls.
