### PR TITLE
Fix broken test `tuple_get_const_rvalue.pass` under GCC 7

### DIFF
--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -16,13 +16,6 @@
 #ifndef _TEST_CONFIG_H
 #define _TEST_CONFIG_H
 
-// Any include from standard library required to have correct state of _GLIBCXX_RELEASE
-#if __has_include(<version>)
-#   include <version>
-#else
-#   include <ciso646>
-#endif
-
 #define _PSTL_TEST_STRING(X) _PSTL_TEST_STRING_AUX(oneapi/dpl/X)
 #define _PSTL_TEST_STRING_AUX(X) #X
 //to support the optional including: <algorithm>, <memory>, <numeric> or <pstl/algorithm>, <pstl/memory>, <pstl/numeric>
@@ -59,11 +52,7 @@
 // GCC10 produces wrong answer calling exclusive_scan using vectorized polices
 #define TEST_GCC10_EXCLUSIVE_SCAN_BROKEN (_GLIBCXX_RELEASE == 10)
 // GCC7 std::get doesn't return const rvalue reference from const rvalue reference of tuple
-#if defined(_GLIBCXX_RELEASE)
-#   define _PSTL_TEST_GCC7_RVALUE_TUPLE_GET_BROKEN (_GLIBCXX_RELEASE < 8)
-#else
-#   define _PSTL_TEST_GCC7_RVALUE_TUPLE_GET_BROKEN 0
-#endif
+#define _PSTL_TEST_GCC7_RVALUE_TUPLE_GET_BROKEN (_GLIBCXX_RELEASE > 0 && _GLIBCXX_RELEASE < 8)
 // Array swap broken on Windows because Microsoft implementation of std::swap function for std::array
 // call some internal function which is not declared as SYCL external and we have compile error
 #if defined(_MSC_VER)

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -17,7 +17,7 @@
 #define _TEST_CONFIG_H
 
 // Any include from standard library required to have correct state of _GLIBCXX_RELEASE
-#if __cplusplus >= 202002L || _MSVC_LANG >= 202002L
+#if __has_include(<version>)
 #   include <version>
 #else
 #   include <cstddef>

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -16,6 +16,13 @@
 #ifndef _TEST_CONFIG_H
 #define _TEST_CONFIG_H
 
+// Any include from standard library required to have correct state of _GLIBCXX_RELEASE
+#if __cplusplus >= 202002L || _MSVC_LANG >= 202002L
+#   include <version>
+#else
+#   include <cstddef>
+#endif
+
 #define _PSTL_TEST_STRING(X) _PSTL_TEST_STRING_AUX(oneapi/dpl/X)
 #define _PSTL_TEST_STRING_AUX(X) #X
 //to support the optional including: <algorithm>, <memory>, <numeric> or <pstl/algorithm>, <pstl/memory>, <pstl/numeric>

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -20,7 +20,7 @@
 #if __has_include(<version>)
 #   include <version>
 #else
-#   include <cstddef>
+#   include <ciso646>
 #endif
 
 #define _PSTL_TEST_STRING(X) _PSTL_TEST_STRING_AUX(oneapi/dpl/X)

--- a/test/xpu_api/tuple/tuple.tuple/tuple.elem/tuple_get_const_rvalue.pass.cpp
+++ b/test/xpu_api/tuple/tuple.tuple/tuple.elem/tuple_get_const_rvalue.pass.cpp
@@ -53,9 +53,12 @@ kernel_test()
 int
 main()
 {
+    bool bProcessed = false;
+
 #if !_PSTL_TEST_GCC7_RVALUE_TUPLE_GET_BROKEN
     kernel_test();
+    bProcessed = true;
 #endif // !_PSTL_TEST_GCC7_RVALUE_TUPLE_GET_BROKEN
 
-    return TestUtils::done(!_PSTL_TEST_GCC7_RVALUE_TUPLE_GET_BROKEN);
+    return TestUtils::done(bProcessed);
 }


### PR DESCRIPTION
In this PR we fix broken test `tuple_get_const_rvalue.pass` under GCC 7.

In the file `test/support/test_config.h` we taking a look at `_GLIBCXX_RELEASE` state :
```C++
// GCC7 std::get doesn't return const rvalue reference from const rvalue reference of tuple
#if defined(_GLIBCXX_RELEASE)
#   define _PSTL_TEST_GCC7_RVALUE_TUPLE_GET_BROKEN (_GLIBCXX_RELEASE < 8)
#else
#   define _PSTL_TEST_GCC7_RVALUE_TUPLE_GET_BROKEN 0
#endif
```

But in concrete case it's not enough, because not files from standard library has been included before and `_GLIBCXX_RELEASE` is undefined: so we have
`#   define _PSTL_TEST_GCC7_RVALUE_TUPLE_GET_BROKEN 0` 
as result.
In this case the test `test/xpu_api/tuple/tuple.tuple/tuple.elem/tuple_get_const_rvalue.pass.cpp` has compile errors due https://gcc.gnu.org/onlinedocs/gcc-7.5.0/cpp/Defined.html.
