### PR TITLE
[KT] Single workgroup compilation opt out

### DIFF
--- a/include/oneapi/dpl/experimental/kt/kernel_param.h
+++ b/include/oneapi/dpl/experimental/kt/kernel_param.h
@@ -18,12 +18,13 @@ namespace oneapi::dpl::experimental::kt
 {
 
 template <std::uint16_t __data_per_work_item, std::uint16_t __work_group_size,
-          typename _KernelName = oneapi::dpl::execution::DefaultKernelName>
+          typename _KernelName = oneapi::dpl::execution::DefaultKernelName, typename _SingleWgOptOut = std::false_type>
 struct kernel_param
 {
     static constexpr std::uint16_t data_per_workitem = __data_per_work_item;
     static constexpr std::uint16_t workgroup_size = __work_group_size;
     using kernel_name = _KernelName;
+    using single_wg_opt_out = _SingleWgOptOut;
 };
 
 } // namespace oneapi::dpl::experimental::kt

--- a/include/oneapi/dpl/experimental/kt/single_pass_scan.h
+++ b/include/oneapi/dpl/experimental/kt/single_pass_scan.h
@@ -440,14 +440,18 @@ __single_pass_scan(sycl::queue __queue, _InRange&& __in_rng, _OutRange&& __out_r
     // Next power of 2 greater than or equal to __n
     auto __n_uniform = ::oneapi::dpl::__internal::__dpl_bit_ceil(__n);
 
-    // Perform a single-work group scan if the input is small
-    if (oneapi::dpl::__par_backend_hetero::__group_scan_fits_in_slm<_Type>(__queue, __n, __n_uniform))
+    if constexpr (std::negation_v<typename _KernelParam::single_wg_opt_out>)
     {
-        return oneapi::dpl::__par_backend_hetero::__parallel_transform_scan_single_group(
-            oneapi::dpl::__internal::__device_backend_tag{},
-            oneapi::dpl::execution::__dpl::make_device_policy<typename _KernelParam::kernel_name>(__queue),
-            std::forward<_InRange>(__in_rng), std::forward<_OutRange>(__out_rng), __n,
-            oneapi::dpl::__internal::__no_op{}, unseq_backend::__no_init_value<_Type>{}, __binary_op, std::true_type{});
+        // Perform a single-work group scan if the input is small
+        if (oneapi::dpl::__par_backend_hetero::__group_scan_fits_in_slm<_Type>(__queue, __n, __n_uniform))
+        {
+            return oneapi::dpl::__par_backend_hetero::__parallel_transform_scan_single_group(
+                oneapi::dpl::__internal::__device_backend_tag{},
+                oneapi::dpl::execution::__dpl::make_device_policy<typename _KernelParam::kernel_name>(__queue),
+                std::forward<_InRange>(__in_rng), std::forward<_OutRange>(__out_rng), __n,
+                oneapi::dpl::__internal::__no_op{}, unseq_backend::__no_init_value<_Type>{}, __binary_op,
+                std::true_type{});
+        }
     }
 
     constexpr std::size_t __workgroup_size = _KernelParam::workgroup_size;
@@ -664,13 +668,16 @@ single_pass_copy_if_impl(sycl::queue __queue, _InRng&& __in_rng, _OutRng&& __out
     // Next power of 2 greater than or equal to __n
     auto __n_uniform = ::oneapi::dpl::__internal::__dpl_bit_ceil(__n);
 
-    //If we fit in a single WG SLM, use the single wg version from oneDPL main
-    if (oneapi::dpl::__par_backend_hetero::__group_copy_if_fits_in_slm(__queue, __n, __n_uniform))
+    if constexpr (std::negation_v<typename _KernelParam::single_wg_opt_out>)
     {
-        return oneapi::dpl::__par_backend_hetero::__dispatch_small_copy_if(
-            oneapi::dpl::execution::__dpl::make_device_policy<_KernelName>(__queue), __n,
-            std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), std::forward<_NumCopiedRng>(__num_rng),
-            __pred);
+        //If we fit in a single WG SLM, use the single wg version from oneDPL main
+        if (oneapi::dpl::__par_backend_hetero::__group_copy_if_fits_in_slm(__queue, __n, __n_uniform))
+        {
+            return oneapi::dpl::__par_backend_hetero::__dispatch_small_copy_if(
+                oneapi::dpl::execution::__dpl::make_device_policy<_KernelName>(__queue), __n,
+                std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng),
+                std::forward<_NumCopiedRng>(__num_rng), __pred);
+        }
     }
     constexpr std::size_t __workgroup_size = _KernelParam::workgroup_size;
     constexpr std::size_t __elems_per_workitem = _KernelParam::data_per_workitem;

--- a/test/kt/CMakeLists.txt
+++ b/test/kt/CMakeLists.txt
@@ -130,7 +130,7 @@ if (ONEDPL_TEST_ENABLE_KT_ESIMD)
     _generate_esimd_sort_test("esimd_radix_sort" "256" "32" "double" "" 1000) # segfault
 endif()
 
-function (_generate_gpu_single_pass_test _alg _data_per_work_item _work_group_size _type)
+function (_generate_gpu_single_pass_test _alg _data_per_work_item _work_group_size _type _single_wg_optout)
 
     if ((NOT TARGET "build-${_alg}-kt-tests") AND (NOT TARGET "run-${_alg}-kt-tests"))
         add_custom_target("build-${_alg}-kt-tests" COMMENT "Build all ${_alg} kernel template tests")
