### PR TITLE
[Test] Replacing bad type to check for device_copyable

### DIFF
--- a/test/parallel_api/iterator/transform_iterator.pass.cpp
+++ b/test/parallel_api/iterator/transform_iterator.pass.cpp
@@ -174,10 +174,12 @@ test_copyable()
     static_assert(sycl::is_device_copyable_v<decltype(trans_count)>,
                   "transform_iterator is not device copyable with a counting iterator and noop lambda");
 
-    std::vector<int> array(10, 0);
-    auto trans_array = ::dpl::make_transform_iterator(array.begin(), [](auto i) { return i; });
+    sycl::queue q;
+    int* ptr = sycl::malloc_shared<int>(1, q);
+    auto trans_array = ::dpl::make_transform_iterator(ptr, [](auto i) { return i; });
     static_assert(sycl::is_device_copyable_v<decltype(trans_array)>,
-                  "transform_iterator is not device copyable with a host iterator and noop lambda");
+                  "transform_iterator is not device copyable with a pointer and noop lambda");
+    sycl::free(ptr, q);
 
     static_assert(sycl::is_device_copyable_v<
                       oneapi::dpl::transform_iterator<constant_iterator_device_copyable, noop_device_copyable>>,


### PR DESCRIPTION
It doesn't make sense to check a std::vector::iterator allocated on the host for device_copyability.  

We don't want to copy this to the device anyway.  A smarter check is to check with a pointer to usm shared memory.
Generally, this check passes anyway, however in some configurations on windows, std::vector:iterator is non device_copyable, resulting in a trigger for this static assertion.