### PR TITLE
[Tests] Adjusting std lib macros to lazily evaluation

### DIFF
--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -52,6 +52,8 @@
 // GCC10 produces wrong answer calling exclusive_scan using vectorized polices
 #define TEST_GCC10_EXCLUSIVE_SCAN_BROKEN (_GLIBCXX_RELEASE == 10)
 // GCC7 std::get doesn't return const rvalue reference from const rvalue reference of tuple
+// Defining this all on one line to delay evaluation of `_GLIBCXX_RELEASE` until later, when
+// _PSTL_TEST_GCC7_RVALUE_TUPLE_GET_BROKEN is being used, and we can be confident that std lib macros are defined
 #define _PSTL_TEST_GCC7_RVALUE_TUPLE_GET_BROKEN (_GLIBCXX_RELEASE > 0 && _GLIBCXX_RELEASE < 8)
 // Array swap broken on Windows because Microsoft implementation of std::swap function for std::array
 // call some internal function which is not declared as SYCL external and we have compile error
@@ -100,14 +102,13 @@
 
 // Check for C++ standard and standard library for the use of ranges API
 #if !defined(_ENABLE_RANGES_TESTING)
-#define _TEST_RANGES_FOR_CPP_17_DPCPP_BE_ONLY TEST_DPCPP_BACKEND_PRESENT
-#if defined(_GLIBCXX_RELEASE)
-#    define _ENABLE_RANGES_TESTING (_TEST_RANGES_FOR_CPP_17_DPCPP_BE_ONLY && _GLIBCXX_RELEASE >= 8 && __GLIBCXX__ >= 20180502)
-#elif defined(_LIBCPP_VERSION)
-#    define _ENABLE_RANGES_TESTING (_TEST_RANGES_FOR_CPP_17_DPCPP_BE_ONLY && _LIBCPP_VERSION >= 7000)
-#else
-#    define _ENABLE_RANGES_TESTING (_TEST_RANGES_FOR_CPP_17_DPCPP_BE_ONLY)
-#endif
+#   define _TEST_RANGES_FOR_CPP_17_DPCPP_BE_ONLY TEST_DPCPP_BACKEND_PRESENT
+// Defining this all on one line to delay evaluation of `defined(_GLIBCXX_RELEASE)` and `defined(_LIBCPP_VERSION)` until
+// later, when _ENABLE_RANGES_TESTING is being used, and we can be confident that std lib macros are defined
+#   define _ENABLE_RANGES_TESTING (_TEST_RANGES_FOR_CPP_17_DPCPP_BE_ONLY &&                                            \
+                                   ((defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE >= 8 && __GLIBCXX__ >= 20180502) || \
+                                    (defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 7000) ||                           \
+                                    (!defined(_GLIBCXX_RELEASE) && !defined(_LIBCPP_VERSION))))
 #endif //!defined(_ENABLE_RANGES_TESTING)
 
 #define TEST_HAS_NO_INT128
@@ -133,6 +134,8 @@
 #define _PSTL_ICC_TEST_COMPLEX_POLAR_BROKEN_TEST_EDGES __INTEL_LLVM_COMPILER
 #define _PSTL_ICC_TEST_COMPLEX_ISINF_BROKEN (_MSVC_STL_VERSION && __INTEL_LLVM_COMPILER)
 #define _PSTL_ICC_TEST_COMPLEX_ISNAN_BROKEN (_MSVC_STL_VERSION && __INTEL_LLVM_COMPILER)
+// Defining this all on one line to delay evaluation of `_GLIBCXX_RELEASE` until later, when
+// _PSTL_ICC_TEST_UNDERLYING_TYPE_BROKEN is being used, and we can be confident that std lib macros are defined
 #define _PSTL_ICC_TEST_UNDERLYING_TYPE_BROKEN (_GLIBCXX_RELEASE && _GLIBCXX_RELEASE < 9)
 
 // Known limitation:

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -106,9 +106,9 @@
 // Defining this all on one line to delay evaluation of `defined(_GLIBCXX_RELEASE)` and `defined(_LIBCPP_VERSION)` until
 // later, when _ENABLE_RANGES_TESTING is being used, and we can be confident that std lib macros are defined
 #   define _ENABLE_RANGES_TESTING (_TEST_RANGES_FOR_CPP_17_DPCPP_BE_ONLY &&                                            \
-                                   ((defined(_GLIBCXX_RELEASE) && _GLIBCXX_RELEASE >= 8 && __GLIBCXX__ >= 20180502) || \
-                                    (defined(_LIBCPP_VERSION) && _LIBCPP_VERSION >= 7000) ||                           \
-                                    (!defined(_GLIBCXX_RELEASE) && !defined(_LIBCPP_VERSION))))
+                                   ((_GLIBCXX_RELEASE > 0 && _GLIBCXX_RELEASE >= 8 && __GLIBCXX__ >= 20180502) || \
+                                    (_LIBCPP_VERSION > 0 && _LIBCPP_VERSION >= 7000) ||                           \
+                                    (!_GLIBCXX_RELEASE && !_LIBCPP_VERSION)))
 #endif //!defined(_ENABLE_RANGES_TESTING)
 
 #define TEST_HAS_NO_INT128


### PR DESCRIPTION
Following the lead of https://github.com/oneapi-src/oneDPL/pull/1543, we have a similar issue in another place.

This PR adjusts the standard library implementation specific macros withing `test_config.h` to be lazily evaluated later when they are used, and we can be confident that a standard library header will have been included.  

During `test_config.h`, generally this is the first include, and we do not have knowledge of the standard library, so `#if` checks in macro definitions here can lead to mismatched results to if they are lazily evaluated.  

For `transform2_ranges_factory_sycl.pass`, this can cause compiler errors in situations where `_GLIBCXX_RELEASE < 8`.

I've also added comments to be more explicit about this to be able to avoid similar errors in the future.


In the serial backends, we see compiler errors when including some standard library header from `test_config.h` to populate these macros, instead of relying upon this lazy evaluation. This should be investigated, but for now lets apply this workaround.