### PR TITLE
Improve kernel name generation for unnamed lambda (kernel templates)

### DIFF
--- a/test/kt/esimd_radix_sort.cpp
+++ b/test/kt/esimd_radix_sort.cpp
@@ -185,13 +185,13 @@ template <typename T, bool IsAscending, std::uint8_t RadixBits, typename KernelP
 void
 test_general_cases(sycl::queue q, std::size_t size, KernelParam param)
 {
-    test_usm<T, IsAscending, RadixBits, sycl::usm::alloc::shared>(q, size, TestUtils::get_new_kernel_params<0>(param));
-    test_usm<T, IsAscending, RadixBits, sycl::usm::alloc::device>(q, size, TestUtils::get_new_kernel_params<1>(param));
-    test_sycl_iterators<T, IsAscending, RadixBits>(q, size, TestUtils::get_new_kernel_params<2>(param));
-    test_sycl_buffer<T, IsAscending, RadixBits>(q, size, TestUtils::get_new_kernel_params<3>(param));
+    test_usm<T, IsAscending, RadixBits, sycl::usm::alloc::shared>(q, size, TestUtils::adjust_kernel_name<0>(param));
+    test_usm<T, IsAscending, RadixBits, sycl::usm::alloc::device>(q, size, TestUtils::adjust_kernel_name<1>(param));
+    test_sycl_iterators<T, IsAscending, RadixBits>(q, size, TestUtils::adjust_kernel_name<2>(param));
+    test_sycl_buffer<T, IsAscending, RadixBits>(q, size, TestUtils::adjust_kernel_name<3>(param));
 #if _ENABLE_RANGES_TESTING
-    test_all_view<T, IsAscending, RadixBits>(q, size, TestUtils::get_new_kernel_params<4>(param));
-    test_subrange_view<T, IsAscending, RadixBits>(q, size, TestUtils::get_new_kernel_params<5>(param));
+    test_all_view<T, IsAscending, RadixBits>(q, size, TestUtils::adjust_kernel_name<4>(param));
+    test_subrange_view<T, IsAscending, RadixBits>(q, size, TestUtils::adjust_kernel_name<5>(param));
 #endif // _ENABLE_RANGES_TESTING
 }
 
@@ -217,11 +217,11 @@ main()
             for (auto size : sort_sizes)
             {
                 test_general_cases<TEST_KEY_TYPE, Ascending, TestRadixBits>(
-                    q, size, TestUtils::get_new_kernel_params<0>(params));
+                    q, size, TestUtils::adjust_kernel_name<0>(params));
                 test_general_cases<TEST_KEY_TYPE, Descending, TestRadixBits>(
-                    q, size, TestUtils::get_new_kernel_params<1>(params));
+                    q, size, TestUtils::adjust_kernel_name<1>(params));
             }
