### PR TITLE
Fix device_copyable for internal tuple with non trivially copyable elements

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -100,6 +100,9 @@ struct __brick_fill;
 template <class _Tag, typename _ExecutionPolicy, typename _Tp, typename>
 struct __brick_fill_n;
 
+template <typename... T>
+struct tuple;
+
 } // namespace oneapi::dpl::__internal
 
 template <typename _Pred>
@@ -218,6 +221,12 @@ template <typename _Predicate, typename _ValueType>
 struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::__create_mask_unique_copy, _Predicate,
                                                        _ValueType)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_Predicate, _ValueType>
+{
+};
+
+template <typename... _Types>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::tuple, _Types...)>
+    : oneapi::dpl::__internal::__are_all_device_copyable<_Types...>
 {
 };
 

--- a/test/general/implementation_details/device_copyable.pass.cpp
+++ b/test/general/implementation_details/device_copyable.pass.cpp
@@ -222,6 +222,13 @@ test_device_copyable()
     static_assert(sycl::is_device_copyable_v<
                       oneapi::dpl::__internal::__create_mask_unique_copy<noop_device_copyable, int_device_copyable>>,
                   "__create_mask_unique_copy is not device copyable with device copyable types");
+    //tuple
+    static_assert(sycl::is_device_copyable_v<oneapi::dpl::__internal::tuple<int_device_copyable, int_device_copyable>>,
+                  "tuple is not device copyable with device copyable types");
+    static_assert(
+        sycl::is_device_copyable_v<oneapi::dpl::__internal::tuple<std::tuple<int_device_copyable, int_device_copyable>,
+                                                                  int_device_copyable, int_device_copyable>>,
+        "tuple is not device copyable with device copyable types");
 }
 
 void
@@ -431,6 +438,13 @@ test_non_device_copyable()
         !sycl::is_device_copyable_v<
             oneapi::dpl::__internal::__create_mask_unique_copy<noop_non_device_copyable, int_non_device_copyable>>,
         "__create_mask_unique_copy is device copyable with non device copyable types");
+    //tuple
+    static_assert(
+        !sycl::is_device_copyable_v<oneapi::dpl::__internal::tuple<int_non_device_copyable, int_device_copyable>>,
+        "tuple is device copyable with non device copyable types");
+    static_assert(!sycl::is_device_copyable_v<oneapi::dpl::__internal::tuple<
+                      std::tuple<int_non_device_copyable, int_device_copyable>, int_device_copyable>>,
+                  "tuple is device copyable with non device copyable types");
 }
 
 #endif // TEST_DPCPP_BACKEND_PRESENT


### PR DESCRIPTION
Fix for device copyability for oneDPL's internal tuple for non-trivially copyable element types which are device copyable. (like std::tuple)
