### PR TITLE
Fix `std::log2` compile error - undefined function

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -23,6 +23,7 @@
 #include <cassert>
 #include <algorithm>
 #include <type_traits>
+#include <cmath>
 
 #include "../../iterator_impl.h"
 #include "../../execution_impl.h"
@@ -1586,7 +1587,7 @@ struct __parallel_sort_submitter<_IdType, __internal::__optional_kernel_name<_Le
         __steps = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __chunk);
 
         const ::std::size_t __n_power2 = oneapi::dpl::__internal::__dpl_bit_ceil(__n);
-        const ::std::int64_t __n_iter = ::std::log2(__n_power2) - ::std::log2(__leaf);
+        const ::std::int64_t __n_iter = std::log2(__n_power2) - std::log2(__leaf);
         for (::std::int64_t __i = 0; __i < __n_iter; ++__i)
         {
             __event1 = __exec.queue().submit([&, __n_sorted, __data_in_temp](sycl::handler& __cgh) {


### PR DESCRIPTION
In this PR we fix compile error: no member named 'log2' in namespace 'std'; did you mean 'sycl::log2'?

```C++
======== ranlux_24_48_base_test log file =============================================
Test result: compfail compiler exit status 1
-------- compiler output  ----------------------------------------------
In file included from ranlux_24_48_base_test.pass.cpp:30:
In file included from ./support/utils.h:24:
In file included from dpl/latest/include/oneapi/dpl/execution:66:
In file included from dpl/latest/include/oneapi/dpl/pstl/algorithm_impl.h:31:
In file included from dpl/latest/include/oneapi/dpl/pstl/parallel_backend.h:32:
dpl/latest/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:1580:41: error: no member named 'log2' in namespace 'std'; did you mean 'sycl::log2'?
 1580 |         const ::std::int64_t __n_iter = ::std::log2(__n_power2) - ::std::log2(__leaf);
      |                                         ^~~~~~~~~~~
      |                                         sycl::log2
/netbatchro/cache/deploy-1-d89ac59eca9d6b148552e4b3afda8026/bin/compiler/../../include/sycl/detail/builtins/math_functions.inc:184:34: note: 'sycl::log2' declared here
  184 | BUILTIN_GENF_NATIVE_OPT(ONE_ARG, log2)
      |                                  ^
In file included from ranlux_24_48_base_test.pass.cpp:30:
In file included from ./support/utils.h:24:
In file included from dpl/latest/include/oneapi/dpl/execution:66:
In file included from dpl/latest/include/oneapi/dpl/pstl/algorithm_impl.h:31:
In file included from dpl/latest/include/oneapi/dpl/pstl/parallel_backend.h:32:
dpl/latest/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:1580:67: error: no member named 'log2' in namespace 'std'; did you mean 'sycl::log2'?
 1580 |         const ::std::int64_t __n_iter = ::std::log2(__n_power2) - ::std::log2(__leaf);
      |                                                                   ^~~~~~~~~~~
      |                                                                   sycl::log2
/bin/compiler/../../include/sycl/detail/builtins/math_functions.inc:184:34: note: 'sycl::log2' declared here
  184 | BUILTIN_GENF_NATIVE_OPT(ONE_ARG, log2)
      |                                  ^
2 errors generated.
======== ranlux_24_48_base_test log file =============================================
-------- other files (possibly of interest)
ranlux_24_48_base_test.pass.cpp
 
```