### PR TITLE
Performance improvements of `__parallel_find_or` + `__device_backend_tag`

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -682,42 +682,19 @@ bool
 __pattern_any_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last,
                  _Pred __pred)
 {
-    using _difference_type = typename ::std::iterator_traits<_Iterator>::difference_type;
-
-    const _difference_type __n = __last - __first;
-    if (__n == 0)
+    if (__first == __last)
         return false;
 
-    using _result_type = oneapi::dpl::__internal::tuple<bool, _difference_type>;
-    const auto __init = _result_type{false, __n};
+    using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<_ExecutionPolicy, _Pred>;
 
-    // __counting_iterator_t - iterate position (index) in source data
-    using __counting_iterator_t = oneapi::dpl::counting_iterator<_difference_type>;
+    auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
+    auto __buf = __keep(__first, __last);
 
-    using _zipped_data_type = typename std::iterator_traits<decltype(oneapi::dpl::make_zip_iterator(__first, __counting_iterator_t{0}))>::value_type;
-
-    __find_if_binary_reduce_op<_zipped_data_type, /*_IsFirst*/ std::true_type> __reduce_op;
-    __find_if_unary_transform_op<_zipped_data_type, _Pred> __transform_op{__pred};
-
-    using _Functor = unseq_backend::walk_n<_ExecutionPolicy, decltype(__transform_op)>;
-    using _RepackedTp = __par_backend_hetero::__repacked_tuple_t<_result_type>;
-
-    auto __keep_src_data = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
-    auto __buf_src_data = __keep_src_data(__first, __last);
-
-    const __counting_iterator_t __counting_it_first{0}, __counting_it_last{__n};
-    auto __keep_counting_it = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, __counting_iterator_t>();
-    auto __buf_counting_it = __keep_counting_it(__counting_it_first, __counting_it_last);
-
-    auto res =
-        oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp, std::true_type /*is_commutative*/>(
-            _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-            __reduce_op, _Functor{__transform_op},
-            unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
-            oneapi::dpl::__ranges::make_zip_view(__buf_src_data.all_view(), __buf_counting_it.all_view()))
-            .get();
-
-    return std::get<0>(res);
+    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
+        _BackendTag{},
+        __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>(
+            ::std::forward<_ExecutionPolicy>(__exec)),
+        _Predicate{__pred}, __par_backend_hetero::__parallel_or_tag{}, __buf.all_view());
 }
 
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -646,6 +646,37 @@ __pattern_count(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator 
 // any_of
 //------------------------------------------------------------------------
 
+template <typename _Typle, typename _UnaryTransformOp>
+struct __find_if_unary_transform_op
+{
+    _UnaryTransformOp __transform_op;
+
+    template <typename Arg>
+    _Typle
+    operator()(const Arg& arg) const
+    {
+        return {__transform_op(std::get<0>(arg)), std::get<1>(arg)};
+    }
+};
+
+template <typename _Typle, typename _IsFirst>
+struct __find_if_binary_reduce_op
+{
+    _Typle
+    operator()(const _Typle& op1, const _Typle& op2) const
+    {
+        if (std::get<0>(op1) && std::get<0>(op2))
+        {
+            if constexpr (_IsFirst{})
+                return {true, std::min(std::get<1>(op1), std::get<1>(op2))};
+            else
+                return {true, std::max(std::get<1>(op1), std::get<1>(op2))};
+        }
+
+        return std::get<0>(op1) ? op1 : op2;
+    }
+};
+
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _Pred>
 bool
 __pattern_any_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last,

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -572,9 +572,9 @@ __pattern_adjacent_find(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _I
 
     // TODO: in case of conflicting names
     // __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>()
-    bool result = __par_backend_hetero::__parallel_find_or(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
-        _Predicate{adjacent_find_fn<_BinaryPredicate>{__predicate}}, __par_backend_hetero::__parallel_or_tag{},
+    bool result = __par_backend_hetero::__parallel_find_any(
+        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+        _Predicate{adjacent_find_fn<_BinaryPredicate>{__predicate}},
         oneapi::dpl::__ranges::make_zip_view(__buf1.all_view(), __buf2.all_view()));
 
     // inverted conditional because of
@@ -659,11 +659,11 @@ __pattern_any_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator
     auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
     auto __buf = __keep(__first, __last);
 
-    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
+    return oneapi::dpl::__par_backend_hetero::__parallel_find_any(
         _BackendTag{},
         __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>(
-            ::std::forward<_ExecutionPolicy>(__exec)),
-        _Predicate{__pred}, __par_backend_hetero::__parallel_or_tag{}, __buf.all_view());
+            std::forward<_ExecutionPolicy>(__exec)),
+        _Predicate{__pred}, __buf.all_view());
 }
 
 //------------------------------------------------------------------------
@@ -687,9 +687,8 @@ __pattern_equal(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator1
 
     // TODO: in case of conflicting names
     // __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>()
-    return !__par_backend_hetero::__parallel_find_or(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), _Predicate{equal_predicate<_Pred>{__pred}},
-        __par_backend_hetero::__parallel_or_tag{},
+    return !__par_backend_hetero::__parallel_find_any(
+        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), _Predicate{equal_predicate<_Pred>{__pred}},
         oneapi::dpl::__ranges::make_zip_view(__buf1.all_view(), __buf2.all_view()));
 }
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -694,7 +694,8 @@ __pattern_any_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator
     // __counting_iterator_t - iterate position (index) in source data
     using __counting_iterator_t = oneapi::dpl::counting_iterator<_difference_type>;
 
-    using _zipped_data_type = typename std::iterator_traits<decltype(oneapi::dpl::make_zip_iterator(__first, __counting_iterator_t{0}))>::value_type;
+    using _zipped_data_type = typename std::iterator_traits<decltype(oneapi::dpl::make_zip_iterator(
+        __first, __counting_iterator_t{0}))>::value_type;
 
     __find_if_binary_reduce_op<_zipped_data_type, /*_IsFirst*/ std::true_type> __reduce_op;
     __find_if_unary_transform_op<_zipped_data_type, _Pred> __transform_op{__pred};
