### PR TITLE
Pinning dependencies per OSSF security practices and coverting to ASCII

### DIFF
--- a/documentation/library_guide/requirements.txt
+++ b/documentation/library_guide/requirements.txt
@@ -10,8 +10,8 @@ sphinxcontrib_htmlhelp<2.0.4
 sphinxcontrib_qthelp<1.0.6
 sphinxcontrib-serializinghtml<1.1.10
 
-sphinx_book_theme
+sphinx_book_theme==1.1.2
 sphinx-intl==2.0.0
-sphinx-tabs
-sphinx-prompt
-sphinx_substitution_extensions
+sphinx-tabs==3.4.5
+sphinx-prompt==1.8.0
+sphinx_substitution_extensions==2024.2.25

--- a/documentation/library_guide/requirements.txt
+++ b/documentation/library_guide/requirements.txt
@@ -10,8 +10,8 @@ sphinxcontrib_htmlhelp<2.0.4
 sphinxcontrib_qthelp<1.0.6
 sphinxcontrib-serializinghtml<1.1.10
 
-sphinx_book_theme==1.1.2
+sphinx_book_theme==1.0.1
 sphinx-intl==2.0.0
 sphinx-tabs==3.4.5
-sphinx-prompt==1.8.0
-sphinx_substitution_extensions==2024.2.25
+sphinx-prompt==1.5.0
+sphinx_substitution_extensions==2022.2.16


### PR DESCRIPTION
https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies recommends explicitly pinning dependencies to reduce several security risks.

Line endings in the file were inconsistent so I converted them all to ASCII instead of a mix of CR and CRLF line endings.