### PR TITLE
Change usage of _PSTL_UD[R/S]_PRESENT macros

### DIFF
--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -3882,7 +3882,7 @@ _RandomAccessIterator
 __brick_min_element(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
                     /* __is_vector = */ ::std::true_type) noexcept
 {
-#if _ONEDPL_IS_ONE_OR_EMPTY(_PSTL_UDR_PRESENT) || _ONEDPL_UDR_PRESENT
+#if /*_PSTL_UDR_PRESENT ||*/ _ONEDPL_UDR_PRESENT
     return __unseq_backend::__simd_min_element(__first, __last - __first, __comp);
 #else
     return ::std::min_element(__first, __last, __comp);
@@ -3949,7 +3949,7 @@ template <typename _RandomAccessIterator, typename _Compare>
 __brick_minmax_element(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
                        /* __is_vector = */ ::std::true_type) noexcept
 {
-#if _ONEDPL_IS_ONE_OR_EMPTY(_PSTL_UDR_PRESENT) || _ONEDPL_UDR_PRESENT
+#if /*_PSTL_UDR_PRESENT ||*/ _ONEDPL_UDR_PRESENT
     return __unseq_backend::__simd_minmax_element(__first, __last - __first, __comp);
 #else
     return ::std::minmax_element(__first, __last, __comp);

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -3882,7 +3882,7 @@ _RandomAccessIterator
 __brick_min_element(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
                     /* __is_vector = */ ::std::true_type) noexcept
 {
-#if _ONEDPL_DEFINED_AND_NOT_ZERO(_PSTL_UDR_PRESENT) || _ONEDPL_UDR_PRESENT
+#if _ONEDPL_DEFINED_AND_IS_ONE(_PSTL_UDR_PRESENT) || _ONEDPL_UDR_PRESENT
     return __unseq_backend::__simd_min_element(__first, __last - __first, __comp);
 #else
     return ::std::min_element(__first, __last, __comp);
@@ -3949,7 +3949,7 @@ template <typename _RandomAccessIterator, typename _Compare>
 __brick_minmax_element(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
                        /* __is_vector = */ ::std::true_type) noexcept
 {
-#if _ONEDPL_DEFINED_AND_NOT_ZERO(_PSTL_UDR_PRESENT) || _ONEDPL_UDR_PRESENT
+#if _ONEDPL_DEFINED_AND_IS_ONE(_PSTL_UDR_PRESENT) || _ONEDPL_UDR_PRESENT
     return __unseq_backend::__simd_minmax_element(__first, __last - __first, __comp);
 #else
     return ::std::minmax_element(__first, __last, __comp);

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -3882,7 +3882,7 @@ _RandomAccessIterator
 __brick_min_element(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
                     /* __is_vector = */ ::std::true_type) noexcept
 {
-#if /*_PSTL_UDR_PRESENT ||*/ _ONEDPL_UDR_PRESENT
+#if _ONEDPL_UDR_PRESENT // _PSTL_UDR_PRESENT
     return __unseq_backend::__simd_min_element(__first, __last - __first, __comp);
 #else
     return ::std::min_element(__first, __last, __comp);
@@ -3949,7 +3949,7 @@ template <typename _RandomAccessIterator, typename _Compare>
 __brick_minmax_element(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
                        /* __is_vector = */ ::std::true_type) noexcept
 {
-#if /*_PSTL_UDR_PRESENT ||*/ _ONEDPL_UDR_PRESENT
+#if _ONEDPL_UDR_PRESENT // _PSTL_UDR_PRESENT
     return __unseq_backend::__simd_minmax_element(__first, __last - __first, __comp);
 #else
     return ::std::minmax_element(__first, __last, __comp);

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -3882,7 +3882,7 @@ _RandomAccessIterator
 __brick_min_element(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
                     /* __is_vector = */ ::std::true_type) noexcept
 {
-#if _ONEDPL_DEFINED_AND_IS_ONE(_PSTL_UDR_PRESENT) || _ONEDPL_UDR_PRESENT
+#if _ONEDPL_IS_ONE_OR_EMPTY(_PSTL_UDR_PRESENT) || _ONEDPL_UDR_PRESENT
     return __unseq_backend::__simd_min_element(__first, __last - __first, __comp);
 #else
     return ::std::min_element(__first, __last, __comp);
@@ -3949,7 +3949,7 @@ template <typename _RandomAccessIterator, typename _Compare>
 __brick_minmax_element(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
                        /* __is_vector = */ ::std::true_type) noexcept
 {
-#if _ONEDPL_DEFINED_AND_IS_ONE(_PSTL_UDR_PRESENT) || _ONEDPL_UDR_PRESENT
+#if _ONEDPL_IS_ONE_OR_EMPTY(_PSTL_UDR_PRESENT) || _ONEDPL_UDR_PRESENT
     return __unseq_backend::__simd_minmax_element(__first, __last - __first, __comp);
 #else
     return ::std::minmax_element(__first, __last, __comp);

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -3882,11 +3882,17 @@ _RandomAccessIterator
 __brick_min_element(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
                     /* __is_vector = */ ::std::true_type) noexcept
 {
-#if (_PSTL_UDR_PRESENT || _ONEDPL_UDR_PRESENT)
-    return __unseq_backend::__simd_min_element(__first, __last - __first, __comp);
-#else
-    return ::std::min_element(__first, __last, __comp);
+    // On some platforms, _PSTL_UDR_PRESENT is defined but empty
+#if (_PSTL_UDR_PRESENT + 0)
+    constexpr bool __use_simd_min_element = _PSTL_UDR_PRESENT;
+#else //  _ONEDPL_UDR_PRESENT should always be defined
+    constexpr bool __use_simd_min_element = _ONEDPL_UDR_PRESENT;
 #endif
+
+    if constexpr (__use_simd_min_element)
+        return __unseq_backend::__simd_min_element(__first, __last - __first, __comp);
+    else
+        return ::std::min_element(__first, __last, __comp);
 }
 
 template <class _Tag, typename _ExecutionPolicy, typename _ForwardIterator, typename _Compare>
@@ -3949,11 +3955,17 @@ template <typename _RandomAccessIterator, typename _Compare>
 __brick_minmax_element(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
                        /* __is_vector = */ ::std::true_type) noexcept
 {
-#if (_PSTL_UDR_PRESENT || _ONEDPL_UDR_PRESENT)
-    return __unseq_backend::__simd_minmax_element(__first, __last - __first, __comp);
-#else
-    return ::std::minmax_element(__first, __last, __comp);
+    // On some platforms, _PSTL_UDR_PRESENT is defined but empty
+#if (_PSTL_UDR_PRESENT + 0)
+    constexpr bool __use_simd_minmax_element = _PSTL_UDR_PRESENT;
+#else //  _ONEDPL_UDR_PRESENT should always be defined
+    constexpr bool __use_simd_minmax_element = _ONEDPL_UDR_PRESENT;
 #endif
+
+    if constexpr (__use_simd_minmax_element)
+        return __unseq_backend::__simd_minmax_element(__first, __last - __first, __comp);
+    else
+        return ::std::minmax_element(__first, __last, __comp);
 }
 
 template <class _Tag, typename _ExecutionPolicy, typename _ForwardIterator, typename _Compare>

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -3882,17 +3882,11 @@ _RandomAccessIterator
 __brick_min_element(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
                     /* __is_vector = */ ::std::true_type) noexcept
 {
-    // On some platforms, _PSTL_UDR_PRESENT is defined but empty
-#if (_PSTL_UDR_PRESENT + 0)
-    constexpr bool __use_simd_min_element = _PSTL_UDR_PRESENT;
-#else //  _ONEDPL_UDR_PRESENT should always be defined
-    constexpr bool __use_simd_min_element = _ONEDPL_UDR_PRESENT;
+#if _ONEDPL_DEFINED_AND_NOT_ZERO(_PSTL_UDR_PRESENT) || _ONEDPL_UDR_PRESENT
+    return __unseq_backend::__simd_min_element(__first, __last - __first, __comp);
+#else
+    return ::std::min_element(__first, __last, __comp);
 #endif
-
-    if constexpr (__use_simd_min_element)
-        return __unseq_backend::__simd_min_element(__first, __last - __first, __comp);
-    else
-        return ::std::min_element(__first, __last, __comp);
 }
 
 template <class _Tag, typename _ExecutionPolicy, typename _ForwardIterator, typename _Compare>
@@ -3955,17 +3949,11 @@ template <typename _RandomAccessIterator, typename _Compare>
 __brick_minmax_element(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
                        /* __is_vector = */ ::std::true_type) noexcept
 {
-    // On some platforms, _PSTL_UDR_PRESENT is defined but empty
-#if (_PSTL_UDR_PRESENT + 0)
-    constexpr bool __use_simd_minmax_element = _PSTL_UDR_PRESENT;
-#else //  _ONEDPL_UDR_PRESENT should always be defined
-    constexpr bool __use_simd_minmax_element = _ONEDPL_UDR_PRESENT;
+#if _ONEDPL_DEFINED_AND_NOT_ZERO(_PSTL_UDR_PRESENT) || _ONEDPL_UDR_PRESENT
+    return __unseq_backend::__simd_minmax_element(__first, __last - __first, __comp);
+#else
+    return ::std::minmax_element(__first, __last, __comp);
 #endif
-
-    if constexpr (__use_simd_minmax_element)
-        return __unseq_backend::__simd_minmax_element(__first, __last - __first, __comp);
-    else
-        return ::std::minmax_element(__first, __last, __comp);
 }
 
 template <class _Tag, typename _ExecutionPolicy, typename _ForwardIterator, typename _Compare>

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -213,13 +213,21 @@ __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __la
                        _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op, _Inclusive,
                        /*is_vector=*/::std::true_type) noexcept
 {
-#if (_PSTL_UDS_PRESENT || _ONEDPL_UDS_PRESENT)
-    if (_Inclusive() || !oneapi::dpl::__internal::__iterators_possibly_equal(__first, __result))
-    {
-        return __unseq_backend::__simd_scan(__first, __last - __first, __result, __unary_op, __init, __binary_op,
-                                            _Inclusive());
-    }
+    // On some platforms, _PSTL_UDS_PRESENT is defined but empty
+#if (_PSTL_UDS_PRESENT + 0)
+    constexpr bool __use_simd_scan = _PSTL_UDS_PRESENT;
+#else //  _ONEDPL_UDS_PRESENT should always be defined
+    constexpr bool __use_simd_scan = _ONEDPL_UDS_PRESENT;
 #endif
+
+    if constexpr (__use_simd_scan)
+    {
+        if (_Inclusive() || !oneapi::dpl::__internal::__iterators_possibly_equal(__first, __result))
+        {
+            return __unseq_backend::__simd_scan(__first, __last - __first, __result, __unary_op, __init, __binary_op,
+                                                _Inclusive());
+        }
+    }
     // We need to call serial brick here to call function for inclusive and exclusive scan that depends on _Inclusive() value
     return __internal::__brick_transform_scan(__first, __last, __result, __unary_op, __init, __binary_op, _Inclusive(),
                                               /*is_vector=*/::std::false_type());

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -213,7 +213,7 @@ __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __la
                        _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op, _Inclusive,
                        /*is_vector=*/::std::true_type) noexcept
 {
-#if _ONEDPL_DEFINED_AND_NOT_ZERO(_PSTL_UDS_PRESENT) || _ONEDPL_UDS_PRESENT
+#if _ONEDPL_DEFINED_AND_IS_ONE(_PSTL_UDS_PRESENT) || _ONEDPL_UDS_PRESENT
     if (_Inclusive() || !oneapi::dpl::__internal::__iterators_possibly_equal(__first, __result))
     {
         return __unseq_backend::__simd_scan(__first, __last - __first, __result, __unary_op, __init, __binary_op,

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -213,14 +213,13 @@ __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __la
                        _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op, _Inclusive,
                        /*is_vector=*/::std::true_type) noexcept
 {
-#if _ONEDPL_DEFINED_AND_IS_ONE(_PSTL_UDS_PRESENT) || _ONEDPL_UDS_PRESENT
+#if _ONEDPL_IS_ONE_OR_EMPTY(_PSTL_UDS_PRESENT) || _ONEDPL_UDS_PRESENT
     if (_Inclusive() || !oneapi::dpl::__internal::__iterators_possibly_equal(__first, __result))
     {
         return __unseq_backend::__simd_scan(__first, __last - __first, __result, __unary_op, __init, __binary_op,
                                             _Inclusive());
     }
 #endif
-
     // We need to call serial brick here to call function for inclusive and exclusive scan that depends on _Inclusive() value
     return __internal::__brick_transform_scan(__first, __last, __result, __unary_op, __init, __binary_op, _Inclusive(),
                                               /*is_vector=*/::std::false_type());

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -213,7 +213,7 @@ __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __la
                        _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op, _Inclusive,
                        /*is_vector=*/::std::true_type) noexcept
 {
-#if _ONEDPL_IS_ONE_OR_EMPTY(_PSTL_UDS_PRESENT) || _ONEDPL_UDS_PRESENT
+#if /*_PSTL_UDS_PRESENT ||*/ _ONEDPL_UDS_PRESENT
     if (_Inclusive() || !oneapi::dpl::__internal::__iterators_possibly_equal(__first, __result))
     {
         return __unseq_backend::__simd_scan(__first, __last - __first, __result, __unary_op, __init, __binary_op,

--- a/include/oneapi/dpl/pstl/numeric_impl.h
+++ b/include/oneapi/dpl/pstl/numeric_impl.h
@@ -213,7 +213,7 @@ __brick_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __la
                        _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op, _Inclusive,
                        /*is_vector=*/::std::true_type) noexcept
 {
-#if /*_PSTL_UDS_PRESENT ||*/ _ONEDPL_UDS_PRESENT
+#if _ONEDPL_UDS_PRESENT // PSTL_UDS_PRESENT
     if (_Inclusive() || !oneapi::dpl::__internal::__iterators_possibly_equal(__first, __result))
     {
         return __unseq_backend::__simd_scan(__first, __last - __first, __result, __unary_op, __init, __binary_op,

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -41,6 +41,8 @@
 #    include <cstring> // memcpy
 #endif
 
+#define _ONEDPL_DEFINED_AND_NOT_ZERO(X) (X + 0)
+
 namespace oneapi
 {
 namespace dpl

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -41,19 +41,6 @@
 #    include <cstring> // memcpy
 #endif
 
-#define _ONEDPL_IS_EMPTY_STRING(_X) ((0 - _X - 1) == 1 && (_X - 0) != -2)
-#define _ONEDPL_IS_ONE(_X) ((_X - 1) == 0)
-
-// This macro is needed because there are two ways that input defines are used:
-//
-//   1. A feature X is enabled if the macro X is defined as 1 and disabled if
-//      the macro X is defined as 0
-//   2. A feature X is enabled if the macro X is defined with no value (i.e.,
-//      an empty macro) and disabled if the macro is undefined
-//
-//  We want to catch both cases in a single macro
-#define _ONEDPL_IS_ONE_OR_EMPTY(_X) (_ONEDPL_IS_EMPTY_STRING(_X) || _ONEDPL_IS_ONE(_X))
-
 namespace oneapi
 {
 namespace dpl

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -52,7 +52,7 @@
 //      an empty macro) and disabled if the macro is undefined
 //
 //  We want to catch both cases in a single macro
-#define _ONEDPL_DEFINED_AND_IS_ONE(_X) (_ONEDPL_IS_EMPTY_STRING(_X) || _ONEDPL_IS_ONE(_X))
+#define _ONEDPL_IS_ONE_OR_EMPTY(_X) (_ONEDPL_IS_EMPTY_STRING(_X) || _ONEDPL_IS_ONE(_X))
 
 namespace oneapi
 {

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -41,8 +41,8 @@
 #    include <cstring> // memcpy
 #endif
 
-#define _ONEDPL_IS_EMPTY_STRING(_X) ((0-_X-1)==1 && (_X-0)!=-2)
-#define _ONEDPL_IS_ONE(_X) ((_X-1)==0)
+#define _ONEDPL_IS_EMPTY_STRING(_X) ((0 - _X - 1) == 1 && (_X - 0) != -2)
+#define _ONEDPL_IS_ONE(_X) ((_X - 1) == 0)
 
 // This macro is needed because there are two ways that input defines are used:
 //

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -41,7 +41,18 @@
 #    include <cstring> // memcpy
 #endif
 
-#define _ONEDPL_DEFINED_AND_NOT_ZERO(X) (X + 0)
+#define _ONEDPL_IS_EMPTY_STRING(_X) ((0-_X-1)==1 && (_X-0)!=-2)
+#define _ONEDPL_IS_ONE(_X) ((_X-1)==0)
+
+// This macro is needed because there are two ways that input defines are used:
+//
+//   1. A feature X is enabled if the macro X is defined as 1 and disabled if
+//      the macro X is defined as 0
+//   2. A feature X is enabled if the macro X is defined with no value (i.e.,
+//      an empty macro) and disabled if the macro is undefined
+//
+//  We want to catch both cases in a single macro
+#define _ONEDPL_DEFINED_AND_IS_ONE(_X) (_ONEDPL_IS_EMPTY_STRING(_X) || _ONEDPL_IS_ONE(_X))
 
 namespace oneapi
 {


### PR DESCRIPTION
On some platforms, specifically Fedora 40 with GCC 14, the included `pstl_config.h` is such that the macros  `_PSTL_UDR_PRESENT` and `_PSTL_UDS_PRESENT` are present but defined as an empty macro. This is causing compilation errors.

In this PR, we work around the empty macros by first testing `_PSTL_UDR_PRESENT + 0`, which evaluates to `+0` (i.e., false) if the macro is undefined and the correct value if it is defined.