### PR TITLE
Add Slack information as a way to contact oneDPL developers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ You can find oneDPL samples at the [oneDPL Samples](https://github.com/oneapi-sr
 ## Support and Contribution
 Please report issues and suggestions via [GitHub issues](https://github.com/oneapi-src/oneDPL/issues).
 
+You can also contact oneDPL developers via [UXL Foundation Slack](https://slack-invite.uxlfoundation.org/) using
+the [#onedpl](https://uxlfoundation.slack.com/channels/onedpl) channel.
+
 ## Governance
 
 The oneDPL project is governed by the [UXL Foundation] and you can get involved in


### PR DESCRIPTION
This PR addresses the following items in the oneDPL migration to UXL Foundation governance:
https://github.com/uxlfoundation/open-source-working-group/issues/6
https://github.com/uxlfoundation/open-source-working-group/issues/11
https://github.com/uxlfoundation/open-source-working-group/issues/31