### PR TITLE
[oneDPL][hetero] Re-woring sycl::is_device_copyable trait specializations for oneDPL types

### DIFF
--- a/include/oneapi/dpl/pstl/algorithm_fwd.h
+++ b/include/oneapi/dpl/pstl/algorithm_fwd.h
@@ -405,20 +405,6 @@ __pattern_search_n(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessI
 template <class _Tag, typename _ExecutionPolicy, typename = void>
 struct __brick_copy_n;
 
-} //__internal
-} //dpl
-} //oneapi
-
-template<class _Tag, typename _ExecutionPolicy, typename _SpecTag>
-struct _ONEDPL_IS_DEVICE_COPYABLE(oneapi::dpl::__internal::__brick_copy_n, _Tag, _ExecutionPolicy, _SpecTag):
-    oneapi::dpl::__internal::__is_types_device_copyable<> {};
-
-namespace oneapi
-{
-namespace dpl
-{
-namespace __internal
-{
 template <class _Tag, typename _ExecutionPolicy, typename = void>
 struct __brick_copy;
 

--- a/include/oneapi/dpl/pstl/algorithm_fwd.h
+++ b/include/oneapi/dpl/pstl/algorithm_fwd.h
@@ -405,10 +405,20 @@ __pattern_search_n(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessI
 template <class _Tag, typename _ExecutionPolicy, typename = void>
 struct __brick_copy_n;
 
+} //__internal
+} //dpl
+} //oneapi
+
 template<class _Tag, typename _ExecutionPolicy, typename _SpecTag>
-struct _ONEDPL_IS_DEVICE_COPYABLE(__brick_copy_n, _Tag, _ExecutionPolicy, _SpecTag):
+struct _ONEDPL_IS_DEVICE_COPYABLE(oneapi::dpl::__internal::__brick_copy_n, _Tag, _ExecutionPolicy, _SpecTag):
     oneapi::dpl::__internal::__is_types_device_copyable<> {};
 
+namespace oneapi
+{
+namespace dpl
+{
+namespace __internal
+{
 template <class _Tag, typename _ExecutionPolicy, typename = void>
 struct __brick_copy;
 

--- a/include/oneapi/dpl/pstl/algorithm_fwd.h
+++ b/include/oneapi/dpl/pstl/algorithm_fwd.h
@@ -405,6 +405,10 @@ __pattern_search_n(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessI
 template <class _Tag, typename _ExecutionPolicy, typename = void>
 struct __brick_copy_n;
 
+template<class _Tag, typename _ExecutionPolicy, typename _SpecTag>
+struct _ONEDPL_IS_DEVICE_COPYABLE(__brick_copy_n, _Tag, _ExecutionPolicy, _SpecTag):
+    oneapi::dpl::__internal::__is_types_device_copyable<> {};
+
 template <class _Tag, typename _ExecutionPolicy, typename = void>
 struct __brick_copy;
 

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1066,6 +1066,8 @@ struct __brick_copy_n<_Tag, _ExecutionPolicy,
     {
         return ::std::copy_n(__first, __n, __result);
     }
+
+    _ONEDPL_IS_DEVICE_COPYABLE()
 };
 
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -375,6 +375,8 @@ struct __brick_copy_n<__hetero_tag<_BackendTag>, _ExecutionPolicy>
     {
         __target = ::std::forward<_SourceT>(__source);
     }
+
+    _ONEDPL_IS_DEVICE_COPYABLE()
 };
 
 template <typename _BackendTag, typename _ExecutionPolicy>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -102,7 +102,6 @@ _ONEDPL_DEVICE_COPYABLE(oneapi::dpl::__par_backend_hetero::__early_exit_find_or)
 
 _ONEDPL_DEVICE_COPYABLE(oneapi::dpl::unseq_backend::walk_n)
 _ONEDPL_DEVICE_COPYABLE(oneapi::dpl::unseq_backend::walk_adjacent_difference)
-_ONEDPL_DEVICE_COPYABLE(oneapi::dpl::unseq_backend::transform_reduce)
 _ONEDPL_DEVICE_COPYABLE(oneapi::dpl::unseq_backend::reduce_over_group)
 _ONEDPL_DEVICE_COPYABLE(oneapi::dpl::unseq_backend::single_match_pred_by_idx)
 _ONEDPL_DEVICE_COPYABLE(oneapi::dpl::unseq_backend::multiple_match_pred)
@@ -149,7 +148,6 @@ _ONEDPL_DEVICE_COPYABLE(oneapi::dpl::internal::segmented_scan_fun)
 _ONEDPL_DEVICE_COPYABLE(oneapi::dpl::internal::scatter_and_accumulate_fun)
 _ONEDPL_DEVICE_COPYABLE(oneapi::dpl::internal::transform_if_stencil_fun)
 
-_ONEDPL_DEVICE_COPYABLE(oneapi::dpl::zip_iterator)
 _ONEDPL_DEVICE_COPYABLE(oneapi::dpl::transform_iterator)
 _ONEDPL_DEVICE_COPYABLE(oneapi::dpl::permutation_iterator)
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -302,6 +302,11 @@ struct transform_reduce
     }
 };
 
+template <typename _ExecutionPolicy, ::std::uint8_t __iters_per_work_item, typename _Operation1, typename _Operation2,
+          typename _Tp, typename _Commutative>
+struct _ONEDPL_IS_DEVICE_COPYABLE(transform_reduce, _ExecutionPolicy, __iters_per_work_item, _Operation1, _Operation2,
+    _Tp, _Commutative): dpl::__internal::__is_types_device_copyable<_Tp, _Operation1, _Operation2> {};
+
 // Reduce local reductions of each work item to a single reduced element per work group. The local reductions are held
 // in local memory. sycl::reduce_over_group is used for supported data types and operations. All other operations are
 // processed in order and without a known identity.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -300,24 +300,10 @@ struct transform_reduce
         else
             return oneapi::dpl::__internal::__dpl_ceiling_div(__n, __iters_per_work_item);
     }
