### PR TITLE
Additional includes into test/support/test_config.h

### DIFF
--- a/include/oneapi/dpl/internal/common_config.h
+++ b/include/oneapi/dpl/internal/common_config.h
@@ -61,8 +61,8 @@
 #            define __PSTL_USE_PAR_POLICIES 0
 #        endif
 #        ifdef __PSTL_PAR_BACKEND_TBB
-#             undef __PSTL_PAR_BACKEND_TBB
-#             define __PSTL_PAR_BACKEND_TBB 0
+#            undef __PSTL_PAR_BACKEND_TBB
+#            define __PSTL_PAR_BACKEND_TBB 0
 #        endif
 #        define PSTL_USE_PARALLEL_POLICIES (_GLIBCXX_RELEASE != 9)
 #    endif

--- a/include/oneapi/dpl/internal/common_config.h
+++ b/include/oneapi/dpl/internal/common_config.h
@@ -56,6 +56,14 @@
 #    endif // __has_include(<tbb/version.h>)
 // - TBB is not found (libstdc++ v9)
 #    if !__has_include(<tbb/tbb.h>) && !defined(PSTL_USE_PARALLEL_POLICIES)
+#        ifdef __PSTL_USE_PAR_POLICIES
+#            undef __PSTL_USE_PAR_POLICIES
+#            define __PSTL_USE_PAR_POLICIES 0
+#        endif
+#        ifdef __PSTL_PAR_BACKEND_TBB
+#             undef __PSTL_PAR_BACKEND_TBB
+#             define __PSTL_PAR_BACKEND_TBB 0
+#        endif
 #        define PSTL_USE_PARALLEL_POLICIES (_GLIBCXX_RELEASE != 9)
 #    endif
 #endif // __cplusplus >= 201703L

--- a/test/general/header_order_ranges_0.pass.cpp
+++ b/test/general/header_order_ranges_0.pass.cpp
@@ -13,8 +13,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/cstddef> // for definition _GLIBCXX_RELEASE, __GLIBCXX or _LIBCPP_VERSION
-
 #include "support/test_config.h"
 
 #if _ENABLE_RANGES_TESTING

--- a/test/general/header_order_ranges_1.pass.cpp
+++ b/test/general/header_order_ranges_1.pass.cpp
@@ -13,8 +13,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/cstddef> // for definition _GLIBCXX_RELEASE, __GLIBCXX or _LIBCPP_VERSION
-
 #include "support/test_config.h"
 
 #if _ENABLE_RANGES_TESTING

--- a/test/general/interface_check.pass.cpp
+++ b/test/general/interface_check.pass.cpp
@@ -13,6 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "support/test_config.h"
+
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/functional>
@@ -24,7 +26,6 @@
 #include <functional>
 #include <iterator>
 #include <vector>
-#include "support/test_config.h"
 
 using oneapi::dpl::counting_iterator;
 using oneapi::dpl::discard_iterator;

--- a/test/kt/single_pass_scan.cpp
+++ b/test/kt/single_pass_scan.cpp
@@ -12,6 +12,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 //
 //===----------------------------------------------------------------------===//
+
 #include "../support/test_config.h"
 
 #include <oneapi/dpl/experimental/kernel_templates>

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
@@ -13,11 +13,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "support/test_config.h"
+
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/iterator>
 
-#include "support/test_config.h"
 #include "support/utils.h"
 #include "support/binary_search_utils.h"
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
@@ -13,11 +13,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "support/test_config.h"
+
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/iterator>
 
-#include "support/test_config.h"
 #include "support/utils.h"
 #include "support/binary_search_utils.h"
 

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
@@ -13,11 +13,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "support/test_config.h"
+
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/algorithm>
 #include <oneapi/dpl/iterator>
 
-#include "support/test_config.h"
 #include "support/utils.h"
 #include "support/binary_search_utils.h"
 

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
@@ -13,12 +13,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "support/test_config.h"
+
 #include "oneapi/dpl/execution"
 #include "oneapi/dpl/algorithm"
 #include "oneapi/dpl/iterator"
 #include "oneapi/dpl/complex"
 
