### PR TITLE
[Tests] Shorten sycl_iterator and permutation_iterator tests 

### DIFF
--- a/test/general/sycl_iterator/sycl_iterator_find.pass.cpp
+++ b/test/general/sycl_iterator/sycl_iterator_find.pass.cpp
@@ -19,7 +19,7 @@
 
 DEFINE_TEST(test_adjacent_find)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_adjacent_find)
+    DEFINE_TEST_CONSTRUCTOR(test_adjacent_find, 2.0f, 0.5f)
 
     template <typename Policy, typename Iterator, typename Size>
     void
@@ -114,7 +114,7 @@ DEFINE_TEST(test_adjacent_find)
 
 DEFINE_TEST(test_is_sorted_until)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_is_sorted_until)
+    DEFINE_TEST_CONSTRUCTOR(test_is_sorted_until, 2.0f, 0.5f)
 
     template <typename Policy, typename Iterator, typename Size>
     void
@@ -213,7 +213,7 @@ DEFINE_TEST(test_is_sorted_until)
 
 DEFINE_TEST(test_is_sorted)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_is_sorted)
+    DEFINE_TEST_CONSTRUCTOR(test_is_sorted, 2.0f, 0.5f)
 
     template <typename Policy, typename Iterator, typename Size>
     void
@@ -310,7 +310,7 @@ DEFINE_TEST(test_is_sorted)
 
 DEFINE_TEST(test_any_all_none_of)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_any_all_none_of)
+    DEFINE_TEST_CONSTRUCTOR(test_any_all_none_of, 2.0f, 0.5f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -377,7 +377,7 @@ DEFINE_TEST(test_any_all_none_of)
 
 DEFINE_TEST(test_find_if)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_find_if)
+    DEFINE_TEST_CONSTRUCTOR(test_find_if, 2.0f, 0.5f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -432,7 +432,7 @@ DEFINE_TEST(test_find_if)
 
 DEFINE_TEST(test_search_n)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_search_n)
+    DEFINE_TEST_CONSTRUCTOR(test_search_n, 2.0f, 0.5f)
 
     template <typename Policy, typename Iterator, typename Size>
     void
@@ -557,7 +557,7 @@ DEFINE_TEST(test_search_n)
 
 DEFINE_TEST(test_is_heap)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_is_heap)
+    DEFINE_TEST_CONSTRUCTOR(test_is_heap, 2.0f, 0.5f)
 
     template <typename Policy, typename Iterator, typename Size>
     void
@@ -613,7 +613,7 @@ DEFINE_TEST(test_is_heap)
 
 DEFINE_TEST(test_is_heap_until)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_is_heap_until)
+    DEFINE_TEST_CONSTRUCTOR(test_is_heap_until, 2.0f, 0.5f)
 
     template <typename Policy, typename Iterator, typename Size>
     void
@@ -658,7 +658,7 @@ DEFINE_TEST(test_is_heap_until)
 
 DEFINE_TEST(test_equal)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_equal)
+    DEFINE_TEST_CONSTRUCTOR(test_equal, 2.0f, 0.5f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -694,7 +694,7 @@ DEFINE_TEST(test_equal)
 
 DEFINE_TEST(test_find_first_of)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_find_first_of)
+    DEFINE_TEST_CONSTRUCTOR(test_find_first_of, 2.0f, 0.5f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -768,7 +768,7 @@ DEFINE_TEST(test_find_first_of)
 
 DEFINE_TEST(test_search)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_search)
+    DEFINE_TEST_CONSTRUCTOR(test_search, 2.0f, 0.5f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -827,7 +827,7 @@ DEFINE_TEST(test_search)
 
 DEFINE_TEST(test_mismatch)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_mismatch)
+    DEFINE_TEST_CONSTRUCTOR(test_mismatch, 2.0f, 0.5f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -869,7 +869,7 @@ DEFINE_TEST(test_mismatch)
 
 DEFINE_TEST(test_find_end)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_find_end)
+    DEFINE_TEST_CONSTRUCTOR(test_find_end, 2.0f, 0.5f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void

--- a/test/general/sycl_iterator/sycl_iterator_find.pass.cpp
+++ b/test/general/sycl_iterator/sycl_iterator_find.pass.cpp
@@ -19,7 +19,7 @@
 
 DEFINE_TEST(test_adjacent_find)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_adjacent_find, 2.0f, 0.5f)
+    DEFINE_TEST_CONSTRUCTOR(test_adjacent_find, 2.0f, 0.65f)
 
     template <typename Policy, typename Iterator, typename Size>
     void
@@ -114,7 +114,7 @@ DEFINE_TEST(test_adjacent_find)
 
 DEFINE_TEST(test_is_sorted_until)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_is_sorted_until, 2.0f, 0.5f)
+    DEFINE_TEST_CONSTRUCTOR(test_is_sorted_until, 2.0f, 0.65f)
 
     template <typename Policy, typename Iterator, typename Size>
     void
@@ -213,7 +213,7 @@ DEFINE_TEST(test_is_sorted_until)
 
 DEFINE_TEST(test_is_sorted)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_is_sorted, 2.0f, 0.5f)
+    DEFINE_TEST_CONSTRUCTOR(test_is_sorted, 2.0f, 0.65f)
 
     template <typename Policy, typename Iterator, typename Size>
     void
@@ -310,7 +310,7 @@ DEFINE_TEST(test_is_sorted)
 
 DEFINE_TEST(test_any_all_none_of)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_any_all_none_of, 2.0f, 0.5f)
+    DEFINE_TEST_CONSTRUCTOR(test_any_all_none_of, 2.0f, 0.65f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -377,7 +377,7 @@ DEFINE_TEST(test_any_all_none_of)
 
 DEFINE_TEST(test_find_if)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_find_if, 2.0f, 0.5f)
+    DEFINE_TEST_CONSTRUCTOR(test_find_if, 2.0f, 0.65f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -432,7 +432,7 @@ DEFINE_TEST(test_find_if)
 
 DEFINE_TEST(test_search_n)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_search_n, 2.0f, 0.5f)
+    DEFINE_TEST_CONSTRUCTOR(test_search_n, 2.0f, 0.65f)
 
     template <typename Policy, typename Iterator, typename Size>
     void
@@ -442,7 +442,7 @@ DEFINE_TEST(test_search_n)
 
         typedef typename ::std::iterator_traits<Iterator>::value_type T;
 
-        ::std::iota(host_keys.get(), host_keys.get() + n, T(5));
+        ::std::iota(host_keys.get(), host_keys.get() + n, T(100));
 
         // Search for sequence at the end
         {
@@ -557,7 +557,7 @@ DEFINE_TEST(test_search_n)
 
 DEFINE_TEST(test_is_heap)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_is_heap, 2.0f, 0.5f)
+    DEFINE_TEST_CONSTRUCTOR(test_is_heap, 2.0f, 0.65f)
 
     template <typename Policy, typename Iterator, typename Size>
     void
@@ -613,7 +613,7 @@ DEFINE_TEST(test_is_heap)
 
 DEFINE_TEST(test_is_heap_until)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_is_heap_until, 2.0f, 0.5f)
+    DEFINE_TEST_CONSTRUCTOR(test_is_heap_until, 2.0f, 0.65f)
 
     template <typename Policy, typename Iterator, typename Size>
     void
@@ -658,7 +658,7 @@ DEFINE_TEST(test_is_heap_until)
 
 DEFINE_TEST(test_equal)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_equal, 2.0f, 0.5f)
+    DEFINE_TEST_CONSTRUCTOR(test_equal, 2.0f, 0.65f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -694,7 +694,7 @@ DEFINE_TEST(test_equal)
 
 DEFINE_TEST(test_find_first_of)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_find_first_of, 2.0f, 0.5f)
+    DEFINE_TEST_CONSTRUCTOR(test_find_first_of, 2.0f, 0.65f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -768,7 +768,7 @@ DEFINE_TEST(test_find_first_of)
 
 DEFINE_TEST(test_search)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_search, 2.0f, 0.5f)
+    DEFINE_TEST_CONSTRUCTOR(test_search, 2.0f, 0.65f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -827,7 +827,7 @@ DEFINE_TEST(test_search)
 
 DEFINE_TEST(test_mismatch)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_mismatch, 2.0f, 0.5f)
+    DEFINE_TEST_CONSTRUCTOR(test_mismatch, 2.0f, 0.65f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -869,7 +869,7 @@ DEFINE_TEST(test_mismatch)
 
 DEFINE_TEST(test_find_end)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_find_end, 2.0f, 0.5f)
+    DEFINE_TEST_CONSTRUCTOR(test_find_end, 2.0f, 0.65f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void

--- a/test/general/sycl_iterator/sycl_iterator_for.pass.cpp
+++ b/test/general/sycl_iterator/sycl_iterator_for.pass.cpp
@@ -96,7 +96,7 @@ struct policy_name_wrapper
 
 DEFINE_TEST(test_uninitialized_fill)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_uninitialized_fill)
+    DEFINE_TEST_CONSTRUCTOR(test_uninitialized_fill, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -120,7 +120,7 @@ DEFINE_TEST(test_uninitialized_fill)
 
 DEFINE_TEST(test_uninitialized_fill_n)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_uninitialized_fill_n)
+    DEFINE_TEST_CONSTRUCTOR(test_uninitialized_fill_n, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -142,7 +142,7 @@ DEFINE_TEST(test_uninitialized_fill_n)
 
 DEFINE_TEST(test_uninitialized_default_construct)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_uninitialized_default_construct)
+    DEFINE_TEST_CONSTRUCTOR(test_uninitialized_default_construct, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -169,7 +169,7 @@ DEFINE_TEST(test_uninitialized_default_construct)
 
 DEFINE_TEST(test_uninitialized_default_construct_n)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_uninitialized_default_construct_n)