+
+    _ONEDPL_IS_DEVICE_COPYABLE(_Tp, _Operation1, _Operation2)
 };
 
-} //unseq_backend
-} //dpl
-} //oneapi
-
-template <typename _ExecutionPolicy, ::std::uint8_t __iters_per_work_item, typename _Operation1, typename _Operation2,
-          typename _Tp, typename _Commutative>
-struct _ONEDPL_IS_DEVICE_COPYABLE(oneapi::dpl::unseq_backend::transform_reduce, _ExecutionPolicy, __iters_per_work_item,
-                                 _Operation1, _Operation2, _Tp, _Commutative):
-    oneapi::dpl::__internal::__is_types_device_copyable<_Tp, _Operation1, _Operation2> {};
-
-namespace oneapi
-{
-namespace dpl
-{
-namespace unseq_backend
-{
 // Reduce local reductions of each work item to a single reduced element per work group. The local reductions are held
 // in local memory. sycl::reduce_over_group is used for supported data types and operations. All other operations are
 // processed in order and without a known identity.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -305,7 +305,7 @@ struct transform_reduce
 template <typename _ExecutionPolicy, ::std::uint8_t __iters_per_work_item, typename _Operation1, typename _Operation2,
           typename _Tp, typename _Commutative>
 struct _ONEDPL_IS_DEVICE_COPYABLE(transform_reduce, _ExecutionPolicy, __iters_per_work_item, _Operation1, _Operation2,
-    _Tp, _Commutative): dpl::__internal::__is_types_device_copyable<_Tp, _Operation1, _Operation2> {};
+    _Tp, _Commutative): oneapi::dpl::__internal::__is_types_device_copyable<_Tp, _Operation1, _Operation2> {};
 
 // Reduce local reductions of each work item to a single reduced element per work group. The local reductions are held
 // in local memory. sycl::reduce_over_group is used for supported data types and operations. All other operations are

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -302,11 +302,22 @@ struct transform_reduce
     }
 };
 
+} //unseq_backend
+} //dpl
+} //oneapi
+
 template <typename _ExecutionPolicy, ::std::uint8_t __iters_per_work_item, typename _Operation1, typename _Operation2,
           typename _Tp, typename _Commutative>
-struct _ONEDPL_IS_DEVICE_COPYABLE(transform_reduce, _ExecutionPolicy, __iters_per_work_item, _Operation1, _Operation2,
-    _Tp, _Commutative): oneapi::dpl::__internal::__is_types_device_copyable<_Tp, _Operation1, _Operation2> {};
+struct _ONEDPL_IS_DEVICE_COPYABLE(oneapi::dpl::unseq_backend::transform_reduce, _ExecutionPolicy, __iters_per_work_item,
+                                 _Operation1, _Operation2, _Tp, _Commutative):
+    oneapi::dpl::__internal::__is_types_device_copyable<_Tp, _Operation1, _Operation2> {};
 
