### PR TITLE
Work around the global policy issue in a backward-compatible manner

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -160,17 +160,19 @@ class device_policy
 #if _ONEDPL_FPGA_DEVICE
 struct DefaultKernelNameFPGA;
 
-using __fpga_default_selector =
-#if _ONEDPL_FPGA_EMU
-    __dpl_sycl::__fpga_emulator_selector;
-#else
-    __dpl_sycl::__fpga_selector;
-#endif
-
 template <unsigned int factor = 1, typename KernelName = DefaultKernelNameFPGA>
 class fpga_policy : public device_policy<KernelName>
 {
     using base = device_policy<KernelName>;
+
+    static inline auto __fpga_default_selector()
+    {
+#if _ONEDPL_FPGA_EMU
+        return __dpl_sycl::__fpga_emulator_selector();
+#else
+        return __dpl_sycl::__fpga_selector();
+#endif
+    }
 
   public:
     static constexpr unsigned int unroll_factor = factor;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -54,7 +54,7 @@ class alignas(sycl::queue) __queue_holder
 
     bool __has_queue() const
     {
-        bool res = (__buf[0] == 0); // If the first size-of-pointer bytes are zeros, we consider there is no valid queue
+        bool res = (__buf[0] != 0); // If the first size-of-pointer bytes are zeros, we consider there is no valid queue
         std::atomic_signal_fence(std::memory_order_acq_rel); // to prevent possible reordering due to type punning
         return res;
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -148,28 +148,29 @@ class device_policy
     sycl::queue
     queue() const
     {
-        return __q.__queue_ref();
+        return q.__queue_ref();
     }
 
   private:
-    static_assert(sizeof(__internal::__queue_holder)==sizeof(sycl::queue));
-    static_assert(alignof(__internal::__queue_holder)==alignof(sycl::queue));
+    static_assert(sizeof(__internal::__queue_holder) == sizeof(sycl::queue));
+    static_assert(alignof(__internal::__queue_holder) == alignof(sycl::queue));
     __internal::__queue_holder q;
 };
 
 #if _ONEDPL_FPGA_DEVICE
 struct DefaultKernelNameFPGA;
 
+using __fpga_default_selector =
+#if _ONEDPL_FPGA_EMU
+    __dpl_sycl::__fpga_emulator_selector;
+#else
+    __dpl_sycl::__fpga_selector;
+#endif
+
 template <unsigned int factor = 1, typename KernelName = DefaultKernelNameFPGA>
 class fpga_policy : public device_policy<KernelName>
 {
     using base = device_policy<KernelName>;
-    using __fpga_default_selector =
-#if _ONEDPL_FPGA_EMU
-        __dpl_sycl::__fpga_emulator_selector;
-#else
-        __dpl_sycl::__fpga_selector;
-#endif
 
   public:
     static constexpr unsigned int unroll_factor = factor;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -185,9 +185,6 @@ class fpga_policy : public device_policy<KernelName>
     fpga_policy(const fpga_policy<other_factor, OtherName>& other) : base(other.queue()){};
     explicit fpga_policy(sycl::queue q) : base(q) {}
     explicit fpga_policy(sycl::device d) : base(d) {}
-#if _ONEDPL_PREDEFINED_POLICIES
-    explicit fpga_policy(__internal::__global_instance_tag t) : base(t) {}
-#endif
 };
 #endif // _ONEDPL_FPGA_DEVICE
 
@@ -201,7 +198,7 @@ class fpga_policy : public device_policy<KernelName>
 
 inline device_policy<> dpcpp_default{__internal::__global_instance_tag{}};
 #        if _ONEDPL_FPGA_DEVICE
-inline fpga_policy<> dpcpp_fpga{__internal::__global_instance_tag{}};
+inline fpga_policy<> dpcpp_fpga{};
 #        endif // _ONEDPL_FPGA_DEVICE
 
 #    endif // _ONEDPL___cplusplus >= 201703L

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -53,7 +53,7 @@ class alignas(sycl::queue) __queue_holder
 
     bool __has_queue() const
     {
-        bool res = nullptr!=reinterpret_cast<void*&>(*this);
+        bool res = nullptr!=reinterpret_cast<void* const&>(*this);
         std::atomic_signal_fence(std::memory_order_acq_rel); // mitigate possible reordering due to type punning
         return res;
     }
@@ -110,7 +110,7 @@ class alignas(sycl::queue) __queue_holder
             __queue_ref() = std::move(__h.__queue_ref());
         return *this;
     }
