### PR TITLE
Fix errors in `__pattern_sort` implementations and its calls

### DIFF
--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -2397,6 +2397,8 @@ void
 __pattern_sort(_Tag, _ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
                _IsMoveConstructible) noexcept
 {
+    static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag> || !_IsMoveConstructible::value);
+
     ::std::sort(__first, __last, __comp);
 }
 

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -2397,7 +2397,7 @@ void
 __pattern_sort(_Tag, _ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
                _IsMoveConstructible) noexcept
 {
-    static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
+    static_assert(__is_host_dispatch_tag_v<_Tag>);
 
     ::std::sort(__first, __last, __comp);
 }

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -2397,8 +2397,6 @@ void
 __pattern_sort(_Tag, _ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
                _IsMoveConstructible) noexcept
 {
-    static_assert(__is_host_dispatch_tag_v<_Tag>);
-
     ::std::sort(__first, __last, __comp);
 }
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1511,7 +1511,7 @@ __pattern_partial_sort_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& 
         __pattern_sort(
             __tag,
             __par_backend_hetero::make_wrapped_policy<__partial_sort_1>(::std::forward<_ExecutionPolicy>(__exec)),
-            __out_first, __out_end, __comp, typename ::std::is_move_constructible<_OutValueType>::type());
+            __out_first, __out_end, __comp, typename std::is_move_constructible<_OutValueType>::type());
 
         return __out_end;
     }


### PR DESCRIPTION
In this PR we implement another approach for the problem found in https://github.com/oneapi-src/oneDPL/pull/1599

What we doing in this PR:
- remove `static_assert` check of `tag` type from  `__pattern_sort` + tag implemetation.
- pass real sign of `is_move_constructible` value into `__pattern_sort` from `__pattern_partial_sort_copy` + hetero impl.

Looks like this approach fixing all topics described by @akukanov at https://github.com/oneapi-src/oneDPL/pull/1599#issuecomment-2129859538

The approach from this PR is compatible with implementation of `__pattern_sort` from our up-stream:
https://github.com/search?q=repo%3Allvm%2Fllvm-project%20path%3A%2F%5Epstl%5C%2Finclude%5C%2Fpstl%5C%2F%2F%20__pattern_sort(&type=code
where each call of `__pattern_sort` for non-`move_constructible` data types is processed by serial implementation:
```C++
template <class _Tag, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _IsMoveConstructible>
void
__pattern_sort(_Tag, _ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
               _IsMoveConstructible) noexcept
{
    std::sort(__first, __last, __comp);
}
```
Before this PR the idea that "each call of `__pattern_sort` for non-`move_constructible` data types is processed by serial implementation" has been broken in `oneDPL` implementation.

### Just for note

I think `oneDPL` implementation still doesn't support preconditions for `std::sort` :
1) The preconditions from https://en.cppreference.com/w/cpp/algorithm/sort requirements:
**If any of the following conditions is satisfied, the behavior is undefined**:
	(until C++11)
		The type of *first is not Swappable.				
	(since C++11)
		RandomIt is not ValueSwappable.
			The type of *first is not MoveConstructible.
			The type of *first is not MoveAssignable.
2) The preconditions from https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2023/n4971.pdf,
paragraph 27.8.2.1 sort [sort]:
**Preconditions**: The range [first, last) is a valid heap with respect to comp and proj. For the overloads
in namespace std, RandomAccessIterator meets the Cpp17ValueSwappable requirements (16.4.4.3)
and the type of *first meets the Cpp17MoveConstructible (Table 31) and Cpp17MoveAssignable
(Table 33) requirements.

Also, looks like the same preconditions has place for std::sort with ranges too.