@@ -702,17 +703,18 @@ __pattern_any_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator
     using _Functor = unseq_backend::walk_n<_ExecutionPolicy, decltype(__transform_op)>;
     using _RepackedTp = __par_backend_hetero::__repacked_tuple_t<_result_type>;
 
-    auto __keep_src_data = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
+    auto __keep_src_data =
+        oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
     auto __buf_src_data = __keep_src_data(__first, __last);
 
     const __counting_iterator_t __counting_it_first{0}, __counting_it_last{__n};
-    auto __keep_counting_it = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, __counting_iterator_t>();
+    auto __keep_counting_it =
+        oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, __counting_iterator_t>();
     auto __buf_counting_it = __keep_counting_it(__counting_it_first, __counting_it_last);
 
     auto res =
         oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp, std::true_type /*is_commutative*/>(
-            _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-            __reduce_op, _Functor{__transform_op},
+            _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), __reduce_op, _Functor{__transform_op},
             unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
             oneapi::dpl::__ranges::make_zip_view(__buf_src_data.all_view(), __buf_counting_it.all_view()))
             .get();
@@ -781,7 +783,8 @@ __pattern_find_if(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterato
     // __counting_iterator_t - iterate position (index) in source data
     using __counting_iterator_t = oneapi::dpl::counting_iterator<_difference_type>;
 
-    using _zipped_data_type = typename std::iterator_traits<decltype(oneapi::dpl::make_zip_iterator(__first, __counting_iterator_t{0}))>::value_type;
+    using _zipped_data_type = typename std::iterator_traits<decltype(oneapi::dpl::make_zip_iterator(
+        __first, __counting_iterator_t{0}))>::value_type;
 
     __find_if_binary_reduce_op<_zipped_data_type, /*_IsFirst*/ std::true_type> __reduce_op;
     __find_if_unary_transform_op<_zipped_data_type, _Pred> __transform_op{__pred};
@@ -789,17 +792,18 @@ __pattern_find_if(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterato
     using _Functor = unseq_backend::walk_n<_ExecutionPolicy, decltype(__transform_op)>;
     using _RepackedTp = __par_backend_hetero::__repacked_tuple_t<_result_type>;
 
-    auto __keep_src_data = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
+    auto __keep_src_data =
+        oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
     auto __buf_src_data = __keep_src_data(__first, __last);
 
     const __counting_iterator_t __counting_it_first{0}, __counting_it_last{__n};
-    auto __keep_counting_it = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, __counting_iterator_t>();
+    auto __keep_counting_it =
+        oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, __counting_iterator_t>();
     auto __buf_counting_it = __keep_counting_it(__counting_it_first, __counting_it_last);
 
     auto res =
         oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp, std::true_type /*is_commutative*/>(
-            _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-            __reduce_op, _Functor{__transform_op},
+            _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), __reduce_op, _Functor{__transform_op},
             unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
             oneapi::dpl::__ranges::make_zip_view(__buf_src_data.all_view(), __buf_counting_it.all_view()))
             .get();

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -646,37 +646,6 @@ __pattern_count(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator 
 // any_of
 //------------------------------------------------------------------------
 
-template <typename _Typle, typename _UnaryTransformOp>
-struct __find_if_unary_transform_op
-{
-    _UnaryTransformOp __transform_op;
-
-    template <typename Arg>
-    _Typle
-    operator()(const Arg& arg) const
-    {
-        return {__transform_op(std::get<0>(arg)), std::get<1>(arg)};
-    }
-};
-
-template <typename _Typle, typename _IsFirst>
-struct __find_if_binary_reduce_op
-{
-    _Typle
-    operator()(const _Typle& op1, const _Typle& op2) const
-    {
-        if (std::get<0>(op1) && std::get<0>(op2))
-        {
-            if constexpr (_IsFirst{})
-                return {true, std::min(std::get<1>(op1), std::get<1>(op2))};
-            else
-                return {true, std::max(std::get<1>(op1), std::get<1>(op2))};
-        }
-
-        return std::get<0>(op1) ? op1 : op2;
-    }
-};
-
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _Pred>
 bool
 __pattern_any_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last,

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -769,16 +769,42 @@ _Iterator
 __pattern_find_if(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last,
                   _Pred __pred)
 {
-    if (__first == __last)
+    using _difference_type = typename ::std::iterator_traits<_Iterator>::difference_type;
+
+    const _difference_type __n = __last - __first;
+    if (__n == 0)
         return __last;
 
-    using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<_ExecutionPolicy, _Pred>;
+    using _result_type = oneapi::dpl::__internal::tuple<bool, _difference_type>;
+    const auto __init = _result_type{false, __n};
 
-    return __par_backend_hetero::__parallel_find(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
-        __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first),
-        __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__last), _Predicate{__pred},
-        ::std::true_type{});
+    // __counting_iterator_t - iterate position (index) in source data
+    using __counting_iterator_t = oneapi::dpl::counting_iterator<_difference_type>;
+
+    using _zipped_data_type = typename std::iterator_traits<decltype(oneapi::dpl::make_zip_iterator(__first, __counting_iterator_t{0}))>::value_type;
+
+    __find_if_binary_reduce_op<_zipped_data_type, /*_IsFirst*/ std::true_type> __reduce_op;
+    __find_if_unary_transform_op<_zipped_data_type, _Pred> __transform_op{__pred};
+
+    using _Functor = unseq_backend::walk_n<_ExecutionPolicy, decltype(__transform_op)>;
+    using _RepackedTp = __par_backend_hetero::__repacked_tuple_t<_result_type>;
+
+    auto __keep_src_data = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
+    auto __buf_src_data = __keep_src_data(__first, __last);
+
+    const __counting_iterator_t __counting_it_first{0}, __counting_it_last{__n};
+    auto __keep_counting_it = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, __counting_iterator_t>();
+    auto __buf_counting_it = __keep_counting_it(__counting_it_first, __counting_it_last);
+
+    auto res =
+        oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp, std::true_type /*is_commutative*/>(
+            _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+            __reduce_op, _Functor{__transform_op},
+            unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
+            oneapi::dpl::__ranges::make_zip_view(__buf_src_data.all_view(), __buf_counting_it.all_view()))
+            .get();
+
+    return std::get<0>(res) ? __first + std::get<1>(res) : __last;
 }
 
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -646,24 +646,24 @@ __pattern_count(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator 
 // any_of
 //------------------------------------------------------------------------
 
-template <typename _Typle, typename _UnaryTransformOp>
+template <typename _Tuple, typename _UnaryTransformOp>
 struct __find_if_unary_transform_op
 {
     _UnaryTransformOp __transform_op;
 
     template <typename Arg>
-    _Typle
+    _Tuple
     operator()(const Arg& arg) const
     {
         return {__transform_op(std::get<0>(arg)), std::get<1>(arg)};
     }
 };
 
-template <typename _Typle, typename _IsFirst>
+template <typename _Tuple, typename _IsFirst>
 struct __find_if_binary_reduce_op
 {
-    _Typle
-    operator()(const _Typle& op1, const _Typle& op2) const
+    _Tuple
+    operator()(const _Tuple& op1, const _Tuple& op2) const
     {
         if (std::get<0>(op1) && std::get<0>(op2))
         {

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -646,24 +646,24 @@ __pattern_count(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator 
 // any_of
 //------------------------------------------------------------------------
 
-template <typename _Tuple, typename _UnaryTransformOp>
+template <typename _Typle, typename _UnaryTransformOp>
 struct __find_if_unary_transform_op
 {
     _UnaryTransformOp __transform_op;
 
     template <typename Arg>
-    _Tuple
+    _Typle
     operator()(const Arg& arg) const
     {
         return {__transform_op(std::get<0>(arg)), std::get<1>(arg)};
     }
 };
 
-template <typename _Tuple, typename _IsFirst>
+template <typename _Typle, typename _IsFirst>
 struct __find_if_binary_reduce_op
 {
-    _Tuple
-    operator()(const _Tuple& op1, const _Tuple& op2) const
+    _Typle
+    operator()(const _Typle& op1, const _Typle& op2) const
     {
         if (std::get<0>(op1) && std::get<0>(op2))
         {

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -769,42 +769,16 @@ _Iterator
 __pattern_find_if(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last,
                   _Pred __pred)
 {
-    using _difference_type = typename ::std::iterator_traits<_Iterator>::difference_type;
-
-    const _difference_type __n = __last - __first;
-    if (__n == 0)
+    if (__first == __last)
         return __last;
 
-    using _result_type = oneapi::dpl::__internal::tuple<bool, _difference_type>;
-    const auto __init = _result_type{false, __n};
+    using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<_ExecutionPolicy, _Pred>;
 
-    // __counting_iterator_t - iterate position (index) in source data
-    using __counting_iterator_t = oneapi::dpl::counting_iterator<_difference_type>;
-
-    using _zipped_data_type = typename std::iterator_traits<decltype(oneapi::dpl::make_zip_iterator(__first, __counting_iterator_t{0}))>::value_type;
-
-    __find_if_binary_reduce_op<_zipped_data_type, /*_IsFirst*/ std::true_type> __reduce_op;
-    __find_if_unary_transform_op<_zipped_data_type, _Pred> __transform_op{__pred};
-
-    using _Functor = unseq_backend::walk_n<_ExecutionPolicy, decltype(__transform_op)>;
-    using _RepackedTp = __par_backend_hetero::__repacked_tuple_t<_result_type>;
-
-    auto __keep_src_data = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
-    auto __buf_src_data = __keep_src_data(__first, __last);
-
-    const __counting_iterator_t __counting_it_first{0}, __counting_it_last{__n};
-    auto __keep_counting_it = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, __counting_iterator_t>();
-    auto __buf_counting_it = __keep_counting_it(__counting_it_first, __counting_it_last);
-
-    auto res =
-        oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp, std::true_type /*is_commutative*/>(
-            _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-            __reduce_op, _Functor{__transform_op},
-            unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
-            oneapi::dpl::__ranges::make_zip_view(__buf_src_data.all_view(), __buf_counting_it.all_view()))
-            .get();
-
-    return std::get<0>(res) ? __first + std::get<1>(res) : __last;
+    return __par_backend_hetero::__parallel_find(
+        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
+        __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first),
+        __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__last), _Predicate{__pred},
+        ::std::true_type{});
 }
 
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -682,19 +682,42 @@ bool
 __pattern_any_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last,
                  _Pred __pred)
 {
-    if (__first == __last)
+    using _difference_type = typename ::std::iterator_traits<_Iterator>::difference_type;
+
+    const _difference_type __n = __last - __first;
+    if (__n == 0)
         return false;
 
-    using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<_ExecutionPolicy, _Pred>;
+    using _result_type = oneapi::dpl::__internal::tuple<bool, _difference_type>;
+    const auto __init = _result_type{false, __n};
 
-    auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
-    auto __buf = __keep(__first, __last);
+    // __counting_iterator_t - iterate position (index) in source data
+    using __counting_iterator_t = oneapi::dpl::counting_iterator<_difference_type>;
 
-    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
-        _BackendTag{},
-        __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>(
-            ::std::forward<_ExecutionPolicy>(__exec)),
-        _Predicate{__pred}, __par_backend_hetero::__parallel_or_tag{}, __buf.all_view());
+    using _zipped_data_type = typename std::iterator_traits<decltype(oneapi::dpl::make_zip_iterator(__first, __counting_iterator_t{0}))>::value_type;
+
+    __find_if_binary_reduce_op<_zipped_data_type, /*_IsFirst*/ std::true_type> __reduce_op;
+    __find_if_unary_transform_op<_zipped_data_type, _Pred> __transform_op{__pred};
+
+    using _Functor = unseq_backend::walk_n<_ExecutionPolicy, decltype(__transform_op)>;
+    using _RepackedTp = __par_backend_hetero::__repacked_tuple_t<_result_type>;
+
+    auto __keep_src_data = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
+    auto __buf_src_data = __keep_src_data(__first, __last);
+
+    const __counting_iterator_t __counting_it_first{0}, __counting_it_last{__n};
+    auto __keep_counting_it = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, __counting_iterator_t>();
+    auto __buf_counting_it = __keep_counting_it(__counting_it_first, __counting_it_last);
+
+    auto res =
+        oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp, std::true_type /*is_commutative*/>(
+            _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+            __reduce_op, _Functor{__transform_op},
+            unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
+            oneapi::dpl::__ranges::make_zip_view(__buf_src_data.all_view(), __buf_counting_it.all_view()))
+            .get();
+
+    return std::get<0>(res);
 }
 
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -694,8 +694,7 @@ __pattern_any_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator
     // __counting_iterator_t - iterate position (index) in source data
     using __counting_iterator_t = oneapi::dpl::counting_iterator<_difference_type>;
 
-    using _zipped_data_type = typename std::iterator_traits<decltype(oneapi::dpl::make_zip_iterator(
-        __first, __counting_iterator_t{0}))>::value_type;
+    using _zipped_data_type = typename std::iterator_traits<decltype(oneapi::dpl::make_zip_iterator(__first, __counting_iterator_t{0}))>::value_type;
 
     __find_if_binary_reduce_op<_zipped_data_type, /*_IsFirst*/ std::true_type> __reduce_op;
     __find_if_unary_transform_op<_zipped_data_type, _Pred> __transform_op{__pred};
@@ -703,18 +702,17 @@ __pattern_any_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator
     using _Functor = unseq_backend::walk_n<_ExecutionPolicy, decltype(__transform_op)>;
     using _RepackedTp = __par_backend_hetero::__repacked_tuple_t<_result_type>;
 
-    auto __keep_src_data =
-        oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
+    auto __keep_src_data = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
     auto __buf_src_data = __keep_src_data(__first, __last);
 
     const __counting_iterator_t __counting_it_first{0}, __counting_it_last{__n};
-    auto __keep_counting_it =
-        oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, __counting_iterator_t>();
+    auto __keep_counting_it = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, __counting_iterator_t>();
     auto __buf_counting_it = __keep_counting_it(__counting_it_first, __counting_it_last);
 
     auto res =
         oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp, std::true_type /*is_commutative*/>(
-            _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), __reduce_op, _Functor{__transform_op},
+            _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+            __reduce_op, _Functor{__transform_op},
             unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
             oneapi::dpl::__ranges::make_zip_view(__buf_src_data.all_view(), __buf_counting_it.all_view()))
             .get();
@@ -783,8 +781,7 @@ __pattern_find_if(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterato
     // __counting_iterator_t - iterate position (index) in source data
     using __counting_iterator_t = oneapi::dpl::counting_iterator<_difference_type>;
 
-    using _zipped_data_type = typename std::iterator_traits<decltype(oneapi::dpl::make_zip_iterator(
-        __first, __counting_iterator_t{0}))>::value_type;
+    using _zipped_data_type = typename std::iterator_traits<decltype(oneapi::dpl::make_zip_iterator(__first, __counting_iterator_t{0}))>::value_type;
 
     __find_if_binary_reduce_op<_zipped_data_type, /*_IsFirst*/ std::true_type> __reduce_op;
     __find_if_unary_transform_op<_zipped_data_type, _Pred> __transform_op{__pred};
@@ -792,18 +789,17 @@ __pattern_find_if(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterato
     using _Functor = unseq_backend::walk_n<_ExecutionPolicy, decltype(__transform_op)>;
     using _RepackedTp = __par_backend_hetero::__repacked_tuple_t<_result_type>;
 
-    auto __keep_src_data =
-        oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
+    auto __keep_src_data = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
     auto __buf_src_data = __keep_src_data(__first, __last);
 
     const __counting_iterator_t __counting_it_first{0}, __counting_it_last{__n};
-    auto __keep_counting_it =
-        oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, __counting_iterator_t>();
+    auto __keep_counting_it = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, __counting_iterator_t>();
     auto __buf_counting_it = __keep_counting_it(__counting_it_first, __counting_it_last);
 
     auto res =
         oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp, std::true_type /*is_commutative*/>(
-            _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), __reduce_op, _Functor{__transform_op},
+            _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+            __reduce_op, _Functor{__transform_op},
             unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
             oneapi::dpl::__ranges::make_zip_view(__buf_src_data.all_view(), __buf_counting_it.all_view()))
             .get();

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -105,9 +105,8 @@ __pattern_equal(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range1&& 
 
     // TODO: in case of conflicting names
     // __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>()
-    return !oneapi::dpl::__par_backend_hetero::__parallel_find_or(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), _Predicate{equal_predicate<_Pred>{__pred}},
-        oneapi::dpl::__par_backend_hetero::__parallel_or_tag{},
+    return !oneapi::dpl::__par_backend_hetero::__parallel_find_any(
+        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), _Predicate{equal_predicate<_Pred>{__pred}},
         oneapi::dpl::__ranges::zip_view(::std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2)));
 }
 
@@ -126,10 +125,10 @@ __pattern_find_if(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&&
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<_ExecutionPolicy, _Pred>;
     using _TagType = oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_Range>;
 
-    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
+    return oneapi::dpl::__par_backend_hetero::__parallel_find_first(
         _BackendTag{},
         __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__find_policy_wrapper>(
-            ::std::forward<_ExecutionPolicy>(__exec)),
+            std::forward<_ExecutionPolicy>(__exec)),
         _Predicate{__pred}, _TagType{}, ::std::forward<_Range>(__rng));
 }
 
@@ -156,10 +155,10 @@ __pattern_find_end(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _
     using _Predicate = unseq_backend::multiple_match_pred<_ExecutionPolicy, _Pred>;
     using _TagType = __par_backend_hetero::__parallel_find_backward_tag<_Range1>;
 
-    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
+    return oneapi::dpl::__par_backend_hetero::__parallel_find_first(
         _BackendTag{},
         __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__find_policy_wrapper>(
-            ::std::forward<_ExecutionPolicy>(__exec)),
+            std::forward<_ExecutionPolicy>(__exec)),
         _Predicate{__pred}, _TagType{}, ::std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2));
 }
 
