### PR TITLE
Performance improvements of `__pattern_any_of`, `__pattern_find_if`

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -670,19 +670,44 @@ bool
 __pattern_any_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last,
                  _Pred __pred)
 {
-    if (__first == __last)
+    using _difference_type = typename ::std::iterator_traits<_Iterator>::difference_type;
+
+    const _difference_type __n = __last - __first;
+    if (__n == 0)
         return false;
 
-    using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<_ExecutionPolicy, _Pred>;
+    using _result_type = oneapi::dpl::__internal::tuple<bool, _difference_type>;
+    const auto __init = _result_type{false, __n};
 
-    auto __keep = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
-    auto __buf = __keep(__first, __last);
+    // __counting_iterator_t - iterate position (index) in source data
+    using __counting_iterator_t = oneapi::dpl::counting_iterator<_difference_type>;
 
-    return oneapi::dpl::__par_backend_hetero::__parallel_find_or(
-        _BackendTag{},
-        __par_backend_hetero::make_wrapped_policy<__par_backend_hetero::__or_policy_wrapper>(
-            ::std::forward<_ExecutionPolicy>(__exec)),
-        _Predicate{__pred}, __par_backend_hetero::__parallel_or_tag{}, __buf.all_view());
+    using _zipped_data_type = typename std::iterator_traits<decltype(oneapi::dpl::make_zip_iterator(
+        __first, __counting_iterator_t{0}))>::value_type;
+
+    __find_if_binary_reduce_op<_zipped_data_type, /*_IsFirst*/ std::true_type> __reduce_op;
+    __find_if_unary_transform_op<_zipped_data_type, _Pred> __transform_op{__pred};
+
+    using _Functor = unseq_backend::walk_n<_ExecutionPolicy, decltype(__transform_op)>;
+    using _RepackedTp = __par_backend_hetero::__repacked_tuple_t<_result_type>;
+
+    auto __keep_src_data =
+        oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
+    auto __buf_src_data = __keep_src_data(__first, __last);
+
+    const __counting_iterator_t __counting_it_first{0}, __counting_it_last{__n};
+    auto __keep_counting_it =
+        oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, __counting_iterator_t>();
+    auto __buf_counting_it = __keep_counting_it(__counting_it_first, __counting_it_last);
+
+    auto res =
+        oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp, std::true_type /*is_commutative*/>(
+            _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), __reduce_op, _Functor{__transform_op},
+            unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
+            oneapi::dpl::__ranges::make_zip_view(__buf_src_data.all_view(), __buf_counting_it.all_view()))
+            .get();
+
+    return std::get<0>(res);
 }
 
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -759,16 +759,44 @@ _Iterator
 __pattern_find_if(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last,
                   _Pred __pred)
 {
-    if (__first == __last)
+    using _difference_type = typename ::std::iterator_traits<_Iterator>::difference_type;
+
+    const _difference_type __n = __last - __first;
+    if (__n == 0)
         return __last;
 
-    using _Predicate = oneapi::dpl::unseq_backend::single_match_pred<_ExecutionPolicy, _Pred>;
+    using _result_type = oneapi::dpl::__internal::tuple<bool, _difference_type>;
+    const auto __init = _result_type{false, __n};
 
-    return __par_backend_hetero::__parallel_find(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
-        __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__first),
-        __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::read>(__last), _Predicate{__pred},
-        ::std::true_type{});
+    // __counting_iterator_t - iterate position (index) in source data
+    using __counting_iterator_t = oneapi::dpl::counting_iterator<_difference_type>;
+
+    using _zipped_data_type = typename std::iterator_traits<decltype(oneapi::dpl::make_zip_iterator(
+        __first, __counting_iterator_t{0}))>::value_type;
+
+    __find_if_binary_reduce_op<_zipped_data_type, /*_IsFirst*/ std::true_type> __reduce_op;
+    __find_if_unary_transform_op<_zipped_data_type, _Pred> __transform_op{__pred};
+
+    using _Functor = unseq_backend::walk_n<_ExecutionPolicy, decltype(__transform_op)>;
+    using _RepackedTp = __par_backend_hetero::__repacked_tuple_t<_result_type>;
+
+    auto __keep_src_data =
+        oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator>();
+    auto __buf_src_data = __keep_src_data(__first, __last);
+
+    const __counting_iterator_t __counting_it_first{0}, __counting_it_last{__n};
+    auto __keep_counting_it =
+        oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, __counting_iterator_t>();
+    auto __buf_counting_it = __keep_counting_it(__counting_it_first, __counting_it_last);
+
+    auto res =
+        oneapi::dpl::__par_backend_hetero::__parallel_transform_reduce<_RepackedTp, std::true_type /*is_commutative*/>(
+            _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), __reduce_op, _Functor{__transform_op},
+            unseq_backend::__init_value<_RepackedTp>{__init}, // initial value
+            oneapi::dpl::__ranges::make_zip_view(__buf_src_data.all_view(), __buf_counting_it.all_view()))
+            .get();
+
+    return std::get<0>(res) ? __first + std::get<1>(res) : __last;
 }
 
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -634,6 +634,37 @@ __pattern_count(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator 
 // any_of
 //------------------------------------------------------------------------
 
+template <typename _Tuple, typename _UnaryTransformOp>
+struct __find_if_unary_transform_op
+{
+    _UnaryTransformOp __transform_op;
+
+    template <typename Arg>
+    _Tuple
+    operator()(const Arg& arg) const
+    {
+        return {__transform_op(std::get<0>(arg)), std::get<1>(arg)};
+    }
+};
+
+template <typename _Tuple, typename _IsFirst>
+struct __find_if_binary_reduce_op
+{
+    _Tuple
+    operator()(const _Tuple& op1, const _Tuple& op2) const
+    {
+        if (std::get<0>(op1) && std::get<0>(op2))
+        {
+            if constexpr (_IsFirst{})
+                return {true, std::min(std::get<1>(op1), std::get<1>(op2))};
+            else
+                return {true, std::max(std::get<1>(op1), std::get<1>(op2))};
+        }
+
+        return std::get<0>(op1) ? op1 : op2;
+    }
+};
+
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _Pred>
 bool
 __pattern_any_of(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last,


### PR DESCRIPTION
In this PR we made some performance improvements:
- `__pattern_any_of(__hetero_tag` has been implemented on `__parallel_transform_reduce`;
- `__pattern_find_if(__hetero_tag` has been implemented on `__parallel_transform_reduce` (gave us the same results as without this change but with https://github.com/oneapi-src/oneDPL/pull/1617).

My experiments shows significant performance boost for subset of algorithms after these changes.