+    DEFINE_TEST_CONSTRUCTOR(test_uninitialized_default_construct_n, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -195,7 +195,7 @@ DEFINE_TEST(test_uninitialized_default_construct_n)
 
 DEFINE_TEST(test_uninitialized_value_construct)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_uninitialized_value_construct)
+    DEFINE_TEST_CONSTRUCTOR(test_uninitialized_value_construct, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -220,7 +220,7 @@ DEFINE_TEST(test_uninitialized_value_construct)
 
 DEFINE_TEST(test_uninitialized_value_construct_n)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_uninitialized_value_construct_n)
+    DEFINE_TEST_CONSTRUCTOR(test_uninitialized_value_construct_n, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -245,7 +245,7 @@ DEFINE_TEST(test_uninitialized_value_construct_n)
 
 DEFINE_TEST(test_destroy)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_destroy)
+    DEFINE_TEST_CONSTRUCTOR(test_destroy, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -272,7 +272,7 @@ DEFINE_TEST(test_destroy)
 
 DEFINE_TEST(test_destroy_n)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_destroy_n)
+    DEFINE_TEST_CONSTRUCTOR(test_destroy_n, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -299,7 +299,7 @@ DEFINE_TEST(test_destroy_n)
 
 DEFINE_TEST(test_fill)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_fill)
+    DEFINE_TEST_CONSTRUCTOR(test_fill, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -320,7 +320,7 @@ DEFINE_TEST(test_fill)
 
 DEFINE_TEST(test_fill_n)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_fill_n)
+    DEFINE_TEST_CONSTRUCTOR(test_fill_n, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -341,7 +341,7 @@ DEFINE_TEST(test_fill_n)
 
 DEFINE_TEST(test_generate)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_generate)
+    DEFINE_TEST_CONSTRUCTOR(test_generate, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -364,7 +364,7 @@ DEFINE_TEST(test_generate)
 
 DEFINE_TEST(test_generate_n)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_generate_n)
+    DEFINE_TEST_CONSTRUCTOR(test_generate_n, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -386,7 +386,7 @@ DEFINE_TEST(test_generate_n)
 
 DEFINE_TEST(test_for_each)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_for_each)
+    DEFINE_TEST_CONSTRUCTOR(test_for_each, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -415,7 +415,7 @@ DEFINE_TEST(test_for_each)
 
 DEFINE_TEST(test_for_each_n)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_for_each_n)
+    DEFINE_TEST_CONSTRUCTOR(test_for_each_n, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -440,7 +440,7 @@ DEFINE_TEST(test_for_each_n)
 
 DEFINE_TEST(test_replace)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_replace)
+    DEFINE_TEST_CONSTRUCTOR(test_replace, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -465,7 +465,7 @@ DEFINE_TEST(test_replace)
 
 DEFINE_TEST(test_replace_if)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_replace_if)
+    DEFINE_TEST_CONSTRUCTOR(test_replace_if, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -490,7 +490,7 @@ DEFINE_TEST(test_replace_if)
 
 DEFINE_TEST(test_reverse)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_reverse)
+    DEFINE_TEST_CONSTRUCTOR(test_reverse, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -517,7 +517,7 @@ DEFINE_TEST(test_reverse)
 
 DEFINE_TEST(test_rotate)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_rotate)
+    DEFINE_TEST_CONSTRUCTOR(test_rotate, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -544,7 +544,7 @@ DEFINE_TEST(test_rotate)
 
 DEFINE_TEST(test_includes)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_includes)
+    DEFINE_TEST_CONSTRUCTOR(test_includes, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -580,7 +580,7 @@ DEFINE_TEST(test_includes)
 
 DEFINE_TEST(test_swap_ranges)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_swap_ranges)
+    DEFINE_TEST_CONSTRUCTOR(test_swap_ranges, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -621,7 +621,7 @@ DEFINE_TEST(test_swap_ranges)
 
 DEFINE_TEST(test_reverse_copy)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_reverse_copy)
+    DEFINE_TEST_CONSTRUCTOR(test_reverse_copy, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -650,7 +650,7 @@ DEFINE_TEST(test_reverse_copy)
 
 DEFINE_TEST(test_rotate_copy)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_rotate_copy)
+    DEFINE_TEST_CONSTRUCTOR(test_rotate_copy, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -678,7 +678,7 @@ DEFINE_TEST(test_rotate_copy)
 
 DEFINE_TEST(test_uninitialized_copy)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_uninitialized_copy)
+    DEFINE_TEST_CONSTRUCTOR(test_uninitialized_copy, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -704,7 +704,7 @@ DEFINE_TEST(test_uninitialized_copy)
 
 DEFINE_TEST(test_uninitialized_copy_n)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_uninitialized_copy_n)
+    DEFINE_TEST_CONSTRUCTOR(test_uninitialized_copy_n, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -730,7 +730,7 @@ DEFINE_TEST(test_uninitialized_copy_n)
 
 DEFINE_TEST(test_uninitialized_move)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_uninitialized_move)
+    DEFINE_TEST_CONSTRUCTOR(test_uninitialized_move, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -755,7 +755,7 @@ DEFINE_TEST(test_uninitialized_move)
 
 DEFINE_TEST(test_uninitialized_move_n)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_uninitialized_move_n)
+    DEFINE_TEST_CONSTRUCTOR(test_uninitialized_move_n, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -782,7 +782,7 @@ DEFINE_TEST(test_uninitialized_move_n)
 
 DEFINE_TEST(test_transform_unary)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_transform_unary)
+    DEFINE_TEST_CONSTRUCTOR(test_transform_unary, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -811,7 +811,7 @@ DEFINE_TEST(test_transform_unary)
 
 DEFINE_TEST(test_transform_binary)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_transform_binary)
+    DEFINE_TEST_CONSTRUCTOR(test_transform_binary, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -837,7 +837,7 @@ DEFINE_TEST(test_transform_binary)
 
 DEFINE_TEST(test_replace_copy)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_replace_copy)
+    DEFINE_TEST_CONSTRUCTOR(test_replace_copy, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -862,7 +862,7 @@ DEFINE_TEST(test_replace_copy)
 
 DEFINE_TEST(test_replace_copy_if)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_replace_copy_if)
+    DEFINE_TEST_CONSTRUCTOR(test_replace_copy_if, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -888,7 +888,7 @@ DEFINE_TEST(test_replace_copy_if)
 
 DEFINE_TEST(test_copy)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_copy)
+    DEFINE_TEST_CONSTRUCTOR(test_copy, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -914,7 +914,7 @@ DEFINE_TEST(test_copy)
 
 DEFINE_TEST(test_copy_n)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_copy_n)
+    DEFINE_TEST_CONSTRUCTOR(test_copy_n, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -940,7 +940,7 @@ DEFINE_TEST(test_copy_n)
 
 DEFINE_TEST(test_move)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_move)
+    DEFINE_TEST_CONSTRUCTOR(test_move, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -967,7 +967,7 @@ DEFINE_TEST(test_move)
 
 DEFINE_TEST(test_adjacent_difference)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_adjacent_difference)
+    DEFINE_TEST_CONSTRUCTOR(test_adjacent_difference, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void

--- a/test/general/sycl_iterator/sycl_iterator_reduce.pass.cpp
+++ b/test/general/sycl_iterator/sycl_iterator_reduce.pass.cpp
@@ -19,7 +19,7 @@
 
 DEFINE_TEST(test_reduce)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_reduce, 1.0f, 1.0f)
+    DEFINE_TEST_CONSTRUCTOR(test_reduce, 2.0f, 0.80f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -51,7 +51,7 @@ DEFINE_TEST(test_reduce)
 
 DEFINE_TEST(test_transform_reduce_unary)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_transform_reduce_unary, 1.0f, 1.0f)
+    DEFINE_TEST_CONSTRUCTOR(test_transform_reduce_unary, 2.0f, 0.80f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -75,7 +75,7 @@ DEFINE_TEST(test_transform_reduce_unary)
 
 DEFINE_TEST(test_min_element)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_min_element, 1.0f, 1.0f)
+    DEFINE_TEST_CONSTRUCTOR(test_min_element, 2.0f, 0.80f)
 
     template <typename Policy, typename Iterator, typename Size>
     void
@@ -118,7 +118,7 @@ DEFINE_TEST(test_min_element)
 
 DEFINE_TEST(test_max_element)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_max_element, 1.0f, 1.0f)
+    DEFINE_TEST_CONSTRUCTOR(test_max_element, 2.0f, 0.80f)
 
     template <typename Policy, typename Iterator, typename Size>
     void
@@ -158,7 +158,7 @@ DEFINE_TEST(test_max_element)
 
 DEFINE_TEST(test_minmax_element)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_minmax_element, 1.0f, 1.0f)
+    DEFINE_TEST_CONSTRUCTOR(test_minmax_element, 2.0f, 0.80f)
 
     template <typename Policy, typename Iterator, typename Size>
     void
@@ -209,7 +209,7 @@ DEFINE_TEST(test_minmax_element)
 
 DEFINE_TEST(test_count)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_count, 1.0f, 1.0f)
+    DEFINE_TEST_CONSTRUCTOR(test_count, 2.0f, 0.80f)
 
     template <typename Policy, typename Iterator, typename Size>
     void
@@ -261,7 +261,7 @@ DEFINE_TEST(test_count)
 
 DEFINE_TEST(test_count_if)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_count_if, 1.0f, 1.0f)
+    DEFINE_TEST_CONSTRUCTOR(test_count_if, 2.0f, 0.80f)
 
     template <typename Policy, typename Iterator, typename Size>
     void
@@ -313,7 +313,7 @@ DEFINE_TEST(test_count_if)
 
 DEFINE_TEST(test_is_partitioned)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_is_partitioned, 1.0f, 1.0f)
+    DEFINE_TEST_CONSTRUCTOR(test_is_partitioned, 2.0f, 0.80f)
 
     template <typename Policy, typename Iterator, typename Size>
     void