-            test_small_sizes<TEST_KEY_TYPE, Ascending, TestRadixBits>(q, TestUtils::get_new_kernel_params<3>(params));
+            test_small_sizes<TEST_KEY_TYPE, Ascending, TestRadixBits>(q, TestUtils::adjust_kernel_name<3>(params));
         }
         catch (const ::std::exception& exc)
         {

--- a/test/kt/esimd_radix_sort.cpp
+++ b/test/kt/esimd_radix_sort.cpp
@@ -185,13 +185,13 @@ template <typename T, bool IsAscending, std::uint8_t RadixBits, typename KernelP
 void
 test_general_cases(sycl::queue q, std::size_t size, KernelParam param)
 {
-    test_usm<T, IsAscending, RadixBits, sycl::usm::alloc::shared>(q, size, TestUtils::adjust_kernel_name<0>(param));
-    test_usm<T, IsAscending, RadixBits, sycl::usm::alloc::device>(q, size, TestUtils::adjust_kernel_name<1>(param));
-    test_sycl_iterators<T, IsAscending, RadixBits>(q, size, TestUtils::adjust_kernel_name<2>(param));
-    test_sycl_buffer<T, IsAscending, RadixBits>(q, size, TestUtils::adjust_kernel_name<3>(param));
+    test_usm<T, IsAscending, RadixBits, sycl::usm::alloc::shared>(q, size, TestUtils::create_new_kernel_param_idx<0>(param));
+    test_usm<T, IsAscending, RadixBits, sycl::usm::alloc::device>(q, size, TestUtils::create_new_kernel_param_idx<1>(param));
+    test_sycl_iterators<T, IsAscending, RadixBits>(q, size, TestUtils::create_new_kernel_param_idx<2>(param));
+    test_sycl_buffer<T, IsAscending, RadixBits>(q, size, TestUtils::create_new_kernel_param_idx<3>(param));
 #if _ENABLE_RANGES_TESTING
-    test_all_view<T, IsAscending, RadixBits>(q, size, TestUtils::adjust_kernel_name<4>(param));
-    test_subrange_view<T, IsAscending, RadixBits>(q, size, TestUtils::adjust_kernel_name<5>(param));
+    test_all_view<T, IsAscending, RadixBits>(q, size, TestUtils::create_new_kernel_param_idx<4>(param));
+    test_subrange_view<T, IsAscending, RadixBits>(q, size, TestUtils::create_new_kernel_param_idx<5>(param));
 #endif // _ENABLE_RANGES_TESTING
 }
 
@@ -217,11 +217,11 @@ main()
             for (auto size : sort_sizes)
             {
                 test_general_cases<TEST_KEY_TYPE, Ascending, TestRadixBits>(
-                    q, size, TestUtils::adjust_kernel_name<0>(params));
+                    q, size, TestUtils::create_new_kernel_param_idx<0>(params));
                 test_general_cases<TEST_KEY_TYPE, Descending, TestRadixBits>(
-                    q, size, TestUtils::adjust_kernel_name<1>(params));
+                    q, size, TestUtils::create_new_kernel_param_idx<1>(params));
             }
-            test_small_sizes<TEST_KEY_TYPE, Ascending, TestRadixBits>(q, TestUtils::adjust_kernel_name<3>(params));
+            test_small_sizes<TEST_KEY_TYPE, Ascending, TestRadixBits>(q, TestUtils::create_new_kernel_param_idx<3>(params));
         }
         catch (const ::std::exception& exc)
         {

--- a/test/kt/esimd_radix_sort_by_key.cpp
+++ b/test/kt/esimd_radix_sort_by_key.cpp
@@ -103,13 +103,13 @@ int main()
             for (auto size : sort_sizes)
             {
                 test_usm<TEST_KEY_TYPE, TEST_VALUE_TYPE, Ascending, TestRadixBits, sycl::usm::alloc::shared>(
-                    q, size, TestUtils::get_new_kernel_params<0>(params));
+                    q, size, TestUtils::adjust_kernel_name<0>(params));
                 test_usm<TEST_KEY_TYPE, TEST_VALUE_TYPE, Descending, TestRadixBits, sycl::usm::alloc::shared>(
-                    q, size, TestUtils::get_new_kernel_params<1>(params));
+                    q, size, TestUtils::adjust_kernel_name<1>(params));
                 test_sycl_buffer<TEST_KEY_TYPE, TEST_VALUE_TYPE, Ascending, TestRadixBits>(
-                    q, size, TestUtils::get_new_kernel_params<2>(params));
+                    q, size, TestUtils::adjust_kernel_name<2>(params));
                 test_sycl_buffer<TEST_KEY_TYPE, TEST_VALUE_TYPE, Descending, TestRadixBits>(
-                    q, size, TestUtils::get_new_kernel_params<3>(params));
+                    q, size, TestUtils::adjust_kernel_name<3>(params));
             }
         }
         catch (const ::std::exception& exc)

