### PR TITLE
[Tests] Fix for set_intersection kernel names

### DIFF
--- a/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_common.h
+++ b/test/parallel_api/algorithm/alg.sorting/alg.set.operations/set_common.h
@@ -145,7 +145,8 @@ struct test_set_intersection
         auto expect = sequences.first;
         auto out = sequences.second;
         auto expect_res = ::std::set_intersection(first1, last1, first2, last2, expect.begin(), comp);
-        auto res = ::std::set_intersection(exec, first1, last1, first2, last2, out.begin(), comp);
+        auto res = ::std::set_intersection(create_new_policy_idx<0>(std::forward<Policy>(exec)), first1, last1, first2,
+                                           last2, out.begin(), comp);
 
         EXPECT_TRUE(expect_res - expect.begin() == res - out.begin(), "wrong result for set_intersection");
         EXPECT_EQ_N(expect.begin(), out.begin(), ::std::distance(out.begin(), res), "wrong set_intersection effect");
@@ -173,9 +174,9 @@ struct test_set_intersection
             auto zip_out = oneapi::dpl::make_zip_iterator(sequences.second.begin(), out_ints.begin());
 
             auto zip_expect_res = std::set_intersection(zip_first1, zip_last1, zip_first2, zip_last2, zip_expect,
-                                                          comp_select_first(comp));
-            auto zip_res = std::set_intersection(exec, zip_first1, zip_last1, zip_first2, zip_last2, zip_out,
-                                                   comp_select_first(comp));
+                                                        comp_select_first(comp));
+            auto zip_res = std::set_intersection(create_new_policy_idx<1>(std::forward<Policy>(exec)), zip_first1,
+                                                 zip_last1, zip_first2, zip_last2, zip_out, comp_select_first(comp));
             EXPECT_TRUE(zip_expect_res - zip_expect == zip_res - zip_out, "wrong result for zipped set_intersection");
             EXPECT_EQ_N(zip_expect, zip_out, std::distance(zip_out, zip_res), "wrong zipped set_intersection effect");
         }

--- a/test/parallel_api/iterator/permutation_iterator_parallel_for.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_for.pass.cpp
@@ -51,8 +51,8 @@ DEFINE_TEST_PERM_IT(test_transform, PermItIndexTag)
     {
         if constexpr (is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>)
         {
-            auto exec1 = TestUtils::create_new_policy_idx<Policy, 0>(exec);
-            auto exec2 = TestUtils::create_new_policy_idx<Policy, 1>(exec);
+            auto exec1 = TestUtils::create_new_policy_idx<0>(exec);
+            auto exec2 = TestUtils::create_new_policy_idx<1>(exec);
 
             TestDataTransfer<UDTKind::eKeys, Size> host_keys(*this, n);     // source data for transform
             TestDataTransfer<UDTKind::eVals, Size> host_vals(*this, n);     // result data of transform

--- a/test/parallel_api/iterator/permutation_iterator_parallel_merge.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_merge.pass.cpp
@@ -34,9 +34,9 @@ DEFINE_TEST_PERM_IT(test_merge, PermItIndexTag)
     {
         if constexpr (is_base_of_iterator_category_v<::std::random_access_iterator_tag, Iterator1>)
         {
-            auto exec1 = TestUtils::create_new_policy_idx<Policy, 0>(exec);
-            auto exec2 = TestUtils::create_new_policy_idx<Policy, 1>(exec);
-            auto exec3 = TestUtils::create_new_policy_idx<Policy, 2>(exec);
+            auto exec1 = TestUtils::create_new_policy_idx<0>(exec);
+            auto exec2 = TestUtils::create_new_policy_idx<1>(exec);
+            auto exec3 = TestUtils::create_new_policy_idx<2>(exec);
 
             TestDataTransfer<UDTKind::eKeys, Size> host_keys(*this, n);                                 // source data(1) for merge
             TestDataTransfer<UDTKind::eVals, Size> host_vals(*this, n);                                 // source data(2) for merge

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -878,12 +878,12 @@ create_new_policy(Policy&& policy)
     return ::std::forward<Policy>(policy);
 }
 
-template <typename _NewKernelName, int idx, typename Policy>
+template <int idx, typename Policy>
 auto
 create_new_policy_idx(Policy&& policy)
 {
 #if TEST_DPCPP_BACKEND_PRESENT
-    return create_new_policy<TestUtils::new_kernel_name<_NewKernelName, idx>>(::std::forward<Policy>(policy));
+    return create_new_policy<TestUtils::new_kernel_name<Policy, idx>>(::std::forward<Policy>(policy));
 #else
     return ::std::forward<Policy>(policy);
 #endif


### PR DESCRIPTION
Fixes set intersection kernel names.
Removes some unnecessary parts from a utility for generating new kernel names

Bug introduced in #983 