### PR TITLE
[test] Speed up the reduce_by_segment.pass test

### DIFF
--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -351,7 +351,6 @@ main()
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
     run_test<::std::uint64_t, UserBinaryPredicate<::std::uint64_t>, MaxFunctor<::std::uint64_t>>();
-    run_test<float, ::std::equal_to<float>, ::std::plus<float>>();
     run_test<::std::complex<float>, UserBinaryPredicate<::std::complex<float>>, MaxFunctor<::std::complex<float>>>();
 
     run_test<int, ::std::equal_to<int>, ::std::plus<int>>();

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -157,18 +157,17 @@ DEFINE_TEST_2(test_reduce_by_segment, BinaryPredicate, BinaryOperation)
         if constexpr (std::is_same_v<std::equal_to<KeyT>, std::decay_t<BinaryPredicate>> &&
                       std::is_same_v<std::plus<ValT>, std::decay_t<BinaryOperation>>)
         {
-            res = oneapi::dpl::reduce_by_segment(std::forward<Policy>(exec), keys_first, keys_last, vals_first,
-                                                 key_res_first, val_res_first);
+            res = oneapi::dpl::reduce_by_segment(exec, keys_first, keys_last, vals_first, key_res_first, val_res_first);
         }
         else if constexpr (std::is_same_v<std::plus<ValT>, std::decay_t<BinaryOperation>>)
         {
-            res = oneapi::dpl::reduce_by_segment(std::forward<Policy>(exec), keys_first, keys_last, vals_first,
-                                                 key_res_first, val_res_first, BinaryPredicate());
+            res = oneapi::dpl::reduce_by_segment(exec, keys_first, keys_last, vals_first, key_res_first, val_res_first,
+                                                 BinaryPredicate());
         }
         else
         {
-            res = oneapi::dpl::reduce_by_segment(std::forward<Policy>(exec), keys_first, keys_last, vals_first,
-                                                 key_res_first, val_res_first, BinaryPredicate(), BinaryOperation());
+            res = oneapi::dpl::reduce_by_segment(exec, keys_first, keys_last, vals_first, key_res_first, val_res_first,
+                                                 BinaryPredicate(), BinaryOperation());
         }
         exec.queue().wait_and_throw();
 

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -353,7 +353,6 @@ main()
     test_flag_pred<sycl::usm::alloc::device, class KernelName2, dpl::complex<float>>();
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-    run_test<::std::uint64_t, UserBinaryPredicate<::std::uint64_t>, MaxFunctor<::std::uint64_t>>();
     run_test<::std::complex<float>, UserBinaryPredicate<::std::complex<float>>, MaxFunctor<::std::complex<float>>>();
 
     run_test<int, ::std::equal_to<int>, ::std::plus<int>>();

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -350,13 +350,17 @@ main()
     test_flag_pred<sycl::usm::alloc::device, class KernelName2, dpl::complex<float>>();
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-    run_test<::std::uint32_t, UserBinaryPredicate<::std::uint32_t>, MaxFunctor<::std::uint32_t>>();
+    run_test<::std::uint64_t, UserBinaryPredicate<::std::uint64_t>, MaxFunctor<::std::uint64_t>>();
+    run_test<float, ::std::equal_to<float>, ::std::plus<float>>();
     run_test<::std::complex<float>, UserBinaryPredicate<::std::complex<float>>, MaxFunctor<::std::complex<float>>>();
 
     run_test<int, ::std::equal_to<int>, ::std::plus<int>>();
+    run_test<float, ::std::equal_to<float>, ::std::plus<float>>();
     run_test<double, ::std::equal_to<double>, ::std::plus<double>>();
 
     // TODO investigate possible overflow: see issue #1416
+    run_test_on_device<int, ::std::equal_to<int>, ::std::multiplies<int>>();
+    run_test_on_device<float, ::std::equal_to<float>, ::std::multiplies<float>>();
     run_test_on_device<double, ::std::equal_to<double>, ::std::multiplies<double>>();
 
     return TestUtils::done();

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -150,24 +150,24 @@ DEFINE_TEST_2(test_reduce_by_segment, BinaryPredicate, BinaryOperation)
         typedef typename ::std::iterator_traits<Iterator1>::value_type KeyT;
         typedef typename ::std::iterator_traits<Iterator2>::value_type ValT;
 