+namespace oneapi
+{
+namespace dpl
+{
+namespace unseq_backend
+{
 // Reduce local reductions of each work item to a single reduced element per work group. The local reductions are held
 // in local memory. sycl::reduce_over_group is used for supported data types and operations. All other operations are
 // processed in order and without a known identity.

--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -382,6 +382,10 @@ class zip_iterator
     __it_types __my_it_;
 };
 
+template<typename... _Types>
+struct _ONEDPL_IS_DEVICE_COPYABLE(zip_iterator, _Types...):
+    oneapi::dpl::__internal::__is_types_device_copyable<_Types...> {};
+
 template <typename... _Tp>
 zip_iterator<_Tp...>
 make_zip_iterator(_Tp... __args)

--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -382,10 +382,6 @@ class zip_iterator
     __it_types __my_it_;
 };
 
-template<typename... _Types>
-struct _ONEDPL_IS_DEVICE_COPYABLE(zip_iterator, _Types...):
-    oneapi::dpl::__internal::__is_types_device_copyable<_Types...> {};
-
 template <typename... _Tp>
 zip_iterator<_Tp...>
 make_zip_iterator(_Tp... __args)
@@ -400,6 +396,17 @@ make_zip_iterator(std::tuple<_Tp...> __arg)
     return zip_iterator<_Tp...>(__arg);
 }
 
