### PR TITLE
[oneDPL] + oneapi::dpl::__internal::__compare

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1821,9 +1821,8 @@ auto
 __parallel_stable_sort(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
                        _Range&& __rng, _Compare __comp, _Proj __proj)
 {
-    auto __cmp_f = oneapi::dpl::__internal::__compare<_Compare, _Proj>{__comp, __proj};
     return __parallel_sort_impl(__backend_tag, ::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range>(__rng),
-                                __cmp_f);
+                                oneapi::dpl::__internal::__compare<_Compare, _Proj>{__comp, __proj});
 }
 
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1821,9 +1821,7 @@ auto
 __parallel_stable_sort(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
                        _Range&& __rng, _Compare __comp, _Proj __proj)
 {
-    auto __cmp_f = [__comp, __proj](const auto& __a, const auto& __b) mutable {
-        return __comp(__proj(__a), __proj(__b));
-    };
+    auto __cmp_f = oneapi::dpl::__internal::__compare<_Compare, _Proj>{__comp, __proj};
     return __parallel_sort_impl(__backend_tag, ::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range>(__rng),
                                 __cmp_f);
 }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -58,6 +58,9 @@ class __equal_value;
 template <typename _Tp>
 class __not_equal_value;
 
+template <typename _Comp, typename _Proj>
+class __compare;
+
 template <typename _Pred>
 class __transform_functor;
 
@@ -132,6 +135,12 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::
 template <typename _Tp>
 struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::__not_equal_value, _Tp)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_Tp>
+{
+};
+
+template <typename _Comp, typename _Proj>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__internal::__compare, _Comp, _Proj)>
+    : oneapi::dpl::__internal::__are_all_device_copyable<_Comp, _Proj>
 {
 };
 

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -129,12 +129,11 @@ class __pstl_assign
 };
 
 template <typename _Comp, typename _Proj>
-class __compare
+struct __compare
 {
     _Comp __comp;
     _Proj __proj;
 
-  public:
     template <typename _Xp, typename _Yp>
     bool
     operator()(_Xp&& __x, _Yp&& __y)

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -128,6 +128,21 @@ class __pstl_assign
     }
 };
 
+template <typename _Comp, typename _Proj>
+class __compare
+{
+    _Comp __comp;
+    _Proj __proj;
+
+  public:
+    template <typename _Xp, typename _Yp>
+    bool
+    operator()(_Xp&& __x, _Yp&& __y)
+    {
+        return __comp(__proj(std::forward<_Xp>(__x)), __proj(std::forward<_Yp>(__y)));
+    }
+};
+
 //! "==" comparison.
 /** Not called "equal" to avoid (possibly unfounded) concerns about accidental invocation via
     argument-dependent name lookup by code expecting to find the usual ::std::equal. */

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -131,14 +131,15 @@ class __pstl_assign
 template <typename _Comp, typename _Proj>
 struct __compare
 {
-    _Comp __comp;
-    _Proj __proj;
+    //'mutable' is to relax the requirements for a user comparator or/and projection type operator() may be non-const
+    mutable _Comp __comp;
+    mutable _Proj __proj;
 
     template <typename _Xp, typename _Yp>
     bool
-    operator()(_Xp&& __x, _Yp&& __y)
+    operator()(const _Xp& __x, const _Yp& __y) const
     {
-        return __comp(__proj(std::forward<_Xp>(__x)), __proj(std::forward<_Yp>(__y)));
+        return __comp(__x, __y);
     }
 };
 

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -139,7 +139,7 @@ struct __compare
     bool
     operator()(const _Xp& __x, const _Yp& __y) const
     {
-        return __comp(__x, __y);
+        return __comp(__proj(__x), __proj(__y));
     }
 };
 


### PR DESCRIPTION
This PR introduces oneapi::dpl::__internal::__compare which replace a lambda in hetero __parallel_stable_sort pattern