@@ -364,7 +364,7 @@ DEFINE_TEST(test_is_partitioned)
 
 DEFINE_TEST(test_transform_reduce_binary)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_transform_reduce_binary, 1.0f, 1.0f)
+    DEFINE_TEST_CONSTRUCTOR(test_transform_reduce_binary, 2.0f, 0.80f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -389,7 +389,7 @@ DEFINE_TEST(test_transform_reduce_binary)
 // TODO: move unique cases to test_lexicographical_compare
 DEFINE_TEST(test_lexicographical_compare)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_lexicographical_compare, 1.0f, 1.0f)
+    DEFINE_TEST_CONSTRUCTOR(test_lexicographical_compare, 2.0f, 0.80f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void

--- a/test/general/sycl_iterator/sycl_iterator_reduce.pass.cpp
+++ b/test/general/sycl_iterator/sycl_iterator_reduce.pass.cpp
@@ -19,7 +19,7 @@
 
 DEFINE_TEST(test_reduce)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_reduce)
+    DEFINE_TEST_CONSTRUCTOR(test_reduce, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -51,7 +51,7 @@ DEFINE_TEST(test_reduce)
 
 DEFINE_TEST(test_transform_reduce_unary)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_transform_reduce_unary)
+    DEFINE_TEST_CONSTRUCTOR(test_transform_reduce_unary, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -75,7 +75,7 @@ DEFINE_TEST(test_transform_reduce_unary)
 
 DEFINE_TEST(test_min_element)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_min_element)
+    DEFINE_TEST_CONSTRUCTOR(test_min_element, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator, typename Size>
     void
@@ -118,7 +118,7 @@ DEFINE_TEST(test_min_element)
 
 DEFINE_TEST(test_max_element)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_max_element)
+    DEFINE_TEST_CONSTRUCTOR(test_max_element, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator, typename Size>
     void
@@ -158,7 +158,7 @@ DEFINE_TEST(test_max_element)
 
 DEFINE_TEST(test_minmax_element)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_minmax_element)
+    DEFINE_TEST_CONSTRUCTOR(test_minmax_element, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator, typename Size>
     void
@@ -209,7 +209,7 @@ DEFINE_TEST(test_minmax_element)
 
 DEFINE_TEST(test_count)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_count)
+    DEFINE_TEST_CONSTRUCTOR(test_count, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator, typename Size>
     void
@@ -261,7 +261,7 @@ DEFINE_TEST(test_count)
 
 DEFINE_TEST(test_count_if)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_count_if)
+    DEFINE_TEST_CONSTRUCTOR(test_count_if, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator, typename Size>
     void
@@ -313,7 +313,7 @@ DEFINE_TEST(test_count_if)
 
 DEFINE_TEST(test_is_partitioned)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_is_partitioned)
+    DEFINE_TEST_CONSTRUCTOR(test_is_partitioned, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator, typename Size>
     void
@@ -364,7 +364,7 @@ DEFINE_TEST(test_is_partitioned)
 
 DEFINE_TEST(test_transform_reduce_binary)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_transform_reduce_binary)
+    DEFINE_TEST_CONSTRUCTOR(test_transform_reduce_binary, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -389,7 +389,7 @@ DEFINE_TEST(test_transform_reduce_binary)
 // TODO: move unique cases to test_lexicographical_compare
 DEFINE_TEST(test_lexicographical_compare)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_lexicographical_compare)
+    DEFINE_TEST_CONSTRUCTOR(test_lexicographical_compare, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void

--- a/test/general/sycl_iterator/sycl_iterator_scan.pass.cpp
+++ b/test/general/sycl_iterator/sycl_iterator_scan.pass.cpp
@@ -35,7 +35,7 @@ get_size(Size n)
 
 DEFINE_TEST(test_remove)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_remove)
+    DEFINE_TEST_CONSTRUCTOR(test_remove, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator, typename Size>
     void
@@ -69,7 +69,7 @@ DEFINE_TEST(test_remove)
 
 DEFINE_TEST(test_remove_if)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_remove_if)
+    DEFINE_TEST_CONSTRUCTOR(test_remove_if, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator, typename Size>
     void
@@ -107,7 +107,7 @@ DEFINE_TEST(test_remove_if)
 
 DEFINE_TEST(test_unique)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_unique)
+    DEFINE_TEST_CONSTRUCTOR(test_unique, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator, typename Size>
     void
@@ -157,7 +157,7 @@ DEFINE_TEST(test_unique)
 
 DEFINE_TEST(test_partition)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_partition)
+    DEFINE_TEST_CONSTRUCTOR(test_partition, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator, typename Size>
     void
@@ -200,7 +200,7 @@ DEFINE_TEST(test_partition)
 
 DEFINE_TEST(test_transform_inclusive_scan)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_transform_inclusive_scan)
+    DEFINE_TEST_CONSTRUCTOR(test_transform_inclusive_scan, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -259,7 +259,7 @@ DEFINE_TEST(test_transform_inclusive_scan)
 
 DEFINE_TEST(test_transform_exclusive_scan)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_transform_exclusive_scan)
+    DEFINE_TEST_CONSTRUCTOR(test_transform_exclusive_scan, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -297,7 +297,7 @@ DEFINE_TEST(test_transform_exclusive_scan)
 
 DEFINE_TEST(test_copy_if)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_copy_if)
+    DEFINE_TEST_CONSTRUCTOR(test_copy_if, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -351,7 +351,7 @@ DEFINE_TEST(test_copy_if)
 
 DEFINE_TEST(test_unique_copy)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_unique_copy)
+    DEFINE_TEST_CONSTRUCTOR(test_unique_copy, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -404,7 +404,7 @@ DEFINE_TEST(test_unique_copy)
 
 DEFINE_TEST(test_partition_copy)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_partition_copy)
+    DEFINE_TEST_CONSTRUCTOR(test_partition_copy, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     void
@@ -482,7 +482,7 @@ DEFINE_TEST(test_partition_copy)
 
 DEFINE_TEST(test_set_intersection)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_set_intersection)
+    DEFINE_TEST_CONSTRUCTOR(test_set_intersection, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     void
@@ -536,7 +536,7 @@ DEFINE_TEST(test_set_intersection)
 
 DEFINE_TEST(test_set_difference)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_set_difference)
+    DEFINE_TEST_CONSTRUCTOR(test_set_difference, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     void
@@ -567,7 +567,7 @@ DEFINE_TEST(test_set_difference)
 
 DEFINE_TEST(test_set_union)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_set_union)
+    DEFINE_TEST_CONSTRUCTOR(test_set_union, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     void
@@ -599,7 +599,7 @@ DEFINE_TEST(test_set_union)
 
 DEFINE_TEST(test_set_symmetric_difference)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_set_symmetric_difference)
+    DEFINE_TEST_CONSTRUCTOR(test_set_symmetric_difference, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     void

--- a/test/general/sycl_iterator/sycl_iterator_scan.pass.cpp
+++ b/test/general/sycl_iterator/sycl_iterator_scan.pass.cpp
@@ -35,7 +35,7 @@ get_size(Size n)
 
 DEFINE_TEST(test_remove)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_remove, 1.0f, 1.0f)
+    DEFINE_TEST_CONSTRUCTOR(test_remove, 2.0f, 0.65f)
 
     template <typename Policy, typename Iterator, typename Size>
     void
@@ -69,7 +69,7 @@ DEFINE_TEST(test_remove)
 
 DEFINE_TEST(test_remove_if)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_remove_if, 1.0f, 1.0f)
+    DEFINE_TEST_CONSTRUCTOR(test_remove_if, 2.0f, 0.65f)
 
     template <typename Policy, typename Iterator, typename Size>
     void
@@ -107,7 +107,7 @@ DEFINE_TEST(test_remove_if)
 
 DEFINE_TEST(test_unique)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_unique, 1.0f, 1.0f)
+    DEFINE_TEST_CONSTRUCTOR(test_unique, 2.0f, 0.65f)
 
     template <typename Policy, typename Iterator, typename Size>
     void
@@ -157,7 +157,7 @@ DEFINE_TEST(test_unique)
 
 DEFINE_TEST(test_partition)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_partition, 1.0f, 1.0f)
+    DEFINE_TEST_CONSTRUCTOR(test_partition, 2.0f, 0.65f)
 
     template <typename Policy, typename Iterator, typename Size>
     void
@@ -200,7 +200,7 @@ DEFINE_TEST(test_partition)
 
 DEFINE_TEST(test_transform_inclusive_scan)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_transform_inclusive_scan, 1.0f, 1.0f)
+    DEFINE_TEST_CONSTRUCTOR(test_transform_inclusive_scan, 2.0f, 0.65f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -259,7 +259,7 @@ DEFINE_TEST(test_transform_inclusive_scan)
 
 DEFINE_TEST(test_transform_exclusive_scan)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_transform_exclusive_scan, 1.0f, 1.0f)
+    DEFINE_TEST_CONSTRUCTOR(test_transform_exclusive_scan, 2.0f, 0.65f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -297,7 +297,7 @@ DEFINE_TEST(test_transform_exclusive_scan)
 
 DEFINE_TEST(test_copy_if)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_copy_if, 1.0f, 1.0f)
+    DEFINE_TEST_CONSTRUCTOR(test_copy_if, 2.0f, 0.65f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -351,7 +351,7 @@ DEFINE_TEST(test_copy_if)
 
 DEFINE_TEST(test_unique_copy)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_unique_copy, 1.0f, 1.0f)
+    DEFINE_TEST_CONSTRUCTOR(test_unique_copy, 2.0f, 0.65f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -404,7 +404,7 @@ DEFINE_TEST(test_unique_copy)
 
 DEFINE_TEST(test_partition_copy)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_partition_copy, 1.0f, 1.0f)