@@ -180,11 +179,11 @@ __pattern_find_first_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R
     using _TagType = oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_Range1>;
 
     //TODO: To check whether it makes sense to iterate over the second sequence in case of __rng1.size() < __rng2.size()
-    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
+    return oneapi::dpl::__par_backend_hetero::__parallel_find_first(
         _BackendTag{},
         __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__find_policy_wrapper>(
-            ::std::forward<_ExecutionPolicy>(__exec)),
-        _Predicate{__pred}, _TagType{}, ::std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2));
+            std::forward<_ExecutionPolicy>(__exec)),
+        _Predicate{__pred}, _TagType{}, std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2));
 }
 
 //------------------------------------------------------------------------
@@ -199,11 +198,11 @@ __pattern_any_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&& 
         return false;
 
     using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<_ExecutionPolicy, _Pred>;
-    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
+    return oneapi::dpl::__par_backend_hetero::__parallel_find_any(
         _BackendTag{},
         __par_backend_hetero::make_wrapped_policy<oneapi::dpl::__par_backend_hetero::__or_policy_wrapper>(
-            ::std::forward<_ExecutionPolicy>(__exec)),
-        _Predicate{__pred}, oneapi::dpl::__par_backend_hetero::__parallel_or_tag{}, ::std::forward<_Range>(__rng));
+            std::forward<_ExecutionPolicy>(__exec)),
+        _Predicate{__pred}, std::forward<_Range>(__rng));
 }
 
 //------------------------------------------------------------------------