+        initialize_data(host_keys.get(), host_vals.get(), host_res_keys.get(), host_res.get(), n);
+        update_data(host_keys, host_vals, host_res_keys, host_res);
+
         std::pair<Iterator3, Iterator4> res;
         if constexpr (std::is_same_v<std::equal_to<KeyT>, std::decay_t<BinaryPredicate>> &&
                       std::is_same_v<std::plus<ValT>, std::decay_t<BinaryOperation>>)
         {
-            auto new_policy = make_new_policy<new_kernel_name<Policy, 0>>(exec);
-            res = oneapi::dpl::reduce_by_segment(std::move(new_policy), keys_first, keys_last, vals_first,
+            res = oneapi::dpl::reduce_by_segment(std::forward<Policy>(exec), keys_first, keys_last, vals_first,
                                                  key_res_first, val_res_first);
         }
-        else if constexpr (std::is_same_v<std::equal_to<KeyT>, std::decay_t<BinaryPredicate>>)
+        else if constexpr (std::is_same_v<std::plus<ValT>, std::decay_t<BinaryOperation>>)
         {
-            auto new_policy = make_new_policy<new_kernel_name<Policy, 1>>(exec);
-            res = oneapi::dpl::reduce_by_segment(std::move(new_policy), keys_first, keys_last, vals_first,
+            res = oneapi::dpl::reduce_by_segment(std::forward<Policy>(exec), keys_first, keys_last, vals_first,
                                                  key_res_first, val_res_first, BinaryPredicate());
         }
         else
         {
-            auto new_policy = make_new_policy<new_kernel_name<Policy, 2>>(exec);
-            res = oneapi::dpl::reduce_by_segment(std::move(new_policy), keys_first, keys_last, vals_first,
+            res = oneapi::dpl::reduce_by_segment(std::forward<Policy>(exec), keys_first, keys_last, vals_first,
                                                  key_res_first, val_res_first, BinaryPredicate(), BinaryOperation());
         }
         exec.queue().wait_and_throw();
@@ -194,6 +194,9 @@ DEFINE_TEST_2(test_reduce_by_segment, BinaryPredicate, BinaryOperation)
     {
         typedef typename ::std::iterator_traits<Iterator1>::value_type KeyT;
         typedef typename ::std::iterator_traits<Iterator2>::value_type ValT;
+
+        initialize_data(keys_first, vals_first, key_res_first, val_res_first, n);
+
         std::pair<Iterator3, Iterator4> res;
         if constexpr (std::is_same_v<std::equal_to<KeyT>, std::decay_t<BinaryPredicate>> &&
                       std::is_same_v<std::plus<ValT>, std::decay_t<BinaryOperation>>)
@@ -201,7 +204,7 @@ DEFINE_TEST_2(test_reduce_by_segment, BinaryPredicate, BinaryOperation)
             res = oneapi::dpl::reduce_by_segment(std::forward<Policy>(exec), keys_first, keys_last, vals_first,
                                                  key_res_first, val_res_first);
         }
-        else if constexpr (std::is_same_v<std::equal_to<KeyT>, std::decay_t<BinaryPredicate>>)
+        else if constexpr (std::is_same_v<std::plus<ValT>, std::decay_t<BinaryOperation>>)
         {
             res = oneapi::dpl::reduce_by_segment(std::forward<Policy>(exec), keys_first, keys_last, vals_first,
                                                  key_res_first, val_res_first, BinaryPredicate());


### PR DESCRIPTION
`reduce_by_segment.pass` has become a bottleneck in CI runtime and is taking excessively long compared to similar tests. I have made the following adjustments to speed it up:

- Previously for custom binary predicates and / or operators, we would first test the case with the default predicate and default operator (`std::plus<T>` and `std::equal_to<T>`) on the underlying data and then the default predicate and custom operator before testing with the custom predicate and custom operator. In my opinion, this is overtesting `std::equal_to` and `std::plus`. which is ultimately leading to long compilation and run times. I have replaced this to only test with the custom predicate and operator and use the default predicate / operator APIs if possible with a compile time check.
- We had several tests with same the same operator and predicate but different datatype. I have reduced this to save time.
- Lastly, I switched `run_test<::std::uint64_t, UserBinaryPredicate<::std::uint64_t>, MaxFunctor<::std::uint64_t>>();` to use `uint32_t` We already test with an 8-byte type elsewhere and realized this test is commonly skipped due to lack of 64-bit int support on some devices.