### PR TITLE
[Tests] Speedup permutation iterator partial sort 

### DIFF
--- a/test/parallel_api/iterator/permutation_iterator_parallel_partial_sort.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_partial_sort.pass.cpp
@@ -74,6 +74,7 @@ DEFINE_TEST_PERM_IT(test_partial_sort, PermItIndexTag)
         }
     }
 };
+
 template <typename ValueType, typename PermItIndexTag>
 void
 run_algo_tests()

--- a/test/parallel_api/iterator/permutation_iterator_parallel_partial_sort.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_partial_sort.pass.cpp
@@ -31,10 +31,10 @@ DEFINE_TEST_PERM_IT(test_partial_sort, PermItIndexTag)
             *it = n - index;
     }
 
-    template <typename TIterator>
-    void check_results(TIterator itBegin, TIterator itEnd)
+    template <typename Policy, typename TIterator>
+    void check_results(const Policy& exec, TIterator itBegin, TIterator itEnd)
     {
-        const auto result = std::is_sorted(itBegin, itEnd);
+        const auto result = std::is_sorted(exec, itBegin, itEnd);
         EXPECT_TRUE(result, "Wrong partial_sort data results");
     }
 
@@ -68,13 +68,12 @@ DEFINE_TEST_PERM_IT(test_partial_sort, PermItIndexTag)
                         wait_and_throw(exec);
 
                         // Check results
-                        check_results(partialSortResult.begin(), partialSortResult.end());
+                        check_results(exec, partialSortResult.begin(), partialSortResult.end());
                     }
                 });
         }
     }
 };
-
 template <typename ValueType, typename PermItIndexTag>
 void
 run_algo_tests()

--- a/test/parallel_api/iterator/permutation_iterator_parallel_partial_sort.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_partial_sort.pass.cpp
@@ -31,10 +31,10 @@ DEFINE_TEST_PERM_IT(test_partial_sort, PermItIndexTag)
             *it = n - index;
     }
 
-    template <typename Policy, typename TIterator>
-    void check_results(const Policy& exec, TIterator itBegin, TIterator itEnd)
+    template <typename TIterator>
+    void check_results(TIterator itBegin, TIterator itEnd)
     {
-        const auto result = std::is_sorted(exec, itBegin, itEnd);
+        const auto result = std::is_sorted(oneapi::dpl::execution::par_unseq, itBegin, itEnd);
         EXPECT_TRUE(result, "Wrong partial_sort data results");
     }
 
@@ -68,7 +68,7 @@ DEFINE_TEST_PERM_IT(test_partial_sort, PermItIndexTag)
                         wait_and_throw(exec);
 
                         // Check results
-                        check_results(exec, partialSortResult.begin(), partialSortResult.end());
+                        check_results(partialSortResult.begin(), partialSortResult.end());
                     }
                 });
         }

--- a/test/parallel_api/iterator/permutation_iterator_parallel_partial_sort.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_partial_sort.pass.cpp
@@ -55,8 +55,9 @@ DEFINE_TEST_PERM_IT(test_partial_sort, PermItIndexTag)
                 [&](auto permItBegin, auto permItEnd)
                 {
                     const auto testing_n = permItEnd - permItBegin;
-
-                    for (::std::size_t p = 0; p < testing_n; p = p <= 16 ? p + 1 : ::std::size_t(31.415 * p))
+                    // run at most 3 iters per n, 0 elements should be noop / cheap
+                    const auto partial_sorting_step = std::max(testing_n / 2, decltype(testing_n){1});
+                    for (::std::size_t p = 0; p <= testing_n; p += partial_sorting_step)
                     {
                         dpl::partial_sort(exec, permItBegin, permItBegin + p, permItEnd);
                         wait_and_throw(exec);


### PR DESCRIPTION
Speedup the tests for permutation iterator partial sort by running the verification in parallel on the host (instead of a transfer back to the device), and most importantly cutting down the number of iterations run of the "partial" part of the sort.