### PR TITLE
[oneDPL][make] + fix behavior (building exe file)  in cases of non-dpcpp backends

### DIFF
--- a/make/Makefile
+++ b/make/Makefile
@@ -66,7 +66,7 @@ test_%.offload.exe: test_%.offload$(OBJ_SFX) exception_list.offload$(OBJ_SFX)
 	$(CPLUS) $(CPLUS_FLAGS) $(KEY)c $< $(FKEY)o$@
 else
 %.pass.exe: %.pass.cpp $(PSTL_LIB_NAME) $(test_hdr) $(proj_root)/make/Makefile
-	$(CPLUS) $(CPLUS_FLAGS) $(LDFLAGS) $(DYN_LDFLAGS) $(PSTL_LIB_LINK) $<
+	$(CPLUS) $(CPLUS_FLAGS) $(LDFLAGS) $(DYN_LDFLAGS) $(PSTL_LIB_LINK) $< $(FKEY)o$@
 endif
 
 else ifneq (,$(filter $(backend), sycl sycl_only))


### PR DESCRIPTION
[oneDPL][make] + fix behavior (building exe file) in cases of non-dpcpp backends: -o<filename>.exe

Currently, oneDPL make file doesn't  build exe file (just compiles) in case of  non-dpcpp backends (tbb, omp, etc)
The PR introduces the change which  fixes that bug.