### PR TITLE
[Tests] Fix header include for device_copyable.pass

### DIFF
--- a/test/general/implementation_details/device_copyable.pass.cpp
+++ b/test/general/implementation_details/device_copyable.pass.cpp
@@ -25,7 +25,7 @@ using namespace TestUtils;
 #if TEST_DPCPP_BACKEND_PRESENT
 
 #    include "support/utils_device_copyable.h"
-#    include "sycl.hpp"
+#    include "support/utils_sycl_defs.h"
 
 void
 test_device_copyable()


### PR DESCRIPTION
Resolves incorrect header inclusion for sycl.hpp.  
This PR uses our local `util_sycl_defs.h` in place of `sycl.hpp` to ensure we have access to sycl device_copyable checks.