### PR TITLE
Fix for iterators with const-qualified value type

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -177,6 +177,36 @@ struct __vector_iter_distinguishes_by_allocator<
 {
 };
 
+template <typename Iter, typename Void = void>
+struct __is_known_usm_vector_iter_impl : std::false_type
+{
+};
+
+template <typename Iter>
+struct __is_known_usm_vector_iter_impl<
+    Iter, std::enable_if_t<std::conjunction<
+              std::disjunction<std::is_same<Iter, oneapi::dpl::__internal::__usm_shared_alloc_vec_iter<Iter>>,
+                               std::is_same<Iter, oneapi::dpl::__internal::__usm_host_alloc_vec_iter<Iter>>>,
+              oneapi::dpl::__internal::__vector_iter_distinguishes_by_allocator<Iter>>::value>> : std::true_type
+{
+};
+
+template <typename Iter, typename Void = void>
+struct __is_known_usm_vector_iter : std::false_type
+{
+};
+
+//We must avoid instantiating vector of const, reference, or function elements
+template <typename Iter>
+struct __is_known_usm_vector_iter<
+    Iter, std::enable_if_t<std::conjunction<
+              std::negation<std::disjunction<std::is_const<typename std::iterator_traits<Iter>::value_type>,
+                                             std::is_reference<typename std::iterator_traits<Iter>::value_type>,
+                                             std::is_function<typename std::iterator_traits<Iter>::value_type>>>,
+              oneapi::dpl::__internal::__is_known_usm_vector_iter_impl<Iter>>::value>> : std::true_type
+{
+};
+
 } // namespace __internal
 
 template <typename T, typename Allocator>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -196,7 +196,7 @@ struct __is_known_usm_vector_iter : std::false_type
 {
 };
 
-//We must avoid instantiating vector of const, reference, or function elements
+//We must avoid instantiating vector of const, reference, or function elements to avoid ill-formed vector instantiation
 template <typename Iter>
 struct __is_known_usm_vector_iter<
     Iter, std::enable_if_t<std::conjunction<

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -79,7 +79,11 @@ class all_view
     {
         return begin() + size();
     }
-    __return_t& operator[](__diff_type i) const { return begin()[i]; }
+    __return_t&
+    operator[](__diff_type i) const
+    {
+        return begin()[i];
+    }
 
     __diff_type
     size() const
@@ -209,11 +213,8 @@ struct is_passed_directly<Iter, ::std::enable_if_t<Iter::is_passed_directly::val
 
 //support std::vector::iterator with usm host / shared allocator as passed directly
 template <typename Iter>
-struct is_passed_directly<
-    Iter, std::enable_if_t<(std::is_same_v<Iter, oneapi::dpl::__internal::__usm_shared_alloc_vec_iter<Iter>> ||
-                            std::is_same_v<Iter, oneapi::dpl::__internal::__usm_host_alloc_vec_iter<Iter>>) &&
-                            oneapi::dpl::__internal::__vector_iter_distinguishes_by_allocator<Iter>::value>> :
-                                std::true_type
+struct is_passed_directly<Iter, std::enable_if_t<oneapi::dpl::__internal::__is_known_usm_vector_iter<Iter>::value>>
+    : std::true_type
 {
 };
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -79,11 +79,7 @@ class all_view
     {
         return begin() + size();
     }
-    __return_t&
-    operator[](__diff_type i) const
-    {
-        return begin()[i];
-    }
+    __return_t& operator[](__diff_type i) const { return begin()[i]; }
 
     __diff_type
     size() const


### PR DESCRIPTION
Iterator inputs to parallel APIs with a device policy which have a const-qualified value type are experiencing build errors on with MSVC or GCC standard library implementation because of static assertions in the class definition for std::vector.  

Our check for USM allocated vector iterators checks all input iterators, and within the check, instantiates a `std::vector` with a value type which matches the input iterator's value type. Prior to this PR, we do not protect against "ill formed" vector instantiations, like const-qualified, reference, or function types.  When the value type of the input iterator are any of these, the build hits `std::vector` [static assertions ](https://github.com/microsoft/STL/blob/0515a05b394596de92d08cb0f352614479a2a883/stl/inc/xmemory#L898C1-L903C80) while attempting to determine if the iterator is a USM allocator std::vector iterator.
This bug was introduced in #1438.

This PR adds a short circuit to avoid such ill-formed std::vector instantiations for specific value types (reference, const, and function types).  These will not be USM allocated std::vector iterators, so it should not effect our ability to detect those types.

This fixes the bug reproducer as reported.  I have also confirmed that input data processing still works as intended using #1429.
