### PR TITLE
Fix errors in `__pattern_sort` implementations and calls

### DIFF
--- a/include/oneapi/dpl/pstl/algorithm_fwd.h
+++ b/include/oneapi/dpl/pstl/algorithm_fwd.h
@@ -741,11 +741,7 @@ __pattern_partition_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomA
 // sort
 //------------------------------------------------------------------------
 
-template <class _ExecutionPolicy, class _RandomAccessIterator>
-decltype(auto)
-__select_backend_pattern_sort(_ExecutionPolicy&&, _RandomAccessIterator);
-
-    template <class _Tag, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
+template <class _Tag, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
 void
 __pattern_sort(_Tag, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _Compare) noexcept;
 

--- a/include/oneapi/dpl/pstl/algorithm_fwd.h
+++ b/include/oneapi/dpl/pstl/algorithm_fwd.h
@@ -741,15 +741,13 @@ __pattern_partition_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomA
 // sort
 //------------------------------------------------------------------------
 
-template <class _Tag, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _IsMoveConstructible>
+template <class _Tag, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
 void
-__pattern_sort(_Tag, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _Compare,
-               _IsMoveConstructible) noexcept;
+__pattern_sort(_Tag, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _Compare) noexcept;
 
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
 void
-__pattern_sort(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _Compare,
-               /*is_move_constructible=*/::std::true_type);
+__pattern_sort(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _Compare);
 
 //------------------------------------------------------------------------
 // stable_sort

--- a/include/oneapi/dpl/pstl/algorithm_fwd.h
+++ b/include/oneapi/dpl/pstl/algorithm_fwd.h
@@ -741,7 +741,11 @@ __pattern_partition_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomA
 // sort
 //------------------------------------------------------------------------
 
-template <class _Tag, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
+template <class _ExecutionPolicy, class _RandomAccessIterator>
+decltype(auto)
+__select_backend_pattern_sort(_ExecutionPolicy&&, _RandomAccessIterator);
+
+    template <class _Tag, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
 void
 __pattern_sort(_Tag, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _Compare) noexcept;
 

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -2392,10 +2392,9 @@ __pattern_partition_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _
 // sort
 //------------------------------------------------------------------------
 
-template <class _Tag, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _IsMoveConstructible>
+template <class _Tag, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
 void
-__pattern_sort(_Tag, _ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
-               _IsMoveConstructible) noexcept
+__pattern_sort(_Tag, _ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
 
@@ -2405,10 +2404,13 @@ __pattern_sort(_Tag, _ExecutionPolicy&&, _RandomAccessIterator __first, _RandomA
 template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
 void
 __pattern_sort(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
-               _RandomAccessIterator __last, _Compare __comp,
-               /*is_move_constructible=*/::std::true_type)
+               _RandomAccessIterator __last, _Compare __comp)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
+
+    using __value_type = typename std::iterator_traits<_RandomAccessIterator>::value_type;
+    static_assert(std::is_move_constructible<__value_type>::value,
+                  "The value type of RandomAccessIterator should be move constructible.");
 
     __internal::__except_handler([&]() {
         __par_backend::__parallel_stable_sort(

--- a/include/oneapi/dpl/pstl/glue_algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_impl.h
@@ -656,52 +656,15 @@ partition_copy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIter
                                                              __first, __last, __out_true, __out_false, __pred);
 }
 
-inline const oneapi::dpl::execution::parallel_policy&
-get_pattern_sort_unvectorized_policy(const oneapi::dpl::execution::parallel_unsequenced_policy&)
-{
-    return oneapi::dpl::execution::par;
-}
-
-inline const oneapi::dpl::execution::sequenced_policy&
-get_pattern_sort_unvectorized_policy(const oneapi::dpl::execution::unsequenced_policy&)
-{
-    return oneapi::dpl::execution::seq;
-}
-
-template <typename _ExecutionPolicy>
-const _ExecutionPolicy&
-get_pattern_sort_unvectorized_policy(const _ExecutionPolicy& __exec)
-{
-    return __exec;
-}
-
-template <class _ExecutionPolicy, class _RandomAccessIterator>
-decltype(auto)
-__select_backend_pattern_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first)
-{
-    using __value_type = typename ::std::iterator_traits<_RandomAccessIterator>::value_type;
-    if constexpr (std::is_move_constructible_v<__value_type>)
-    {
-        return oneapi::dpl::__internal::__select_backend(__exec, __first);
-    }
-    else
-    {
-        // Special case when value_type is not move constructible: we should use unsequenced policies for sorting
-        return oneapi::dpl::__internal::__select_backend(get_pattern_sort_unvectorized_policy(__exec), __first);
-    }
-}
-
 // [alg.sort]
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp)
 {
-    // Special case of __select_backend implementation for __pattern_sort
-    const auto __pattern_sort_dispatch_tag = __select_backend_pattern_sort(__exec, __first);
+    const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    oneapi::dpl::__internal::__pattern_sort(__pattern_sort_dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
-                                            __first, __last, __comp);
+    oneapi::dpl::__internal::__pattern_sort(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last);
 }
 
 template <class _ExecutionPolicy, class _RandomAccessIterator>

--- a/include/oneapi/dpl/pstl/glue_algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_impl.h
@@ -656,15 +656,52 @@ partition_copy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIter
                                                              __first, __last, __out_true, __out_false, __pred);
 }
 