-#include "support/test_config.h"
 #include "support/utils.h"
 #include "support/scan_serial_impl.h"
 

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -13,12 +13,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "support/test_config.h"
+
 #include "oneapi/dpl/execution"
 #include "oneapi/dpl/algorithm"
 #include "oneapi/dpl/iterator"
 #include "oneapi/dpl/complex"
 
-#include "support/test_config.h"
 #include "support/utils.h"
 #include "support/scan_serial_impl.h"
 

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -21,13 +21,14 @@
 #    define ONEDPL_WORKAROUND_FOR_IGPU_64BIT_REDUCTION _ONEDPL_TEST_FORCE_WORKAROUND_FOR_IGPU_64BIT_REDUCTION
 #endif
 
+#include "support/test_config.h"
+
 #include "oneapi/dpl/execution"
 #include "oneapi/dpl/algorithm"
 #include "oneapi/dpl/numeric"
 #include "oneapi/dpl/iterator"
 #include "oneapi/dpl/complex"
 
-#include "support/test_config.h"
 #include "support/utils.h"
 #include "support/utils_invoke.h"
 #include "support/reduce_serial_impl.h"

--- a/test/parallel_api/numeric/numeric.ops/scan_2.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan_2.pass.cpp
@@ -16,11 +16,12 @@
 // We create this additional test for test functional of inclusive scan
 // and exclusive scan for an in-place and non-in-place scan variants.
 
+#include "support/test_config.h"
+
 #include "oneapi/dpl/execution"
 #include "oneapi/dpl/algorithm"
 #include "oneapi/dpl/iterator"
 
-#include "support/test_config.h"
 #include "support/utils.h"
 #include "support/scan_serial_impl.h"
 

--- a/test/parallel_api/ranges/adjacent_find_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/adjacent_find_ranges_sycl.pass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
+
+#include <oneapi/dpl/execution>
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/all_any_none_of_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/all_any_none_of_ranges_sycl.pass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
+
+#include <oneapi/dpl/execution>
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/copy_if_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/copy_if_ranges_sycl.pass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
+
+#include <oneapi/dpl/execution>
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/copy_ranges_factory_sycl.pass.cpp
+++ b/test/parallel_api/ranges/copy_ranges_factory_sycl.pass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
+
+#include <oneapi/dpl/execution>
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/copy_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/copy_ranges_sycl.pass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
+
+#include <oneapi/dpl/execution>
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/count_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/count_ranges_sycl.pass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
+
+#include <oneapi/dpl/execution>
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/equal_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/equal_ranges_sycl.pass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
+
+#include <oneapi/dpl/execution>
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/exclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/exclusive_scan_ranges_sycl.pass.cpp
@@ -13,10 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
 
+#include <oneapi/dpl/execution>
 #include <oneapi/dpl/numeric>
 
 #if _ENABLE_RANGES_TESTING

--- a/test/parallel_api/ranges/fill_generate_factory.pass.cpp
+++ b/test/parallel_api/ranges/fill_generate_factory.pass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
+
+#include <oneapi/dpl/execution>
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/find_end_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/find_end_ranges_sycl.pass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
+
+#include <oneapi/dpl/execution>
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/find_first_of_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/find_first_of_ranges_sycl.pass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
+
+#include <oneapi/dpl/execution>
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/find_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/find_ranges_sycl.pass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
+
+#include <oneapi/dpl/execution>
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/for_each_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/for_each_ranges_sycl.pass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
+
+#include <oneapi/dpl/execution>
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/guard_view.pass.cpp
+++ b/test/parallel_api/ranges/guard_view.pass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
+
+#include <oneapi/dpl/execution>
 
 #if _ENABLE_RANGES_TESTING
 #    include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/inclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/inclusive_scan_ranges_sycl.pass.cpp
@@ -13,10 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
 
+#include <oneapi/dpl/execution>
 #include <oneapi/dpl/numeric>
 
 #if _ENABLE_RANGES_TESTING