+    DEFINE_TEST_CONSTRUCTOR(test_partition_copy, 2.0f, 0.65f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     void
@@ -482,7 +482,7 @@ DEFINE_TEST(test_partition_copy)
 
 DEFINE_TEST(test_set_intersection)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_set_intersection, 1.0f, 1.0f)
+    DEFINE_TEST_CONSTRUCTOR(test_set_intersection, 2.0f, 0.65f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     void
@@ -536,7 +536,7 @@ DEFINE_TEST(test_set_intersection)
 
 DEFINE_TEST(test_set_difference)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_set_difference, 1.0f, 1.0f)
+    DEFINE_TEST_CONSTRUCTOR(test_set_difference, 2.0f, 0.65f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     void
@@ -567,7 +567,7 @@ DEFINE_TEST(test_set_difference)
 
 DEFINE_TEST(test_set_union)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_set_union, 1.0f, 1.0f)
+    DEFINE_TEST_CONSTRUCTOR(test_set_union, 2.0f, 0.65f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     void
@@ -599,7 +599,7 @@ DEFINE_TEST(test_set_union)
 
 DEFINE_TEST(test_set_symmetric_difference)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_set_symmetric_difference, 1.0f, 1.0f)
+    DEFINE_TEST_CONSTRUCTOR(test_set_symmetric_difference, 2.0f, 0.65f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     void

--- a/test/general/sycl_iterator/sycl_iterator_sort.pass.cpp
+++ b/test/general/sycl_iterator/sycl_iterator_sort.pass.cpp
@@ -19,7 +19,7 @@
 
 DEFINE_TEST(test_sort)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_sort)
+    DEFINE_TEST_CONSTRUCTOR(test_sort, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -77,7 +77,7 @@ DEFINE_TEST(test_sort)
 
 DEFINE_TEST(test_stable_sort)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_stable_sort)
+    DEFINE_TEST_CONSTRUCTOR(test_stable_sort, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -136,7 +136,7 @@ DEFINE_TEST(test_stable_sort)
 
 DEFINE_TEST(test_partial_sort)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_partial_sort)
+    DEFINE_TEST_CONSTRUCTOR(test_partial_sort, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -187,7 +187,7 @@ DEFINE_TEST(test_partial_sort)
 
 DEFINE_TEST(test_partial_sort_copy)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_partial_sort_copy)
+    DEFINE_TEST_CONSTRUCTOR(test_partial_sort_copy, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -251,7 +251,7 @@ DEFINE_TEST(test_partial_sort_copy)
 
 DEFINE_TEST(test_inplace_merge)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_inplace_merge)
+    DEFINE_TEST_CONSTRUCTOR(test_inplace_merge, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator, typename Size>
     void
@@ -287,7 +287,7 @@ DEFINE_TEST(test_inplace_merge)
 
 DEFINE_TEST(test_nth_element)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_nth_element)
+    DEFINE_TEST_CONSTRUCTOR(test_nth_element, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -338,7 +338,7 @@ DEFINE_TEST(test_nth_element)
 
 DEFINE_TEST(test_merge)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_merge)
+    DEFINE_TEST_CONSTRUCTOR(test_merge, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     void

--- a/test/general/sycl_iterator/sycl_iterator_sort.pass.cpp
+++ b/test/general/sycl_iterator/sycl_iterator_sort.pass.cpp
@@ -19,7 +19,7 @@
 
 DEFINE_TEST(test_sort)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_sort, 1.0f, 1.0f)
+    DEFINE_TEST_CONSTRUCTOR(test_sort, 2.0f, 0.65f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -77,7 +77,7 @@ DEFINE_TEST(test_sort)
 
 DEFINE_TEST(test_stable_sort)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_stable_sort, 1.0f, 1.0f)
+    DEFINE_TEST_CONSTRUCTOR(test_stable_sort, 2.0f, 0.65f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -136,7 +136,7 @@ DEFINE_TEST(test_stable_sort)
 
 DEFINE_TEST(test_partial_sort)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_partial_sort, 1.0f, 1.0f)
+    DEFINE_TEST_CONSTRUCTOR(test_partial_sort, 2.0f, 0.65f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -187,7 +187,7 @@ DEFINE_TEST(test_partial_sort)
 
 DEFINE_TEST(test_partial_sort_copy)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_partial_sort_copy, 1.0f, 1.0f)
+    DEFINE_TEST_CONSTRUCTOR(test_partial_sort_copy, 2.0f, 0.65f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -251,7 +251,7 @@ DEFINE_TEST(test_partial_sort_copy)
 
 DEFINE_TEST(test_inplace_merge)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_inplace_merge, 1.0f, 1.0f)
+    DEFINE_TEST_CONSTRUCTOR(test_inplace_merge, 2.0f, 0.65f)
 
     template <typename Policy, typename Iterator, typename Size>
     void
@@ -287,7 +287,7 @@ DEFINE_TEST(test_inplace_merge)
 
 DEFINE_TEST(test_nth_element)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_nth_element, 1.0f, 1.0f)
+    DEFINE_TEST_CONSTRUCTOR(test_nth_element, 2.0f, 0.65f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -338,7 +338,7 @@ DEFINE_TEST(test_nth_element)
 
 DEFINE_TEST(test_merge)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_merge, 1.0f, 1.0f)
+    DEFINE_TEST_CONSTRUCTOR(test_merge, 2.0f, 0.65f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     void

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/binary.search/binary_search.pass.cpp
@@ -28,7 +28,7 @@ using namespace TestUtils;
 
 DEFINE_TEST(test_binary_search)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_binary_search)
+    DEFINE_TEST_CONSTRUCTOR(test_binary_search, 1.0f, 1.0f)
 
     // TODO: replace data generation with random data and update check to compare result to
     // the result of the serial algorithm

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/lower.bound/lower_bound.pass.cpp
@@ -30,7 +30,7 @@ using namespace TestUtils;
 
 DEFINE_TEST(test_lower_bound)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_lower_bound)
+    DEFINE_TEST_CONSTRUCTOR(test_lower_bound, 1.0f, 1.0f)
 
     // TODO: replace data generation with random data and update check to compare result to
     // the result of the serial algorithm

--- a/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/alg.binary.search/upper.bound/upper_bound.pass.cpp
@@ -28,7 +28,7 @@ using namespace TestUtils;
 
 DEFINE_TEST(test_upper_bound)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_upper_bound)
+    DEFINE_TEST_CONSTRUCTOR(test_upper_bound, 1.0f, 1.0f)
 
     // TODO: replace data generation with random data and update check to compare result to
     // the result of the serial algorithm

--- a/test/parallel_api/iterator/permutation_iterator_common.h
+++ b/test/parallel_api/iterator/permutation_iterator_common.h
@@ -62,7 +62,7 @@ wait_and_throw(ExecutionPolicy&& exec)
 }
 
 // DEFINE_TEST_PERM_IT should be used to declare permutation iterator tests
-#define DEFINE_TEST_PERM_IT(TestClassName, TemplateParams)                                                             \
+#define DEFINE_TEST_PERM_IT(TestClassName, TemplateParams, ScaleStepValue, ScaleMaxNValue)                             \
     template <typename TestValueType, typename TemplateParams>                                                         \
     struct TestClassName : TestUtils::test_base<TestValueType>
 
@@ -76,6 +76,8 @@ wait_and_throw(ExecutionPolicy&& exec)
     template <UDTKind kind, typename Size>                                                                             \
     using TestDataTransfer = typename TestUtils::test_base<TestValueType>::template TestDataTransfer<kind, Size>;      \
                                                                                                                        \
-    using UsedValueType = TestValueType;
+    using UsedValueType = TestValueType;                                                                               \
+    static constexpr float ScaleMax = ScaleMaxNValue;                                                                         \
+    static constexpr float ScaleStep = ScaleStepValue;
 
 #endif // _PERMUTATION_ITERATOR_COMMON_H

--- a/test/parallel_api/iterator/permutation_iterator_common.h
+++ b/test/parallel_api/iterator/permutation_iterator_common.h
@@ -62,12 +62,12 @@ wait_and_throw(ExecutionPolicy&& exec)
 }
 
 // DEFINE_TEST_PERM_IT should be used to declare permutation iterator tests
-#define DEFINE_TEST_PERM_IT(TestClassName, TemplateParams, ScaleStepValue, ScaleMaxNValue)                             \
+#define DEFINE_TEST_PERM_IT(TestClassName, TemplateParams)                                                             \
     template <typename TestValueType, typename TemplateParams>                                                         \
     struct TestClassName : TestUtils::test_base<TestValueType>
 
 // DEFINE_TEST_PERM_IT_CONSTRUCTOR should be used to declare permutation iterator tests constructor
