### PR TITLE
Only declaration required as make_wrapped_policy template params

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -168,9 +168,7 @@ __pattern_walk3(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIt
 //------------------------------------------------------------------------
 
 template <typename _Name>
-struct __walk_brick_wrapper
-{
-};
+struct __walk_brick_wrapper;
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator, typename _Function>
 void
@@ -187,9 +185,7 @@ __pattern_walk_brick(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec,
 }
 
 template <typename _Name>
-struct __walk_brick_n_wrapper
-{
-};
+struct __walk_brick_n_wrapper;
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator, typename _Size,
           typename _Function>
@@ -209,9 +205,7 @@ __pattern_walk_brick_n(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exe
 //------------------------------------------------------------------------
 
 template <typename _Name>
-struct __walk2_brick_wrapper
-{
-};
+struct __walk2_brick_wrapper;
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator1, typename _ForwardIterator2,
           typename _Brick>
@@ -226,9 +220,7 @@ __pattern_walk2_brick(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec
 }
 
 template <typename _Name>
-struct __walk2_brick_n_wrapper
-{
-};
+struct __walk2_brick_n_wrapper;
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator1, typename _Size,
           typename _ForwardIterator2, typename _Brick>
@@ -247,9 +239,7 @@ __pattern_walk2_brick_n(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __ex
 //------------------------------------------------------------------------
 
 template <typename _Name>
-struct __walk2_transform_if_wrapper
-{
-};
+struct __walk2_transform_if_wrapper;
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator1, typename _ForwardIterator2,
           typename _Function>
@@ -268,9 +258,7 @@ __pattern_walk2_transform_if(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&&
 }
 
 template <typename _Name>
-struct __walk3_transform_if_wrapper
-{
-};
+struct __walk3_transform_if_wrapper;
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator1, typename _ForwardIterator2,
           typename _ForwardIterator3, typename _Function>
@@ -1002,13 +990,10 @@ __pattern_unique_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec
 }
 
 template <typename _Name>
-class copy_back_wrapper
-{
-};
+class copy_back_wrapper;
+
 template <typename _Name>
-class copy_back_wrapper2
-{
-};
+class copy_back_wrapper2;
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _Predicate>
 _Iterator
@@ -1970,9 +1955,7 @@ __pattern_set_symmetric_difference(__hetero_tag<_BackendTag> __tag, _ExecutionPo
 }
 
 template <typename _Name>
-class __shift_left_right
-{
-};
+class __shift_left_right;
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Range>
 oneapi::dpl::__internal::__difference_t<_Range>

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -990,10 +990,10 @@ __pattern_unique_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec
 }
 
 template <typename _Name>
-class copy_back_wrapper;
+struct copy_back_wrapper;
 
 template <typename _Name>
-class copy_back_wrapper2;
+struct copy_back_wrapper2;
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _Predicate>
 _Iterator
@@ -1955,7 +1955,7 @@ __pattern_set_symmetric_difference(__hetero_tag<_BackendTag> __tag, _ExecutionPo
 }
 
 template <typename _Name>
-class __shift_left_right;
+struct __shift_left_right;
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Range>
 oneapi::dpl::__internal::__difference_t<_Range>

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -58,10 +58,10 @@ __pattern_walk_n(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Function
 //------------------------------------------------------------------------
 
 template <typename _Name>
-class __swap1_wrapper;
+struct __swap1_wrapper;
 
 template <typename _Name>
-class __swap2_wrapper;
+struct __swap2_wrapper;
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Function>
 bool
@@ -475,10 +475,10 @@ __pattern_unique(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ra
 //------------------------------------------------------------------------
 
 template <typename _Name>
-class __copy1_wrapper;
+struct __copy1_wrapper;
 
 template <typename _Name>
-class __copy2_wrapper;
+struct __copy2_wrapper;
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3,
           typename _Compare>
@@ -632,22 +632,22 @@ __pattern_minmax_element(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _
 //------------------------------------------------------------------------
 
 template <typename _Name>
-class __copy_keys_wrapper;
+struct __copy_keys_wrapper;
 
 template <typename _Name>
-class __copy_values_wrapper;
+struct __copy_values_wrapper;
 
 template <typename _Name>
-class __reduce1_wrapper;
+struct __reduce1_wrapper;
 
 template <typename _Name>
-class __reduce2_wrapper;
+struct __reduce2_wrapper;
 
 template <typename _Name>
-class __assign_key1_wrapper;
+struct __assign_key1_wrapper;
 
 template <typename _Name>
-class __assign_key2_wrapper;
+struct __assign_key2_wrapper;
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3,
           typename _Range4, typename _BinaryPredicate, typename _BinaryOperator>

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -58,14 +58,10 @@ __pattern_walk_n(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Function
 //------------------------------------------------------------------------
 
 template <typename _Name>
-class __swap1_wrapper
-{
-};
+class __swap1_wrapper;
 
 template <typename _Name>
-class __swap2_wrapper
-{
-};
+class __swap2_wrapper;
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Function>
 bool
@@ -479,14 +475,10 @@ __pattern_unique(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ra
 //------------------------------------------------------------------------
 
 template <typename _Name>
-class __copy1_wrapper
-{
-};
+class __copy1_wrapper;
 
 template <typename _Name>
-class __copy2_wrapper
-{
-};
+class __copy2_wrapper;
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3,
           typename _Compare>
@@ -640,34 +632,22 @@ __pattern_minmax_element(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _
 //------------------------------------------------------------------------
 
 template <typename _Name>
-class __copy_keys_wrapper
-{
-};
+class __copy_keys_wrapper;
 
 template <typename _Name>
-class __copy_values_wrapper
-{
-};
+class __copy_values_wrapper;
 
 template <typename _Name>
-class __reduce1_wrapper
-{
-};
+class __reduce1_wrapper;
 
 template <typename _Name>
-class __reduce2_wrapper
-{
-};
+class __reduce2_wrapper;
 
 template <typename _Name>
-class __assign_key1_wrapper
-{
-};
+class __assign_key1_wrapper;
 
 template <typename _Name>
-class __assign_key2_wrapper
-{
-};
+class __assign_key2_wrapper;
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3,
           typename _Range4, typename _BinaryPredicate, typename _BinaryOperator>

--- a/include/oneapi/dpl/pstl/hetero/histogram_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/histogram_impl_hetero.h
@@ -113,9 +113,7 @@ __make_binhash_manager(oneapi::dpl::__internal::__custom_boundary_binhash<_Rando
 }
 
 template <typename _Name>
-struct __hist_fill_zeros_wrapper
-{
-};
+struct __hist_fill_zeros_wrapper;
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _RandomAccessIterator1, typename _Size,
           typename _BinHash, typename _RandomAccessIterator2>


### PR DESCRIPTION
In this PR we doing the next things:
1) Only declaration required as `make_wrapped_policy` template param
2) For aligning we declare these things always as `struct`.

The goal - to align these structures: their body isn't required.
And we have a lot of the same structures without body.
For example, 
```C++
template <typename Name>
class ExclusiveScan1;
template <typename Name>
class ExclusiveScan2;
```
and so far and so on.