### PR TITLE
Fix accessor usage in `__usm_or_buffer_accessor` class

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -20,6 +20,8 @@
 #include <memory>
 #include <type_traits>
 #include <tuple>
+#include <optional>
+#include <utility>      // for std::in_place
 
 #include "../../iterator_impl.h"
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -491,8 +491,7 @@ struct __usm_or_buffer_accessor
     {
     }
     __usm_or_buffer_accessor(sycl::handler& __cgh, sycl::buffer<_T, 1>* __sycl_buf, size_t __acc_offset)
-        : __acc_opt(std::in_place, *__sycl_buf, __cgh, sycl::read_write, __dpl_sycl::__no_init{}),
-          __offset(__acc_offset)
+        : __usm_or_buffer_accessor(__cgh, __sycl_buf), __offset(__acc_offset)
     {
     }
 


### PR DESCRIPTION
In this PR we fixing compile error from tests:
```C++
In file included from /test/general/header_inclusion_order_async_1.pass.cpp:15:
In file included from /include/oneapi/dpl/execution:60:
In file included from /include/oneapi/dpl/internal/async_impl/glue_async_impl.h:20:
In file included from /include/oneapi/dpl/internal/async_impl/async_impl_hetero.h:20:
In file included from /include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h:22:
In file included from /include/oneapi/dpl/pstl/parallel_backend.h:32:
In file included from /include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h:32:
/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h:490:5: error: constructor for 'oneapi::dpl::__par_backend_hetero::__usm_host_or_buffer_accessor<float>' must explicitly initialize the member '__acc' which does not have a default constructor
    __usm_host_or_buffer_accessor(sycl::handler& __cgh, _T* __usm_buf) : __ptr(__usm_buf), __usm(true) {}
    ^
/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h:546:24: note: in instantiation of member function 'oneapi::dpl::__par_backend_hetero::__usm_host_or_buffer_accessor<float>::__usm_host_or_buffer_accessor' requested here
        return __usm ? __usm_host_or_buffer_accessor<_T>(__cgh, __usm_buf.get())
                       ^
/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h:478:18: note: member is declared here
    __accessor_t __acc;
                 ^
/../include/sycl/CL/sycl/accessor.hpp:788:28: note: 'sycl::accessor<float, 1, sycl::access::mode::read_write, sycl::access::target::global_buffer, sycl::access::placeholder::false_t>' declared here
class __SYCL_SPECIAL_CLASS accessor :
                           ^
1 error generated.
```

Due `Table 62. Constructors of the deprecated constant accessor` from https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_deprecated_features_of_the_accessor_class,
the `sycl::accessor` class doesn't has default constructor.