-#define DEFINE_TEST_PERM_IT_CONSTRUCTOR(TestClassName)                                                                 \
+#define DEFINE_TEST_PERM_IT_CONSTRUCTOR(TestClassName, ScaleStepValue, ScaleMaxNValue)                                                                 \
     TestClassName(test_base_data<TestValueType>& _test_base_data)                                                      \
         : TestUtils::test_base<TestValueType>(_test_base_data)                                                         \
     {                                                                                                                  \

--- a/test/parallel_api/iterator/permutation_iterator_parallel_find.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_find.pass.cpp
@@ -18,7 +18,7 @@
 #include "permutation_iterator_common.h"
 
 // dpl::find, dpl::find_if, dpl::find_if_not -> __parallel_find -> _parallel_find_or
-DEFINE_TEST_PERM_IT(test_find, PermItIndexTag)
+DEFINE_TEST_PERM_IT(test_find, PermItIndexTag, 1.0f, 1.0f)
 {
     DEFINE_TEST_PERM_IT_CONSTRUCTOR(test_find)
 

--- a/test/parallel_api/iterator/permutation_iterator_parallel_find.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_find.pass.cpp
@@ -18,9 +18,9 @@
 #include "permutation_iterator_common.h"
 
 // dpl::find, dpl::find_if, dpl::find_if_not -> __parallel_find -> _parallel_find_or
-DEFINE_TEST_PERM_IT(test_find, PermItIndexTag, 1.0f, 1.0f)
+DEFINE_TEST_PERM_IT(test_find, PermItIndexTag)
 {
-    DEFINE_TEST_PERM_IT_CONSTRUCTOR(test_find)
+    DEFINE_TEST_PERM_IT_CONSTRUCTOR(test_find, 1.0f, 1.0f)
 
     template <typename TIterator>
     void generate_data(TIterator itBegin, TIterator itEnd, TestValueType initVal)

--- a/test/parallel_api/iterator/permutation_iterator_parallel_for.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_for.pass.cpp
@@ -19,7 +19,7 @@
 
 // dpl::transform -> __parallel_for
 // Requirements: only for random_access_iterator
-DEFINE_TEST_PERM_IT(test_transform, PermItIndexTag)
+DEFINE_TEST_PERM_IT(test_transform, PermItIndexTag, 1.0f, 1.0f)
 {
     DEFINE_TEST_PERM_IT_CONSTRUCTOR(test_transform)
 

--- a/test/parallel_api/iterator/permutation_iterator_parallel_for.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_for.pass.cpp
@@ -19,9 +19,9 @@
 
 // dpl::transform -> __parallel_for
 // Requirements: only for random_access_iterator
-DEFINE_TEST_PERM_IT(test_transform, PermItIndexTag, 1.0f, 1.0f)
+DEFINE_TEST_PERM_IT(test_transform, PermItIndexTag)
 {
-    DEFINE_TEST_PERM_IT_CONSTRUCTOR(test_transform)
+    DEFINE_TEST_PERM_IT_CONSTRUCTOR(test_transform, 1.0f, 1.0f)
 
     struct TransformOp
     {

--- a/test/parallel_api/iterator/permutation_iterator_parallel_merge.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_merge.pass.cpp
@@ -18,7 +18,7 @@
 #include "permutation_iterator_common.h"
 
 // dpl::merge, dpl::inplace_merge -> __parallel_merge
-DEFINE_TEST_PERM_IT(test_merge, PermItIndexTag)
+DEFINE_TEST_PERM_IT(test_merge, PermItIndexTag, 1.0, 1.0)
 {
     DEFINE_TEST_PERM_IT_CONSTRUCTOR(test_merge)
 

--- a/test/parallel_api/iterator/permutation_iterator_parallel_merge.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_merge.pass.cpp
@@ -18,9 +18,9 @@
 #include "permutation_iterator_common.h"
 
 // dpl::merge, dpl::inplace_merge -> __parallel_merge
-DEFINE_TEST_PERM_IT(test_merge, PermItIndexTag, 1.0, 1.0)
+DEFINE_TEST_PERM_IT(test_merge, PermItIndexTag)
 {
-    DEFINE_TEST_PERM_IT_CONSTRUCTOR(test_merge)
+    DEFINE_TEST_PERM_IT_CONSTRUCTOR(test_merge, 2.0f, 0.65f)
 
     template <typename TIterator>
     void generate_data(TIterator itBegin, TIterator itEnd, TestValueType initVal)

--- a/test/parallel_api/iterator/permutation_iterator_parallel_or.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_or.pass.cpp
@@ -18,7 +18,7 @@
 #include "permutation_iterator_common.h"
 
 // dpl::is_heap, dpl::includes -> __parallel_or -> _parallel_find_or
-DEFINE_TEST_PERM_IT(test_is_heap, PermItIndexTag)
+DEFINE_TEST_PERM_IT(test_is_heap, PermItIndexTag, 1.0f, 1.0f)
 {
     DEFINE_TEST_PERM_IT_CONSTRUCTOR(test_is_heap)
 

--- a/test/parallel_api/iterator/permutation_iterator_parallel_or.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_or.pass.cpp
@@ -18,9 +18,9 @@
 #include "permutation_iterator_common.h"
 
 // dpl::is_heap, dpl::includes -> __parallel_or -> _parallel_find_or
-DEFINE_TEST_PERM_IT(test_is_heap, PermItIndexTag, 1.0f, 1.0f)
+DEFINE_TEST_PERM_IT(test_is_heap, PermItIndexTag)
 {
-    DEFINE_TEST_PERM_IT_CONSTRUCTOR(test_is_heap)
+    DEFINE_TEST_PERM_IT_CONSTRUCTOR(test_is_heap, 1.0f, 1.0f)
 
     template <typename TIterator>
     void generate_data(TIterator itBegin, TIterator itEnd, TestValueType initVal)

--- a/test/parallel_api/iterator/permutation_iterator_parallel_partial_sort.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_partial_sort.pass.cpp
@@ -19,7 +19,7 @@
 
 // test_partial_sort : dpl::partial_sort -> __parallel_partial_sort
 // Requirements: only for random_access_iterator
-DEFINE_TEST_PERM_IT(test_partial_sort, PermItIndexTag)
+DEFINE_TEST_PERM_IT(test_partial_sort, PermItIndexTag, 1.0f, 1.0f)
 {
     DEFINE_TEST_PERM_IT_CONSTRUCTOR(test_partial_sort)
 

--- a/test/parallel_api/iterator/permutation_iterator_parallel_partial_sort.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_partial_sort.pass.cpp
@@ -19,9 +19,9 @@
 
 // test_partial_sort : dpl::partial_sort -> __parallel_partial_sort
 // Requirements: only for random_access_iterator
-DEFINE_TEST_PERM_IT(test_partial_sort, PermItIndexTag, 1.0f, 1.0f)
+DEFINE_TEST_PERM_IT(test_partial_sort, PermItIndexTag)
 {
-    DEFINE_TEST_PERM_IT_CONSTRUCTOR(test_partial_sort)
+    DEFINE_TEST_PERM_IT_CONSTRUCTOR(test_partial_sort, 1.0f, 1.0f)
 
     template <typename TIterator, typename Size>
     void generate_data(TIterator itBegin, TIterator itEnd, Size n)

--- a/test/parallel_api/iterator/permutation_iterator_parallel_stable_sort.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_stable_sort.pass.cpp
@@ -19,7 +19,7 @@
 
 // test_sort : dpl::sort -> __parallel_stable_sort
 // Requirements: only for random_access_iterator
-DEFINE_TEST_PERM_IT(test_sort, PermItIndexTag)
+DEFINE_TEST_PERM_IT(test_sort, PermItIndexTag, 1.0f, 1.0f)
 {
     DEFINE_TEST_PERM_IT_CONSTRUCTOR(test_sort)
 

--- a/test/parallel_api/iterator/permutation_iterator_parallel_stable_sort.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_stable_sort.pass.cpp
@@ -19,9 +19,9 @@
 
 // test_sort : dpl::sort -> __parallel_stable_sort
 // Requirements: only for random_access_iterator
-DEFINE_TEST_PERM_IT(test_sort, PermItIndexTag, 1.0f, 1.0f)
+DEFINE_TEST_PERM_IT(test_sort, PermItIndexTag)
 {
-    DEFINE_TEST_PERM_IT_CONSTRUCTOR(test_sort)
+    DEFINE_TEST_PERM_IT_CONSTRUCTOR(test_sort, 2.0f, 0.65f)
 
     template <typename TIterator, typename Size>
     void generate_data(TIterator itBegin, TIterator itEnd, Size n)

--- a/test/parallel_api/iterator/permutation_iterator_parallel_transform_reduce.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_transform_reduce.pass.cpp
@@ -19,9 +19,9 @@
 
 // dpl::reduce, dpl::transform_reduce -> __parallel_transform_reduce
 // Requirements: only for random_access_iterator
-DEFINE_TEST_PERM_IT(test_transform_reduce, PermItIndexTag, 1.0f, 1.0f)
+DEFINE_TEST_PERM_IT(test_transform_reduce, PermItIndexTag)
 {
-    DEFINE_TEST_PERM_IT_CONSTRUCTOR(test_transform_reduce)
+    DEFINE_TEST_PERM_IT_CONSTRUCTOR(test_transform_reduce, 1.0f, 1.0f)
 
     template <typename TIterator>
     void generate_data(TIterator itBegin, TIterator itEnd, TestValueType initVal)

--- a/test/parallel_api/iterator/permutation_iterator_parallel_transform_reduce.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_transform_reduce.pass.cpp
@@ -19,7 +19,7 @@
 
 // dpl::reduce, dpl::transform_reduce -> __parallel_transform_reduce
 // Requirements: only for random_access_iterator
-DEFINE_TEST_PERM_IT(test_transform_reduce, PermItIndexTag)
+DEFINE_TEST_PERM_IT(test_transform_reduce, PermItIndexTag, 1.0f, 1.0f)
 {
     DEFINE_TEST_PERM_IT_CONSTRUCTOR(test_transform_reduce)
 

--- a/test/parallel_api/iterator/permutation_iterator_parallel_transform_scan.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_transform_scan.pass.cpp
@@ -19,9 +19,9 @@
 
 // dpl::remove_if -> __parallel_transform_scan
 // Requirements: only for random_access_iterator
-DEFINE_TEST_PERM_IT(test_remove_if, PermItIndexTag, 1.0f, 1.0f)
+DEFINE_TEST_PERM_IT(test_remove_if, PermItIndexTag)
 {
-    DEFINE_TEST_PERM_IT_CONSTRUCTOR(test_remove_if)
+    DEFINE_TEST_PERM_IT_CONSTRUCTOR(test_remove_if, 1.0f, 1.0f)
 
     template <typename TIterator, typename Size>
     void generate_data(TIterator itBegin, TIterator itEnd, Size n)

--- a/test/parallel_api/iterator/permutation_iterator_parallel_transform_scan.pass.cpp
+++ b/test/parallel_api/iterator/permutation_iterator_parallel_transform_scan.pass.cpp
@@ -19,7 +19,7 @@
 
 // dpl::remove_if -> __parallel_transform_scan
 // Requirements: only for random_access_iterator
-DEFINE_TEST_PERM_IT(test_remove_if, PermItIndexTag)
+DEFINE_TEST_PERM_IT(test_remove_if, PermItIndexTag, 1.0f, 1.0f)
 {
     DEFINE_TEST_PERM_IT_CONSTRUCTOR(test_remove_if)
 

--- a/test/parallel_api/iterator/transform_iterator.pass.cpp
+++ b/test/parallel_api/iterator/transform_iterator.pass.cpp
@@ -31,7 +31,7 @@ using namespace TestUtils;
 
 DEFINE_TEST(test_copy)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_copy)
+    DEFINE_TEST_CONSTRUCTOR(test_copy, 1.0f, 1.0f)
 
     template <typename ExecutionPolicy, typename Iterator1, typename Iterator2, typename Size, typename TExpectedValue>
     void operator()(ExecutionPolicy&& exec, Iterator1 first1, Iterator1 last1, Iterator2 first2, Size n, TExpectedValue expected_value)

--- a/test/parallel_api/iterator/zip_iterator.pass.cpp
+++ b/test/parallel_api/iterator/zip_iterator.pass.cpp
@@ -105,7 +105,7 @@ using namespace oneapi::dpl::execution;
 
 DEFINE_TEST(test_for_each)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_for_each)
+    DEFINE_TEST_CONSTRUCTOR(test_for_each, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -143,7 +143,7 @@ DEFINE_TEST(test_for_each)
 
 DEFINE_TEST(test_for_each_structured_binding)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_for_each_structured_binding)
+    DEFINE_TEST_CONSTRUCTOR(test_for_each_structured_binding, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -186,7 +186,7 @@ DEFINE_TEST(test_for_each_structured_binding)
 
 DEFINE_TEST(test_transform_reduce_unary)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_transform_reduce_unary)
+    DEFINE_TEST_CONSTRUCTOR(test_transform_reduce_unary, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -219,7 +219,7 @@ DEFINE_TEST(test_transform_reduce_unary)
 
 DEFINE_TEST(test_transform_reduce_binary)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_transform_reduce_binary)
+    DEFINE_TEST_CONSTRUCTOR(test_transform_reduce_binary, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -252,7 +252,7 @@ DEFINE_TEST(test_transform_reduce_binary)
 
 DEFINE_TEST(test_min_element)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_min_element)
+    DEFINE_TEST_CONSTRUCTOR(test_min_element, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator, typename Size>
     void
@@ -299,7 +299,7 @@ DEFINE_TEST(test_min_element)
 
 DEFINE_TEST(test_count_if)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_count_if)
+    DEFINE_TEST_CONSTRUCTOR(test_count_if, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator, typename Size>
     void
@@ -339,7 +339,7 @@ DEFINE_TEST(test_count_if)
 
 DEFINE_TEST(test_equal)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_equal)
+    DEFINE_TEST_CONSTRUCTOR(test_equal, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -389,7 +389,7 @@ DEFINE_TEST(test_equal)
 #if defined(_PSTL_TEST_EQUAL_STRUCTURED_BINDING)
 DEFINE_TEST(test_equal_structured_binding)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_equal_structured_binding)
+    DEFINE_TEST_CONSTRUCTOR(test_equal_structured_binding, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -451,7 +451,7 @@ DEFINE_TEST(test_equal_structured_binding)
 
 DEFINE_TEST(test_find_if)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_find_if)
+    DEFINE_TEST_CONSTRUCTOR(test_find_if, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -508,7 +508,7 @@ DEFINE_TEST(test_find_if)
 
 DEFINE_TEST(test_transform_inclusive_scan)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_transform_inclusive_scan)
+    DEFINE_TEST_CONSTRUCTOR(test_transform_inclusive_scan, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -547,7 +547,7 @@ DEFINE_TEST(test_transform_inclusive_scan)
 
 DEFINE_TEST(test_unique)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_unique)
+    DEFINE_TEST_CONSTRUCTOR(test_unique, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Size>
     void
@@ -592,7 +592,7 @@ DEFINE_TEST(test_unique)
 
 DEFINE_TEST(test_unique_copy)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_unique_copy)
+    DEFINE_TEST_CONSTRUCTOR(test_unique_copy, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -641,7 +641,7 @@ DEFINE_TEST(test_unique_copy)
 
 DEFINE_TEST(test_merge)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_merge)
+    DEFINE_TEST_CONSTRUCTOR(test_merge, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     void
@@ -717,7 +717,7 @@ DEFINE_TEST(test_merge)
 
 DEFINE_TEST(test_stable_sort)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_stable_sort)
+    DEFINE_TEST_CONSTRUCTOR(test_stable_sort, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -758,7 +758,7 @@ DEFINE_TEST(test_stable_sort)
 
 DEFINE_TEST(test_lexicographical_compare)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_lexicographical_compare)
+    DEFINE_TEST_CONSTRUCTOR(test_lexicographical_compare, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -821,7 +821,7 @@ struct Assigner{
 // Make sure that it's possible to use counting iterator inside zip iterator
 DEFINE_TEST(test_counting_zip_transform)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_counting_zip_transform)
+    DEFINE_TEST_CONSTRUCTOR(test_counting_zip_transform, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void
@@ -875,7 +875,7 @@ DEFINE_TEST(test_counting_zip_transform)
 //make sure its possible to use a discard iterator in a zip iterator
 DEFINE_TEST(test_counting_zip_discard)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_counting_zip_discard)
+    DEFINE_TEST_CONSTRUCTOR(test_counting_zip_discard, 1.0f, 1.0f)
 
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
     void

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
@@ -35,7 +35,7 @@ using namespace TestUtils;
 
 DEFINE_TEST_2(test_exclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_exclusive_scan_by_segment)
+    DEFINE_TEST_CONSTRUCTOR(test_exclusive_scan_by_segment, 1.0f, 1.0f)
 
     template <typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     void initialize_data(Iterator1 host_keys, Iterator2 host_vals, Iterator3 host_val_res, Size n)

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -35,7 +35,7 @@ using namespace TestUtils;
 
 DEFINE_TEST_2(test_inclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_inclusive_scan_by_segment)
+    DEFINE_TEST_CONSTRUCTOR(test_inclusive_scan_by_segment, 1.0f, 1.0f)
 
     template <typename Iterator1, typename Iterator2, typename Iterator3, typename Size>
     void initialize_data(Iterator1 host_keys, Iterator2 host_vals, Iterator3 host_val_res, Size n)

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -47,7 +47,7 @@ using namespace TestUtils;
 
 DEFINE_TEST_2(test_reduce_by_segment, BinaryPredicate, BinaryOperation)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_reduce_by_segment)
+    DEFINE_TEST_CONSTRUCTOR(test_reduce_by_segment, 1.0f, 1.0f)
 
     template <typename Iterator1, typename Iterator2, typename Iterator3, typename Iterator4, typename Size>
     void initialize_data(Iterator1 host_keys, Iterator2 host_vals, Iterator3 host_key_res, Iterator4 host_val_res,

--- a/test/parallel_api/numeric/numeric.ops/scan_2.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan_2.pass.cpp
@@ -141,7 +141,7 @@ struct TestingAlgoritmExclusiveScanExt
 
 DEFINE_TEST_1(test_scan_non_inplace, TestingAlgoritm)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_scan_non_inplace)
+    DEFINE_TEST_CONSTRUCTOR(test_scan_non_inplace, 1.0f, 1.0f)
 
     // specialization for hetero policy
     template <typename Policy, typename Iterator1, typename Iterator2, typename Size>
@@ -227,7 +227,7 @@ DEFINE_TEST_1(test_scan_non_inplace, TestingAlgoritm)
 
 DEFINE_TEST_1(test_scan_inplace, TestingAlgoritm)
 {
-    DEFINE_TEST_CONSTRUCTOR(test_scan_inplace)
+    DEFINE_TEST_CONSTRUCTOR(test_scan_inplace, 1.0f, 1.0f)
 
     // specialization for host execution policies
     template <typename Policy, typename Iterator1, typename Size>

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -114,21 +114,23 @@ sycl::queue get_test_queue()
 
 template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName>
 void
-test1buffer()
+test1buffer(float ScaleStep = 1.0f, float ScaleMax = 1.0f)
 {
     sycl::queue queue = get_test_queue(); // usm and allocator requires queue
-
+    const size_t local_max_n = max_n * ScaleMax;
+    const size_t incr_by_one_max = 16 * ScaleMax;
+    const size_t local_step = 3.1415 * ScaleStep;
 #if _PSTL_SYCL_TEST_USM
     { // USM
         // 1. allocate usm memory
         using TestBaseData = test_base_data_usm<alloc_type, TestValueType>;
-        TestBaseData test_base_data(queue, { { max_n, inout1_offset } });
+        TestBaseData test_base_data(queue, { { local_max_n, inout1_offset } });
 
         // 2. create a pointer at first+offset
         auto inout1_offset_first = test_base_data.get_start_from(UDTKind::eKeys);
 
         // 3. run algorithms
-        for (size_t n = 1; n <= max_n; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
+        for (size_t n = 1; n <= local_max_n; n = n <= incr_by_one_max ? n + 1 : size_t(local_step * n))
         {
 #    if _ONEDPL_DEBUG_SYCL
             ::std::cout << "n = " << n << ::std::endl;
@@ -142,13 +144,13 @@ test1buffer()
     { // sycl::buffer
         // 1. create buffers
         using TestBaseData = test_base_data_buffer<TestValueType>;
-        TestBaseData test_base_data({ { max_n, inout1_offset } });
+        TestBaseData test_base_data({ { local_max_n, inout1_offset } });
 
         // 2. create iterators over buffers
         auto inout1_offset_first = test_base_data.get_start_from(UDTKind::eKeys);
 
         // 3. run algorithms
-        for (size_t n = 1; n <= max_n; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
+        for (size_t n = 1; n <= local_max_n; n = n <= incr_by_one_max ? n + 1 : size_t(local_step * n))
         {
 #if _ONEDPL_DEBUG_SYCL
             ::std::cout << "n = " << n << ::std::endl;
@@ -162,23 +164,26 @@ test1buffer()
 
 template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName>
 void
-test2buffers()
+test2buffers(float ScaleStep = 1.0f, float ScaleMax = 1.0f)
 {
     sycl::queue queue = get_test_queue(); // usm and allocator requires queue
+    const size_t local_max_n = max_n * ScaleMax;
+    const size_t incr_by_one_max = 16 * ScaleMax;
+    const size_t local_step = 3.1415 * ScaleStep;
 
 #if _PSTL_SYCL_TEST_USM
     { // USM
         // 1. allocate usm memory
         using TestBaseData = test_base_data_usm<alloc_type, TestValueType>;
-        TestBaseData test_base_data(queue, { { max_n, inout1_offset },
-                                             { max_n, inout2_offset } });
+        TestBaseData test_base_data(queue, { { local_max_n, inout1_offset },
+                                             { local_max_n, inout2_offset } });
 
         // 2. create pointers at first+offset
         auto inout1_offset_first = test_base_data.get_start_from(UDTKind::eKeys);
         auto inout2_offset_first = test_base_data.get_start_from(UDTKind::eVals);
 
         // 3. run algorithms
-        for (size_t n = 1; n <= max_n; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
+        for (size_t n = 1; n <= local_max_n; n = n <= incr_by_one_max ? n + 1 : size_t(local_step * n))
         {
 #    if _ONEDPL_DEBUG_SYCL
             ::std::cout << "n = " << n << ::std::endl;
@@ -193,15 +198,15 @@ test2buffers()
     { // sycl::buffer
         // 1. create buffers
         using TestBaseData = test_base_data_buffer<TestValueType>;
-        TestBaseData test_base_data({ { max_n, inout1_offset },
-                                      { max_n, inout2_offset } });
+        TestBaseData test_base_data({ { local_max_n, inout1_offset },
+                                      { local_max_n, inout2_offset } });
 
         // 2. create iterators over buffers
         auto inout1_offset_first = test_base_data.get_start_from(UDTKind::eKeys);
         auto inout2_offset_first = test_base_data.get_start_from(UDTKind::eVals);
 
         // 3. run algorithms
-        for (size_t n = 1; n <= max_n; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
+        for (size_t n = 1; n <= local_max_n; n = n <= incr_by_one_max ? n + 1 : size_t(local_step * n))
         {
 #if _ONEDPL_DEBUG_SYCL
             ::std::cout << "n = " << n << ::std::endl;
@@ -216,18 +221,21 @@ test2buffers()
 
 template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName>
 void
-test3buffers(int mult = kDefaultMultValue)
+test3buffers(int mult = kDefaultMultValue, float ScaleStep = 1.0f, float ScaleMax = 1.0f)
 {
     sycl::queue queue = get_test_queue(); // usm requires queue
+    const size_t local_max_n = max_n * ScaleMax;
+    const size_t incr_by_one_max = 16 * ScaleMax;
+    const size_t local_step = 3.1415 * ScaleStep;
 
 #if _PSTL_SYCL_TEST_USM
     { // USM
 
         // 1. allocate usm memory
         using TestBaseData = test_base_data_usm<alloc_type, TestValueType>;
-        TestBaseData test_base_data(queue, { { max_n,        inout1_offset },
-                                             { max_n,        inout2_offset },
-                                             { max_n * mult, inout3_offset } });
+        TestBaseData test_base_data(queue, { { local_max_n,        inout1_offset },
+                                             { local_max_n,        inout2_offset },
+                                             { local_max_n * mult, inout3_offset } });
 
         // 2. create pointers at first+offset
         auto inout1_offset_first = test_base_data.get_start_from(UDTKind::eKeys);
@@ -235,7 +243,7 @@ test3buffers(int mult = kDefaultMultValue)
         auto inout3_offset_first = test_base_data.get_start_from(UDTKind::eRes);
 
         // 3. run algorithms
-        for (size_t n = 1; n <= max_n; n = (n <= 16 ? n + 1 : size_t(3.1415 * n)))
+        for (size_t n = 1; n <= local_max_n; n = (n <= incr_by_one_max ? n + 1 : size_t(local_step * n)))
         {
 #    if _ONEDPL_DEBUG_SYCL
             ::std::cout << "n = " << n << ::std::endl;
@@ -251,9 +259,9 @@ test3buffers(int mult = kDefaultMultValue)
     { // sycl::buffer
         // 1. create buffers
         using TestBaseData = test_base_data_buffer<TestValueType>;
-        TestBaseData test_base_data({ { max_n,        inout1_offset },
-                                      { max_n,        inout2_offset },
-                                      { max_n * mult, inout3_offset } });
+        TestBaseData test_base_data({ { local_max_n,        inout1_offset },
+                                      { local_max_n,        inout2_offset },
+                                      { local_max_n * mult, inout3_offset } });
 
         // 2. create iterators over buffers
         auto inout1_offset_first = test_base_data.get_start_from(UDTKind::eKeys);
@@ -261,7 +269,7 @@ test3buffers(int mult = kDefaultMultValue)
         auto inout3_offset_first = test_base_data.get_start_from(UDTKind::eRes);
 
         // 3. run algorithms
-        for (size_t n = 1; n <= max_n; n = (n <= 16 ? n + 1 : size_t(3.1415 * n)))
+        for (size_t n = 1; n <= local_max_n; n = (n <= incr_by_one_max ? n + 1 : size_t(local_step * n)))
         {
 #if _ONEDPL_DEBUG_SYCL
             ::std::cout << "n = " << n << ::std::endl;
@@ -277,19 +285,22 @@ test3buffers(int mult = kDefaultMultValue)
 
 template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName>
 void
-test4buffers(int mult = kDefaultMultValue)
+test4buffers(int mult = kDefaultMultValue, float ScaleStep = 1.0f, float ScaleMax = 1.0f)
 {
     sycl::queue queue = get_test_queue(); // usm requires queue
+    const size_t local_max_n = max_n * ScaleMax;
+    const size_t incr_by_one_max = 16 * ScaleMax;
+    const size_t local_step = 3.1415 * ScaleStep;
 
 #if _PSTL_SYCL_TEST_USM
     { // USM
 
         // 1. allocate usm memory
         using TestBaseData = test_base_data_usm<alloc_type, TestValueType>;
-        TestBaseData test_base_data(queue, { { max_n,        inout1_offset },
-                                             { max_n,        inout2_offset },
-                                             { max_n * mult, inout3_offset },
-                                             { max_n * mult, inout4_offset } });
+        TestBaseData test_base_data(queue, { { local_max_n,        inout1_offset },
+                                             { local_max_n,        inout2_offset },
+                                             { local_max_n * mult, inout3_offset },
+                                             { local_max_n * mult, inout4_offset } });
 
         // 2. create pointers at first+offset
         auto inout1_offset_first = test_base_data.get_start_from(UDTKind::eKeys);
@@ -298,7 +309,7 @@ test4buffers(int mult = kDefaultMultValue)
         auto inout4_offset_first = test_base_data.get_start_from(UDTKind::eRes2);
 
         // 3. run algorithms
-        for (size_t n = 1; n <= max_n; n = (n <= 16 ? n + 1 : size_t(3.1415 * n)))
+        for (size_t n = 1; n <= local_max_n; n = (n <= incr_by_one_max ? n + 1 : size_t(local_step * n)))
         {
 #    if _ONEDPL_DEBUG_SYCL
             ::std::cout << "n = " << n << ::std::endl;
@@ -315,10 +326,10 @@ test4buffers(int mult = kDefaultMultValue)
     { // sycl::buffer
         // 1. create buffers
         using TestBaseData = test_base_data_buffer<TestValueType>;
-        TestBaseData test_base_data({ { max_n,        inout1_offset },
-                                      { max_n,        inout2_offset },
-                                      { max_n * mult, inout3_offset },
-                                      { max_n * mult, inout4_offset } });
+        TestBaseData test_base_data({ { local_max_n,        inout1_offset },
+                                      { local_max_n,        inout2_offset },
+                                      { local_max_n * mult, inout3_offset },
+                                      { local_max_n * mult, inout4_offset } });
 
         // 2. create iterators over buffers
         auto inout1_offset_first = test_base_data.get_start_from(UDTKind::eKeys);
@@ -327,7 +338,7 @@ test4buffers(int mult = kDefaultMultValue)
         auto inout4_offset_first = test_base_data.get_start_from(UDTKind::eRes2);
 
         // 3. run algorithms
-        for (size_t n = 1; n <= max_n; n = (n <= 16 ? n + 1 : size_t(3.1415 * n)))
+        for (size_t n = 1; n <= local_max_n; n = (n <= incr_by_one_max ? n + 1 : size_t(local_step * n)))
         {
 #if _ONEDPL_DEBUG_SYCL
             ::std::cout << "n = " << n << ::std::endl;
@@ -346,28 +357,28 @@ template <sycl::usm::alloc alloc_type, typename TestName>
 ::std::enable_if_t<::std::is_base_of_v<test_base<typename TestName::UsedValueType>, TestName>>
 test1buffer()
 {
-    test1buffer<alloc_type, typename TestName::UsedValueType, TestName>();
+    test1buffer<alloc_type, typename TestName::UsedValueType, TestName>(TestName::ScaleStep, TestName::ScaleMax);
 }
 
 template <sycl::usm::alloc alloc_type, typename TestName>
 ::std::enable_if_t<::std::is_base_of_v<test_base<typename TestName::UsedValueType>, TestName>>
 test2buffers()
 {
-    test2buffers<alloc_type, typename TestName::UsedValueType, TestName>();
+    test2buffers<alloc_type, typename TestName::UsedValueType, TestName>(TestName::ScaleStep, TestName::ScaleMax);
 }
 
 template <sycl::usm::alloc alloc_type, typename TestName>
 ::std::enable_if_t<::std::is_base_of_v<test_base<typename TestName::UsedValueType>, TestName>>
 test3buffers(int mult = kDefaultMultValue)
 {
-    test3buffers<alloc_type, typename TestName::UsedValueType, TestName>(mult);
+    test3buffers<alloc_type, typename TestName::UsedValueType, TestName>(mult, TestName::ScaleStep, TestName::ScaleMax);
 }
 
 template <sycl::usm::alloc alloc_type, typename TestName>
 ::std::enable_if_t<::std::is_base_of_v<test_base<typename TestName::UsedValueType>, TestName>>
 test4buffers(int mult = kDefaultMultValue)
 {
-    test4buffers<alloc_type, typename TestName::UsedValueType, TestName>(mult);
+    test4buffers<alloc_type, typename TestName::UsedValueType, TestName>(mult, TestName::ScaleStep, TestName::ScaleMax);
 }
 
 } /* namespace TestUtils */

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -120,6 +120,13 @@ test1buffer(float ScaleStep = 1.0f, float ScaleMax = 1.0f)
     const size_t local_max_n = max_n * ScaleMax;
     const size_t incr_by_one_max = 16 * ScaleMax;
     const size_t local_step = 3.1415 * ScaleStep;
+
+#if TEST_LONG_RUN
+    local_max_n = std::max(local_max_n, max_n);
+    incr_by_one_max = std::max(incr_by_one_max, 16);
+    local_step = std::min(local_step, 3.1415);
+#endif // TEST_LONG_RUN
+
 #if _PSTL_SYCL_TEST_USM
     { // USM
         // 1. allocate usm memory
@@ -170,6 +177,12 @@ test2buffers(float ScaleStep = 1.0f, float ScaleMax = 1.0f)
     const size_t local_max_n = max_n * ScaleMax;
     const size_t incr_by_one_max = 16 * ScaleMax;
     const size_t local_step = 3.1415 * ScaleStep;
+
+#if TEST_LONG_RUN
+    local_max_n = std::max(local_max_n, max_n);
+    incr_by_one_max = std::max(incr_by_one_max, 16);
+    local_step = std::min(local_step, 3.1415);
+#endif // TEST_LONG_RUN
 
 #if _PSTL_SYCL_TEST_USM
     { // USM
@@ -227,6 +240,12 @@ test3buffers(int mult = kDefaultMultValue, float ScaleStep = 1.0f, float ScaleMa
     const size_t local_max_n = max_n * ScaleMax;
     const size_t incr_by_one_max = 16 * ScaleMax;
     const size_t local_step = 3.1415 * ScaleStep;
+
+#if TEST_LONG_RUN
+    local_max_n = std::max(local_max_n, max_n);
+    incr_by_one_max = std::max(incr_by_one_max, 16);
+    local_step = std::min(local_step, 3.1415);
+#endif // TEST_LONG_RUN
 
 #if _PSTL_SYCL_TEST_USM
     { // USM
@@ -291,6 +310,12 @@ test4buffers(int mult = kDefaultMultValue, float ScaleStep = 1.0f, float ScaleMa
     const size_t local_max_n = max_n * ScaleMax;
     const size_t incr_by_one_max = 16 * ScaleMax;
     const size_t local_step = 3.1415 * ScaleStep;
+
+#if TEST_LONG_RUN
+    local_max_n = std::max(local_max_n, max_n);
+    incr_by_one_max = std::max(incr_by_one_max, 16);
+    local_step = std::min(local_step, 3.1415);
+#endif // TEST_LONG_RUN
 
 #if _PSTL_SYCL_TEST_USM
     { // USM

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -120,13 +120,6 @@ test1buffer(float ScaleStep = 1.0f, float ScaleMax = 1.0f)
     const size_t local_max_n = max_n * ScaleMax;
     const size_t incr_by_one_max = 16 * ScaleMax;
     const size_t local_step = 3.1415 * ScaleStep;
-
-#if TEST_LONG_RUN
-    local_max_n = std::max(local_max_n, max_n);
-    incr_by_one_max = std::max(incr_by_one_max, 16);
-    local_step = std::min(local_step, 3.1415);
-#endif // TEST_LONG_RUN
-
 #if _PSTL_SYCL_TEST_USM
     { // USM
         // 1. allocate usm memory
@@ -177,12 +170,6 @@ test2buffers(float ScaleStep = 1.0f, float ScaleMax = 1.0f)
     const size_t local_max_n = max_n * ScaleMax;
     const size_t incr_by_one_max = 16 * ScaleMax;
     const size_t local_step = 3.1415 * ScaleStep;
-
-#if TEST_LONG_RUN
-    local_max_n = std::max(local_max_n, max_n);
-    incr_by_one_max = std::max(incr_by_one_max, 16);
-    local_step = std::min(local_step, 3.1415);
-#endif // TEST_LONG_RUN
 
 #if _PSTL_SYCL_TEST_USM
     { // USM
@@ -240,12 +227,6 @@ test3buffers(int mult = kDefaultMultValue, float ScaleStep = 1.0f, float ScaleMa
     const size_t local_max_n = max_n * ScaleMax;
     const size_t incr_by_one_max = 16 * ScaleMax;
     const size_t local_step = 3.1415 * ScaleStep;
-
-#if TEST_LONG_RUN
-    local_max_n = std::max(local_max_n, max_n);
-    incr_by_one_max = std::max(incr_by_one_max, 16);
-    local_step = std::min(local_step, 3.1415);
-#endif // TEST_LONG_RUN
 
 #if _PSTL_SYCL_TEST_USM
     { // USM
@@ -310,12 +291,6 @@ test4buffers(int mult = kDefaultMultValue, float ScaleStep = 1.0f, float ScaleMa
     const size_t local_max_n = max_n * ScaleMax;
     const size_t incr_by_one_max = 16 * ScaleMax;
     const size_t local_step = 3.1415 * ScaleStep;
-
-#if TEST_LONG_RUN
-    local_max_n = std::max(local_max_n, max_n);
-    incr_by_one_max = std::max(incr_by_one_max, 16);
-    local_step = std::min(local_step, 3.1415);
-#endif // TEST_LONG_RUN
 
 #if _PSTL_SYCL_TEST_USM
     { // USM

--- a/test/support/utils_test_base.h
+++ b/test/support/utils_test_base.h
@@ -403,7 +403,7 @@ void update_data(TTestDataTransfer& helper, Args&& ...args)
     using TestDataTransfer = typename TestUtils::test_base<TestValueType>::template TestDataTransfer<kind, Size>; \
                                                                                                                   \
     using UsedValueType = TestValueType;                                                                          \
-    static constexpr float ScaleMax = ScaleMaxNValue;                                                                    \
+    static constexpr float ScaleMax = ScaleMaxNValue;                                                             \
     static constexpr float ScaleStep = ScaleStepValue;
 #else
 #define DEFINE_TEST_CONSTRUCTOR(TestClassName, ScaleMaxNValue, ScaleStepValue)

--- a/test/support/utils_test_base.h
+++ b/test/support/utils_test_base.h
@@ -393,7 +393,7 @@ void update_data(TTestDataTransfer& helper, Args&& ...args)
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
 #if TEST_DPCPP_BACKEND_PRESENT
-#define DEFINE_TEST_CONSTRUCTOR(TestClassName)                                                                    \
+#define DEFINE_TEST_CONSTRUCTOR(TestClassName, ScaleStepValue, ScaleMaxNValue)                                    \
     TestClassName(test_base_data<TestValueType>& _test_base_data)                                                 \
         : TestUtils::test_base<TestValueType>(_test_base_data)                                                    \
     {                                                                                                             \
@@ -402,9 +402,11 @@ void update_data(TTestDataTransfer& helper, Args&& ...args)
     template <UDTKind kind, typename Size>                                                                        \
     using TestDataTransfer = typename TestUtils::test_base<TestValueType>::template TestDataTransfer<kind, Size>; \
                                                                                                                   \
-    using UsedValueType = TestValueType;
+    using UsedValueType = TestValueType;                                                                          \
+    static constexpr float ScaleMax = ScaleMaxNValue;                                                                    \
+    static constexpr float ScaleStep = ScaleStepValue;
 #else
-#define DEFINE_TEST_CONSTRUCTOR(TestClassName)
+#define DEFINE_TEST_CONSTRUCTOR(TestClassName, ScaleMaxNValue, ScaleStepValue)
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
 //--------------------------------------------------------------------------------------------------------------------//


### PR DESCRIPTION
Adds infrastructure to be able to shorten some commonly used test infrastructure by 
1) allowing scaling of the `max_n` (100000) and `small_n` (16)
2) allowing scaling of the step (3.14.15) multiplier 

This also corrects a potential error in the search_20 test of `sycl_iterator_find` which for some value of n, could return the incorrect result due to a unintentional extension of the searched for list by the nature of the input data.

A few tests were scaled in this PR to have fewer iterations with different sizes:

sycl_iterator_find
sycl_iterator_reduce
sycl_iterator_scan
sycl_iterator_sort
permutation_iterator_parallel_merge
permutation_iterator_parallel_stable_sort

Others were just given the opportunity for similar shortening.

These patterns should also be tested via their individual tests, independently from the `sycl_iterator` type or the `permutation_iterator` types.  Also, the newly added `input_data_sweep` tests, provide much more coverage for input data processing to `dpcpp` backends.
