### PR TITLE
Fix fp64 aspect error in tests

### DIFF
--- a/test/support/test_complex.h
+++ b/test/support/test_complex.h
@@ -51,9 +51,9 @@ int main(int, char**)                                                           
     using HasntLongDoubleSupportInCompiletime = ::std::false_type;                                    \
                                                                                                       \
     TestUtils::run_test_in_kernel(                                                                    \
-        /* labbda for the case when we have support of double type on device */                       \
+        /* lambda for the case when we have support of double type on device */                       \
         [&]() { run_test<HasDoubleTypeSupportInRuntime, HasntLongDoubleSupportInCompiletime>(); },    \
-        /* labbda for the case when we haven't support of double type on device */                    \
+        /* lambda for the case when we haven't support of double type on device */                    \
         [&]() { run_test<HasntDoubleTypeSupportInRuntime, HasntLongDoubleSupportInCompiletime>(); }); \
                                                                                                       \
     return TestUtils::done();                                                                         \

--- a/test/xpu_api/numerics/c.math/cmath.pass.cpp
+++ b/test/xpu_api/numerics/c.math/cmath.pass.cpp
@@ -101,7 +101,8 @@ void test_abs()
 #pragma clang diagnostic pop
 #endif
 
-    assert(dpl::abs(-1.) == 1);
+    assert(dpl::abs(-1.f) == 1.f);
+    IF_DOUBLE_SUPPORT(assert(dpl::abs(-1.) == 1));
 }
 
 ONEDPL_TEST_DECLARE

--- a/test/xpu_api/numerics/c.math/cmath.pass.cpp
+++ b/test/xpu_api/numerics/c.math/cmath.pass.cpp
@@ -102,7 +102,7 @@ void test_abs()
 #endif
 
     assert(dpl::abs(-1.f) == 1.f);
-    IF_DOUBLE_SUPPORT(assert(dpl::abs(-1.) == 1));
+    IF_DOUBLE_SUPPORT(assert(dpl::abs(-1.) == 1.));
 }
 
 ONEDPL_TEST_DECLARE

--- a/test/xpu_api/numerics/complex.number/cmplx.over/imag.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/imag.pass.cpp
@@ -21,7 +21,7 @@ void
 test(::std::enable_if_t<std::is_integral_v<T>>* = 0)
 {
     static_assert((std::is_same_v<decltype(dpl::imag(T(x))), double>));
-    assert(dpl::imag(x) == 0);
+    assert(dpl::imag(T(x)) == 0);
 
     constexpr T val {x};
     STD_COMPLEX_TESTS_STATIC_ASSERT(dpl::imag(val) == 0);
@@ -34,7 +34,7 @@ void
 test(::std::enable_if_t<!std::is_integral_v<T>>* = 0)
 {
     static_assert((std::is_same_v<decltype(dpl::imag(T(x))), T>));
-    assert(dpl::imag(x) == 0);
+    assert(dpl::imag(T(x)) == 0);
 
     constexpr T val {x};
     STD_COMPLEX_TESTS_STATIC_ASSERT(dpl::imag(val) == 0);
@@ -57,9 +57,9 @@ ONEDPL_TEST_NUM_MAIN
     IF_DOUBLE_SUPPORT(test<double>())
     IF_LONG_DOUBLE_SUPPORT(test<long double>())
 #if _PSTL_TEST_COMPLEX_NON_FLOAT_AVAILABLE
-    test<int>();
-    test<unsigned>();
-    test<long long>();
+    IF_DOUBLE_SUPPORT(test<int>())
+    IF_DOUBLE_SUPPORT(test<unsigned>())
+    IF_DOUBLE_SUPPORT(test<long long>())
 #endif // _PSTL_TEST_COMPLEX_NON_FLOAT_AVAILABLE
 
   return 0;

--- a/test/xpu_api/numerics/complex.number/cmplx.over/real.pass.cpp
+++ b/test/xpu_api/numerics/complex.number/cmplx.over/real.pass.cpp
@@ -21,7 +21,7 @@ void
 test(::std::enable_if_t<std::is_integral_v<T>>* = 0)
 {
     static_assert((std::is_same_v<decltype(dpl::real(T(x))), double>));
-    assert(dpl::real(x) == x);
+    assert(dpl::real(T(x)) == x);
 
     constexpr T val {x};
     STD_COMPLEX_TESTS_STATIC_ASSERT(dpl::real(val) == val);
@@ -34,7 +34,7 @@ void
 test(::std::enable_if_t<!std::is_integral_v<T>>* = 0)
 {
     static_assert((std::is_same_v<decltype(dpl::real(T(x))), T>));
-    assert(dpl::real(x) == x);
+    assert(dpl::real(T(x)) == x);
 
     constexpr T val {x};
     STD_COMPLEX_TESTS_STATIC_ASSERT(dpl::real(val) == val);
@@ -57,9 +57,9 @@ ONEDPL_TEST_NUM_MAIN
     IF_DOUBLE_SUPPORT(test<double>())
     IF_LONG_DOUBLE_SUPPORT(test<long double>())
 #if _PSTL_TEST_COMPLEX_NON_FLOAT_AVAILABLE
-    test<int>();
-    test<unsigned>();
-    test<long long>();
+    IF_DOUBLE_SUPPORT(test<int>())
+    IF_DOUBLE_SUPPORT(test<unsigned>())
+    IF_DOUBLE_SUPPORT(test<long long>())
 #endif // _PSTL_TEST_COMPLEX_NON_FLOAT_AVAILABLE
 
   return 0;


### PR DESCRIPTION
In this PR we fix exceptions `Required aspect fp64 is not supported on the device` in three tests:
- `test/xpu_api/numerics/complex.number/cmplx.over/imag.pass.cpp`;
- `test/xpu_api/numerics/complex.number/cmplx.over/real.pass.cpp`;
- `test/xpu_api/numerics/c.math/cmath.pass.cpp`.