### PR TITLE
notification in slack for PR with RFC label

### DIFF
--- a/.github/workflows/slack-pr.yaml
+++ b/.github/workflows/slack-pr.yaml
@@ -1,0 +1,27 @@
+name: Slack PR Notification
+on:
+  # use pull_request_target to run on PRs from forks and have access to secrets
+  pull_request_target:
+    types: [labeled]
+
+env:
+  SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+  channel: "onedpl"
+
+permissions:
+  pull-requests: read
+
+jobs:
+  rfc:
+    name: RFC Notification
+    runs-on: ubuntu-latest
+    # Trigger when labeling a PR with "RFC"
+    if: |
+      github.event.action == 'labeled' &&
+      contains(toJson(github.event.pull_request.labels.*.name), '"RFC"')
+    steps: 
+    - name: Notify Slack
+      uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
+      with:
+        channel-id: ${{ env.channel }}
+        slack-message: "${{ github.actor }} posted a RFC: ${{ github.event.pull_request.title }}. URL: ${{ github.event.pull_request.html_url }}"


### PR DESCRIPTION
Post notification to onedpl channel in uxlfoundation slack space when a PR is labeled with RFC. To see a sample notification, look at #rc-test channel in uxlfoundation slack workspace. This is same as https://github.com/oneapi-src/oneMKL/pull/481, except the channel name and making the (missing) license consistent with ci.yml.

To be functional, the PR must be merged and someone with admin access to the repo must add SLACK_BOT_TOKEN secret. I can provide the token in DM.

Partially addresses https://github.com/orgs/uxlfoundation/projects/5?pane=issue&itemId=56606873
@vbm23 @timmiesmith 