-    
+
     const sycl::queue& __queue_ref() const
     {
         assert(__has_queue());

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -38,7 +38,8 @@ namespace execution
 inline namespace __dpl
 {
 
-namespace __internal {
+namespace __internal
+{
 
 #if _ONEDPL_PREDEFINED_POLICIES
 struct __global_instance_tag {};
@@ -53,7 +54,7 @@ class alignas(sycl::queue) __queue_holder
 
     bool __has_queue() const
     {
-        bool res = nullptr!=reinterpret_cast<void* const&>(*this);
+        bool res = (nullptr != reinterpret_cast<void* const&>(*this));
         std::atomic_signal_fence(std::memory_order_acq_rel); // mitigate possible reordering due to type punning
         return res;
     }
@@ -70,7 +71,8 @@ class alignas(sycl::queue) __queue_holder
     {
         if (!sycl::device::get_devices().empty())
             new (this) sycl::queue;
-        else {
+        else
+        {
             // an "impossible" case of SYCL providing no devices, which we however must handle
             std::memset(this, 0, sizeof(void*));
             // Since the queue holder does not have a valid queue in this case,
@@ -87,26 +89,19 @@ class alignas(sycl::queue) __queue_holder
     }
 
     // Copy and move operations have to be explicit
-    __queue_holder(const __queue_holder& __h)
-    {
-        new (this) sycl::queue(__h.__queue_ref());
-    }
-
-    __queue_holder(__queue_holder&& __h)
-    {
-        new (this) sycl::queue(std::move(__h.__queue_ref()));
-    }
+    __queue_holder(const __queue_holder& __h) { new (this) sycl::queue(__h.__queue_ref()); }
+    __queue_holder(__queue_holder&& __h)      { new (this) sycl::queue(std::move(__h.__queue_ref())); }
 
     __queue_holder& operator=(const __queue_holder& __h)
     {
-        if (this != &__h) 
+        if (this != &__h)
             __queue_ref() = __h.__queue_ref();
         return *this;
     }
 
     __queue_holder& operator=(__queue_holder&& __h)
     {
-        if (this != &__h) 
+        if (this != &__h)
             __queue_ref() = std::move(__h.__queue_ref());
         return *this;
     }
@@ -147,15 +142,13 @@ class device_policy
     explicit device_policy(sycl::device d_) : q(d_) {}
 #if _ONEDPL_PREDEFINED_POLICIES
     explicit device_policy(__internal::__global_instance_tag t_) : q(t_) {}
-#endl
+#endif
 
     operator sycl::queue() const { return queue(); }
     sycl::queue
     queue() const
     {
         return __q.__queue_ref();
-    }
-
     }
 
   private:
@@ -171,7 +164,7 @@ template <unsigned int factor = 1, typename KernelName = DefaultKernelNameFPGA>
 class fpga_policy : public device_policy<KernelName>
 {
     using base = device_policy<KernelName>;
-    using __fpga_default_selector = 
+    using __fpga_default_selector =
 #if _ONEDPL_FPGA_EMU
         __dpl_sycl::__fpga_emulator_selector;
 #else
@@ -181,9 +174,7 @@ class fpga_policy : public device_policy<KernelName>
   public:
     static constexpr unsigned int unroll_factor = factor;
 
-    fpga_policy() : base(sycl::queue(__fpga_default_selector()))
-    {
-    }
+    fpga_policy() : base(sycl::queue(__fpga_default_selector())) {}
 
     template <unsigned int other_factor, typename OtherName>
     fpga_policy(const fpga_policy<other_factor, OtherName>& other) : base(other.queue()){};
@@ -192,7 +183,6 @@ class fpga_policy : public device_policy<KernelName>
 #if _ONEDPL_PREDEFINED_POLICIES
     explicit fpga_policy(__internal::__global_instance_tag t) : base(t) {}
 #endif
-
 };
 #endif // _ONEDPL_FPGA_DEVICE
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -78,8 +78,8 @@ class alignas(sycl::queue) __queue_holder
             // an "impossible" case of SYCL providing no devices, which we however must handle
             __buf[0] = 0; // nullify the first size-of-pointer bytes of the holder
             // Since the queue holder does not have a valid queue in this case,
-            // the predefined device policies are de-facto unusable.
-            // That seems OK though, because there is no device to run SYCL anyway.
+            // the predefined device policies become de-facto unusable.
+            // That seems OK though, because there is no device to use anyway.
         }
     }
 #endif


### PR DESCRIPTION
This patch proposes a different approach to address the issue #1060.

Previously we tried to re-implement the `device_policy` class in a way that would avoid eager initialization of a SYCL queue in the constructor, and instead would do it on the first use. That cannot be done however without having layout changes for the class, which we prefer to avoid for sake of preserving backward compatibility.

However, the issue #1060 does not really require lazy initialization; it asks for absence of exceptions or any other runtime errors in case a global SYCL queue object cannot be initialized. We use SYCL's default selector to create a queue used by the `dpcpp_default` predefined policy, which is supposed to **always** return a valid device because a SYCL implementation **must** provide at least one valid device. So our current implementation is formally correct, while the problem is observed in a strange environment where SYCL cannot find/initialize any device, even a CPU device; that seems to be a territory of undefined behavior.

Therefore a workaround can be implemented that detects during the construction of `dpcpp_default` that there are no SYCL devices and does not even try to initialize the queue, instead leaving the policy in an unusable state. According to the SYCL specification, the set of available platforms and devices does not change during the program lifetime, therefore our device policies, including `dpcpp_default`, cannot be used anyway (again, it's practically a UB territory) - so just silently ignoring the issue at global policy construction and letting it fire on the actual use seems OK.

The patch here attempts to implement this approach without breaking the class layout. For that, use of `sycl::queue` in the policies is replaced with a specially crafter `__queue_holder`, which has the same size and alignment as `sycl::queue` and uses "placement new" to construct a real queue in the space taken by the holder. In most cases, the queue is constructed unconditionally, but a special constructor for predefined policy instances checks if there is at least one device available. As an indication that the construction was omitted, the first `sizeof(void*)` bytes of the holder are nullified; the rationale is that a SYCL queue is likely implemented as a `shared_ptr` (that's certainly the case for DPC++), which in turn typically holds several pointers to the actual object, a service block or a reference counter, etc. It is highly unlikely therefore that the first bytes in a properly constructed queue object will be equivalent to a null pointer. That validity check, however, is only used in the destructor; all other methods assume that the queue was properly constructed, which is asserted in the `__queue_ref` method that returns a reference to the queue kept in the holder.