--- a/test/kt/esimd_radix_sort_by_key.cpp
+++ b/test/kt/esimd_radix_sort_by_key.cpp
@@ -103,13 +103,13 @@ int main()
             for (auto size : sort_sizes)
             {
                 test_usm<TEST_KEY_TYPE, TEST_VALUE_TYPE, Ascending, TestRadixBits, sycl::usm::alloc::shared>(
-                    q, size, TestUtils::adjust_kernel_name<0>(params));
+                    q, size, TestUtils::create_new_kernel_param_idx<0>(params));
                 test_usm<TEST_KEY_TYPE, TEST_VALUE_TYPE, Descending, TestRadixBits, sycl::usm::alloc::shared>(
-                    q, size, TestUtils::adjust_kernel_name<1>(params));
+                    q, size, TestUtils::create_new_kernel_param_idx<1>(params));
                 test_sycl_buffer<TEST_KEY_TYPE, TEST_VALUE_TYPE, Ascending, TestRadixBits>(
-                    q, size, TestUtils::adjust_kernel_name<2>(params));
+                    q, size, TestUtils::create_new_kernel_param_idx<2>(params));
                 test_sycl_buffer<TEST_KEY_TYPE, TEST_VALUE_TYPE, Descending, TestRadixBits>(
-                    q, size, TestUtils::adjust_kernel_name<3>(params));
+                    q, size, TestUtils::create_new_kernel_param_idx<3>(params));
             }
         }
         catch (const ::std::exception& exc)

--- a/test/kt/esimd_radix_sort_by_key_out_of_place.cpp
+++ b/test/kt/esimd_radix_sort_by_key_out_of_place.cpp
@@ -148,13 +148,13 @@ main()
             for (auto size : sort_sizes)
             {
                 test_usm<TEST_KEY_TYPE, TEST_VALUE_TYPE, Ascending, TestRadixBits, sycl::usm::alloc::shared>(
-                    q, size, TestUtils::get_new_kernel_params<0>(params));
+                    q, size, TestUtils::adjust_kernel_name<0>(params));
                 test_usm<TEST_KEY_TYPE, TEST_VALUE_TYPE, Descending, TestRadixBits, sycl::usm::alloc::shared>(
-                    q, size, TestUtils::get_new_kernel_params<1>(params));
+                    q, size, TestUtils::adjust_kernel_name<1>(params));
                 test_sycl_buffer<TEST_KEY_TYPE, TEST_VALUE_TYPE, Ascending, TestRadixBits>(
-                    q, size, TestUtils::get_new_kernel_params<2>(params));
+                    q, size, TestUtils::adjust_kernel_name<2>(params));
                 test_sycl_buffer<TEST_KEY_TYPE, TEST_VALUE_TYPE, Descending, TestRadixBits>(
-                    q, size, TestUtils::get_new_kernel_params<3>(params));
+                    q, size, TestUtils::adjust_kernel_name<3>(params));
             }
         }
         catch (const ::std::exception& exc)

--- a/test/kt/esimd_radix_sort_by_key_out_of_place.cpp
+++ b/test/kt/esimd_radix_sort_by_key_out_of_place.cpp
@@ -148,13 +148,13 @@ main()
             for (auto size : sort_sizes)
             {
                 test_usm<TEST_KEY_TYPE, TEST_VALUE_TYPE, Ascending, TestRadixBits, sycl::usm::alloc::shared>(
-                    q, size, TestUtils::adjust_kernel_name<0>(params));
+                    q, size, TestUtils::create_new_kernel_param_idx<0>(params));
                 test_usm<TEST_KEY_TYPE, TEST_VALUE_TYPE, Descending, TestRadixBits, sycl::usm::alloc::shared>(
-                    q, size, TestUtils::adjust_kernel_name<1>(params));
+                    q, size, TestUtils::create_new_kernel_param_idx<1>(params));
                 test_sycl_buffer<TEST_KEY_TYPE, TEST_VALUE_TYPE, Ascending, TestRadixBits>(
-                    q, size, TestUtils::adjust_kernel_name<2>(params));
+                    q, size, TestUtils::create_new_kernel_param_idx<2>(params));
                 test_sycl_buffer<TEST_KEY_TYPE, TEST_VALUE_TYPE, Descending, TestRadixBits>(
-                    q, size, TestUtils::adjust_kernel_name<3>(params));
+                    q, size, TestUtils::create_new_kernel_param_idx<3>(params));
             }
         }
         catch (const ::std::exception& exc)