--- a/test/parallel_api/ranges/is_sorted_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/is_sorted_ranges_sycl.pass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
+
+#include <oneapi/dpl/execution>
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/is_sorted_until_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/is_sorted_until_ranges_sycl.pass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
+
+#include <oneapi/dpl/execution>
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/merge_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/merge_ranges_sycl.pass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
+
+#include <oneapi/dpl/execution>
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/minmax_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/minmax_ranges_sycl.pass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
+
+#include <oneapi/dpl/execution>
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/move_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/move_ranges_sycl.pass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
+
+#include <oneapi/dpl/execution>
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/reduce_by_key_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/reduce_by_key_ranges_sycl.pass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
+
+#include <oneapi/dpl/execution>
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/reduce_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/reduce_ranges_sycl.pass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
+
+#include <oneapi/dpl/execution>
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/remove_if_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/remove_if_ranges_sycl.pass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
+
+#include <oneapi/dpl/execution>
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/remove_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/remove_ranges_sycl.pass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
+
+#include <oneapi/dpl/execution>
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/replace_copy_if_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/replace_copy_if_ranges_sycl.pass.cpp
@@ -13,10 +13,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "support/test_config.h"
+
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/algorithm>
-
-#include "support/test_config.h"
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/replace_copy_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/replace_copy_ranges_sycl.pass.cpp
@@ -13,10 +13,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "support/test_config.h"
+
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/algorithm>
-
-#include "support/test_config.h"
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/replace_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/replace_ranges_sycl.pass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
+
+#include <oneapi/dpl/execution>
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/reverse_copy_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/reverse_copy_ranges_sycl.pass.cpp
@@ -13,10 +13,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "support/test_config.h"
+
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/algorithm>
-
-#include "support/test_config.h"
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/reverse_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/reverse_ranges_sycl.pass.cpp
@@ -13,10 +13,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "support/test_config.h"
+
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/algorithm>
-
-#include "support/test_config.h"
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/rotate_copy_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/rotate_copy_ranges_sycl.pass.cpp
@@ -13,10 +13,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "support/test_config.h"
+
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/algorithm>
-
-#include "support/test_config.h"
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/rotate_view.pass.cpp
+++ b/test/parallel_api/ranges/rotate_view.pass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
+
+#include <oneapi/dpl/execution>
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/rotate_view_sycl.pass.cpp
+++ b/test/parallel_api/ranges/rotate_view_sycl.pass.cpp
@@ -13,10 +13,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "support/test_config.h"
+
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/algorithm>
-
-#include "support/test_config.h"
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/search_n_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/search_n_ranges_sycl.pass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
+
+#include <oneapi/dpl/execution>
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/search_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/search_ranges_sycl.pass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
+
+#include <oneapi/dpl/execution>
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/sort_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/sort_ranges_sycl.pass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
+
+#include <oneapi/dpl/execution>
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/stable_sort_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/stable_sort_ranges_sycl.pass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
+
+#include <oneapi/dpl/execution>
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/swap_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/swap_ranges_sycl.pass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
+
+#include <oneapi/dpl/execution>
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/transform_exclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_exclusive_scan_ranges_sycl.pass.cpp
@@ -13,10 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
 
+#include <oneapi/dpl/execution>
 #include <oneapi/dpl/numeric>
 
 #if _ENABLE_RANGES_TESTING

--- a/test/parallel_api/ranges/transform_inclusive_scan_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_inclusive_scan_ranges_sycl.pass.cpp
@@ -13,10 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
 
+#include <oneapi/dpl/execution>
 #include <oneapi/dpl/numeric>
 
 #if _ENABLE_RANGES_TESTING

--- a/test/parallel_api/ranges/transform_ranges_factory_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_ranges_factory_sycl.pass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
+
+#include <oneapi/dpl/execution>
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/transform_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_ranges_sycl.pass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
+
+#include <oneapi/dpl/execution>
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/transform_reduce_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/transform_reduce_ranges_sycl.pass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
+
+#include <oneapi/dpl/execution>
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/unique_copy_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/unique_copy_ranges_sycl.pass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
+
+#include <oneapi/dpl/execution>
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/unique_ranges_sycl.pass.cpp
+++ b/test/parallel_api/ranges/unique_ranges_sycl.pass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
+
+#include <oneapi/dpl/execution>
 
 #if _ENABLE_RANGES_TESTING
 #include <oneapi/dpl/ranges>

--- a/test/parallel_api/ranges/zip_view.pass.cpp
+++ b/test/parallel_api/ranges/zip_view.pass.cpp
@@ -13,9 +13,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <oneapi/dpl/execution>
-
 #include "support/test_config.h"