@@ -237,11 +236,11 @@ __pattern_search(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Ra
     using _Predicate = unseq_backend::multiple_match_pred<_ExecutionPolicy, _Pred>;
     using _TagType = oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_Range1>;
 
-    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
+    return oneapi::dpl::__par_backend_hetero::__parallel_find_first(
         _BackendTag{},
         oneapi::dpl::__par_backend_hetero::make_wrapped_policy<
-            oneapi::dpl::__par_backend_hetero::__find_policy_wrapper>(::std::forward<_ExecutionPolicy>(__exec)),
-        _Predicate{__pred}, _TagType{}, ::std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2));
+            oneapi::dpl::__par_backend_hetero::__find_policy_wrapper>(std::forward<_ExecutionPolicy>(__exec)),
+        _Predicate{__pred}, _TagType{}, std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2));
 }
 
 //------------------------------------------------------------------------
@@ -292,22 +291,37 @@ __pattern_adjacent_find(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _R
 
     using _Predicate =
         oneapi::dpl::unseq_backend::single_match_pred<_ExecutionPolicy, adjacent_find_fn<_BinaryPredicate>>;
-    using _TagType = ::std::conditional_t<__is__or_semantic(), oneapi::dpl::__par_backend_hetero::__parallel_or_tag,
-                                          oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_Range>>;
-
     auto __rng1 = __rng | oneapi::dpl::experimental::ranges::views::take(__rng.size() - 1);
     auto __rng2 = __rng | oneapi::dpl::experimental::ranges::views::drop(1);
 
-    // TODO: in case of conflicting names
-    // __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>()
-    auto result = oneapi::dpl::__par_backend_hetero::__parallel_find_or(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
-        _Predicate{adjacent_find_fn<_BinaryPredicate>{__predicate}}, _TagType{},
-        oneapi::dpl::__ranges::zip_view(__rng1, __rng2));
+    if constexpr (__is__or_semantic())
+    {
+        // TODO: in case of conflicting names
+        // __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>()
+        auto result = oneapi::dpl::__par_backend_hetero::__parallel_find_any(
+            _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+            _Predicate{adjacent_find_fn<_BinaryPredicate>{__predicate}},
+            oneapi::dpl::__ranges::zip_view(__rng1, __rng2));
 
-    // inverted conditional because of
-    // reorder_predicate in glue_algorithm_impl.h
-    return return_value(result, __rng.size(), __is__or_semantic);
+        // inverted conditional because of
+        // reorder_predicate in glue_algorithm_impl.h
+        return return_value(result, __rng.size(), __is__or_semantic);
+    }
+    else
+    {
+	    using _TagType = oneapi::dpl::__par_backend_hetero::__parallel_find_forward_tag<_Range>;
+    
+        // TODO: in case of conflicting names
+        // __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>()
+        auto result = oneapi::dpl::__par_backend_hetero::__parallel_find_first(
+            _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
+            _Predicate{adjacent_find_fn<_BinaryPredicate>{__predicate}}, _TagType{},
+            oneapi::dpl::__ranges::zip_view(__rng1, __rng2));
+
+        // inverted conditional because of
+        // reorder_predicate in glue_algorithm_impl.h
+        return return_value(result, __rng.size(), __is__or_semantic);
+    }
 }
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Range, typename _Predicate>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1055,11 +1055,10 @@ struct __early_exit_find_or
         {
             // Point #B1 - not required to have _ShiftedIdxType
 
-            _IterSize __current_iter = __i;
             // Point #B2 - not required
 
             // Point #B3 - rewritten
-            const auto __shifted_idx = __init_index + __current_iter * __shift;
+            const auto __shifted_idx = __init_index + __i * __shift;
             // Point #B4 - rewritten
             if (__shifted_idx < __n && __pred(__shifted_idx, __rngs...))
             {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1084,12 +1084,12 @@ __parallel_find_any(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPol
 
     // scope is to copy data back to __result after destruction of temporary sycl:buffer
     {
-        sycl::buffer<_AtomicType, 1> __temp(&__result, 1); // temporary storage for global atomic
+        sycl::buffer<_AtomicType, 1> __result_buf(&__result, 1); // temporary storage for global atomic
 
         // main parallel_for
         __exec.queue().submit([&](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rngs...);
-            auto __temp_acc = __temp.template get_access<access_mode::read_write>(__cgh);
+            auto __result_buf_acc = __result_buf.template get_access<access_mode::read_write>(__cgh);
 
 #if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
             __cgh.use_kernel_bundle(__kernel.get_kernel_bundle());
@@ -1102,7 +1102,7 @@ __parallel_find_any(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPol
                                           sycl::range</*dim=*/1>(__wgroup_size)),
                 [=](sycl::nd_item</*dim=*/1> __item_id) {
                     __dpl_sycl::__atomic_ref<_AtomicType, sycl::access::address_space::global_space> __found(
-                        *__dpl_sycl::__get_accessor_ptr(__temp_acc));
+                        *__dpl_sycl::__get_accessor_ptr(__result_buf_acc));
 
                     // Set found state result to global atomic
                     if (__pred(__item_id, __n_iter, __wgroup_size, __rngs...))

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1182,7 +1182,6 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
                 sycl::nd_range</*dim=*/1>(sycl::range</*dim=*/1>(__n_groups * __wgroup_size),
                                           sycl::range</*dim=*/1>(__wgroup_size)),
                 [=](sycl::nd_item</*dim=*/1> __item_id) {
-
                     __dpl_sycl::__atomic_ref<_AtomicType, sycl::access::address_space::global_space> __found(
                         *__dpl_sycl::__get_accessor_ptr(__temp_acc));
                     // Point #A1 - not required
@@ -1211,8 +1210,7 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
 }
 
 // Specialization for __parallel_find_forward_tag, __parallel_find_backward_tag
-template <typename _ExecutionPolicy, typename _Brick, typename _BrickTag,
-          typename... _Ranges>
+template <typename _ExecutionPolicy, typename _Brick, typename _BrickTag, typename... _Ranges>
 oneapi::dpl::__internal::__difference_t<typename oneapi::dpl::__ranges::__get_first_range_type<_Ranges...>::type>
 __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Brick __f,
                    _BrickTag __brick_tag, _Ranges&&... __rngs)
@@ -1295,8 +1293,7 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
                     // Set local atomic value to global atomic
                     if (__local_idx == 0)
                     {
-                        for (auto __old = __found.load(); __comp(__found_local.load(), __old);
-                                __old = __found.load())
+                        for (auto __old = __found.load(); __comp(__found_local.load(), __old); __old = __found.load())
                         {
                             __found.compare_exchange_strong(__old, __found_local.load());
                         }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1124,7 +1124,7 @@ __parallel_find_any(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPol
                     // Set found state result to global atomic
                     if (__found_local != __init_value)
                     {
-                        __found.fetch_or(__found_local);
+                        __found.store(__found_local);
                     }
                 });
         });

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1293,7 +1293,7 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
 
                     // Point #A4
                     // Set local atomic value to global atomic
-                    if (__local_idx == 0 && __comp(__found_local.load(), __found.load()))
+                    if (__local_idx == 0)
                     {
                         for (auto __old = __found.load(); __comp(__found_local.load(), __old);
                                 __old = __found.load())

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1072,7 +1072,7 @@ __parallel_find_any(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPol
 {
     using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
     using _AtomicType = typename __parallel_or_tag::_AtomicType;
-    using _FindOrKernel =
+    using _FindAnyKernel =
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<__find_any_kernel, _CustomName, _Brick,
                                                                                _Ranges...>;
 
@@ -1082,7 +1082,7 @@ __parallel_find_any(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPol
     // TODO: find a way to generalize getting of reliable work-group size
     auto __wgroup_size = oneapi::dpl::__internal::__max_work_group_size(__exec);
 #if _ONEDPL_COMPILE_KERNEL
-    auto __kernel = __internal::__kernel_compiler<_FindOrKernel>::__compile(__exec);
+    auto __kernel = __internal::__kernel_compiler<_FindAnyKernel>::__compile(__exec);
     __wgroup_size = ::std::min(__wgroup_size, oneapi::dpl::__internal::__kernel_work_group_size(__exec, __kernel));
 #endif
     auto __max_cu = oneapi::dpl::__internal::__max_compute_units(__exec);
@@ -1112,7 +1112,7 @@ __parallel_find_any(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPol
 #if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
             __cgh.use_kernel_bundle(__kernel.get_kernel_bundle());
 #endif
-            __cgh.parallel_for<_FindOrKernel>(
+            __cgh.parallel_for<_FindAnyKernel>(
 #if _ONEDPL_COMPILE_KERNEL && !_ONEDPL_KERNEL_BUNDLE_PRESENT
                 __kernel,
 #endif
@@ -1214,7 +1214,7 @@ __parallel_find_first(oneapi::dpl::__internal::__device_backend_tag, _ExecutionP
 {
     using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
     using _AtomicType = typename _BrickTag::_AtomicType;
-    using _FindOrKernel =
+    using _FindFirstKernel =
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<__find_first_kernel, _CustomName, _Brick,
                                                                                _BrickTag, _Ranges...>;
 
@@ -1225,7 +1225,7 @@ __parallel_find_first(oneapi::dpl::__internal::__device_backend_tag, _ExecutionP
     // TODO: find a way to generalize getting of reliable work-group size
     auto __wgroup_size = oneapi::dpl::__internal::__max_work_group_size(__exec);
 #if _ONEDPL_COMPILE_KERNEL
-    auto __kernel = __internal::__kernel_compiler<_FindOrKernel>::__compile(__exec);
+    auto __kernel = __internal::__kernel_compiler<_FindFirstKernel>::__compile(__exec);
     __wgroup_size = ::std::min(__wgroup_size, oneapi::dpl::__internal::__kernel_work_group_size(__exec, __kernel));
 #endif
     auto __max_cu = oneapi::dpl::__internal::__max_compute_units(__exec);
@@ -1257,7 +1257,7 @@ __parallel_find_first(oneapi::dpl::__internal::__device_backend_tag, _ExecutionP
 #if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
             __cgh.use_kernel_bundle(__kernel.get_kernel_bundle());
 #endif
-            __cgh.parallel_for<_FindOrKernel>(
+            __cgh.parallel_for<_FindFirstKernel>(
 #if _ONEDPL_COMPILE_KERNEL && !_ONEDPL_KERNEL_BUNDLE_PRESENT
                 __kernel,
 #endif

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1104,8 +1104,11 @@ __parallel_find_any(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPol
 
                         const std::size_t __local_idx = __item.get_local_id(0);
 
-                        if (__pred(__group_idx, __local_idx, __n_iter, __wgroup_size, __rngs...))
+                        if (!__found_in_any_item_inside_group &&
+                            __pred(__group_idx, __local_idx, __n_iter, __wgroup_size, __rngs...))
+                        {
                             __found_in_any_item_inside_group = true;
+                        }
                     });
 
                     if (__found_in_any_item_inside_group)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1043,13 +1043,8 @@ struct __early_exit_find_any
             __shift = __wg_size - __leader;
         for (_IterSize __i = 0; __i < __n_iter; ++__i)
         {
-            // Point #B1 - not required to have _ShiftedIdxType
-
-            // Point #B2 - not required
-
-            // Point #B3 - rewritten
             const auto __shifted_idx = __init_index + __i * __shift;
-            // Point #B4 - rewritten
+
             if (__shifted_idx < __n && __pred(__shifted_idx, __rngs...))
             {
                 __found_local = __parallel_or_tag::__found_state;
@@ -1121,17 +1116,11 @@ __parallel_find_any(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPol
                 [=](sycl::nd_item</*dim=*/1> __item_id) {
                     __dpl_sycl::__atomic_ref<_AtomicType, sycl::access::address_space::global_space> __found(
                         *__dpl_sycl::__get_accessor_ptr(__temp_acc));
-                    // Point #A1 - not required
 
-                    // Point #A2 - rewritten
                     _AtomicType __found_local = __init_value;
-                    // Point #A2.1 - not required
 
-                    // Point #A3 - rewritten
                     __pred(__item_id, __n_iter, __wgroup_size, __found_local, __rngs...);
-                    // Point #A3.1 - not required
 
-                    // Point #A4 - rewritten
                     // Set found state result to global atomic
                     if (__found_local != __init_value)
                     {
@@ -1178,18 +1167,15 @@ struct __early_exit_find_first
             __shift = __wg_size - __leader;
         for (_IterSize __i = 0; __i < __n_iter; ++__i)
         {
-            // Point #B1
             //in case of find-semantic __shifted_idx must be the same type as the atomic for a correct comparison
             using _ShiftedIdxType = decltype(__found_local.load());
 
             _IterSize __current_iter = __i;
-            // Point #B2
             if constexpr (_BackwardTagType::value)
                 __current_iter = __n_iter - 1 - __i;
 
-            // Point #B3
             const _ShiftedIdxType __shifted_idx = __init_index + __current_iter * __shift;
-            // Point #B4
+
             // TODO:[Performance] the issue with atomic load (in comparison with __shifted_idx for early exit)
             // should be investigated later, with other HW
             if (__shifted_idx < __n && __pred(__shifted_idx, __rngs...))
@@ -1268,25 +1254,19 @@ __parallel_find_first(oneapi::dpl::__internal::__device_backend_tag, _ExecutionP
 
                     __dpl_sycl::__atomic_ref<_AtomicType, sycl::access::address_space::global_space> __found(
                         *__dpl_sycl::__get_accessor_ptr(__temp_acc));
-                    // Point #A1
                     __dpl_sycl::__atomic_ref<_AtomicType, sycl::access::address_space::local_space> __found_local(
                         *__dpl_sycl::__get_accessor_ptr(__temp_local));
 
-                    // Point #A2
                     // 1. Set initial value to local atomic
                     if (__local_idx == 0)
                         __found_local.store(__init_value);
-                    // Point #A2.1
                     __dpl_sycl::__group_barrier(__item_id);
 
-                    // Point #A3
                     // 2. Find any element that satisfies pred and set local atomic value to global atomic
                     constexpr auto __comp = typename _BrickTag::_Compare{};
                     __pred(__item_id, __n_iter, __wgroup_size, __comp, __found_local, __brick_tag, __rngs...);
-                    // Point #A3.1
                     __dpl_sycl::__group_barrier(__item_id);
 
-                    // Point #A4
                     // Set local atomic value to global atomic
                     if (__local_idx == 0)
                     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1160,7 +1160,7 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
     const _AtomicType __init_value = _BrickTag::__init_value(__rng_n);
     _AtomicType __result = __init_value;
 
-    const auto __pred = oneapi::dpl::__par_backend_hetero::__early_exit_find_or<_ExecutionPolicy, _Brick>{__f};
+    const oneapi::dpl::__par_backend_hetero::__early_exit_find_or<_ExecutionPolicy, _Brick> __pred{__f};
 
     // scope is to copy data back to __result after destruction of temporary sycl:buffer
     {
@@ -1243,7 +1243,7 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
     _AtomicType __init_value = _BrickTag::__init_value(__rng_n);
     auto __result = __init_value;
 
-    const auto __pred = oneapi::dpl::__par_backend_hetero::__early_exit_find_or<_ExecutionPolicy, _Brick>{__f};
+    const oneapi::dpl::__par_backend_hetero::__early_exit_find_or<_ExecutionPolicy, _Brick> __pred{__f};
 
     // scope is to copy data back to __result after destruction of temporary sycl:buffer
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1129,7 +1129,7 @@ struct __early_exit_find_or
 template <typename _ExecutionPolicy, typename _Brick, typename... _Ranges>
 bool
 __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Brick __f,
-                   __parallel_or_tag /*__brick_tag*/, _Ranges&&... __rngs)
+                   __parallel_or_tag __brick_tag, _Ranges&&... __rngs)
 {
     using _BrickTag = __parallel_or_tag;
 
@@ -1192,7 +1192,7 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
 
                     // Point #A3 - rewritten
                     constexpr auto __comp = typename _BrickTag::_Compare{};
-                    __pred(__item_id, __n_iter, __wgroup_size, __comp, __found_local, __parallel_or_tag{}, __rngs...);
+                    __pred(__item_id, __n_iter, __wgroup_size, __comp, __found_local, __brick_tag, __rngs...);
                     // Point #A3.1 - not required
 
                     // Point #A4 - rewritten

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1165,7 +1165,7 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
 
     // scope is to copy data back to __result after destruction of temporary sycl:buffer
     {
-        auto __temp = sycl::buffer<_AtomicType, 1>(&__result, 1); // temporary storage for global atomic
+        sycl::buffer<_AtomicType, 1> __temp(&__result, 1); // temporary storage for global atomic
 
         // main parallel_for
         __exec.queue().submit([&](sycl::handler& __cgh) {
@@ -1250,7 +1250,7 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
 
     // scope is to copy data back to __result after destruction of temporary sycl:buffer
     {
-        auto __temp = sycl::buffer<_AtomicType, 1>(&__result, 1); // temporary storage for global atomic
+        sycl::buffer<_AtomicType, 1> __temp(&__result, 1); // temporary storage for global atomic
 
         // main parallel_for
         __exec.queue().submit([&](sycl::handler& __cgh) {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1002,16 +1002,7 @@ struct __parallel_or_tag
     static constexpr _AtomicType __found_state = 1;
     static constexpr _AtomicType __not_found_state = 0;
 
-    struct __compare_state
-    {
-        bool
-        operator()(const _AtomicType __found_local, const _AtomicType __found) const
-        {
-            return __found_local == __found_state && __found == __not_found_state;
-        }
-    };
-
-    using _Compare = __compare_state;
+    struct _Compare{};
 
     // The template parameter is intended to unify __init_value in tags.
     template <typename _DiffType>
@@ -1034,7 +1025,7 @@ struct __early_exit_find_or
     template <typename _NDItemId, typename _IterSize, typename _WgSize, typename _FoundLocalState, typename _Compare,
               typename... _Ranges>
     void
-    operator()(const _NDItemId __item_id, const _IterSize __n_iter, const _WgSize __wg_size, _Compare __comp,
+    operator()(const _NDItemId __item_id, const _IterSize __n_iter, const _WgSize __wg_size, _Compare,
                _FoundLocalState& __found_local, __parallel_or_tag, _Ranges&&... __rngs) const
     {
         const auto __n = oneapi::dpl::__ranges::__get_first_range_size(__rngs...);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -234,12 +234,22 @@ namespace oneapi::dpl::__par_backend_hetero
 {
 
 template <typename _ExecutionPolicy, typename _Pred>
-struct __early_exit_find_or;
+struct __early_exit_find_first;
+
+template <typename _ExecutionPolicy, typename _Pred>
+struct __early_exit_find_any;
 
 } // namespace oneapi::dpl::__par_backend_hetero
 
 template <typename _ExecutionPolicy, typename _Pred>
-struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__early_exit_find_or,
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__early_exit_find_first,
+                                                       _ExecutionPolicy, _Pred)>
+    : oneapi::dpl::__internal::__are_all_device_copyable<_Pred>
+{
+};
+
+template <typename _ExecutionPolicy, typename _Pred>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__early_exit_find_any,
                                                        _ExecutionPolicy, _Pred)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_Pred>
 {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -609,12 +609,12 @@ struct __copy_by_mask
                 // operator to ::std::tuple<U...>, but for some reason this doesn't work(conversion from
                 // ::std::tuple<T...> to ::std::tuple<U..> fails). What does work is the explicit cast below:
                 // for internal::tuple<T..> we define a field that provides a corresponding ::std::tuple<T..>
-                // with matching types. We get this type(see __tuple_type definition above) and use it
+                // with matching types. We get this type(see __typle_type definition above) and use it
                 // for static cast to explicitly convert internal::tuple<T..> -> ::std::tuple<T..>.
                 // Now we have the following assignment ::std::tuple<U..> = ::std::tuple<T..> which works as expected.
                 // NOTE: we only need this explicit conversion when we have internal::tuple and
                 // ::std::tuple as operands, in all the other cases this is not necessary and no conversion
-                // is performed(i.e. __tuple_type is the same type as its operand).
+                // is performed(i.e. __typle_type is the same type as its operand).
                 __assigner(static_cast<__tuple_type>(get<0>(__in_acc[__item_idx])), __out_acc[__out_idx]);
         }
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -609,12 +609,12 @@ struct __copy_by_mask
                 // operator to ::std::tuple<U...>, but for some reason this doesn't work(conversion from
                 // ::std::tuple<T...> to ::std::tuple<U..> fails). What does work is the explicit cast below:
                 // for internal::tuple<T..> we define a field that provides a corresponding ::std::tuple<T..>
-                // with matching types. We get this type(see __typle_type definition above) and use it
+                // with matching types. We get this type(see __tuple_type definition above) and use it
                 // for static cast to explicitly convert internal::tuple<T..> -> ::std::tuple<T..>.
                 // Now we have the following assignment ::std::tuple<U..> = ::std::tuple<T..> which works as expected.
                 // NOTE: we only need this explicit conversion when we have internal::tuple and
                 // ::std::tuple as operands, in all the other cases this is not necessary and no conversion
-                // is performed(i.e. __typle_type is the same type as its operand).
+                // is performed(i.e. __tuple_type is the same type as its operand).
                 __assigner(static_cast<__tuple_type>(get<0>(__in_acc[__item_idx])), __out_acc[__out_idx]);
         }
     }


### PR DESCRIPTION
In this PR we made some performance improvements:
- some performance improvements for `__parallel_find_or` + `__device_backend_tag` for the usage with the `__parallel_or_tag`.

------------------
The changes for
- `__pattern_any_of(__hetero_tag` has been implemented on `__parallel_transform_reduce`;
- `__pattern_find_if(__hetero_tag` has been implemented on `__parallel_transform_reduce`;
has been extracted to the separate PR https://github.com/oneapi-src/oneDPL/pull/1622
and rolled back in this PR.