### PR TITLE
Remove unused defines from test/support/test_config.h

### DIFF
--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -30,9 +30,6 @@
     (!_DEBUG && __INTEL_COMPILER >= 1800 && __INTEL_COMPILER < 1900 && _MSC_VER == 1910)
 // ICC 18 doesn't vectorize the loop
 #define _PSTL_ICC_18_TEST_EARLY_EXIT_MONOTONIC_RELEASE_BROKEN (!_DEBUG && __INTEL_COMPILER && __INTEL_COMPILER == 1800)
-// clang 900.0.38 produces fatal error: error in backend: Section too large
-#define _PSTL_CLANG_TEST_BIG_OBJ_DEBUG_32_BROKEN                                                                      \
-    (__i386__ && PSTL_USE_DEBUG && __clang__ && _PSTL_CLANG_VERSION <= 90000)
 // ICC 18 generates wrong result with omp simd early_exit
 #define _PSTL_ICC_18_TEST_EARLY_EXIT_AVX_RELEASE_BROKEN                                                               \
     (!_DEBUG && __INTEL_COMPILER == 1800 && __AVX__ && !__AVX2__ && !__AVX512__)


### PR DESCRIPTION
In this PR we remove unused defines from the file `test/support/test_config.h` :
- `_PSTL_CLANG_TEST_BIG_OBJ_DEBUG_32_BROKEN`.