### PR TITLE
Fix the format of report method - using `report_duration` in second param

### DIFF
--- a/include/oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h
@@ -174,9 +174,9 @@ class auto_tune_policy
         };
 
         void
-        report(const execution_info::task_time_t&, const typename execution_info::task_time_t::value_type& v) const
+        report(const execution_info::task_time_t&, report_duration v) const
         {
-            tuner_->add_new_timing(resource_, v);
+            tuner_->add_new_timing(resource_, v.count());
         }
     };
 

--- a/include/oneapi/dpl/internal/dynamic_selection_traits.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_traits.h
@@ -108,16 +108,16 @@ struct has_report : decltype(has_report_impl<S, Info>(0))
 {
 };
 
-template <typename S, typename Info>
+template <typename S, typename Info, typename ValueType>
 auto
 has_report_value_impl(...) -> std::false_type;
 
-template <typename S, typename Info>
+template <typename S, typename Info, typename ValueType>
 auto
-has_report_value_impl(int) -> decltype(std::declval<S>().report(std::declval<Info>(), 0), std::true_type{});
+has_report_value_impl(int) -> decltype(std::declval<S>().report(std::declval<Info>(), std::declval<ValueType>()), std::true_type{});
 
-template <typename S, typename Info>
-struct has_report_value : decltype(has_report_value_impl<S, Info>(0))
+template <typename S, typename Info, typename ValueType>
+struct has_report_value : decltype(has_report_value_impl<S, Info, ValueType>(0))
 {
 };
 
@@ -277,7 +277,7 @@ template <typename S, typename Info, typename Value>
 void
 report(S&& s, const Info& i, const Value& v)
 {
-    if constexpr (internal::has_report_value<S, Info>::value)
+    if constexpr (internal::has_report_value<S, Info, Value>::value)
     {
         std::forward<S>(s).report(i, v);
     }
@@ -291,13 +291,13 @@ struct report_info
 template <typename S, typename Info>
 inline constexpr bool report_info_v = report_info<S, Info>::value;
 
-template <typename S, typename Info>
+template <typename S, typename Info, typename ValueType>
 struct report_value
 {
-    static constexpr bool value = internal::has_report_value<S, Info>::value;
+    static constexpr bool value = internal::has_report_value<S, Info, ValueType>::value;
 };
-template <typename S, typename Info>
-inline constexpr bool report_value_v = report_value<S, Info>::value;
+template <typename S, typename Info, typename ValueType>
+inline constexpr bool report_value_v = report_value<S, Info, ValueType>::value;
 
 } // namespace experimental
 } // namespace dpl

--- a/test/support/inline_backend.h
+++ b/test/support/inline_backend.h
@@ -14,6 +14,7 @@
 
 #include <vector>
 #include <atomic>
+#include <chrono>
 
 namespace TestUtils
 {
@@ -50,6 +51,7 @@ class int_inline_backend_t
     using wait_type = int;
     using execution_resource_t = basic_execution_resource_t<resource_type>;
     using resource_container_t = std::vector<execution_resource_t>;
+    using report_duration = std::chrono::milliseconds;
 
   private:
     using native_resource_container_t = std::vector<resource_type>;
@@ -99,8 +101,8 @@ class int_inline_backend_t
     submit(SelectionHandle s, Function&& f, Args&&... args)
     {
         std::chrono::steady_clock::time_point t0;
-        if constexpr (oneapi::dpl::experimental::report_value_v<SelectionHandle,
-                                                                oneapi::dpl::experimental::execution_info::task_time_t>)
+        if constexpr (oneapi::dpl::experimental::report_value_v<
+                          SelectionHandle, oneapi::dpl::experimental::execution_info::task_time_t, report_duration>)
         {
             t0 = std::chrono::steady_clock::now();
         }
@@ -116,11 +118,11 @@ class int_inline_backend_t
         {
             oneapi::dpl::experimental::report(s, oneapi::dpl::experimental::execution_info::task_completion);
         }
-        if constexpr (oneapi::dpl::experimental::report_value_v<SelectionHandle,
-                                                                oneapi::dpl::experimental::execution_info::task_time_t>)
+        if constexpr (oneapi::dpl::experimental::report_value_v<
+                          SelectionHandle, oneapi::dpl::experimental::execution_info::task_time_t, report_duration>)
         {
             report(s, oneapi::dpl::experimental::execution_info::task_time,
-                   (std::chrono::steady_clock::now() - t0).count());
+                   std::chrono::duration_cast<report_duration>(std::chrono::steady_clock::now() - t0));
         }
         return async_waiter{w};
     }


### PR DESCRIPTION
In this PR we fix format of report method:
- describe second param as `report_duration` to avoid potential errors with measure units for this param value;
- change required traits according to previous change.
