### PR TITLE
Remove unnecessary move statements added in #1495

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -222,7 +222,7 @@ struct transform_reduce
         if (__adjusted_global_id + __iters_per_work_item < __adjusted_n)
         {
             // Keep these statements in the same scope to allow for better memory alignment
-            new (&__res.__v) _Tp(std::move(__unary_op(__adjusted_global_id, __acc...)));
+            new (&__res.__v) _Tp(__unary_op(__adjusted_global_id, __acc...));
             _ONEDPL_PRAGMA_UNROLL
             for (_Size __i = 1; __i < __iters_per_work_item; ++__i)
                 __res.__v = __binary_op(__res.__v, __unary_op(__adjusted_global_id + __i, __acc...));
@@ -231,7 +231,7 @@ struct transform_reduce
         {
             const _Size __items_to_process = __adjusted_n - __adjusted_global_id;
             // Keep these statements in the same scope to allow for better memory alignment
-            new (&__res.__v) _Tp(std::move(__unary_op(__adjusted_global_id, __acc...)));
+            new (&__res.__v) _Tp(__unary_op(__adjusted_global_id, __acc...));
             for (_Size __i = 1; __i < __items_to_process; ++__i)
                 __res.__v = __binary_op(__res.__v, __unary_op(__adjusted_global_id + __i, __acc...));
         }
@@ -253,7 +253,7 @@ struct transform_reduce
         // Coalesced load and reduce from global memory
         if (__adjusted_global_id + __stride * __iters_per_work_item < __adjusted_n)
         {
-            new (&__res.__v) _Tp(std::move(__unary_op(__adjusted_global_id, __acc...)));
+            new (&__res.__v) _Tp(__unary_op(__adjusted_global_id, __acc...));
             _ONEDPL_PRAGMA_UNROLL
             for (_Size __i = 1; __i < __iters_per_work_item; ++__i)
                 __res.__v = __binary_op(__res.__v, __unary_op(__adjusted_global_id + __stride * __i, __acc...));
@@ -262,7 +262,7 @@ struct transform_reduce
         {
             const _Size __items_to_process =
                 std::max(((__adjusted_n - __adjusted_global_id - 1) / __stride) + 1, static_cast<_Size>(0));
-            new (&__res.__v) _Tp(std::move(__unary_op(__adjusted_global_id, __acc...)));
+            new (&__res.__v) _Tp(__unary_op(__adjusted_global_id, __acc...));
             for (_Size __i = 1; __i < __items_to_process; ++__i)
                 __res.__v = __binary_op(__res.__v, __unary_op(__adjusted_global_id + __stride * __i, __acc...));
         }


### PR DESCRIPTION
#1495 added move statements which are not needed since the result of `__unary_op` is already an [prvalue](https://en.cppreference.com/w/cpp/language/value_category#prvalue).

See original comment by @SergeyKopienko: https://github.com/oneapi-src/oneDPL/pull/1511#discussion_r1569022127