### PR TITLE
[CI] Fix FPGA emulator installation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,8 @@ jobs:
         if: (matrix.device_type == 'FPGA_EMU')
         run: |
           sudo apt-get install intel-oneapi-runtime-dpcpp-sycl-fpga-emul -y
+          # Fix for oneAPI 2024.2
+          echo ${LINUX_ONEAPI_PATH}/lib/intel64/libintelocl_emu.so | sudo tee /etc/OpenCL/vendors/intel_fpgaemu.icd
       - name: Run testing
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,9 +195,7 @@ jobs:
       - name: Install Intel® oneAPI DPC++/C++ Compiler SYCL* FPGA Emulator Runtime
         if: (matrix.device_type == 'FPGA_EMU')
         run: |
-          sudo apt-get install intel-oneapi-runtime-dpcpp-sycl-fpga-emul -y
-          # Fix for oneAPI 2024.2
-          echo ${LINUX_ONEAPI_PATH}/lib/intel64/libintelocl_emu.so | sudo tee /etc/OpenCL/vendors/intel_fpgaemu.icd
+          sudo apt-get install intel-oneapi-compiler-fpga -y
       - name: Run testing
         shell: bash
         run: |


### PR DESCRIPTION
The issue started happening after switching to oneAPI 2024.2. The root cause is currently unclear.

Upd. (June 21):
The issue is fixed by replacing: `intel-oneapi-runtime-dpcpp-sycl-fpga-emul` -> `intel-oneapi-compiler-fpga`.
I communicated with the maintainers of the packages and this is expected behaviour. FPGA emulator is not a part of oneAPI since 2024.2 and should be installed through `intel-oneapi-compiler-fpga`. 