@@ -141,7 +141,7 @@ function (_generate_gpu_single_pass_test _alg _data_per_work_item _work_group_si
     endif()
 
     string(REPLACE "_t" "" _type_short ${_type})
-    set(_target_name "single_pass_${_alg}_dpwi${_data_per_work_item}_wgs${_work_group_size}_${_type_short}")
+    set(_target_name "single_pass_${_alg}_dpwi${_data_per_work_item}_wgs${_work_group_size}_${_type_short}_${_single_wg_optout}")
     set(_test_path "single_pass_${_alg}.cpp")
 
     #_generate_test_randomly(${_target_name} ${_test_path} ${_probability_permille})
@@ -152,6 +152,7 @@ function (_generate_gpu_single_pass_test _alg _data_per_work_item _work_group_si
 
         target_compile_definitions(${_target_name} PRIVATE TEST_DATA_PER_WORK_ITEM=${_data_per_work_item})
         target_compile_definitions(${_target_name} PRIVATE TEST_WORK_GROUP_SIZE=${_work_group_size})
+        target_compile_definitions(${_target_name} PRIVATE TEST_SINGLE_WG_OPTOUT=${_single_wg_optout})
         target_compile_definitions(${_target_name} PRIVATE TEST_TYPE=${_type})
     endif()
 
@@ -167,13 +168,15 @@ function(_generate_gpu_single_pass_tests)
         foreach (_data_per_work_item ${_data_per_work_item_all})
             foreach (_work_group_size ${_work_group_size_all})
                 foreach (_type ${_type_all})
-                    _generate_gpu_single_pass_test(${_alg} ${_data_per_work_item} ${_work_group_size} ${_type})
+                    _generate_gpu_single_pass_test(${_alg} ${_data_per_work_item} ${_work_group_size} ${_type} "false")
                 endforeach()
             endforeach()
         endforeach()
+        # to not double the number of tests, check single wg output with a single test per alg
+        _generate_gpu_single_pass_test(${_alg} "8" "512" "float" "true")
 
         _generate_test("single_pass_${_alg}" "single_pass_${_alg}.cpp")
-        target_compile_definitions("single_pass_${_alg}" PRIVATE TEST_DATA_PER_WORK_ITEM=8 TEST_WORK_GROUP_SIZE=256 TEST_TYPE=uint32_t)
+        target_compile_definitions("single_pass_${_alg}" PRIVATE TEST_DATA_PER_WORK_ITEM=8 TEST_WORK_GROUP_SIZE=256 TEST_TYPE=uint32_t TEST_SINGLE_WG_OPTOUT=false)
     endforeach()
 
 endfunction()

--- a/test/kt/single_pass_copy_if.cpp
+++ b/test/kt/single_pass_copy_if.cpp
@@ -232,10 +232,14 @@ main()
 #if LOG_TEST_INFO
     std::cout << "TEST_DATA_PER_WORK_ITEM : " << TEST_DATA_PER_WORK_ITEM << "\n"
               << "TEST_WORK_GROUP_SIZE    : " << TEST_WORK_GROUP_SIZE << "\n"
+              << "TEST_SINGLE_WG_OPTOUT   : " << TEST_SINGLE_WG_OPTOUT << "\n"
               << "TEST_TYPE               : " << TypeInfo().name<TEST_TYPE>() << std::endl;
 #endif
 
-    constexpr oneapi::dpl::experimental::kt::kernel_param<TEST_DATA_PER_WORK_ITEM, TEST_WORK_GROUP_SIZE> params;
+    constexpr oneapi::dpl::experimental::kt::kernel_param<
+        TEST_DATA_PER_WORK_ITEM, TEST_WORK_GROUP_SIZE,
+        /*opt_out_single_wg=*/std::bool_constant<TEST_SINGLE_WG_OPTOUT>>
+        params;
     auto q = TestUtils::get_test_queue();
     bool run_test = can_run_test<decltype(params), TEST_TYPE>(q, params);
 

--- a/test/kt/single_pass_scan.cpp
+++ b/test/kt/single_pass_scan.cpp
@@ -206,10 +206,14 @@ main()
 #if LOG_TEST_INFO
     std::cout << "TEST_DATA_PER_WORK_ITEM : " << TEST_DATA_PER_WORK_ITEM << "\n"
               << "TEST_WORK_GROUP_SIZE    : " << TEST_WORK_GROUP_SIZE << "\n"
+              << "TEST_SINGLE_WG_OPTOUT   : " << TEST_SINGLE_WG_OPTOUT << "\n"
               << "TEST_TYPE               : " << TypeInfo().name<TEST_TYPE>() << std::endl;
 #endif
 
-    constexpr oneapi::dpl::experimental::kt::kernel_param<TEST_DATA_PER_WORK_ITEM, TEST_WORK_GROUP_SIZE> params;
+    constexpr oneapi::dpl::experimental::kt::kernel_param<
+        TEST_DATA_PER_WORK_ITEM, TEST_WORK_GROUP_SIZE,
+        /*opt_out_single_wg=*/std::bool_constant<TEST_SINGLE_WG_OPTOUT>>
+        params;
     auto q = TestUtils::get_test_queue();
     bool run_test = can_run_test<decltype(params), TEST_TYPE>(q, params);
 


### PR DESCRIPTION
This PR adds a way for users to opt out of compiling single workgroup kernels, if they know they will not be using or gain benefit from them.

This currently is targeted at the copy_if_kt branch, but once that is merged, we will target main.  If we decide against that PR, we can refactor this PR and target to main.