### PR TITLE
[Tests] Missing TestUtils helper restored 

### DIFF
--- a/test/parallel_api/iterator/input_data_sweep_usm_allocator.pass.cpp
+++ b/test/parallel_api/iterator/input_data_sweep_usm_allocator.pass.cpp
@@ -26,7 +26,8 @@
 // are being tested, and to limit the number of types to be within reason.
 
 #if TEST_DPCPP_BACKEND_PRESENT
-
+namespace TestUtils
+{
 template <typename Iter, typename ValueType = typename std::iterator_traits<Iter>::value_type>
 using __default_alloc_vec_iter = typename std::vector<ValueType>::iterator;
 
@@ -55,6 +56,7 @@ struct __vector_impl_distinguishes_usm_allocator_from_default<
     : std::true_type
 {
 };
+} //namespace TestUtils
 
 template <typename T, int __recurse, typename Policy>
 void
@@ -72,14 +74,14 @@ test_usm_shared_alloc(Policy&& policy, T trash, size_t n, const std::string& typ
 
         //Only test as source iterator for permutation iterator if we can expect it to work
         // (if the vector implementation distiguishes its iterator for this type)
-        wrap_recurse<__recurse, 0, /*__read =*/true, /*__reset_read=*/true, /*__write=*/true,
-                     /*__check_write=*/true, /*__usable_as_perm_map=*/true,
-                     /*__usable_as_perm_src=*/
-                     __vector_impl_distinguishes_usm_allocator_from_default<decltype(shared_data_vec.begin())>::value,
-                     /*__is_reversible=*/true>(policy, shared_data_vec.begin(), shared_data_vec.end(), counting,
-                                               copy_out.get_data(), shared_data_vec.begin(), copy_out.get_data(),
-                                               counting, trash,
-                                               std::string("usm_shared_alloc_vector<") + type_text + std::string(">"));
+        wrap_recurse<
+            __recurse, 0, /*__read =*/true, /*__reset_read=*/true, /*__write=*/true,
+            /*__check_write=*/true, /*__usable_as_perm_map=*/true,
+            /*__usable_as_perm_src=*/
+            TestUtils::__vector_impl_distinguishes_usm_allocator_from_default<decltype(shared_data_vec.begin())>::value,
+            /*__is_reversible=*/true>(policy, shared_data_vec.begin(), shared_data_vec.end(), counting,
+                                      copy_out.get_data(), shared_data_vec.begin(), copy_out.get_data(), counting,
+                                      trash, std::string("usm_shared_alloc_vector<") + type_text + std::string(">"));
     }
     else
     {
@@ -103,12 +105,13 @@ test_usm_host_alloc(Policy&& policy, T trash, size_t n, const std::string& type_
 
         //Only test as source iterator for permutation iterator if we can expect it to work
         // (if the vector implementation distiguishes its iterator for this type)
-        wrap_recurse<__recurse, 0, /*__read =*/true, /*__reset_read=*/true, /*__write=*/true,
-                     /*__check_write=*/true, /*__usable_as_perm_map=*/true, /*__usable_as_perm_src=*/
-                     __vector_impl_distinguishes_usm_allocator_from_default<decltype(host_data_vec.begin())>::value,
-                     /*__is_reversible=*/true>(
-            policy, host_data_vec.begin(), host_data_vec.end(), counting, copy_out.get_data(), host_data_vec.begin(),
-            copy_out.get_data(), counting, trash, std::string("usm_host_alloc_vector<") + type_text + std::string(">"));
+        wrap_recurse<
+            __recurse, 0, /*__read =*/true, /*__reset_read=*/true, /*__write=*/true,
+            /*__check_write=*/true, /*__usable_as_perm_map=*/true, /*__usable_as_perm_src=*/
+            TestUtils::__vector_impl_distinguishes_usm_allocator_from_default<decltype(host_data_vec.begin())>::value,
+            /*__is_reversible=*/true>(policy, host_data_vec.begin(), host_data_vec.end(), counting, copy_out.get_data(),
+                                      host_data_vec.begin(), copy_out.get_data(), counting, trash,
+                                      std::string("usm_host_alloc_vector<") + type_text + std::string(">"));
     }
     else
     {

--- a/test/parallel_api/iterator/input_data_sweep_usm_allocator.pass.cpp
+++ b/test/parallel_api/iterator/input_data_sweep_usm_allocator.pass.cpp
@@ -26,37 +26,6 @@
 // are being tested, and to limit the number of types to be within reason.
 
 #if TEST_DPCPP_BACKEND_PRESENT
-namespace TestUtils
-{
-template <typename Iter, typename ValueType = typename std::iterator_traits<Iter>::value_type>
-using __default_alloc_vec_iter = typename std::vector<ValueType>::iterator;
-
-template <typename Iter, typename ValueType = typename std::iterator_traits<Iter>::value_type>
-using __usm_shared_alloc_vec_iter =
-    typename std::vector<ValueType, typename sycl::usm_allocator<ValueType, sycl::usm::alloc::shared>>::iterator;
-
-template <typename Iter, typename ValueType = typename std::iterator_traits<Iter>::value_type>
-using __usm_host_alloc_vec_iter =
-    typename std::vector<ValueType, typename sycl::usm_allocator<ValueType, sycl::usm::alloc::host>>::iterator;
-
-// Evaluates to true if the provided type is an iterator with a value_type and if the implementation of a
-// std::vector<value_type, Alloc>::iterator can be distinguished between three different allocators, the
-// default, usm_shared, and usm_host. If all are distinct, it is very unlikely any non-usm based allocator
-// could be confused with a usm allocator.
-template <typename Iter, typename Void = void>
-struct __vector_impl_distinguishes_usm_allocator_from_default : std::false_type
-{
-};
-
-template <typename Iter>
-struct __vector_impl_distinguishes_usm_allocator_from_default<
-    Iter, std::enable_if_t<!std::is_same_v<__default_alloc_vec_iter<Iter>, __usm_shared_alloc_vec_iter<Iter>> &&
-                           !std::is_same_v<__default_alloc_vec_iter<Iter>, __usm_host_alloc_vec_iter<Iter>> &&
-                           !std::is_same_v<__usm_host_alloc_vec_iter<Iter>, __usm_shared_alloc_vec_iter<Iter>>>>
-    : std::true_type
-{
-};
-} //namespace TestUtils
 
 template <typename T, int __recurse, typename Policy>
 void

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -853,6 +853,35 @@ struct _ZipIteratorAdapter
     }
 };
 
