### PR TITLE
Exclude sycl::half testing on FPGA devices in sort.pass

### DIFF
--- a/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/sort.pass.cpp
@@ -451,7 +451,7 @@ main()
             [](size_t k, size_t val) {
             return std::int16_t(val) * (k % 2 ? 1 : -1); });
 
-#if TEST_DPCPP_BACKEND_PRESENT
+#if TEST_DPCPP_BACKEND_PRESENT && !ONEDPL_FPGA_DEVICE
         auto convert = [](size_t k, size_t val) {
             constexpr std::uint16_t mask = 0xFFFFu;
             std::uint16_t raw = std::uint16_t(val & mask);


### PR DESCRIPTION
`sort.pass` currently fails on FPGA_EMU devices with the following error message:

```
 what():  Required aspect fp16 is not supported on the device
```

This PR removes `sycl::half` testing with FPGA devices to resolve this issue.