--- a/test/kt/esimd_radix_sort_out_of_place.cpp
+++ b/test/kt/esimd_radix_sort_out_of_place.cpp
@@ -210,13 +210,13 @@ template <typename T, bool IsAscending, std::uint8_t RadixBits, typename KernelP
 void
 test_general_cases(sycl::queue q, std::size_t size, KernelParam param)
 {
-    test_usm<T, IsAscending, RadixBits, sycl::usm::alloc::shared>(q, size, TestUtils::adjust_kernel_name<0>(param));
-    test_usm<T, IsAscending, RadixBits, sycl::usm::alloc::device>(q, size, TestUtils::adjust_kernel_name<1>(param));
-    test_sycl_iterators<T, IsAscending, RadixBits>(q, size, TestUtils::adjust_kernel_name<2>(param));
-    test_sycl_buffer<T, IsAscending, RadixBits>(q, size, TestUtils::adjust_kernel_name<3>(param));
+    test_usm<T, IsAscending, RadixBits, sycl::usm::alloc::shared>(q, size, TestUtils::create_new_kernel_param_idx<0>(param));
+    test_usm<T, IsAscending, RadixBits, sycl::usm::alloc::device>(q, size, TestUtils::create_new_kernel_param_idx<1>(param));
+    test_sycl_iterators<T, IsAscending, RadixBits>(q, size, TestUtils::create_new_kernel_param_idx<2>(param));
+    test_sycl_buffer<T, IsAscending, RadixBits>(q, size, TestUtils::create_new_kernel_param_idx<3>(param));
 #if _ENABLE_RANGES_TESTING
-    test_all_view<T, IsAscending, RadixBits>(q, size, TestUtils::adjust_kernel_name<4>(param));
-    test_subrange_view<T, IsAscending, RadixBits>(q, size, TestUtils::adjust_kernel_name<5>(param));
+    test_all_view<T, IsAscending, RadixBits>(q, size, TestUtils::create_new_kernel_param_idx<4>(param));
+    test_subrange_view<T, IsAscending, RadixBits>(q, size, TestUtils::create_new_kernel_param_idx<5>(param));
 #endif // _ENABLE_RANGES_TESTING
 }
 
@@ -242,11 +242,11 @@ main()
             for (auto size : sort_sizes)
             {
                 test_general_cases<TEST_KEY_TYPE, Ascending, TestRadixBits>(
-                    q, size, TestUtils::adjust_kernel_name<0>(params));
+                    q, size, TestUtils::create_new_kernel_param_idx<0>(params));
                 test_general_cases<TEST_KEY_TYPE, Descending, TestRadixBits>(
-                    q, size, TestUtils::adjust_kernel_name<1>(params));
+                    q, size, TestUtils::create_new_kernel_param_idx<1>(params));
             }
