### PR TITLE
Improvements of add_new_timing method

### DIFF
--- a/include/oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h
@@ -124,9 +124,10 @@ class auto_tune_policy
         void
         add_new_timing(resource_with_index_t r, timing_t t)
         {
-            std::lock_guard<std::mutex> l(m_);
             auto index = r.index_;
             timing_t new_value = t;
+
+            std::lock_guard<std::mutex> l(m_);
 
             // ignore the 1st timing to cover for JIT compilation
             auto emplace_res = time_by_index_.try_emplace(index, time_data_t{0, std::numeric_limits<timing_t>::max()});

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h
@@ -131,8 +131,13 @@ class auto_tune_policy
 
             // ignore the 1st timing to cover for JIT compilation
             auto emplace_res = time_by_index_.try_emplace(index, time_data_t{0, std::numeric_limits<timing_t>::max()});
+
+            // emplace_res is std::pair<time_by_index_t::iterator, bool> where
+            //  - emplace_res.first iterate inserted or existing element;
+            //  - emplace_res.second is true if new element inserted, false if element with such key already existed.
             if (!emplace_res.second)
             {
+                // get reference to time_data_t from already existing element
                 auto& td = emplace_res.first->second;
                 auto n = td.num_timings_;
                 new_value = (n * td.value_ + t) / (n + 1);

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/auto_tune_policy.h
@@ -127,14 +127,12 @@ class auto_tune_policy
             std::lock_guard<std::mutex> l(m_);
             auto index = r.index_;
             timing_t new_value = t;
-            if (time_by_index_.count(index) == 0)
+
+            // ignore the 1st timing to cover for JIT compilation
+            auto emplace_res = time_by_index_.try_emplace(index, time_data_t{0, std::numeric_limits<timing_t>::max()});
+            if (!emplace_res.second)
             {
-                // ignore the 1st timing to cover for JIT compilation
-                time_by_index_[index] = time_data_t{0, std::numeric_limits<timing_t>::max()};
-            }
-            else
-            {
-                auto& td = time_by_index_[index];
+                auto& td = emplace_res.first->second;
                 auto n = td.num_timings_;
                 new_value = (n * td.value_ + t) / (n + 1);
                 td.num_timings_ = n + 1;

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/dynamic_load_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/dynamic_load_policy.h
@@ -157,9 +157,10 @@ struct dynamic_load_policy
         }
         if (state_)
         {
-            std::lock_guard<std::mutex> l(state_->m_);
             std::shared_ptr<resource_t> least_loaded;
             int least_load = std::numeric_limits<load_t>::max();
+
+            std::lock_guard<std::mutex> l(state_->m_);
             for (int i = 0; i < state_->resources_.size(); i++)
             {
                 auto r = state_->resources_[i];

--- a/include/oneapi/dpl/internal/dynamic_selection_impl/dynamic_load_policy.h
+++ b/include/oneapi/dpl/internal/dynamic_selection_impl/dynamic_load_policy.h
@@ -161,9 +161,8 @@ struct dynamic_load_policy
             int least_load = std::numeric_limits<load_t>::max();
 
             std::lock_guard<std::mutex> l(state_->m_);
-            for (int i = 0; i < state_->resources_.size(); i++)
+            for (auto r : state_->resources_)
             {
-                auto r = state_->resources_[i];
                 load_t v = r->load_.load();
                 if (!least_loaded || v < least_load)
                 {


### PR DESCRIPTION
In this PR we doing the next steps:
- remove extra search on `time_by_index_` unordered map;
- doing possible actions without mutex.