### PR TITLE
Adding missing includes `parallel_backend_sycl.h`

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -27,6 +27,7 @@
 #include <utility>
 #include <cmath>
 #include <limits>
+#include <cstdint>
 
 #include "../../iterator_impl.h"
 #include "../../execution_impl.h"

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -23,6 +23,10 @@
 #include <cassert>
 #include <algorithm>
 #include <type_traits>
+#include <functional>
+#include <utility>
+#include <cmath>
+#include <limits>
 
 #include "../../iterator_impl.h"
 #include "../../execution_impl.h"


### PR DESCRIPTION
Adding some missing includes.

* `<functional>`  for `std::plus`
* `<utility>` for `std::make_pair`, `std::forward`
* `<limits>` for `std::numerical_limits`
* `<cmath>` for `std::log2`  <-- this is the one which had an error report in some environment / code