+} //oneapi
+} //dpl
+
+template<typename... _Types>
+struct _ONEDPL_IS_DEVICE_COPYABLE(oneapi::dpl::zip_iterator, _Types...):
+    oneapi::dpl::__internal::__is_types_device_copyable<_Types...> {};
+
+namespace oneapi
+{
+namespace dpl
+{
 template <typename _Iter, typename _UnaryFunc>
 class transform_iterator
 {

--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -380,6 +380,8 @@ class zip_iterator
 
   private:
     __it_types __my_it_;
+
+  _ONEDPL_IS_DEVICE_COPYABLE(_Types...)
 };
 
 template <typename... _Tp>
@@ -396,17 +398,6 @@ make_zip_iterator(std::tuple<_Tp...> __arg)
     return zip_iterator<_Tp...>(__arg);
 }
 
-} //oneapi
-} //dpl
-
-template<typename... _Types>
-struct _ONEDPL_IS_DEVICE_COPYABLE(oneapi::dpl::zip_iterator, _Types...):
-    oneapi::dpl::__internal::__is_types_device_copyable<_Types...> {};
-
-namespace oneapi
-{
-namespace dpl
-{
 template <typename _Iter, typename _UnaryFunc>
 class transform_iterator
 {

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -48,6 +48,30 @@ namespace dpl
 namespace __internal
 {
 
+#if _ONEDPL_BACKEND_SYCL
+
+template <typename... _Ts>
+struct __is_types_device_copyable: std::conjunction<sycl::is_device_copyable<_Ts>...> {};
+
+#if __INTEL_LLVM_COMPILER && (__INTEL_LLVM_COMPILER < 20240100)
+#   define _ONEDPL_IS_DEVICE_COPYABLE(TYPE, ...) sycl::is_device_copyable<TYPE<__VA_ARGS__>, \
+    std::enable_if_t<!std::is_trivially_copyable_v<TYPE<__VA_ARGS__>>>>
+#else
+#   define _ONEDPL_IS_DEVICE_COPYABLE(TYPE, ...) sycl::is_device_copyable<TYPE<__VA_ARGS__>>
+#endif //__INTEL_LLVM_COMPILER && (__INTEL_LLVM_COMPILER < 20240100)
+
+#else
+
+template <typename...>
+struct __is_types_device_copyable: std::false_type {};
+
+template <typename>
+struct __is_device_copyable_ignore: std::false_type {};
+
+# define _ONEDPL_IS_DEVICE_COPYABLE(TYPE, ...) oneapi::dpl::__internal::__is_device_copyable_ignore<TYPE<__VA_ARGS__>>
+
+#endif //_ONEDPL_BACKEND_SYCL
+
 template <typename Iterator>
 using is_const_iterator =
     typename ::std::is_const<::std::remove_pointer_t<typename ::std::iterator_traits<Iterator>::pointer>>;
@@ -70,29 +94,6 @@ __except_handler(_Fp __f) -> decltype(__f())
     }
 }
 
-#if _ONEDPL_BACKEND_SYCL
-
-template <typename... _Ts>
-struct __is_types_device_copyable: std::conjunction<sycl::is_device_copyable<_Ts>...> {};
-
-#if __INTEL_LLVM_COMPILER && (__INTEL_LLVM_COMPILER < 20240100)
-#   define _ONEDPL_IS_DEVICE_COPYABLE(TYPE, ...) sycl::is_device_copyable<TYPE<__VA_ARGS__>, \
-    std::enable_if_t<!std::is_trivially_copyable_v<TYPE<__VA_ARGS__>>>>
-#else
-#   define _ONEDPL_IS_DEVICE_COPYABLE(TYPE, ...) sycl::is_device_copyable<TYPE<__VA_ARGS__>>
-#endif //__INTEL_LLVM_COMPILER && (__INTEL_LLVM_COMPILER < 20240100)
-
-#else
-
-template <typename...>
-struct __is_types_device_copyable: std::false_type {};
-
-template <typename>
-struct __is_device_copyable_ignore: std::false_type {};
-
-#   define _ONEDPL_IS_DEVICE_COPYABLE(TYPE, ...) __is_device_copyable_ignore<TYPE<__VA_ARGS__>>
-
-#endif //_ONEDPL_BACKEND_SYCL
 //! Unary operator that returns reference to its argument.
 struct __no_op
 {

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -72,8 +72,8 @@ __except_handler(_Fp __f) -> decltype(__f())
 
 #if _ONEDPL_BACKEND_SYCL
 
-template <typename... Ts>
-struct __is_types_device_copyable: std::conjunction<sycl::is_device_copyable<Ts>...> {};
+template <typename... _Ts>
+struct __is_types_device_copyable: std::conjunction<sycl::is_device_copyable<_Ts>...> {};
 
 #if __INTEL_LLVM_COMPILER && (__INTEL_LLVM_COMPILER < 20240100)
 #   define _ONEDPL_IS_DEVICE_COPYABLE(TYPE, ...) sycl::is_device_copyable<TYPE<__VA_ARGS__>, \
@@ -84,11 +84,11 @@ struct __is_types_device_copyable: std::conjunction<sycl::is_device_copyable<Ts>
 
 #else
 
-template <typename... Ts>
+template <typename...>
 struct __is_types_device_copyable: std::false_type {};
 
-template <typename... Ts>
-__is_device_copyable_ignore: std::false_type {};
+template <typename>
+struct __is_device_copyable_ignore: std::false_type {};
 
 #   define _ONEDPL_IS_DEVICE_COPYABLE(TYPE, ...) __is_device_copyable_ignore<TYPE<__VA_ARGS__>>
 

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -70,6 +70,29 @@ __except_handler(_Fp __f) -> decltype(__f())
     }
 }
 
+#if _ONEDPL_BACKEND_SYCL
+
+template <typename... Ts>
+struct __is_types_device_copyable: std::conjunction<sycl::is_device_copyable<Ts>...> {};
+
+#if __INTEL_LLVM_COMPILER && (__INTEL_LLVM_COMPILER < 20240100)
+#   define _ONEDPL_IS_DEVICE_COPYABLE(TYPE, ...) sycl::is_device_copyable<TYPE<__VA_ARGS__>, \
+    std::enable_if_t<!std::is_trivially_copyable_v<TYPE<__VA_ARGS__>>>>
+#else
+#   define _ONEDPL_IS_DEVICE_COPYABLE(TYPE, ...) sycl::is_device_copyable<TYPE<__VA_ARGS__>>
+#endif //__INTEL_LLVM_COMPILER && (__INTEL_LLVM_COMPILER < 20240100)
+
+#else
+
+template <typename... Ts>
+struct __is_types_device_copyable: std::false_type {};
+
+template <typename... Ts>
+__is_device_copyable_ignore: std::false_type {};
+
+#   define _ONEDPL_IS_DEVICE_COPYABLE(TYPE, ...) __is_device_copyable_ignore<TYPE<__VA_ARGS__>>
+
+#endif //_ONEDPL_BACKEND_SYCL
 //! Unary operator that returns reference to its argument.
 struct __no_op
 {


### PR DESCRIPTION
[oneDPL][hetero] Re-woring sycl::is_device_copyable trait specializations for oneDPL types.

1) After offline discussed internally in oneDPL team, we decide to keep  sycl::is_device_copyable trait specialization next to each oneDPL type definition.
2) Also we have to support the previous  oneAPI compiler version via special macro
3) Also we have to support a case when SYCL backend is not active.

This is a prototype for 3 different oneDPL types: `transform_reduce`, `__brick_copy_n` and `zip_iterator`
(The total number of such  oneDPL types is about 50.)
Also the prototype introduces a common code stuff to define the is_device_copyable trait specializations.

Based on GoDBolt prototype: https://godbolt.org/z/qx8nTaKsK

UPDATE!!!
The prototype was modified: via a special trait in each device copyable oneDPL type