### PR TITLE
Remove assertions in minmax_element binary operator

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -522,9 +522,6 @@ __pattern_minmax_element(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _
         auto __chosen_for_min = __a;
         auto __chosen_for_max = __b;
 
-        assert(get<0>(__a) < get<0>(__b));
-        assert(get<1>(__a) < get<1>(__b));
-
         if (__comp(get<2>(__b), get<2>(__a)))
             __chosen_for_min = ::std::move(__b);
         if (__comp(get<3>(__b), get<3>(__a)))

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -608,9 +608,6 @@ __pattern_minmax_element(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _
         auto __chosen_for_min = __a;
         auto __chosen_for_max = __b;
 
-        assert(get<0>(__a) < get<0>(__b));
-        assert(get<1>(__a) < get<1>(__b));
-
         if (__comp(get<2>(__b), get<2>(__a)))
             __chosen_for_min = ::std::move(__b);
         if (__comp(get<3>(__b), get<3>(__a)))


### PR DESCRIPTION
The current `minmax_element` implementation requires in-order processing since its binary operator assumes that the index of the first input is lower than that of the second input. This is a performance improvement since we can skip the case when both input values are equal. The in-order processing is guaranteed by following the non-commutative reduce pattern. We currently check the index order with assertions with lead to high overheads when compiled without `NDEBUG`. This may lead to test timeouts or user code looking to be hanging. I think the assertions are not needed since we enforce them in the in-order reduce pattern and we don't use them in the similar `min_element` algorithm.