### PR TITLE
[Tests] Fix broken macro so it can be used as expression

### DIFF
--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -55,7 +55,11 @@
 // GCC10 produces wrong answer calling exclusive_scan using vectorized polices
 #define TEST_GCC10_EXCLUSIVE_SCAN_BROKEN (_GLIBCXX_RELEASE == 10)
 // GCC7 std::get doesn't return const rvalue reference from const rvalue reference of tuple
-#define _PSTL_TEST_GCC7_RVALUE_TUPLE_GET_BROKEN (_GLIBCXX_RELEASE && _GLIBCXX_RELEASE < 8)
+#if defined(_GLIBCXX_RELEASE)
+#   define _PSTL_TEST_GCC7_RVALUE_TUPLE_GET_BROKEN (_GLIBCXX_RELEASE < 8)
+#else
+#   define _PSTL_TEST_GCC7_RVALUE_TUPLE_GET_BROKEN 0
+#endif
 // Array swap broken on Windows because Microsoft implementation of std::swap function for std::array
 // call some internal function which is not declared as SYCL external and we have compile error
 #if defined(_MSC_VER)


### PR DESCRIPTION
We can only count on undefined macros to be treated as `0` within `#if` checks.  Within `tuple_get_const_rvalue.pass`, this macro is used as an expression to determine if the test was skipped or not, and this fails when `_GLIBCXX_RELEASE` is undefined.

Here is the usage 
https://github.com/oneapi-src/oneDPL/blob/3d762ceb57721b6fd6059086ccc757e2d2466f08/test/xpu_api/tuple/tuple.tuple/tuple.elem/tuple_get_const_rvalue.pass.cpp#L60

This changes the macro to work both in `#if` and also as an expression, allowing the test to build.


C++ Standard 16.1.4 describes when 0 is used in replacement of undefined identifiers.  (but is only relevant within `#if` checks). 
