### PR TITLE
The implementation of `std::bit_floor` in MS STL does not meet requirements for SYCL device functions

### DIFF
--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -305,10 +305,7 @@
 #endif
 
 // Avoid compile errors due incorrect implementation of std::bit_floor in MS STL: used "extern" variable __isa_available
-#if defined(_MSC_VER) && _ONEDPL_BACKEND_SYCL
-#    define _ONEDPL_STD_BIT_FLOOR_BROKEN 1
-#else
-#    define _ONEDPL_STD_BIT_FLOOR_BROKEN 0
-#endif
+#define _ONEDPL_STD_BIT_FLOOR_BROKEN                                                                                   \
+    (_ONEDPL___cplusplus >= 202002L && _ONEDPL_BACKEND_SYCL && _MSC_VER > 0)
 
 #endif // _ONEDPL_CONFIG_H

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -304,6 +304,7 @@
 #    define _ONEDPL_ICPX_OMP_SIMD_DESTROY_WINDOWS_BROKEN 0
 #endif
 
+// Avoid compile errors due incorrect implementation of std::bit_floor in MS STL: used "extern" variable __isa_available
 #if defined(_MSC_VER) && _ONEDPL_BACKEND_SYCL
 #    define _ONEDPL_STD_BIT_FLOOR_BROKEN 1
 #else

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -304,8 +304,11 @@
 #    define _ONEDPL_ICPX_OMP_SIMD_DESTROY_WINDOWS_BROKEN 0
 #endif
 
-// Avoid compile errors due incorrect implementation of std::bit_floor in MS STL: used "extern" variable __isa_available
-#define _ONEDPL_STD_BIT_FLOOR_BROKEN                                                                                   \
-    (_ONEDPL___cplusplus >= 202002L && _ONEDPL_BACKEND_SYCL && _MSC_VER > 0)
+// The implementation of std::bit_floor in MS STL does not meet requirements for SYCL device functions
+#if defined(_MSC_VER) && (__SYCL_DEVICE_ONLY__ || __SYCL_SINGLE_SOURCE__)
+#    define _ONEDPL_STD_BIT_FLOOR_BROKEN 1
+#else
+#    define _ONEDPL_STD_BIT_FLOOR_BROKEN 0
+#endif
 
 #endif // _ONEDPL_CONFIG_H

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -304,4 +304,10 @@
 #    define _ONEDPL_ICPX_OMP_SIMD_DESTROY_WINDOWS_BROKEN 0
 #endif
 
