### PR TITLE
device_vector refactor into remote_vector 

### DIFF
--- a/include/oneapi/dpl/internal/distributed_ranges_impl/shp/containers/duplicated_vector.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/shp/containers/duplicated_vector.hpp
@@ -5,7 +5,7 @@
 #pragma once
 
 #include <oneapi/dpl/internal/distributed_ranges_impl/shp/allocators.hpp>
-#include <oneapi/dpl/internal/distributed_ranges_impl/shp/device_vector.hpp>
+#include <oneapi/dpl/internal/distributed_ranges_impl/shp/remote_vector.hpp>
 
 namespace oneapi::dpl::experimental::dr::shp
 {
@@ -14,7 +14,7 @@ template <typename T, typename Allocator = device_allocator<T>>
 class duplicated_vector
 {
   public:
-    using segment_type = device_vector<T, Allocator>;
+    using segment_type = remote_vector<T, Allocator>;
 
     using value_type = T;
     using size_type = std::size_t;

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/shp/distributed_vector.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/shp/distributed_vector.hpp
@@ -11,7 +11,7 @@
 #include <oneapi/dpl/internal/distributed_ranges_impl/detail/segments_tools.hpp>
 #include <oneapi/dpl/internal/distributed_ranges_impl/shp/allocators.hpp>
 #include <oneapi/dpl/internal/distributed_ranges_impl/shp/device_ptr.hpp>
-#include <oneapi/dpl/internal/distributed_ranges_impl/shp/device_vector.hpp>
+#include <oneapi/dpl/internal/distributed_ranges_impl/shp/remote_vector.hpp>
 #include <oneapi/dpl/internal/distributed_ranges_impl/shp/vector.hpp>
 
 namespace oneapi::dpl::experimental::dr::shp
@@ -138,8 +138,8 @@ template <typename T, typename Allocator = device_allocator<T>>
 struct distributed_vector
 {
   public:
-    using segment_type = device_vector<T, Allocator>;
-    using const_segment_type = std::add_const_t<device_vector<T, Allocator>>;
+    using segment_type = remote_vector<T, Allocator>;
+    using const_segment_type = std::add_const_t<remote_vector<T, Allocator>>;
 
     using value_type = T;
     using size_type = std::size_t;

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/shp/remote_vector.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/shp/remote_vector.hpp
@@ -11,10 +11,10 @@ namespace oneapi::dpl::experimental::dr::shp
 {
 
 template <typename T, typename Allocator>
-class device_vector : public vector<T, Allocator>
+class remote_vector : public vector<T, Allocator>
 {
   public:
-    constexpr device_vector() noexcept {}
+    constexpr remote_vector() noexcept {}
 
     using base = vector<T, Allocator>;
 
@@ -22,7 +22,7 @@ class device_vector : public vector<T, Allocator>
     using size_type = std::size_t;
     using difference_type = std::size_t;
 
-    constexpr device_vector(size_type count, const Allocator& alloc, size_type rank) : base(count, alloc), rank_(rank)
+    constexpr remote_vector(size_type count, const Allocator& alloc, size_type rank) : base(count, alloc), rank_(rank)
     {
     }
 
@@ -37,6 +37,6 @@ class device_vector : public vector<T, Allocator>
 };
 
 template <class Alloc>
-device_vector(std::size_t, const Alloc, std::size_t) -> device_vector<typename Alloc::value_type, Alloc>;
+remote_vector(std::size_t, const Alloc, std::size_t) -> remote_vector<typename Alloc::value_type, Alloc>;
 
 } // namespace oneapi::dpl::experimental::dr::shp

--- a/test/distributed-ranges/shp/containers.cpp
+++ b/test/distributed-ranges/shp/containers.cpp
@@ -107,7 +107,7 @@ TYPED_TEST(DistributedVectorTest, Resize) {
 
 template <typename AllocT> class DeviceVectorTest : public testing::Test {
 public:
-  using DeviceVec = dr::shp::device_vector<typename AllocT::value_type, AllocT>;
+  using DeviceVec = dr::shp::remote_vector<typename AllocT::value_type, AllocT>;
 };
 
 TYPED_TEST_SUITE(DeviceVectorTest, AllocatorTypes);


### PR DESCRIPTION
Refactor to avoid ambiguity between  ```oneapi::dpl::experimental::dr::shp::device_vector``` and ```dpct::device_vector```