### PR TITLE
Introduce smart constructor and destructor calls common helpers

### DIFF
--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1145,7 +1145,7 @@ struct __brick_move_destroy
         return __unseq_backend::__simd_assign(__first, __last - __first, __result,
                                               [](_RandomAccessIterator1 __first, _RandomAccessIterator2 __result) {
                                                   *__result = ::std::move(*__first);
-                                                  (*__first).~_IteratorValueType();
+                                                  oneapi::dpl::__utils::__op_smart_dtor<_IteratorValueType>{}(*__first);
                                               });
     }
 
@@ -1158,7 +1158,7 @@ struct __brick_move_destroy
         for (; __first != __last; ++__first, ++__result)
         {
             *__result = ::std::move(*__first);
-            (*__first).~_IteratorValueType();
+            oneapi::dpl::__utils::__op_smart_dtor<_IteratorValueType>{}(*__first);
         }
         return __result;
     }
@@ -2618,10 +2618,12 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
                                                   __i, __j, __d_first + (__i - __r), _IsVector{});
                                           });
 
-            if constexpr (!::std::is_trivially_destructible_v<_T1>)
+            if constexpr (oneapi::dpl::__utils::__op_smart_dtor<_T1>::required)
+            {
                 __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __r + __n2,
                                               __r + __n1,
                                               [](_T1* __i, _T1* __j) { __brick_destroy(__i, __j, _IsVector{}); });
+            }
 
             return __d_first + __n2;
         }

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -1495,10 +1495,7 @@ __remove_elements(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomA
                 __internal::__brick_copy_by_mask(
                     __first + __i, __first + __i + __len, __result + __initial, __mask + __i,
                     [](_RandomAccessIterator __x, _Tp* __z) {
-                        if constexpr (::std::is_trivial_v<_Tp>)
-                            *__z = ::std::move(*__x);
-                        else
-                            ::new (::std::addressof(*__z)) _Tp(::std::move(*__x));
+                        oneapi::dpl::__utils::__op_smart_ctor<_Tp>{}(std::addressof(*__z), std::move(*__x));
                     },
                     _IsVector{});
             },
@@ -2603,7 +2600,7 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
                     // 1. Copy elements from input to raw memory
                     for (_T1* __k = __i; __k != __j; ++__k, ++__it)
                     {
-                        ::new (__k) _T2(*__it);
+                        oneapi::dpl::__utils::__op_smart_ctor<_T2>{}(__k, *__it);
                     }
 
                     // 2. Sort elements in temporary buffer
@@ -3092,10 +3089,7 @@ __pattern_inplace_merge(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _R
     _Tp* __r = __buf.get();
     __internal::__except_handler([&]() {
         auto __move_values = [](_RandomAccessIterator __x, _Tp* __z) {
-            if constexpr (::std::is_trivial_v<_Tp>)
-                *__z = ::std::move(*__x);
-            else
-                ::new (::std::addressof(*__z)) _Tp(::std::move(*__x));
+            oneapi::dpl::__utils::__op_smart_ctor<_Tp>{}(std::addressof(*__z), std::move(*__x));
         };
 
         auto __move_sequences = [](_RandomAccessIterator __first1, _RandomAccessIterator __last1, _Tp* __first2) {

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -2619,11 +2619,9 @@ __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec
                                           });
 
             if constexpr (oneapi::dpl::__utils::__op_smart_dtor<_T1>::required)
-            {
                 __par_backend::__parallel_for(__backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __r + __n2,
                                               __r + __n1,
                                               [](_T1* __i, _T1* __j) { __brick_destroy(__i, __j, _IsVector{}); });
-            }
 
             return __d_first + __n2;
         }

--- a/include/oneapi/dpl/pstl/glue_memory_impl.h
+++ b/include/oneapi/dpl/pstl/glue_memory_impl.h
@@ -217,7 +217,7 @@ destroy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __
     typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType;
     typedef typename ::std::iterator_traits<_ForwardIterator>::reference _ReferenceType;
 
-    if constexpr (!::std::is_trivially_destructible_v<_ValueType>)
+    if constexpr (oneapi::dpl::__utils::__op_smart_dtor<_ValueType>::required)
     {
         const auto __dispatch_tag =
 #if (_PSTL_ICPX_OMP_SIMD_DESTROY_WINDOWS_BROKEN || _ONEDPL_ICPX_OMP_SIMD_DESTROY_WINDOWS_BROKEN)
@@ -226,8 +226,9 @@ destroy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __
             oneapi::dpl::__internal::__select_backend(__exec, __first);
 #endif
 
-        oneapi::dpl::__internal::__pattern_walk1(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first,
-                                                 __last, [](_ReferenceType __val) { __val.~_ValueType(); });
+        oneapi::dpl::__internal::__pattern_walk1(
+            __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+            [](_ReferenceType __val) { oneapi::dpl::__utils::__op_smart_dtor<_ValueType>{}(__val); });
     }
 }
 
@@ -238,7 +239,7 @@ destroy_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n)
     typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType;
     typedef typename ::std::iterator_traits<_ForwardIterator>::reference _ReferenceType;
 
-    if constexpr (::std::is_trivially_destructible_v<_ValueType>)
+    if constexpr (!oneapi::dpl::__utils::__op_smart_dtor<_ValueType>::required)
     {
         return oneapi::dpl::__internal::__pstl_next(__first, __n);
     }
@@ -251,9 +252,9 @@ destroy_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n)
             oneapi::dpl::__internal::__select_backend(__exec, __first);
 #endif
 