+#if defined(_MSC_VER) && _ONEDPL_BACKEND_SYCL
+#    define _ONEDPL_STD_BIT_FLOOR_BROKEN 1
+#else
+#    define _ONEDPL_STD_BIT_FLOOR_BROKEN 0
+#endif
+
 #endif // _ONEDPL_CONFIG_H

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -525,7 +525,7 @@ __dpl_bit_floor(_T __x) noexcept
 {
     if (__x == 0)
         return 0;
-#if __cpp_lib_int_pow2 >= 202002L
+#if __cpp_lib_int_pow2 >= 202002L && !_ONEDPL_STD_BIT_FLOOR_BROKEN
     return ::std::bit_floor(__x);
 #elif _ONEDPL_BACKEND_SYCL
     // Use the count-leading-zeros function


### PR DESCRIPTION
In this PR we void compile error in `std::bit_floor` MS STL implementation :
`error: SYCL kernel cannot use a non-const global variable`
- they using "extern" variable `__isa_available` in the code, which is not acceptable for use in Kernel code.

The purpose of `__isa_available` variable usage described at
https://devblogs.microsoft.com/cppblog/avx-512-auto-vectorization-in-msvc/

The compile error log:

```C++
bin\dpcpp-cl.exe  /nologo /TP -DPSTL_USE_DEBUG -DTBB_USE_DEBUG=1 -D_PSTL_TEST_SUCCESSFUL_KEYWORD=1 -D__TBB_NO_IMPLICIT_LINKAGE=1 -Itest -Iinclude -IC:\localdisk\tools\inteloneapi\latest\tbb\latest\include -DTEST_LONG_RUN=1 -fsycl /EHsc /Zi /Ob0 /Od /RTC1 -MDd /clang:-fno-fast-math /bigobj /Zc:__cplusplus /EHsc /Qopenmp-simd -fno-sycl-unnamed-lambda -Qstd:c++20 -QMD -QMT test\CMakeFiles\binary_search.pass.dir\parallel_api\algorithm\alg.sorting\alg.binary.search\binary.search\binary_search.pass.cpp.obj -QMF test\CMakeFiles\binary_search.pass.dir\parallel_api\algorithm\alg.sorting\alg.binary.search\binary.search\binary_search.pass.cpp.obj.d /Fotest\CMakeFiles\binary_search.pass.dir\parallel_api\algorithm\alg.sorting\alg.binary.search\binary.search\binary_search.pass.cpp.obj /Fdtest\CMakeFiles\binary_search.pass.dir\ -c test\parallel_api\algorithm\alg.sorting\alg.binary.search\binary.search\binary_search.pass.cpp
icx-cl: warning: use of 'dpcpp-cl' is deprecated and will be removed in a future release. Use 'icx-cl -fsycl' [-Wdeprecated]
In file included from test\parallel_api\algorithm\alg.sorting\alg.binary.search\binary.search\binary_search.pass.cpp:16:
In file included from include\oneapi\dpl\execution:23:
In file included from C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.38.33130\include\execution:18:
In file included from C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.38.33130\include\numeric:13:
C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.38.33130\include\__msvc_bit_utils.hpp(131,41): error: SYCL kernel cannot use a non-const global variable
  131 |     const bool _Definitely_have_lzcnt = __isa_available >= _Stl_isa_available_avx2;
      |                                         ^
C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.38.33130\include\__msvc_bit_utils.hpp(103,14): error: builtin is not supported on this target
  103 |         if (!_BitScanReverse(&_Result, _Val)) {
      |              ^
C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.38.33130\include\__msvc_bit_utils.hpp(135,16): note: called by '_Checked_x86_x64_countl_zero<unsigned int>'
  135 |         return _Countl_zero_bsr(_Val);
      |                ^
C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.38.33130\include\bit(196,16): note: called by 'countl_zero<unsigned int, 0>'
  196 |         return _Checked_x86_x64_countl_zero(_Val);
      |                ^
C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.38.33130\include\bit(124,81): note: called by 'bit_floor<unsigned int, 0>'
  124 |     return static_cast<_Ty>(_Ty{1} << (_Unsigned_integer_digits<_Ty> - 1 - _STD countl_zero(_Val)));
      |                                                                                 ^
include\oneapi\dpl\pstl\utils.h(529,19): note: called by '__dpl_bit_floor<unsigned int>'
  529 |     return ::std::bit_floor(__x);
      |                   ^
include\oneapi\dpl\pstl\utils.h(681,24): note: called by '__shars_lower_bound<oneapi::dpl::__ranges::guard_view<unsigned long long *>, unsigned int, unsigned long long, oneapi::dpl::__internal::__pstl_less>'
  681 |     _Size __cur_pow2 = __dpl_bit_floor(__n);
      |                        ^
include\oneapi\dpl\internal\binary_search_impl.h(66,51): note: called by 'search_impl<unsigned int, unsigned long long, oneapi::dpl::__ranges::zip_view<oneapi::dpl::__ranges::guard_view<unsigned long long *>, oneapi::dpl::__ranges::guard_view<unsigned long long *>, oneapi::dpl::__ranges::guard_view<unsigned long long *>>>'
   66 |             auto value = oneapi::dpl::__internal::__shars_lower_bound(get<0>(acc.tuple()), start_orig, end_orig,
      |                                                   ^
include\oneapi\dpl\internal\binary_search_impl.h(77,13): note: called by 'operator()<unsigned long long, oneapi::dpl::__ranges::zip_view<oneapi::dpl::__ranges::guard_view<unsigned long long *>, oneapi::dpl::__ranges::guard_view<unsigned long long *>, oneapi::dpl::__ranges::guard_view<unsigned long long *>>>'
   77 |             search_impl<std::uint32_t>(idx, acc);
      |             ^
include\oneapi\dpl\pstl\hetero\dpcpp\parallel_backend_sycl.h(245,17): note: called by 'operator()'
  245 |                 __brick(__idx, __rngs...);
      |                 ^
include\sycl\handler.hpp(1536,5): note: called by 'kernel_parallel_for<TestUtils::unique_kernel_name<oneapi::dpl::execution::device_policy<TestUtils::unique_kernel_name<test_binary_search<unsigned long long>, 0>>, 0>, sycl::item<1, true>, (lambda at include\oneapi\dpl\pstl\hetero\dpcpp\parallel_backend_sycl.h:243:75)>'
 1536 |     KernelFunc(detail::Builder::getElement(detail::declptr<ElementType>()));
      |     ^
In file included from test\parallel_api\algorithm\alg.sorting\alg.binary.search\binary.search\binary_search.pass.cpp:16:
In file included from include\oneapi\dpl\execution:23:
In file included from C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.38.33130\include\execution:18:
In file included from C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.38.33130\include\numeric:13:
C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.38.33130\include\__msvc_bit_utils.hpp(131,41): error: SYCL kernel cannot use a non-const global variable
  131 |     const bool _Definitely_have_lzcnt = __isa_available >= _Stl_isa_available_avx2;
      |                                         ^
C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.38.33130\include\__msvc_bit_utils.hpp(118,14): error: builtin is not supported on this target
  118 |         if (!_BitScanReverse64(&_Result, _Val)) {
      |              ^
C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.38.33130\include\__msvc_bit_utils.hpp(135,16): note: called by '_Checked_x86_x64_countl_zero<unsigned long long>'
  135 |         return _Countl_zero_bsr(_Val);
      |                ^
C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.38.33130\include\bit(196,16): note: called by 'countl_zero<unsigned long long, 0>'
  196 |         return _Checked_x86_x64_countl_zero(_Val);
      |                ^
C:\Program Files\Microsoft Visual Studio\2022\Professional\VC\Tools\MSVC\14.38.33130\include\bit(124,81): note: called by 'bit_floor<unsigned long long, 0>'
  124 |     return static_cast<_Ty>(_Ty{1} << (_Unsigned_integer_digits<_Ty> - 1 - _STD countl_zero(_Val)));
      |                                                                                 ^
include\oneapi\dpl\pstl\utils.h(529,19): note: called by '__dpl_bit_floor<unsigned long long>'
  529 |     return ::std::bit_floor(__x);
      |                   ^
include\oneapi\dpl\pstl\utils.h(681,24): note: called by '__shars_lower_bound<oneapi::dpl::__ranges::guard_view<unsigned long long *>, unsigned long long, unsigned long long, oneapi::dpl::__internal::__pstl_less>'
  681 |     _Size __cur_pow2 = __dpl_bit_floor(__n);
      |                        ^
include\oneapi\dpl\internal\binary_search_impl.h(66,51): note: called by 'search_impl<unsigned long long, unsigned long long, oneapi::dpl::__ranges::zip_view<oneapi::dpl::__ranges::guard_view<unsigned long long *>, oneapi::dpl::__ranges::guard_view<unsigned long long *>, oneapi::dpl::__ranges::guard_view<unsigned long long *>>>'
   66 |             auto value = oneapi::dpl::__internal::__shars_lower_bound(get<0>(acc.tuple()), start_orig, end_orig,
      |                                                   ^
include\oneapi\dpl\internal\binary_search_impl.h(79,13): note: called by 'operator()<unsigned long long, oneapi::dpl::__ranges::zip_view<oneapi::dpl::__ranges::guard_view<unsigned long long *>, oneapi::dpl::__ranges::guard_view<unsigned long long *>, oneapi::dpl::__ranges::guard_view<unsigned long long *>>>'
   79 |             search_impl<std::uint64_t>(idx, acc);
      |             ^
include\oneapi\dpl\pstl\hetero\dpcpp\parallel_backend_sycl.h(245,17): note: called by 'operator()'
  245 |                 __brick(__idx, __rngs...);
      |                 ^
include\sycl\handler.hpp(1536,5): note: called by 'kernel_parallel_for<TestUtils::unique_kernel_name<oneapi::dpl::execution::device_policy<TestUtils::unique_kernel_name<test_binary_search<unsigned long long>, 0>>, 0>, sycl::item<1, true>, (lambda at include\oneapi\dpl\pstl\hetero\dpcpp\parallel_backend_sycl.h:243:75)>'
 1536 |     KernelFunc(detail::Builder::getElement(detail::declptr<ElementType>()));

      |     ^

4 errors generated.
```