-            test_small_sizes<TEST_KEY_TYPE, Ascending, TestRadixBits>(q, TestUtils::adjust_kernel_name<3>(params));
+            test_small_sizes<TEST_KEY_TYPE, Ascending, TestRadixBits>(q, TestUtils::create_new_kernel_param_idx<3>(params));
         }
         catch (const ::std::exception& exc)
         {

--- a/test/kt/esimd_radix_sort_out_of_place.cpp
+++ b/test/kt/esimd_radix_sort_out_of_place.cpp
@@ -210,13 +210,13 @@ template <typename T, bool IsAscending, std::uint8_t RadixBits, typename KernelP
 void
 test_general_cases(sycl::queue q, std::size_t size, KernelParam param)
 {
-    test_usm<T, IsAscending, RadixBits, sycl::usm::alloc::shared>(q, size, TestUtils::get_new_kernel_params<0>(param));
-    test_usm<T, IsAscending, RadixBits, sycl::usm::alloc::device>(q, size, TestUtils::get_new_kernel_params<1>(param));
-    test_sycl_iterators<T, IsAscending, RadixBits>(q, size, TestUtils::get_new_kernel_params<2>(param));
-    test_sycl_buffer<T, IsAscending, RadixBits>(q, size, TestUtils::get_new_kernel_params<3>(param));
+    test_usm<T, IsAscending, RadixBits, sycl::usm::alloc::shared>(q, size, TestUtils::adjust_kernel_name<0>(param));
+    test_usm<T, IsAscending, RadixBits, sycl::usm::alloc::device>(q, size, TestUtils::adjust_kernel_name<1>(param));
+    test_sycl_iterators<T, IsAscending, RadixBits>(q, size, TestUtils::adjust_kernel_name<2>(param));
+    test_sycl_buffer<T, IsAscending, RadixBits>(q, size, TestUtils::adjust_kernel_name<3>(param));
 #if _ENABLE_RANGES_TESTING
-    test_all_view<T, IsAscending, RadixBits>(q, size, TestUtils::get_new_kernel_params<4>(param));
-    test_subrange_view<T, IsAscending, RadixBits>(q, size, TestUtils::get_new_kernel_params<5>(param));
+    test_all_view<T, IsAscending, RadixBits>(q, size, TestUtils::adjust_kernel_name<4>(param));
+    test_subrange_view<T, IsAscending, RadixBits>(q, size, TestUtils::adjust_kernel_name<5>(param));
 #endif // _ENABLE_RANGES_TESTING
 }
 
@@ -242,11 +242,11 @@ main()
             for (auto size : sort_sizes)
             {
                 test_general_cases<TEST_KEY_TYPE, Ascending, TestRadixBits>(
-                    q, size, TestUtils::get_new_kernel_params<0>(params));
+                    q, size, TestUtils::adjust_kernel_name<0>(params));
                 test_general_cases<TEST_KEY_TYPE, Descending, TestRadixBits>(
-                    q, size, TestUtils::get_new_kernel_params<1>(params));
+                    q, size, TestUtils::adjust_kernel_name<1>(params));
             }