+
+#include <oneapi/dpl/execution>
 
 #if _ENABLE_RANGES_TESTING
 #    include <oneapi/dpl/ranges>

--- a/test/support/test_complex.h
+++ b/test/support/test_complex.h
@@ -16,11 +16,12 @@
 #ifndef _TEST_COMPLEX_H
 #define _TEST_COMPLEX_H
 
+#include "test_config.h"
+
 #include <oneapi/dpl/complex>
 
 #include "utils.h"
 #include "utils_invoke.h"
-#include "test_config.h"
 
 #include <type_traits>
 #include <cassert>

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -16,6 +16,13 @@
 #ifndef _TEST_CONFIG_H
 #define _TEST_CONFIG_H
 
+// Any include from standard library required to have correct state of _GLIBCXX_RELEASE
+#if __has_include(<version>)
+#   include <version>
+#else
+#   include <ciso646>
+#endif
+
 #define _PSTL_TEST_STRING(X) _PSTL_TEST_STRING_AUX(oneapi/dpl/X)
 #define _PSTL_TEST_STRING_AUX(X) #X
 //to support the optional including: <algorithm>, <memory>, <numeric> or <pstl/algorithm>, <pstl/memory>, <pstl/numeric>

--- a/test/support/test_dynamic_load_utils.h
+++ b/test/support/test_dynamic_load_utils.h
@@ -10,12 +10,14 @@
 #ifndef _ONEDPL_TEST_DYNAMIC_LOAD_UTILS_H
 #define _ONEDPL_TEST_DYNAMIC_LOAD_UTILS_H
 
+#include "support/test_config.h"
+
 #include <thread>
 #include <chrono>
 #include <random>
 #include <algorithm>
 #include <iostream>
-#include "support/test_config.h"
+
 #if TEST_DYNAMIC_SELECTION_AVAILABLE
 
 namespace TestUtils

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -17,15 +17,14 @@
 
 // File contains common utilities for SYCL that tests rely on
 
-// Do not #include <algorithm>, because if we do we will not detect accidental dependencies.
+#include "test_config.h"
 
+// Do not #include <algorithm>, because if we do we will not detect accidental dependencies.
 #include <iterator>
 
 #if TEST_DPCPP_BACKEND_PRESENT
 #include "utils_sycl_defs.h"
 #endif // TEST_DPCPP_BACKEND_PRESENT
-
-#include "test_config.h"
 
 #include _PSTL_TEST_HEADER(iterator)
 #include "oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h"

--- a/test/xpu_api/cmath/nearbyint/xpu_nearbyint.pass.cpp
+++ b/test/xpu_api/cmath/nearbyint/xpu_nearbyint.pass.cpp
@@ -13,9 +13,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include "support/test_config.h"
+
 #include <oneapi/dpl/cmath>
 
-#include "support/test_config.h"
 #include "support/utils.h"
 #include "support/utils_invoke.h"
 


### PR DESCRIPTION
In this PR we have 3 big changes:

1) In the file `test/support/test_config.h` we add inclusion of some files from standard library to have correct definitions of used defines:
```C++
// Any include from standard library required to have correct state of _GLIBCXX_RELEASE
#if __has_include(<version>)
#   include <version>
#else
#   include <ciso646>
#endif
```
2) In all tests now we include `test/support/test_config.h` at first place.
No additional includes required anymore if they are really not required for the test: [example1](https://github.com/oneapi-src/oneDPL/pull/1548/files#diff-d6f212e5d19f8d89f8e4da0e0289b29c43a44037d21c70dda8240c9d96a5ea0f), [example2](https://github.com/oneapi-src/oneDPL/pull/1548/files#diff-4e77151a0523c3322ea0d9e095266b06653bac4e259a6688665ccd3cb71da8c9)
3) For CI errors after (1) and (2) @kboyarinov prepared the fix for the failed CI tasks at `include/oneapi/dpl/internal/common_config.h` : see [changes](https://github.com/oneapi-src/oneDPL/pull/1548/files#diff-4c32e30dceaeba2ff83a44fecd56fb4bfe504e60b3f0e2bed77a74abc0b54176).
Also this fix resolves a lot of errors in the tests compiled with `g++` compiler.

Also we have the alternative approach at https://github.com/oneapi-src/oneDPL/pull/1555