-        return oneapi::dpl::__internal::__pattern_walk1_n(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
-                                                          __first, __n,
-                                                          [](_ReferenceType __val) { __val.~_ValueType(); });
+        return oneapi::dpl::__internal::__pattern_walk1_n(
+            __dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __n,
+            [](_ReferenceType __val) { oneapi::dpl::__utils::__op_smart_dtor<_ValueType>{}(__val); });
     }
 }
 

--- a/include/oneapi/dpl/pstl/glue_memory_impl.h
+++ b/include/oneapi/dpl/pstl/glue_memory_impl.h
@@ -27,6 +27,7 @@
 #include "algorithm_fwd.h"
 
 #include "execution_impl.h"
+#include "parallel_backend_utils.h"
 
 #include <type_traits>
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -617,7 +617,7 @@ __radix_sort_reorder_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments,
                     if (__self_lidx < __residual)
                     {
                         __output_rng[__new_offset_idx] = std::move(__in_val.__v);
-                        __in_val.__v.~_ValueT();
+                        oneapi::dpl::__utils::__op_smart_dtor<_ValueT>{}(__in_val.__v);
                     }
                 }
             });

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -600,7 +600,8 @@ __radix_sort_reorder_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments,
                     if (__self_lidx < __residual)
                     {
                         //initialize the storage via move constructor for _ValueT type
-                        new (&__in_val.__v) _ValueT(std::move(__input_rng[__seg_end + __self_lidx]));
+                        oneapi::dpl::__utils::__op_smart_ctor<_ValueT>{}(
+                            &__in_val.__v, std::move(__input_rng[__seg_end + __self_lidx]));
 
                         __bucket = __get_bucket<(1 << __radix_bits) - 1>(
                             __order_preserving_cast<__is_ascending>(__proj(__in_val.__v)), __radix_offset);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -27,6 +27,8 @@
 
 #include "sycl_traits.h" //SYCL traits specialization for some oneDPL types.
 
+#include "../../parallel_backend_utils.h"
+
 #define _ONEDPL_RADIX_WORKLOAD_TUNING 1
 //To achieve better performance, number of segments and work-group size are variated depending on a number of elements:
 //1. 32K...512K  - number of segments is increased up to 8 times

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -24,9 +24,7 @@
 #include "sycl_defs.h"
 #include "parallel_backend_sycl_utils.h"
 #include "execution_sycl_defs.h"
-
 #include "sycl_traits.h" //SYCL traits specialization for some oneDPL types.
-
 #include "../../parallel_backend_utils.h"
 
 #define _ONEDPL_RADIX_WORKLOAD_TUNING 1

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
@@ -106,7 +106,7 @@ struct __subgroup_radix_sort
         {
             const uint16_t __idx = __wi * __block_size + __i;
             if (__idx < __n)
-                new (&__values[__i]) _ValueT(::std::move(__src[__idx]));
+                oneapi::dpl::__utils::__op_smart_ctor<_ValueT>{}(&__values[__i], std::move(__src[__idx]));
         }
     }
 
@@ -278,7 +278,8 @@ struct __subgroup_radix_sort
                                 {
                                     const uint16_t __r = __indices[__i];
                                     if (__r < __n)
-                                        new (&__exchange_lacc[__r]) _ValT(::std::move(__values.__v[__i]));
+                                        oneapi::dpl::__utils::__op_smart_ctor<_ValT>{}(&__exchange_lacc[__r],
+                                                                                       std::move(__values.__v[__i]));
                                 }
                             }
                             else

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
@@ -254,17 +254,20 @@ struct __subgroup_radix_sort
                                     {
                                         //move the values to source range and destroy the values
                                         __src[__r] = ::std::move(__values.__v[__i]);
-                                        __values.__v[__i].~_ValT();
+                                        oneapi::dpl::__utils::__op_smart_dtor<_ValT>{}(__values.__v[__i]);
                                     }
                                 }
 
                                 //destroy values in exchange buffer
-                                _ONEDPL_PRAGMA_UNROLL
-                                for (uint16_t __i = 0; __i < __block_size; ++__i)
+                                if constexpr (oneapi::dpl::__utils::__op_smart_dtor<_ValT>::required)
                                 {
-                                    const uint16_t __idx = __wi * __block_size + __i;
-                                    if (__idx < __n)
-                                        __exchange_lacc[__idx].~_ValT();
+                                    _ONEDPL_PRAGMA_UNROLL
+                                    for (uint16_t __i = 0; __i < __block_size; ++__i)
+                                    {
+                                        const uint16_t __idx = __wi * __block_size + __i;
+                                        if (__idx < __n)
+                                            oneapi::dpl::__utils::__op_smart_dtor<_ValT>{}(__exchange_lacc[__idx]);
+                                    }
                                 }
 
                                 return;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
@@ -17,6 +17,7 @@
 #define _ONEDPL_parallel_backend_sycl_radix_sort_one_wg_H
 
 #include "sycl_traits.h" //SYCL traits specialization for some oneDPL types.
+#include "../../parallel_backend_utils.h"
 
 //The file is an internal file and the code of that file is included by a major file into the following namespaces:
 //namespace oneapi

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort_one_wg.h
@@ -260,15 +260,12 @@ struct __subgroup_radix_sort
                                 }
 
                                 //destroy values in exchange buffer
-                                if constexpr (oneapi::dpl::__utils::__op_smart_dtor<_ValT>::required)
+                                _ONEDPL_PRAGMA_UNROLL
+                                for (uint16_t __i = 0; __i < __block_size; ++__i)
                                 {
-                                    _ONEDPL_PRAGMA_UNROLL
-                                    for (uint16_t __i = 0; __i < __block_size; ++__i)
-                                    {
-                                        const uint16_t __idx = __wi * __block_size + __i;
-                                        if (__idx < __n)
-                                            oneapi::dpl::__utils::__op_smart_dtor<_ValT>{}(__exchange_lacc[__idx]);
-                                    }
+                                    const uint16_t __idx = __wi * __block_size + __i;
+                                    if (__idx < __n)
+                                        oneapi::dpl::__utils::__op_smart_dtor<_ValT>{}(__exchange_lacc[__idx]);
                                 }
 
                                 return;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -28,6 +28,8 @@
 
 #include "sycl_traits.h" //SYCL traits specialization for some oneDPL types.
 