-            test_small_sizes<TEST_KEY_TYPE, Ascending, TestRadixBits>(q, TestUtils::get_new_kernel_params<3>(params));
+            test_small_sizes<TEST_KEY_TYPE, Ascending, TestRadixBits>(q, TestUtils::adjust_kernel_name<3>(params));
         }
         catch (const ::std::exception& exc)
         {

--- a/test/kt/single_pass_scan.cpp
+++ b/test/kt/single_pass_scan.cpp
@@ -175,12 +175,12 @@ template <typename T, typename BinOp, typename KernelParam>
 void
 test_general_cases(sycl::queue q, std::size_t size, BinOp bin_op, KernelParam param)
 {
-    test_usm<T, sycl::usm::alloc::shared>(q, size, bin_op, TestUtils::adjust_kernel_name<0>(param));
-    test_usm<T, sycl::usm::alloc::device>(q, size, bin_op, TestUtils::adjust_kernel_name<1>(param));
-    test_sycl_iterators<T>(q, size, bin_op, TestUtils::adjust_kernel_name<2>(param));
+    test_usm<T, sycl::usm::alloc::shared>(q, size, bin_op, TestUtils::create_new_kernel_param_idx<0>(param));
+    test_usm<T, sycl::usm::alloc::device>(q, size, bin_op, TestUtils::create_new_kernel_param_idx<1>(param));
+    test_sycl_iterators<T>(q, size, bin_op, TestUtils::create_new_kernel_param_idx<2>(param));
 #if _ENABLE_RANGES_TESTING
-    test_all_view<T>(q, size, bin_op, TestUtils::adjust_kernel_name<3>(param));
-    test_buffer<T>(q, size, bin_op, TestUtils::adjust_kernel_name<4>(param));
+    test_all_view<T>(q, size, bin_op, TestUtils::create_new_kernel_param_idx<3>(param));
+    test_buffer<T>(q, size, bin_op, TestUtils::create_new_kernel_param_idx<4>(param));
 #endif
 }
 
@@ -188,7 +188,7 @@ template <typename T, typename KernelParam>
 void
 test_all_cases(sycl::queue q, std::size_t size, KernelParam param)
 {
-    test_general_cases<T>(q, size, std::plus<T>{}, TestUtils::adjust_kernel_name<0>(param));
+    test_general_cases<T>(q, size, std::plus<T>{}, TestUtils::create_new_kernel_param_idx<0>(param));
 #if _PSTL_GROUP_REDUCTION_MULT_INT64_BROKEN
     static constexpr bool int64_mult_broken = std::is_integral_v<T> && (sizeof(T) == 8);
 #else
@@ -196,7 +196,7 @@ test_all_cases(sycl::queue q, std::size_t size, KernelParam param)
 #endif
     if constexpr (!int64_mult_broken)
     {
-        test_general_cases<T>(q, size, std::multiplies<T>{}, TestUtils::adjust_kernel_name<1>(param));
+        test_general_cases<T>(q, size, std::multiplies<T>{}, TestUtils::create_new_kernel_param_idx<1>(param));
     }
 }
 

--- a/test/kt/single_pass_scan.cpp
+++ b/test/kt/single_pass_scan.cpp
@@ -175,12 +175,12 @@ template <typename T, typename BinOp, typename KernelParam>
 void
 test_general_cases(sycl::queue q, std::size_t size, BinOp bin_op, KernelParam param)
 {
-    test_usm<T, sycl::usm::alloc::shared>(q, size, bin_op, TestUtils::get_new_kernel_params<0>(param));
-    test_usm<T, sycl::usm::alloc::device>(q, size, bin_op, TestUtils::get_new_kernel_params<1>(param));
-    test_sycl_iterators<T>(q, size, bin_op, TestUtils::get_new_kernel_params<2>(param));
+    test_usm<T, sycl::usm::alloc::shared>(q, size, bin_op, TestUtils::adjust_kernel_name<0>(param));
+    test_usm<T, sycl::usm::alloc::device>(q, size, bin_op, TestUtils::adjust_kernel_name<1>(param));
+    test_sycl_iterators<T>(q, size, bin_op, TestUtils::adjust_kernel_name<2>(param));
 #if _ENABLE_RANGES_TESTING
-    test_all_view<T>(q, size, bin_op, TestUtils::get_new_kernel_params<3>(param));
-    test_buffer<T>(q, size, bin_op, TestUtils::get_new_kernel_params<4>(param));
+    test_all_view<T>(q, size, bin_op, TestUtils::adjust_kernel_name<3>(param));
+    test_buffer<T>(q, size, bin_op, TestUtils::adjust_kernel_name<4>(param));
 #endif
 }
 
@@ -188,7 +188,7 @@ template <typename T, typename KernelParam>
 void
 test_all_cases(sycl::queue q, std::size_t size, KernelParam param)
 {
-    test_general_cases<T>(q, size, std::plus<T>{}, TestUtils::get_new_kernel_params<0>(param));
+    test_general_cases<T>(q, size, std::plus<T>{}, TestUtils::adjust_kernel_name<0>(param));
 #if _PSTL_GROUP_REDUCTION_MULT_INT64_BROKEN
     static constexpr bool int64_mult_broken = std::is_integral_v<T> && (sizeof(T) == 8);
 #else
@@ -196,7 +196,7 @@ test_all_cases(sycl::queue q, std::size_t size, KernelParam param)
 #endif
     if constexpr (!int64_mult_broken)
     {
-        test_general_cases<T>(q, size, std::multiplies<T>{}, TestUtils::get_new_kernel_params<1>(param));
+        test_general_cases<T>(q, size, std::multiplies<T>{}, TestUtils::adjust_kernel_name<1>(param));
     }
 }
 

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -48,6 +48,7 @@
 #if TEST_DPCPP_BACKEND_PRESENT
 #    include "utils_sycl.h"
 #    include "oneapi/dpl/experimental/kt/kernel_param.h"
+#    include "oneapi/dpl/execution" // for oneapi::dpl::execution::DefaultKernelName
 #endif
 
 namespace TestUtils
@@ -967,11 +968,19 @@ struct __kernel_name_with_idx
 
 template <int idx, typename KernelParams>
 constexpr auto
-get_new_kernel_params(KernelParams)
+get_new_kernel_params(KernelParams params)
 {
-    return oneapi::dpl::experimental::kt::kernel_param<
+    auto new_params = oneapi::dpl::experimental::kt::kernel_param<
         KernelParams::data_per_workitem, KernelParams::workgroup_size,
         __kernel_name_with_idx<typename KernelParams::kernel_name, idx>>{};
+#if TEST_EXPLICIT_KERNEL_NAMES
+    return new_params;
+#else
+    if constexpr (std::is_same_v<typename KernelParams::kernel_name, oneapi::dpl::execution::DefaultKernelName>)
+        return params;
+    else
+        return new_params;
+#endif // TEST_EXPLICIT_KERNEL_NAMES
 }
 #endif //TEST_DPCPP_BACKEND_PRESENT
 

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -968,7 +968,7 @@ struct __kernel_name_with_idx
 
 template <int idx, typename KernelParams>
 constexpr auto
-get_new_kernel_params(KernelParams params)
+get_new_kernel_params([[maybe_unused]] KernelParams params)
 {
     auto new_params = oneapi::dpl::experimental::kt::kernel_param<
         KernelParams::data_per_workitem, KernelParams::workgroup_size,

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -962,17 +962,17 @@ create_new_policy_idx(Policy&& policy)
 
 #if TEST_DPCPP_BACKEND_PRESENT
 template <typename KernelName, int idx>
-struct __kernel_name_with_idx
+struct kernel_name_with_idx
 {
 };
 
 template <int idx, typename KernelParams>
 constexpr auto
-get_new_kernel_params([[maybe_unused]] KernelParams params)
+adjust_kernel_name([[maybe_unused]] KernelParams params)
 {
     auto new_params = oneapi::dpl::experimental::kt::kernel_param<
         KernelParams::data_per_workitem, KernelParams::workgroup_size,
-        __kernel_name_with_idx<typename KernelParams::kernel_name, idx>>{};
+        kernel_name_with_idx<typename KernelParams::kernel_name, idx>>{};
 #if TEST_EXPLICIT_KERNEL_NAMES
     return new_params;
 #else

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -48,7 +48,6 @@
 #if TEST_DPCPP_BACKEND_PRESENT
 #    include "utils_sycl.h"
 #    include "oneapi/dpl/experimental/kt/kernel_param.h"
-#    include "oneapi/dpl/execution" // for oneapi::dpl::execution::DefaultKernelName
 #endif
 
 namespace TestUtils
@@ -966,20 +965,16 @@ struct kernel_name_with_idx
 {
 };
 
-template <int idx, typename KernelParams>
+template <int idx, typename KernelParam>
 constexpr auto
-adjust_kernel_name([[maybe_unused]] KernelParams params)
+create_new_kernel_param_idx(KernelParam)
 {
-    auto new_params = oneapi::dpl::experimental::kt::kernel_param<
-        KernelParams::data_per_workitem, KernelParams::workgroup_size,
-        kernel_name_with_idx<typename KernelParams::kernel_name, idx>>{};
 #if TEST_EXPLICIT_KERNEL_NAMES
-    return new_params;
+    return oneapi::dpl::experimental::kt::kernel_param<KernelParam::data_per_workitem,
+                                                       KernelParam::workgroup_size,
+                                                       kernel_name_with_idx<typename KernelParam::kernel_name, idx>>{};
 #else
-    if constexpr (std::is_same_v<typename KernelParams::kernel_name, oneapi::dpl::execution::DefaultKernelName>)
-        return params;
-    else
-        return new_params;
+    return KernelParam{};
 #endif // TEST_EXPLICIT_KERNEL_NAMES
 }
 #endif //TEST_DPCPP_BACKEND_PRESENT


### PR DESCRIPTION
Let's test if we allow the compiler to generate unique kernel names for a default kernel name case. 