+inline const oneapi::dpl::execution::parallel_policy&
+get_pattern_sort_unvectorized_policy(const oneapi::dpl::execution::parallel_unsequenced_policy&)
+{
+    return oneapi::dpl::execution::par;
+}
+
+inline const oneapi::dpl::execution::sequenced_policy&
+get_pattern_sort_unvectorized_policy(const oneapi::dpl::execution::unsequenced_policy&)
+{
+    return oneapi::dpl::execution::seq;
+}
+
+template <typename _ExecutionPolicy>
+const _ExecutionPolicy&
+get_pattern_sort_unvectorized_policy(const _ExecutionPolicy& __exec)
+{
+    return __exec;
+}
+
+template <class _ExecutionPolicy, class _RandomAccessIterator>
+decltype(auto)
+__select_backend_pattern_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first)
+{
+    using __value_type = typename ::std::iterator_traits<_RandomAccessIterator>::value_type;
+    if constexpr (std::is_move_constructible_v<__value_type>)
+    {
+        return oneapi::dpl::__internal::__select_backend(__exec, __first);
+    }
+    else
+    {
+        // Special case when value_type is not move constructible: we should use unsequenced policies for sorting
+        return oneapi::dpl::__internal::__select_backend(get_pattern_sort_unvectorized_policy(__exec), __first);
+    }
+}
+
 // [alg.sort]
 
 template <class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy>
 sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp)
 {
-    const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
+    // Special case of __select_backend implementation for __pattern_sort
+    const auto __pattern_sort_dispatch_tag = __select_backend_pattern_sort(__exec, __first);
 
-    oneapi::dpl::__internal::__pattern_sort(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last);
+    oneapi::dpl::__internal::__pattern_sort(__pattern_sort_dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
+                                            __first, __last, __comp);
 }
 
 template <class _ExecutionPolicy, class _RandomAccessIterator>

--- a/include/oneapi/dpl/pstl/glue_algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_impl.h
@@ -664,10 +664,7 @@ sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIter
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    typedef typename ::std::iterator_traits<_RandomAccessIterator>::value_type _InputType;
-
-    oneapi::dpl::__internal::__pattern_sort(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
-                                            __comp, typename ::std::is_move_constructible<_InputType>::type());
+    oneapi::dpl::__internal::__pattern_sort(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last);
 }
 
 template <class _ExecutionPolicy, class _RandomAccessIterator>

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1264,8 +1264,12 @@ __stable_sort_with_projection(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __ex
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _Compare>
 void
 __pattern_sort(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last,
-               _Compare __comp, /*is_move_constructible=*/::std::true_type)
+               _Compare __comp)
 {
+    using __value_type = typename std::iterator_traits<_Iterator>::value_type;
+    static_assert(std::is_move_constructible<__value_type>::value,
+                  "The value type of _Iterator should be move constructible.");
+
     __stable_sort_with_projection(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __comp,
                                   oneapi::dpl::identity{});
 }
@@ -1511,7 +1515,7 @@ __pattern_partial_sort_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
         __pattern_sort(
             __tag,
             __par_backend_hetero::make_wrapped_policy<__partial_sort_1>(::std::forward<_ExecutionPolicy>(__exec)),
-            __out_first, __out_end, __comp, ::std::true_type{});
+            __out_first, __out_end, __comp);
 
         return __out_end;
     }

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1510,16 +1510,14 @@ __pattern_partial_sort_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
         // runtime makes a dependency graph. In that case the call of __pattern_walk2 could be changed to 
         // be asynchronous for better performance.
 
-        // Special case of __select_backend implementation for __pattern_sort
         // TODO is it OK for call inside __pattern_partial_sort_copy?
         //      __pattern_partial_sort_copy hasn't any requirement for value iterated by _OutIterator
         //      and it's possible that it can be not move constructible.
-        const auto __pattern_sort_dispatch_tag = __select_backend_pattern_sort(__exec, __out_first);
 
         // Use regular sort as partial_sort isn't required to be stable.
         //__pattern_sort is a blocking call.
         __pattern_sort(
-            __pattern_sort_dispatch_tag,
+            __tag,
             __par_backend_hetero::make_wrapped_policy<__partial_sort_1>(::std::forward<_ExecutionPolicy>(__exec)),
             __out_first, __out_end, __comp);
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1510,10 +1510,16 @@ __pattern_partial_sort_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
         // runtime makes a dependency graph. In that case the call of __pattern_walk2 could be changed to 
         // be asynchronous for better performance.
 
+        // Special case of __select_backend implementation for __pattern_sort
+        // TODO is it OK for call inside __pattern_partial_sort_copy?
+        //      __pattern_partial_sort_copy hasn't any requirement for value iterated by _OutIterator
+        //      and it's possible that it can be not move constructible.
+        const auto __pattern_sort_dispatch_tag = __select_backend_pattern_sort(__exec, __out_first);
+
         // Use regular sort as partial_sort isn't required to be stable.
         //__pattern_sort is a blocking call.
         __pattern_sort(
-            __tag,
+            __pattern_sort_dispatch_tag,
             __par_backend_hetero::make_wrapped_policy<__partial_sort_1>(::std::forward<_ExecutionPolicy>(__exec)),
             __out_first, __out_end, __comp);
 


### PR DESCRIPTION
In this PR we implement another approach for the problem found in https://github.com/oneapi-src/oneDPL/pull/1599
Also approach from this PR is compatible with implementation of `__pattern_sort` from our up-stream:
https://github.com/search?q=repo%3Allvm%2Fllvm-project%20path%3A%2F%5Epstl%5C%2Finclude%5C%2Fpstl%5C%2F%2F%20__pattern_sort(&type=code

What we doing in this PR:
- remove `static_assert' check of tag type from  `__pattern_sort` + tag implemetation.
- pass real sign of `is_move_constructible` value into `__pattern_sort` from `__pattern_partial_sort_copy` + hetero impl.