### PR TITLE
[Tests] Adding windows vector alg workaround for swap

### DIFF
--- a/test/xpu_api/containers/sequences/array/array.special/swap1.pass.cpp
+++ b/test/xpu_api/containers/sequences/array/array.special/swap1.pass.cpp
@@ -16,6 +16,11 @@
 // <array>
 // template <class T, size_t N> void swap(array<T,N>& x, array<T,N>& y);
 
+// In Windows, as a temporary workaround, disable vector algorithm calls to avoid calls within sycl kernels
+#if defined(_MSC_VER)
+#    define _USE_STD_VECTOR_ALGORITHMS 0
+#endif
+
 #include "support/test_config.h"
 
 #include <oneapi/dpl/array>

--- a/test/xpu_api/containers/sequences/array/array.swap/swap.pass.cpp
+++ b/test/xpu_api/containers/sequences/array/array.swap/swap.pass.cpp
@@ -17,6 +17,11 @@
 // void swap(array& a);
 // namespace std { void swap(array<T, N> &x, array<T, N> &y);
 
+// In Windows, as a temporary workaround, disable vector algorithm calls to avoid calls within sycl kernels
+#if defined(_MSC_VER)
+#    define _USE_STD_VECTOR_ALGORITHMS 0
+#endif
+
 #include "support/test_config.h"
 
 #include <oneapi/dpl/array>


### PR DESCRIPTION
Similar to #766, swap and swap1 tests have issues with precompiled vector algorithms being used, and require a workaround for use in SYCL kernels on windows.