### PR TITLE
[KT] Move esimd functionality into gpu namespace

### DIFF
--- a/documentation/library_guide/kernel_templates/esimd/radix_sort.rst
+++ b/documentation/library_guide/kernel_templates/esimd/radix_sort.rst
@@ -15,7 +15,7 @@ A synopsis of the ``radix_sort`` and ``radix_sort_by_key`` functions is provided
 
    // defined in <oneapi/dpl/experimental/kernel_templates>
 
-   namespace oneapi::dpl::experimental::kt::esimd {
+   namespace oneapi::dpl::experimental::kt::gpu::esimd {
 
    // Sort a single sequence
 

--- a/documentation/library_guide/kernel_templates/esimd_main.rst
+++ b/documentation/library_guide/kernel_templates/esimd_main.rst
@@ -6,7 +6,7 @@ The ESIMD kernel templates are based on `Explicit SIMD SYCL extension
 of Intel® oneAPI DPC++/C++ Compiler.
 This technology only supports Intel GPU devices.
 
-These templates are available in the ``oneapi::dpl::experimental::kt::esimd`` namespace. The following are implemented:
+These templates are available in the ``oneapi::dpl::experimental::kt::gpu::esimd`` namespace. The following are implemented:
 
 * :doc:`radix_sort and radix_sort_by_key <esimd/radix_sort>`
 

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort.h
@@ -174,9 +174,12 @@ radix_sort_by_key(sycl::queue __q, _KeysIterator1 __keys_first, _KeysIterator1 _
 
 namespace oneapi::dpl::experimental::kt
 {
-namespace esimd [[deprecated("Use of oneapi::dpl::experimental::kt::esimd namespace is deprecated "
+namespace esimd
+#if !defined(__SYCL_DEVICE_ONLY__)
+[[deprecated("Use of oneapi::dpl::experimental::kt::esimd namespace is deprecated "
                              "and will be removed in a future release. "
                              "Use oneapi::dpl::experimental::kt::gpu::esimd instead")]]
+#endif
 {
 using oneapi::dpl::experimental::kt::gpu::esimd::radix_sort;
 using oneapi::dpl::experimental::kt::gpu::esimd::radix_sort_by_key;

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort.h
@@ -19,7 +19,7 @@
 #include "internal/esimd_radix_sort_dispatchers.h"
 #include "../../pstl/utils.h"
 
-namespace oneapi::dpl::experimental::kt::esimd
+namespace oneapi::dpl::experimental::kt::gpu::esimd
 {
 
 // TODO: make sure to provide sufficient diagnostic if input does not allow either reading or writing
@@ -170,6 +170,17 @@ radix_sort_by_key(sycl::queue __q, _KeysIterator1 __keys_first, _KeysIterator1 _
                                                                                     ::std::move(__pack_out), __param);
 }
 
+} // namespace oneapi::dpl::experimental::kt::gpu::esimd
+
+namespace oneapi::dpl::experimental::kt
+{
+namespace esimd [[deprecated("Use of oneapi::dpl::experimental::kt::esimd namespace is deprecated "
+                             "and will be removed in a future release. "
+                             "Use oneapi::dpl::experimental::kt::gpu::esimd instead")]]
+{
+    using oneapi::dpl::experimental::kt::gpu::esimd::radix_sort;
+    using oneapi::dpl::experimental::kt::gpu::esimd::radix_sort_by_key;
 } // namespace oneapi::dpl::experimental::kt::esimd
+} // namespace oneapi::dpl::experimental::kt
 
 #endif // _ONEDPL_KT_ESIMD_RADIX_SORT_H

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort.h
@@ -178,8 +178,8 @@ namespace esimd [[deprecated("Use of oneapi::dpl::experimental::kt::esimd namesp
                              "and will be removed in a future release. "
                              "Use oneapi::dpl::experimental::kt::gpu::esimd instead")]]
 {
-    using oneapi::dpl::experimental::kt::gpu::esimd::radix_sort;
-    using oneapi::dpl::experimental::kt::gpu::esimd::radix_sort_by_key;
+using oneapi::dpl::experimental::kt::gpu::esimd::radix_sort;
+using oneapi::dpl::experimental::kt::gpu::esimd::radix_sort_by_key;
 } // namespace oneapi::dpl::experimental::kt::esimd
 } // namespace oneapi::dpl::experimental::kt
 

--- a/include/oneapi/dpl/experimental/kt/esimd_radix_sort.h
+++ b/include/oneapi/dpl/experimental/kt/esimd_radix_sort.h
@@ -176,9 +176,9 @@ namespace oneapi::dpl::experimental::kt
 {
 namespace esimd
 #if !defined(__SYCL_DEVICE_ONLY__)
-[[deprecated("Use of oneapi::dpl::experimental::kt::esimd namespace is deprecated "
-                             "and will be removed in a future release. "
-                             "Use oneapi::dpl::experimental::kt::gpu::esimd instead")]]
+    [[deprecated("Use of oneapi::dpl::experimental::kt::esimd namespace is deprecated "
+                 "and will be removed in a future release. "
+                 "Use oneapi::dpl::experimental::kt::gpu::esimd instead")]]
 #endif
 {
 using oneapi::dpl::experimental::kt::gpu::esimd::radix_sort;

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_defs.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_defs.h
@@ -21,13 +21,13 @@
 // https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_intel_esimd/sycl_ext_intel_esimd.md#static-allocation-of-slm-using-slm_init-function
 #define _ONEDPL_ESIMD_INLINE inline __attribute__((always_inline))
 
-namespace oneapi::dpl::experimental::kt::esimd::__impl
+namespace oneapi::dpl::experimental::kt::gpu::esimd::__impl
 {
 
 // TODO: rename to show the meaning clearly: default vectorization factor
 constexpr int __data_per_step = 16;
 
-} // namespace oneapi::dpl::experimental::kt::esimd::__impl
+} // namespace oneapi::dpl::experimental::kt::gpu::esimd::__impl
 
 // This namespace mostly consists of abstractions on the top of regular ESIMD functions.
 // The purpose is:

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_dispatchers.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_dispatchers.h
@@ -24,7 +24,7 @@
 #include "esimd_radix_sort_kernels.h"
 #include "esimd_radix_sort_submitters.h"
 
-namespace oneapi::dpl::experimental::kt::esimd::__impl
+namespace oneapi::dpl::experimental::kt::gpu::esimd::__impl
 {
 template <typename... _Name>
 class __esimd_radix_sort_one_wg;
@@ -409,6 +409,6 @@ __radix_sort(sycl::queue __q, _RngPack1&& __pack_in, _RngPack2&& __pack_out, _Ke
     }
 }
 
-} // namespace oneapi::dpl::experimental::kt::esimd::__impl
+} // namespace oneapi::dpl::experimental::kt::gpu::esimd::__impl
 
 #endif // _ONEDPL_KT_ESIMD_RADIX_SORT_DISPATCHERS_H

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_kernels.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_kernels.h
@@ -20,7 +20,7 @@
 #include "esimd_defs.h"
 #include "esimd_radix_sort_utils.h"
 
-namespace oneapi::dpl::experimental::kt::esimd::__impl
+namespace oneapi::dpl::experimental::kt::gpu::esimd::__impl
 {
 
 template <bool __is_ascending, ::std::uint8_t __radix_bits, ::std::uint16_t __data_per_work_item,
@@ -749,6 +749,6 @@ struct __radix_sort_onesweep_kernel
     }
 };
 
-} // namespace oneapi::dpl::experimental::kt::esimd::__impl
+} // namespace oneapi::dpl::experimental::kt::gpu::esimd::__impl
 
 #endif // _ONEDPL_KT_ESIMD_RADIX_SORT_KERNELS_H

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_submitters.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_submitters.h
@@ -23,7 +23,7 @@
 #include "esimd_radix_sort_kernels.h"
 #include "esimd_defs.h"
 
-namespace oneapi::dpl::experimental::kt::esimd::__impl
+namespace oneapi::dpl::experimental::kt::gpu::esimd::__impl
 {
 
 //------------------------------------------------------------------------
@@ -171,6 +171,6 @@ struct __radix_sort_copyback_submitter<oneapi::dpl::__par_backend_hetero::__inte
     }
 };
 
-} // namespace oneapi::dpl::experimental::kt::esimd::__impl
+} // namespace oneapi::dpl::experimental::kt::gpu::esimd::__impl
 
 #endif // _ONEDPL_KT_ESIMD_RADIX_SORT_SUBMITTERS_H

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_utils.h
@@ -21,7 +21,7 @@
 
 #include "esimd_defs.h"
 
-namespace oneapi::dpl::experimental::kt::esimd::__impl
+namespace oneapi::dpl::experimental::kt::gpu::esimd::__impl
 {
 
 template <::std::uint8_t __radix_bits, ::std::uint16_t __data_per_workitem, ::std::uint16_t __workgroup_size>
@@ -337,6 +337,6 @@ __make_simd_pack()
     }
 }
 
-} // namespace oneapi::dpl::experimental::kt::esimd::__impl
+} // namespace oneapi::dpl::experimental::kt::gpu::esimd::__impl
 
 #endif // _ONEDPL_KT_ESIMD_RADIX_SORT_UTILS_H

--- a/test/kt/esimd_radix_sort.cpp
+++ b/test/kt/esimd_radix_sort.cpp
@@ -50,7 +50,7 @@ test_all_view(sycl::queue q, std::size_t size, KernelParam param)
     {
         sycl::buffer<T> buf(input.data(), input.size());
         oneapi::dpl::experimental::ranges::all_view<T, sycl::access::mode::read_write> view(buf);
-        oneapi::dpl::experimental::kt::esimd::radix_sort<IsAscending>(q, view, param).wait();
+        oneapi::dpl::experimental::kt::gpu::esimd::radix_sort<IsAscending>(q, view, param).wait();
     }
 
     std::string msg = "wrong results with all_view, n: " + std::to_string(size);
@@ -73,7 +73,7 @@ test_subrange_view(sycl::queue q, std::size_t size, KernelParam param)
     std::stable_sort(expected.begin(), expected.end(), Compare<T, IsAscending>{});
 
     oneapi::dpl::experimental::ranges::views::subrange view(dt_input.get_data(), dt_input.get_data() + size);
-    oneapi::dpl::experimental::kt::esimd::radix_sort<IsAscending>(q, view, param).wait();
+    oneapi::dpl::experimental::kt::gpu::esimd::radix_sort<IsAscending>(q, view, param).wait();
 
     std::vector<T> actual(size);
     dt_input.retrieve_data(actual.begin());
@@ -99,7 +99,7 @@ test_usm(sycl::queue q, std::size_t size, KernelParam param)
 
     std::stable_sort(expected.begin(), expected.end(), Compare<T, IsAscending>{});
 
-    oneapi::dpl::experimental::kt::esimd::radix_sort<IsAscending>(q, dt_input.get_data(), dt_input.get_data() + size,
+    oneapi::dpl::experimental::kt::gpu::esimd::radix_sort<IsAscending>(q, dt_input.get_data(), dt_input.get_data() + size,
                                                                   param)
         .wait();
 
@@ -123,9 +123,18 @@ test_sycl_iterators(sycl::queue q, std::size_t size, KernelParam param)
     std::stable_sort(std::begin(ref), std::end(ref), Compare<T, IsAscending>{});
     {
         sycl::buffer<T> buf(input.data(), input.size());
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
+        // Deprecated namespace is used deliberatelly to make sure the functionality is still available
         oneapi::dpl::experimental::kt::esimd::radix_sort<IsAscending>(q, oneapi::dpl::begin(buf), oneapi::dpl::end(buf),
                                                                       param)
             .wait();
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
     }
 
     std::string msg = "wrong results with oneapi::dpl::begin/end, n: " + std::to_string(size);
@@ -145,7 +154,7 @@ test_sycl_buffer(sycl::queue q, std::size_t size, KernelParam param)
     std::stable_sort(std::begin(ref), std::end(ref), Compare<T, IsAscending>{});
     {
         sycl::buffer<T> buf(input.data(), input.size());
-        oneapi::dpl::experimental::kt::esimd::radix_sort<IsAscending>(q, buf, param).wait();
+        oneapi::dpl::experimental::kt::gpu::esimd::radix_sort<IsAscending>(q, buf, param).wait();
     }
 
     std::string msg = "wrong results with sycl::buffer, n: " + std::to_string(size);
@@ -161,12 +170,12 @@ test_small_sizes(sycl::queue q, KernelParam param)
     generate_data(input.data(), size, 42);
     std::vector<T> ref(input);
 
-    oneapi::dpl::experimental::kt::esimd::radix_sort<IsAscending, RadixBits>(q, oneapi::dpl::begin(input),
+    oneapi::dpl::experimental::kt::gpu::esimd::radix_sort<IsAscending, RadixBits>(q, oneapi::dpl::begin(input),
                                                                            oneapi::dpl::begin(input), param)
         .wait();
     EXPECT_EQ_RANGES(ref, input, "sort modified input data when size == 0");
 
-    oneapi::dpl::experimental::kt::esimd::radix_sort<IsAscending, RadixBits>(q, oneapi::dpl::begin(input),
+    oneapi::dpl::experimental::kt::gpu::esimd::radix_sort<IsAscending, RadixBits>(q, oneapi::dpl::begin(input),
                                                                            oneapi::dpl::begin(input) + 1, param)
         .wait();
     EXPECT_EQ_RANGES(ref, input, "sort modified input data when size == 1");

--- a/test/kt/esimd_radix_sort_by_key.cpp
+++ b/test/kt/esimd_radix_sort_by_key.cpp
@@ -40,7 +40,7 @@ void test_sycl_buffer(sycl::queue q, std::size_t size, KernelParam param)
     {
         sycl::buffer<KeyT> keys(actual_keys.data(), actual_keys.size());
         sycl::buffer<ValueT> values(actual_values.data(), actual_values.size());
-        oneapi::dpl::experimental::kt::esimd::radix_sort_by_key<isAscending, RadixBits>(q, keys, values, param).wait();
+        oneapi::dpl::experimental::kt::gpu::esimd::radix_sort_by_key<isAscending, RadixBits>(q, keys, values, param).wait();
     }
 
     auto expected_first  = oneapi::dpl::make_zip_iterator(std::begin(expected_keys), std::begin(expected_values));
@@ -71,7 +71,7 @@ void test_usm(sycl::queue q, std::size_t size, KernelParam param)
     auto expected_first  = oneapi::dpl::make_zip_iterator(std::begin(expected_keys), std::begin(expected_values));
     std::stable_sort(expected_first, expected_first + size, CompareKey<isAscending>{});
 
-    oneapi::dpl::experimental::kt::esimd::radix_sort_by_key<isAscending, RadixBits>(
+    oneapi::dpl::experimental::kt::gpu::esimd::radix_sort_by_key<isAscending, RadixBits>(
         q, keys.get_data(), keys.get_data() + size, values.get_data(), param).wait();
 
     std::vector<KeyT> actual_keys(size);

--- a/test/kt/esimd_radix_sort_by_key_out_of_place.cpp
+++ b/test/kt/esimd_radix_sort_by_key_out_of_place.cpp
@@ -50,7 +50,7 @@ test_sycl_buffer(sycl::queue q, std::size_t size, KernelParam param)
         sycl::buffer<KeyT> keys_out(actual_keys_out.data(), actual_keys_out.size());
         sycl::buffer<ValueT> values_out(actual_values_out.data(), actual_values_out.size());
 
-        oneapi::dpl::experimental::kt::esimd::radix_sort_by_key<isAscending, RadixBits>(q, keys, values, keys_out,
+        oneapi::dpl::experimental::kt::gpu::esimd::radix_sort_by_key<isAscending, RadixBits>(q, keys, values, keys_out,
                                                                                         values_out, param)
             .wait();
     }
@@ -101,7 +101,7 @@ test_usm(sycl::queue q, std::size_t size, KernelParam param)
     auto expected_first = oneapi::dpl::make_zip_iterator(std::begin(expected_keys), std::begin(expected_values));
     std::stable_sort(expected_first, expected_first + size, CompareKey<isAscending>{});
 
-    oneapi::dpl::experimental::kt::esimd::radix_sort_by_key<isAscending, RadixBits>(
+    oneapi::dpl::experimental::kt::gpu::esimd::radix_sort_by_key<isAscending, RadixBits>(
         q, keys.get_data(), keys.get_data() + size, values.get_data(), keys_out.get_data(), values_out.get_data(),
         param)
         .wait();

--- a/test/kt/esimd_radix_sort_out_of_place.cpp
+++ b/test/kt/esimd_radix_sort_out_of_place.cpp
@@ -55,7 +55,7 @@ test_all_view(sycl::queue q, std::size_t size, KernelParam param)
         sycl::buffer<T> buf_out(output.data(), output.size());
         oneapi::dpl::experimental::ranges::all_view<T, sycl::access::mode::read> view(buf);
         oneapi::dpl::experimental::ranges::all_view<T, sycl::access::mode::read_write> view_out(buf_out);
-        oneapi::dpl::experimental::kt::esimd::radix_sort<IsAscending>(q, view, view_out, param).wait();
+        oneapi::dpl::experimental::kt::gpu::esimd::radix_sort<IsAscending>(q, view, view_out, param).wait();
     }
 
     std::string msg = "input modified with all_view, n: " + std::to_string(size);
@@ -85,7 +85,7 @@ test_subrange_view(sycl::queue q, std::size_t size, KernelParam param)
 
     oneapi::dpl::experimental::ranges::views::subrange view_in(dt_input.get_data(), dt_input.get_data() + size);
     oneapi::dpl::experimental::ranges::views::subrange view_out(dt_output.get_data(), dt_output.get_data() + size);
-    oneapi::dpl::experimental::kt::esimd::radix_sort<IsAscending>(q, view_in, view_out, param).wait();
+    oneapi::dpl::experimental::kt::gpu::esimd::radix_sort<IsAscending>(q, view_in, view_out, param).wait();
 
     std::vector<T> output_actual(size);
     std::vector<T> input_actual(input_ref);
@@ -119,7 +119,7 @@ test_usm(sycl::queue q, std::size_t size, KernelParam param)
 
     std::stable_sort(output_ref.begin(), output_ref.end(), Compare<T, IsAscending>{});
 
-    oneapi::dpl::experimental::kt::esimd::radix_sort<IsAscending>(
+    oneapi::dpl::experimental::kt::gpu::esimd::radix_sort<IsAscending>(
         q, dt_input.get_data(), dt_input.get_data() + size, dt_output.get_data(), param)
         .wait();
 
@@ -151,7 +151,7 @@ test_sycl_iterators(sycl::queue q, std::size_t size, KernelParam param)
     {
         sycl::buffer<T> buf(input.data(), input.size());
         sycl::buffer<T> buf_out(output.data(), output.size());
-        oneapi::dpl::experimental::kt::esimd::radix_sort<IsAscending>(
+        oneapi::dpl::experimental::kt::gpu::esimd::radix_sort<IsAscending>(
             q, oneapi::dpl::begin(buf), oneapi::dpl::end(buf), oneapi::dpl::begin(buf_out), param)
             .wait();
     }
@@ -179,7 +179,7 @@ test_sycl_buffer(sycl::queue q, std::size_t size, KernelParam param)
     {
         sycl::buffer<T> buf(input.data(), input.size());
         sycl::buffer<T> buf_out(output.data(), output.size());
-        oneapi::dpl::experimental::kt::esimd::radix_sort<IsAscending>(q, buf, buf_out, param).wait();
+        oneapi::dpl::experimental::kt::gpu::esimd::radix_sort<IsAscending>(q, buf, buf_out, param).wait();
     }
 
     std::string msg = "modified input data with sycl::buffer, n: " + std::to_string(size);
@@ -199,7 +199,7 @@ test_small_sizes(sycl::queue q, KernelParam param)
     std::vector<T> output(size, T{9});
     std::vector<T> output_ref(size, T{9});
 
-    oneapi::dpl::experimental::kt::esimd::radix_sort<IsAscending, RadixBits>(
+    oneapi::dpl::experimental::kt::gpu::esimd::radix_sort<IsAscending, RadixBits>(
         q, oneapi::dpl::begin(input), oneapi::dpl::begin(input), oneapi::dpl::begin(output), param)
         .wait();
     EXPECT_EQ_RANGES(ref, input, "sort modified input data when size == 0");


### PR DESCRIPTION
The PR moves `esimd` namespace into `gpu` umbrella namespace as a more narrow target for GPU device type. 
The original namespace is now deprecated.