### PR TITLE
[Tests] Avoid usm-allocated vector iterators wrapped in custom iterators for FPGA

### DIFF
--- a/test/parallel_api/iterator/input_data_sweep_usm_allocator.pass.cpp
+++ b/test/parallel_api/iterator/input_data_sweep_usm_allocator.pass.cpp
@@ -109,8 +109,12 @@ main()
     test_usm_shared_alloc<float, 0>(policy1, -666.0f, n, "float");
     test_usm_shared_alloc<double, 0>(policy2, -666.0, n, "double");
     test_usm_shared_alloc<std::uint64_t, 0>(policy3, 999, n, "uint64_t");
+
+    #if !_PSTL_ICPX_FPGA_TEST_USM_VECTOR_ITERATOR_BROKEN
     // big recursion step: 1 and 2 layers of wrapping
     test_usm_shared_alloc<std::int32_t, 2>(policy4, -666, n, "int32_t");
+    #endif // !_PSTL_ICPX_FPGA_TEST_USM_VECTOR_ITERATOR_BROKEN
+
     //only use host alloc for int, it follows the same path as shared alloc
     test_usm_host_alloc<int, 0>(policy5, 666, n, "int");
 

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -195,4 +195,14 @@
 #define _PSTL_ICPX_TEST_MINMAX_ELEMENT_BROKEN                                                                         \
     (TEST_DPCPP_BACKEND_PRESENT && defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER < 20220300)
 
+// oneAPI DPC++ compiler fails to compile the sum of an integer and an iterator to a usm-allocated std vector when
+// building for an FPGA device.  This prevents fpga compilation of usm-allocated std vector wrapped in zip transform and
+// permutation iterators (as a map).
+#if (TEST_DPCPP_BACKEND_PRESENT && defined(ONEDPL_FPGA_DEVICE) && defined(__INTEL_LLVM_COMPILER) &&                   \
+        __INTEL_LLVM_COMPILER <= 20240200)
+#    define _PSTL_ICPX_FPGA_TEST_USM_VECTOR_ITERATOR_BROKEN 1
+#else
+#    define _PSTL_ICPX_FPGA_TEST_USM_VECTOR_ITERATOR_BROKEN 0
+#endif
+
 #endif // _TEST_CONFIG_H

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -196,8 +196,8 @@
     (TEST_DPCPP_BACKEND_PRESENT && defined(__INTEL_LLVM_COMPILER) && __INTEL_LLVM_COMPILER < 20220300)
 
 // oneAPI DPC++ compiler fails to compile the sum of an integer and an iterator to a usm-allocated std vector when
-// building for an FPGA device.  This prevents fpga compilation of usm-allocated std vector wrapped in zip transform and
-// permutation iterators (as a map).
+// building for an FPGA device.  This prevents fpga compilation of usm-allocated std vector wrapped in zip, transform,
+// and permutation iterators (as a map).
 #if (TEST_DPCPP_BACKEND_PRESENT && defined(ONEDPL_FPGA_DEVICE) && defined(__INTEL_LLVM_COMPILER) &&                   \
         __INTEL_LLVM_COMPILER <= 20240200)
 #    define _PSTL_ICPX_FPGA_TEST_USM_VECTOR_ITERATOR_BROKEN 1

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -198,6 +198,7 @@
 // oneAPI DPC++ compiler fails to compile the sum of an integer and an iterator to a usm-allocated std vector when
 // building for an FPGA device.  This prevents fpga compilation of usm-allocated std vector wrapped in zip, transform,
 // and permutation iterators (as a map).
+// TODO: Update intel llvm version number as releases are made until a fix is in place.
 #if (TEST_DPCPP_BACKEND_PRESENT && defined(ONEDPL_FPGA_DEVICE) && defined(__INTEL_LLVM_COMPILER) &&                   \
         __INTEL_LLVM_COMPILER <= 20240200)
 #    define _PSTL_ICPX_FPGA_TEST_USM_VECTOR_ITERATOR_BROKEN 1


### PR DESCRIPTION
In the Intel LLVM compiler when building for FPGA, usm-allocated vector iterators fail to build when summed with an integer.  
This means that using usm-allocated vector iterators cannot be used in a `zip_iterator`, `transform_iterator` or `permutation_iterator` as a map and then dereferenced with the bracket operator.

This PR skips testing these input types for intel llvm compiler 2024.2 or earlier.

(This has been reported to the intel llvm compiler. Depending on when the fix is made, we may need to update the macro with the appropriate version)