### PR TITLE
Performance improvements: insert `break` into `__early_exit_find_or`

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1067,7 +1067,10 @@ struct __early_exit_find_or
             if (__shifted_idx < __n && __pred(__shifted_idx, __rngs...))
             {
                 if constexpr (_OrTagType::value)
+                {
                     __found_local.store(1);
+                    break;
+                }
                 else
                 {
                     for (auto __old = __found_local.load(); __comp(__shifted_idx, __old); __old = __found_local.load())


### PR DESCRIPTION
In this error we fixing performance issue in the `__early_exit_find_or::operator()` :
- we should `break` `for`-loop after call `__found_local.store(1);`

This performance issue has been found during preparation of the PR https://github.com/oneapi-src/oneDPL/pull/1617