+template <typename Iter, typename ValueType = typename std::iterator_traits<Iter>::value_type>
+using __default_alloc_vec_iter = typename std::vector<ValueType>::iterator;
+
+template <typename Iter, typename ValueType = typename std::iterator_traits<Iter>::value_type>
+using __usm_shared_alloc_vec_iter =
+    typename std::vector<ValueType, typename sycl::usm_allocator<ValueType, sycl::usm::alloc::shared>>::iterator;
+
+template <typename Iter, typename ValueType = typename std::iterator_traits<Iter>::value_type>
+using __usm_host_alloc_vec_iter =
+    typename std::vector<ValueType, typename sycl::usm_allocator<ValueType, sycl::usm::alloc::host>>::iterator;
+
+// Evaluates to true if the provided type is an iterator with a value_type and if the implementation of a
+// std::vector<value_type, Alloc>::iterator can be distinguished between three different allocators, the
+// default, usm_shared, and usm_host. If all are distinct, it is very unlikely any non-usm based allocator
+// could be confused with a usm allocator.
+template <typename Iter, typename Void = void>
+struct __vector_impl_distinguishes_usm_allocator_from_default : std::false_type
+{
+};
+
+template <typename Iter>
+struct __vector_impl_distinguishes_usm_allocator_from_default<
+    Iter, std::enable_if_t<!std::is_same_v<__default_alloc_vec_iter<Iter>, __usm_shared_alloc_vec_iter<Iter>> &&
+                           !std::is_same_v<__default_alloc_vec_iter<Iter>, __usm_host_alloc_vec_iter<Iter>> &&
+                           !std::is_same_v<__usm_host_alloc_vec_iter<Iter>, __usm_shared_alloc_vec_iter<Iter>>>>
+    : std::true_type
+{
+};
+
 ////////////////////////////////////////////////////////////////////////////////
 // Implementation of create_new_policy for all policies (host + hetero)
 template <typename Policy>

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -853,6 +853,7 @@ struct _ZipIteratorAdapter
     }
 };
 
+#if TEST_DPCPP_BACKEND_PRESENT
 template <typename Iter, typename ValueType = typename std::iterator_traits<Iter>::value_type>
 using __default_alloc_vec_iter = typename std::vector<ValueType>::iterator;
 
@@ -881,6 +882,7 @@ struct __vector_impl_distinguishes_usm_allocator_from_default<
     : std::true_type
 {
 };
+#endif //TEST_DPCPP_BACKEND_PRESENT
 
 ////////////////////////////////////////////////////////////////////////////////
 // Implementation of create_new_policy for all policies (host + hetero)


### PR DESCRIPTION
A bad rebase before merging #1429  resulted in the removal of some TestUtils meant to avoid using internal namespace details within the tests.  
The lack of these helpers results in a failing `input_data_sweep_usm_allocator.pass`.  This PR restores the structs, allowing the test to build and run.