### PR TITLE
Fix `__pattern_partial_sort_copy` forward declaration

### DIFF
--- a/include/oneapi/dpl/pstl/algorithm_fwd.h
+++ b/include/oneapi/dpl/pstl/algorithm_fwd.h
@@ -803,12 +803,13 @@ _RandomAccessIterator
 __pattern_partial_sort_copy(_Tag, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _RandomAccessIterator,
                             _RandomAccessIterator, _Compare) noexcept;
 
-template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _RandomAccessIterator, class _Compare>
-_RandomAccessIterator
-__pattern_partial_sort_copy(_Tag, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _RandomAccessIterator,
-                            _RandomAccessIterator, _Compare) noexcept;
+template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator1, class _RandomAccessIterator2,
+          class _Compare>
+_RandomAccessIterator2
+__pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator1,
+                            _RandomAccessIterator1, _RandomAccessIterator2, _RandomAccessIterator2, _Compare);
 
-//------------------------------------------------------------------------
+    //------------------------------------------------------------------------
 // adjacent_find
 //------------------------------------------------------------------------
 

--- a/include/oneapi/dpl/pstl/algorithm_fwd.h
+++ b/include/oneapi/dpl/pstl/algorithm_fwd.h
@@ -809,7 +809,7 @@ _RandomAccessIterator2
 __pattern_partial_sort_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator1,
                             _RandomAccessIterator1, _RandomAccessIterator2, _RandomAccessIterator2, _Compare);
 
-    //------------------------------------------------------------------------
+//------------------------------------------------------------------------
 // adjacent_find
 //------------------------------------------------------------------------
 


### PR DESCRIPTION
Fix `__pattern_partial_sort_copy` forward declaration :
 - we forgot to declare `__pattern_partial_sort_copy` with `__parallel_tag` as the first param.
 - 
Instead we had two declarations of the same `__pattern_partial_sort_copy` :
```C++
template <class _Tag, class _ExecutionPolicy, class _ForwardIterator, class _RandomAccessIterator, class _Compare>
_RandomAccessIterator
__pattern_partial_sort_copy(_Tag, _ExecutionPolicy&&, _ForwardIterator, _ForwardIterator, _RandomAccessIterator,
                            _RandomAccessIterator, _Compare) noexcept;
```

This issue has been introduced in the PR https://github.com/oneapi-src/oneDPL/pull/1239