+#include "./../../parallel_backend_utils.h"
+
 namespace oneapi
 {
 namespace dpl

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -72,7 +72,7 @@ __work_group_reduce_kernel(const _NDItemId __item_id, const _Size __n, _Transfor
         __reduce_pattern.apply_init(__init, __result.__v);
         __res_acc[0] = __result.__v;
     }
-    __result.__v.~_Tp();
+    oneapi::dpl::__utils::__op_smart_dtor<_Tp>{}(__result.__v);
 }
 
 // Device kernel that transforms and reduces __n elements to the number of work groups preliminary results.
@@ -98,7 +98,7 @@ __device_reduce_kernel(const _NDItemId __item_id, const _Size __n, _TransformPat
     __result.__v = __reduce_pattern(__item_id, __n_items, __result.__v, __local_mem);
     if (__local_idx == 0)
         __temp_acc[__group_idx] = __result.__v;
-    __result.__v.~_Tp();
+    oneapi::dpl::__utils::__op_smart_dtor<_Tp>{}(__result.__v);
 }
 
 //------------------------------------------------------------------------
@@ -421,7 +421,7 @@ struct __parallel_transform_reduce_impl
 
                             __temp_ptr[__offset_1 + __group_idx] = __result.__v;
                         }
-                        __result.__v.~_Tp();
+                        oneapi::dpl::__utils::__op_smart_dtor<_Tp>{}(__result.__v);
                     });
             });
             __is_first = false;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -222,7 +222,7 @@ struct transform_reduce
         if (__adjusted_global_id + __iters_per_work_item < __adjusted_n)
         {
             // Keep these statements in the same scope to allow for better memory alignment
-            new (&__res.__v) _Tp(__unary_op(__adjusted_global_id, __acc...));
+            oneapi::dpl::__utils::__op_smart_ctor<_Tp>{}(&__res.__v, __unary_op(__adjusted_global_id, __acc...));
             _ONEDPL_PRAGMA_UNROLL
             for (_Size __i = 1; __i < __iters_per_work_item; ++__i)
                 __res.__v = __binary_op(__res.__v, __unary_op(__adjusted_global_id + __i, __acc...));
@@ -231,7 +231,7 @@ struct transform_reduce
         {
             const _Size __items_to_process = __adjusted_n - __adjusted_global_id;
             // Keep these statements in the same scope to allow for better memory alignment
-            new (&__res.__v) _Tp(__unary_op(__adjusted_global_id, __acc...));
+            oneapi::dpl::__utils::__op_smart_ctor<_Tp>{}(&__res.__v, __unary_op(__adjusted_global_id, __acc...));
             for (_Size __i = 1; __i < __items_to_process; ++__i)
                 __res.__v = __binary_op(__res.__v, __unary_op(__adjusted_global_id + __i, __acc...));
         }
@@ -253,7 +253,7 @@ struct transform_reduce
         // Coalesced load and reduce from global memory
         if (__adjusted_global_id + __stride * __iters_per_work_item < __adjusted_n)
         {
-            new (&__res.__v) _Tp(__unary_op(__adjusted_global_id, __acc...));
+            oneapi::dpl::__utils::__op_smart_ctor<_Tp>{}(&__res.__v, __unary_op(__adjusted_global_id, __acc...));
             _ONEDPL_PRAGMA_UNROLL
             for (_Size __i = 1; __i < __iters_per_work_item; ++__i)
                 __res.__v = __binary_op(__res.__v, __unary_op(__adjusted_global_id + __stride * __i, __acc...));
@@ -262,7 +262,7 @@ struct transform_reduce
         {
             const _Size __items_to_process =
                 std::max(((__adjusted_n - __adjusted_global_id - 1) / __stride) + 1, static_cast<_Size>(0));
-            new (&__res.__v) _Tp(__unary_op(__adjusted_global_id, __acc...));
+            oneapi::dpl::__utils::__op_smart_ctor<_Tp>{}(&__res.__v, __unary_op(__adjusted_global_id, __acc...));
             for (_Size __i = 1; __i < __items_to_process; ++__i)
                 __res.__v = __binary_op(__res.__v, __unary_op(__adjusted_global_id + __stride * __i, __acc...));
         }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -22,6 +22,7 @@
 #include "../../onedpl_config.h"
 #include "../../utils.h"
 #include "sycl_defs.h"
+#include "../../parallel_backend_utils.h"
 
 namespace oneapi
 {

--- a/include/oneapi/dpl/pstl/memory_impl.h
+++ b/include/oneapi/dpl/pstl/memory_impl.h
@@ -66,8 +66,10 @@ __brick_destroy(_Iterator __first, _Iterator __last, /*vector*/ ::std::false_typ
 {
     using _ValueType = typename ::std::iterator_traits<_Iterator>::value_type;
 
+    static_assert(oneapi::dpl::__utils::__op_smart_dtor<_ValueType>::required);
+
     for (; __first != __last; ++__first)
-        __first->~_ValueType();
+        oneapi::dpl::__utils::__op_smart_dtor<_ValueType>{}(*__first);
 }
 
 template <typename _RandomAccessIterator>
@@ -77,7 +79,11 @@ __brick_destroy(_RandomAccessIterator __first, _RandomAccessIterator __last, /*v
     using _ValueType = typename ::std::iterator_traits<_RandomAccessIterator>::value_type;
     using _ReferenceType = typename ::std::iterator_traits<_RandomAccessIterator>::reference;
 
-    __unseq_backend::__simd_walk_1(__first, __last - __first, [](_ReferenceType __x) { __x.~_ValueType(); });
+    static_assert(oneapi::dpl::__utils::__op_smart_dtor<_ValueType>::required);
+
+    __unseq_backend::__simd_walk_1(__first, __last - __first, [](_ReferenceType __x) {
+        oneapi::dpl::__utils::__op_smart_dtor<_ValueType>{}(__x);
+    });
 }
 
 //------------------------------------------------------------------------
@@ -172,7 +178,10 @@ struct __op_destroy<_ExecutionPolicy>
     operator()(_TargetT& __target) const
     {
         using _TargetValueType = ::std::decay_t<_TargetT>;
-        __target.~_TargetValueType();
+
+        static_assert(oneapi::dpl::__utils::__op_smart_dtor<_TargetValueType>::required);
+
+        oneapi::dpl::__utils::__op_smart_dtor<_TargetValueType>{}(__target);
     }
 };
 

--- a/include/oneapi/dpl/pstl/memory_impl.h
+++ b/include/oneapi/dpl/pstl/memory_impl.h
@@ -67,8 +67,6 @@ __brick_destroy(_Iterator __first, _Iterator __last, /*vector*/ ::std::false_typ
 {
     using _ValueType = typename ::std::iterator_traits<_Iterator>::value_type;
 
-    static_assert(oneapi::dpl::__utils::__op_smart_dtor<_ValueType>::required);
-
     for (; __first != __last; ++__first)
         oneapi::dpl::__utils::__op_smart_dtor<_ValueType>{}(*__first);
 }
@@ -79,8 +77,6 @@ __brick_destroy(_RandomAccessIterator __first, _RandomAccessIterator __last, /*v
 {
     using _ValueType = typename ::std::iterator_traits<_RandomAccessIterator>::value_type;
     using _ReferenceType = typename ::std::iterator_traits<_RandomAccessIterator>::reference;
-
-    static_assert(oneapi::dpl::__utils::__op_smart_dtor<_ValueType>::required);
 
     __unseq_backend::__simd_walk_1(__first, __last - __first, [](_ReferenceType __x) {
         oneapi::dpl::__utils::__op_smart_dtor<_ValueType>{}(__x);
@@ -179,8 +175,6 @@ struct __op_destroy<_ExecutionPolicy>
     operator()(_TargetT& __target) const
     {
         using _TargetValueType = ::std::decay_t<_TargetT>;
-
-        static_assert(oneapi::dpl::__utils::__op_smart_dtor<_TargetValueType>::required);
 
         oneapi::dpl::__utils::__op_smart_dtor<_TargetValueType>{}(__target);
     }

--- a/include/oneapi/dpl/pstl/memory_impl.h
+++ b/include/oneapi/dpl/pstl/memory_impl.h
@@ -139,7 +139,6 @@ struct __op_uninitialized_move<_ExecutionPolicy>
     operator()(_SourceT&& __source, _TargetT& __target) const
     {
         using _TargetValueType = ::std::decay_t<_TargetT>;
-
         oneapi::dpl::__utils::__op_smart_ctor<_TargetValueType>{}(std::addressof(__target), std::move(__source));
     }
 };
@@ -158,7 +157,6 @@ struct __op_uninitialized_fill<_SourceT, _ExecutionPolicy>
     operator()(_TargetT& __target) const
     {
         using _TargetValueType = ::std::decay_t<_TargetT>;
-
         oneapi::dpl::__utils::__op_smart_ctor<_TargetValueType>{}(std::addressof(__target), __source);
     }
 };
@@ -175,7 +173,6 @@ struct __op_destroy<_ExecutionPolicy>
     operator()(_TargetT& __target) const
     {
         using _TargetValueType = ::std::decay_t<_TargetT>;
-
         oneapi::dpl::__utils::__op_smart_dtor<_TargetValueType>{}(__target);
     }
 };
@@ -192,7 +189,6 @@ struct __op_uninitialized_default_construct<_ExecutionPolicy>
     operator()(_TargetT& __target) const
     {
         using _TargetValueType = ::std::decay_t<_TargetT>;
-
         ::new (::std::addressof(__target)) _TargetValueType;
     }
 };
@@ -209,7 +205,6 @@ struct __op_uninitialized_value_construct<_ExecutionPolicy>
     operator()(_TargetT& __target) const
     {
         using _TargetValueType = ::std::decay_t<_TargetT>;
-
         oneapi::dpl::__utils::__op_smart_ctor<_TargetValueType>{}(std::addressof(__target));
     }
 };

--- a/include/oneapi/dpl/pstl/memory_impl.h
+++ b/include/oneapi/dpl/pstl/memory_impl.h
@@ -21,6 +21,7 @@
 
 #include "memory_fwd.h"
 #include "unseq_backend_simd.h"
+#include "parallel_backend_utils.h"
 
 namespace oneapi
 {

--- a/include/oneapi/dpl/pstl/memory_impl.h
+++ b/include/oneapi/dpl/pstl/memory_impl.h
@@ -40,9 +40,8 @@ __brick_uninitialized_move(_ForwardIterator __first, _ForwardIterator __last, _O
 {
     using _ValueType = typename ::std::iterator_traits<_OutputIterator>::value_type;
     for (; __first != __last; ++__first, ++__result)
-    {
-        ::new (::std::addressof(*__result)) _ValueType(::std::move(*__first));
-    }
+        oneapi::dpl::__utils::__op_smart_ctor<_ValueType>{}(std::addressof(*__result), std::move(*__first));
+
     return __result;
 }
 
@@ -56,8 +55,9 @@ __brick_uninitialized_move(_RandomAccessIterator __first, _RandomAccessIterator 
     using _ReferenceType2 = typename ::std::iterator_traits<_OutputIterator>::reference;
 
     return __unseq_backend::__simd_walk_2(
-        __first, __last - __first, __result,
-        [](_ReferenceType1 __x, _ReferenceType2 __y) { ::new (::std::addressof(__y)) __ValueType(::std::move(__x)); });
+        __first, __last - __first, __result, [](_ReferenceType1 __x, _ReferenceType2 __y) {
+            oneapi::dpl::__utils::__op_smart_ctor<__ValueType>{}(std::addressof(__y), std::move(__x));
+        });
 }
 
 template <typename _Iterator>
@@ -91,9 +91,8 @@ __brick_uninitialized_copy(_ForwardIterator __first, _ForwardIterator __last, _O
 {
     using _ValueType = typename ::std::iterator_traits<_OutputIterator>::value_type;
     for (; __first != __last; ++__first, ++__result)
-    {
-        ::new (::std::addressof(*__result)) _ValueType(*__first);
-    }
+        oneapi::dpl::__utils::__op_smart_ctor<_ValueType>{}(std::addressof(*__result), *__first);
+
     return __result;
 }
 
@@ -107,8 +106,9 @@ __brick_uninitialized_copy(_RandomAccessIterator __first, _RandomAccessIterator 
     using _ReferenceType2 = typename ::std::iterator_traits<_OutputIterator>::reference;
 
     return __unseq_backend::__simd_walk_2(
-        __first, __last - __first, __result,
-        [](_ReferenceType1 __x, _ReferenceType2 __y) { ::new (::std::addressof(__y)) __ValueType(__x); });
+        __first, __last - __first, __result, [](_ReferenceType1 __x, _ReferenceType2 __y) {
+            oneapi::dpl::__utils::__op_smart_ctor<__ValueType>{}(std::addressof(__y), __x);
+        });
 }
 
 template <typename _ExecutionPolicy>
@@ -119,10 +119,8 @@ struct __op_uninitialized_copy<_ExecutionPolicy>
     operator()(_SourceT&& __source, _TargetT& __target) const
     {
         using _TargetValueType = std::decay_t<_TargetT>;
-        if constexpr (std::is_trivial_v<_TargetValueType>)
-            __target = std::forward<_SourceT>(__source);
-        else
-            ::new (std::addressof(__target)) _TargetValueType(std::forward<_SourceT>(__source));
+        oneapi::dpl::__utils::__op_smart_ctor<_TargetValueType>{}(std::addressof(__target),
+                                                                  std::forward<_SourceT>(__source));
     }
 };
 
@@ -139,7 +137,7 @@ struct __op_uninitialized_move<_ExecutionPolicy>
     {
         using _TargetValueType = ::std::decay_t<_TargetT>;
 
-        ::new (::std::addressof(__target)) _TargetValueType(::std::move(__source));
+        oneapi::dpl::__utils::__op_smart_ctor<_TargetValueType>{}(std::addressof(__target), std::move(__source));
     }
 };
 
@@ -158,7 +156,7 @@ struct __op_uninitialized_fill<_SourceT, _ExecutionPolicy>
     {
         using _TargetValueType = ::std::decay_t<_TargetT>;
 
-        ::new (::std::addressof(__target)) _TargetValueType(__source);
+        oneapi::dpl::__utils::__op_smart_ctor<_TargetValueType>{}(std::addressof(__target), __source);
     }
 };
 
@@ -208,7 +206,7 @@ struct __op_uninitialized_value_construct<_ExecutionPolicy>
     {
         using _TargetValueType = ::std::decay_t<_TargetT>;
 
-        ::new (::std::addressof(__target)) _TargetValueType();
+        oneapi::dpl::__utils::__op_smart_ctor<_TargetValueType>{}(std::addressof(__target));
     }
 };
 

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -153,8 +153,11 @@ struct __par_trans_red_body
     ~__par_trans_red_body()
     {
         // 17.6.5.12 tells us to not worry about catching exceptions from destructors.
-        if (_M_has_sum)
-            sum().~_Tp();
+        if constexpr (oneapi::dpl::__utils::__op_smart_dtor<_Tp>::required)
+        {
+            if (_M_has_sum)
+                oneapi::dpl::__utils::__op_smart_dtor<_Tp>{}(sum());
+        }
     }
 
     void
@@ -224,8 +227,11 @@ class __trans_scan_body
     ~__trans_scan_body()
     {
         // 17.6.5.12 tells us to not worry about catching exceptions from destructors.
-        if (_M_has_sum)
-            sum().~_Tp();
+        if constexpr (oneapi::dpl::__utils::__op_smart_dtor<_Tp>::required)
+        {
+            if (_M_has_sum)
+                oneapi::dpl::__utils::__op_smart_dtor<_Tp>{}(sum());
+        }
     }
 
     _Tp&
@@ -885,7 +891,7 @@ class __merge_func
         else
         {
             __move_range()(_M_z_beg + _M_zs, _M_z_beg + _M_zs + __nx, _M_x_beg + _M_xs);
-            if constexpr (!::std::is_trivially_destructible_v<_ValueType>)
+            if constexpr (oneapi::dpl::__utils::__op_smart_dtor<_ValueType>::required)
                 __cleanup_range()(_M_z_beg + _M_zs, _M_z_beg + _M_zs + __nx);
         }
 
@@ -902,7 +908,7 @@ class __merge_func
         else
         {
             __move_range()(_M_z_beg + _M_zs + __nx, _M_z_beg + _M_zs + __nx + __ny, _M_x_beg + _M_ys);
-            if constexpr (!::std::is_trivially_destructible_v<_ValueType>)
+            if constexpr (oneapi::dpl::__utils::__op_smart_dtor<_ValueType>::required)
                 __cleanup_range()(_M_z_beg + _M_zs + __nx, _M_z_beg + _M_zs + __nx + __ny);
         }
 
@@ -938,7 +944,7 @@ class __merge_func
             _M_leaf_merge(_M_z_beg + _M_xs, _M_z_beg + _M_xe, _M_z_beg + _M_ys, _M_z_beg + _M_ye, _M_x_beg + _M_zs,
                           _M_comp, __move_value(), __move_value(), __move_range(), __move_range());
 
-            if constexpr (!::std::is_trivially_destructible_v<_ValueType>)
+            if constexpr (oneapi::dpl::__utils::__op_smart_dtor<_ValueType>::required)
             {
                 __cleanup_range()(_M_z_beg + _M_xs, _M_z_beg + _M_xe);
                 __cleanup_range()(_M_z_beg + _M_ys, _M_z_beg + _M_ye);

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -171,8 +171,9 @@ struct __par_trans_red_body
         if (!_M_has_sum)
         {
             __TBB_ASSERT(__range.size() > 1, "there should be at least 2 elements");
-            new (&_M_sum_storage)
-                _Tp(_M_combine(_M_u(__i), _M_u(__i + 1))); // The condition i+1 < j is provided by the grain size of 3
+            oneapi::dpl::__utils::__op_smart_ctor<_Tp>{}(
+                (_Tp*)_M_sum_storage,
+                _M_combine(_M_u(__i), _M_u(__i + 1))); // The condition i+1 < j is provided by the grain size of 3
             _M_has_sum = true;
             ::std::advance(__i, 2);
             if (__i == __j)
@@ -241,7 +242,7 @@ class __trans_scan_body
         _Index __j = __range.end();
         if (!_M_has_sum)
         {
-            new (&_M_sum_storage) _Tp(_M_u(__i));
+            oneapi::dpl::__utils::__op_smart_ctor<_Tp>{}((_Tp*)_M_sum_storage, _M_u(__i));
             _M_has_sum = true;
             ++__i;
             if (__i == __j)
@@ -265,7 +266,7 @@ class __trans_scan_body
         }
         else
         {
-            new (&_M_sum_storage) _Tp(__a.sum());
+            oneapi::dpl::__utils::__op_smart_ctor<_Tp>{}((_Tp*)_M_sum_storage, __a.sum());
             _M_has_sum = true;
         }
     }
@@ -747,7 +748,7 @@ class __merge_func
         void
         operator()(Iterator1 __x, Iterator2 __z)
         {
-            ::new (::std::addressof(*__z)) _ValueType(::std::move(*__x));
+            oneapi::dpl::__utils::__op_smart_ctor<_ValueType>{}(std::addressof(*__z), std::move(*__x));
         }
     };
 

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -153,11 +153,8 @@ struct __par_trans_red_body
     ~__par_trans_red_body()
     {
         // 17.6.5.12 tells us to not worry about catching exceptions from destructors.
-        if constexpr (oneapi::dpl::__utils::__op_smart_dtor<_Tp>::required)
-        {
-            if (_M_has_sum)
-                oneapi::dpl::__utils::__op_smart_dtor<_Tp>{}(sum());
-        }
+        if (_M_has_sum)
+            oneapi::dpl::__utils::__op_smart_dtor<_Tp>{}(sum());
     }
 
     void
@@ -227,11 +224,8 @@ class __trans_scan_body
     ~__trans_scan_body()
     {
         // 17.6.5.12 tells us to not worry about catching exceptions from destructors.
-        if constexpr (oneapi::dpl::__utils::__op_smart_dtor<_Tp>::required)
-        {
-            if (_M_has_sum)
-                oneapi::dpl::__utils::__op_smart_dtor<_Tp>{}(sum());
-        }
+        if (_M_has_sum)
+            oneapi::dpl::__utils::__op_smart_dtor<_Tp>{}(sum());
     }
 
     _Tp&

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -28,12 +28,6 @@ namespace dpl
 {
 namespace __utils
 {
-//------------------------------------------------------------------------
-// Uninitialized / initialized copy / move for trivial / non-trivial types
-//------------------------------------------------------------------------
-
-// struct __op_smart_ctor - helper struct for uninitialized/initialized copy/move operations.
-// It can be used to perform copy/move operations for scalar and non-scalar types.
 template <typename _ValueType>
 struct __op_smart_ctor
 {
@@ -65,15 +59,10 @@ struct __op_smart_ctor
     }
 };
 
-// struct __op_smart_dtor - helper struct for destructor calls.
-// It can be used to perform destructor calls for types,
-// which are not trivially-destructible (we call destructor)
-// and for all other types (we doesn't call destructor).
 template <typename _ValueType>
 struct __op_smart_dtor
 {
     static_assert(std::is_same_v<_ValueType, std::decay_t<_ValueType>>);
-
     static constexpr bool required = !std::is_trivially_destructible_v<_ValueType>;
 
     inline void
@@ -125,14 +114,10 @@ struct __serial_destroy
     operator()(_RandomAccessIterator __zs, _RandomAccessIterator __ze)
     {
         typedef typename ::std::iterator_traits<_RandomAccessIterator>::value_type _ValueType;
-
-        if constexpr (oneapi::dpl::__utils::__op_smart_dtor<_ValueType>::required)
+        while (__zs != __ze)
         {
-            while (__zs != __ze)
-            {
-                --__ze;
-                oneapi::dpl::__utils::__op_smart_dtor<_ValueType>{}(*__ze);
-            }
+            --__ze;
+            oneapi::dpl::__utils::__op_smart_dtor<_ValueType>{}(*__ze);
         }
     }
 };

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -28,6 +28,70 @@ namespace dpl
 {
 namespace __utils
 {
+//------------------------------------------------------------------------
+// Uninitialized / initialized copy / move for trivial / non-trivial types
+//------------------------------------------------------------------------
+
+// struct __op_smart_ctor - helper struct for uninitialized/initialized copy/move operations.
+// It can be used to perform copy/move operations for scalar and non-scalar types.
+template <typename _ValueType>
+struct __op_smart_ctor
+{
+    using _ValueTypeDecayed = std::decay_t<_ValueType>;
+
+    // Construct value in place
+    /*
+     * _ValueTypeDecayed* __p_value_to - pointer to the value for construction
+     */
+    inline void
+    operator()(_ValueTypeDecayed* __p_value_to) const
+    {
+        if constexpr (std::is_scalar_v<_ValueTypeDecayed>)
+        {
+            // no assignment required here
+        }
+        else
+        {
+            ::new (__p_value_to) _ValueTypeDecayed();
+        }
+    }
+
+    // Uninitialized (for scalar types) / initialized (for other types) copy
+    /**
+     * _ValueTypeDecayed* __p_value_to - pointer to the value for construction
+     * @param const _ValueTypeDecayed& __value_from - source value
+     */
+    inline void
+    operator()(_ValueTypeDecayed* __p_value_to, const _ValueTypeDecayed& __value_from) const
+    {
+        if constexpr (std::is_scalar_v<_ValueTypeDecayed>)
+        {
+            *__p_value_to = __value_from;
+        }
+        else
+        {
+            ::new (__p_value_to) _ValueTypeDecayed(__value_from);
+        }
+    }
+
+    // Uninitialized (for scalar types) / initialized (for other types) move
+    /**
+     * _ValueTypeDecayed* __p_value_to - pointer to the value for construction
+     * @param _ValueTypeDecayed&& __value_from - source value
+     */
+    inline void
+    operator()(_ValueTypeDecayed* __p_value_to, _ValueTypeDecayed&& __value_from) const
+    {
+        if constexpr (std::is_scalar_v<_ValueTypeDecayed>)
+        {
+            *__p_value_to = std::forward<_ValueTypeDecayed>(__value_from);
+        }
+        else
+        {
+            ::new (__p_value_to) _ValueTypeDecayed(std::forward<_ValueTypeDecayed>(__value_from));
+        }
+    }
+};
 
 //------------------------------------------------------------------------
 // raw buffer (with specified _TAllocator)

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -37,7 +37,7 @@ struct __op_smart_ctor
     inline void
     operator()(_ValueTypeDecayed* __p_value_to, Args&&... args) const
     {
-        if constexpr (std::is_scalar_v<_ValueTypeDecayed> && sizeof...(Args) <= 1)
+        if constexpr (std::is_trivial_v<_ValueTypeDecayed> && sizeof...(Args) <= 1)
         {
             if constexpr (sizeof...(Args) == 1)
             {

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -153,10 +153,14 @@ struct __serial_destroy
     operator()(_RandomAccessIterator __zs, _RandomAccessIterator __ze)
     {
         typedef typename ::std::iterator_traits<_RandomAccessIterator>::value_type _ValueType;
-        while (__zs != __ze)
+
+        if constexpr (oneapi::dpl::__utils::__op_smart_dtor<_ValueType>::required)
         {
-            --__ze;
-            (*__ze).~_ValueType();
+            while (__zs != __ze)
+            {
+                --__ze;
+                oneapi::dpl::__utils::__op_smart_dtor<_ValueType>{}(*__ze);
+            }
         }
     }
 };

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -273,12 +273,12 @@ __set_union_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _Fo
             return __cc_range(__first1, __last1, __result);
         if (__comp(*__first2, *__first1))
         {
-            ::new (::std::addressof(*__result)) _Tp(*__first2);
+            __op_smart_ctor<_Tp>{}(std::addressof(*__result), *__first2);
             ++__first2;
         }
         else
         {
-            ::new (::std::addressof(*__result)) _Tp(*__first1);
+            __op_smart_ctor<_Tp>{}(std::addressof(*__result), *__first1);
             if (!__comp(*__first1, *__first2))
                 ++__first2;
             ++__first1;
@@ -337,7 +337,7 @@ __set_difference_construct(_ForwardIterator1 __first1, _ForwardIterator1 __last1
 
         if (__comp(*__first1, *__first2))
         {
-            ::new (::std::addressof(*__result)) _Tp(*__first1);
+            __op_smart_ctor<_Tp>{}(std::addressof(*__result), *__first1);
             ++__result;
             ++__first1;
         }
@@ -366,7 +366,7 @@ __set_symmetric_difference_construct(_ForwardIterator1 __first1, _ForwardIterato
 
         if (__comp(*__first1, *__first2))
         {
-            ::new (::std::addressof(*__result)) _Tp(*__first1);
+            __op_smart_ctor<_Tp>{}(std::addressof(*__result), *__first1);
             ++__result;
             ++__first1;
         }
@@ -374,7 +374,7 @@ __set_symmetric_difference_construct(_ForwardIterator1 __first1, _ForwardIterato
         {
             if (__comp(*__first2, *__first1))
             {
-                ::new (::std::addressof(*__result)) _Tp(*__first2);
+                __op_smart_ctor<_Tp>{}(std::addressof(*__result), *__first2);
                 ++__result;
             }
             else

--- a/include/oneapi/dpl/pstl/parallel_backend_utils.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_utils.h
@@ -93,6 +93,25 @@ struct __op_smart_ctor
     }
 };
 
+// struct __op_smart_dtor - helper struct for destructor calls.
+// It can be used to perform destructor calls for types,
+// which are not trivially-destructible (we call destructor)
+// and for all other types (we doesn't call destructor).
+template <typename _ValueType>
+struct __op_smart_dtor
+{
+    static_assert(std::is_same_v<_ValueType, std::decay_t<_ValueType>>);
+
+    static constexpr bool required = !std::is_trivially_destructible_v<_ValueType>;
+
+    inline void
+    operator()(_ValueType& __value) const
+    {
+        if constexpr (required)
+            __value.~_ValueType();
+    }
+};
+
 //------------------------------------------------------------------------
 // raw buffer (with specified _TAllocator)
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -19,6 +19,7 @@
 #include <type_traits>
 
 #include "utils.h"
+#include "parallel_backend_utils.h"
 
 // This header defines the minimum set of vector routines required
 // to support Parallel STL.

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -519,10 +519,13 @@ __simd_transform_reduce(_Size __n, _Tp __init, _BinaryOperation __binary_op, _Un
             __init = __binary_op(__init, __lane[__i]);
         }
         // destroyer
-        _ONEDPL_PRAGMA_SIMD
-        for (_Size __i = 0; __i < __block_size; ++__i)
+        if constexpr (oneapi::dpl::__utils::__op_smart_dtor<_Tp>::required)
         {
-            __lane[__i].~_Tp();
+            _ONEDPL_PRAGMA_SIMD
+            for (_Size __i = 0; __i < __block_size; ++__i)
+            {
+                oneapi::dpl::__utils::__op_smart_dtor<_Tp>{}(__lane[__i]);
+            }
         }
     }
     else

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -494,7 +494,7 @@ __simd_transform_reduce(_Size __n, _Tp __init, _BinaryOperation __binary_op, _Un
         _ONEDPL_PRAGMA_SIMD
         for (_Size __i = 0; __i < __block_size; ++__i)
         {
-            ::new (__lane + __i) _Tp(__binary_op(__f(__i), __f(__block_size + __i)));
+            oneapi::dpl::__utils::__op_smart_ctor<_Tp>{}(__lane + __i, __binary_op(__f(__i), __f(__block_size + __i)));
         }
         // main loop
         _Size __i = 2 * __block_size;

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -520,13 +520,10 @@ __simd_transform_reduce(_Size __n, _Tp __init, _BinaryOperation __binary_op, _Un
             __init = __binary_op(__init, __lane[__i]);
         }
         // destroyer
-        if constexpr (oneapi::dpl::__utils::__op_smart_dtor<_Tp>::required)
+        _ONEDPL_PRAGMA_SIMD
+        for (_Size __i = 0; __i < __block_size; ++__i)
         {
-            _ONEDPL_PRAGMA_SIMD
-            for (_Size __i = 0; __i < __block_size; ++__i)
-            {
-                oneapi::dpl::__utils::__op_smart_dtor<_Tp>{}(__lane[__i]);
-            }
+            oneapi::dpl::__utils::__op_smart_dtor<_Tp>{}(__lane[__i]);
         }
     }
     else


### PR DESCRIPTION
Example: https://godbolt.org/z/3MYz3EaKb

## The main idea
The main idea - to unify constructor calls, constructors with assignment/move calls and destructor calls in oneDPL code.
This approach give us ability to make same things by similar way and avoid some errors:
- assignment without constructor call and etc.;
- destructor calls for data types where it's not mandatory required and some loops for that;
- give us ability to clarify in the future the conditions of constructor/destructor calls in one place of oneDPL code.

## How we achieve this goal
### `struct __op_smart_ctor` - constructor call :
```C++
template <typename _ValueType>
struct __op_smart_ctor
{
    using _ValueTypeDecayed = std::decay_t<_ValueType>;

    template <typename... Args>
    inline void
    operator()(_ValueTypeDecayed* __p_value_to, Args&&... args) const
    {
        if constexpr (std::is_trivial_v<_ValueTypeDecayed> && sizeof...(Args) <= 1)
        {
            if constexpr (sizeof...(Args) == 1)
            {
                __assign_impl(__p_value_to, std::forward<Args>(args)...);
            }
        }
        else
        {
            ::new (__p_value_to) _ValueTypeDecayed(std::forward<Args>(args)...);
        }
    }

  private:
    template <typename Arg>
    inline void
    __assign_impl(_ValueTypeDecayed* __p_value_to, Arg&& arg) const
    {
        *__p_value_to = std::forward<Arg>(arg);
    }
};
```

### `struct __op_smart_dtor` - destructor call :
```C++
template <typename _ValueType>
struct __op_smart_dtor
{
    static_assert(std::is_same_v<_ValueType, std::decay_t<_ValueType>>);

    static constexpr bool required = !std::is_trivially_destructible_v<_ValueType>;

    inline void
    operator()(_ValueType& __value) const
    {
        if constexpr (required)
            __value.~_ValueType();
    }
};
```

[std::is_scalar_v](https://en.cppreference.com/w/cpp/types/is_scalar) - [ScalarType](https://en.cppreference.com/w/cpp/named_req/ScalarType)

[std::is_trivial_v](https://en.cppreference.com/w/cpp/types/is_trivial) - [Trivial types](https://en.cppreference.com/w/cpp/named_req/TrivialType)

[std::is_trivially_destructible_v](https://en.cppreference.com/w/cpp/types/is_destructible)