### PR TITLE
[RNG] Adding operators ==, !=, << and >> for engines and distributions

### DIFF
--- a/include/oneapi/dpl/internal/random_impl/bernoulli_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/bernoulli_distribution.h
@@ -128,13 +128,14 @@ class bernoulli_distribution
         return result_portion_internal<size_of_type_, _Engine>(__engine, __params, __random_nums);
     }
 
-    friend bool operator==(const bernoulli_distribution& _x, const bernoulli_distribution& _y)
+    friend bool operator==(const bernoulli_distribution& __x, const bernoulli_distribution& __y)
     {
-        return _x.p_ == _y.p_;
+        return __x.p_ == __y.p_;
     }
-    friend bool operator!=(const bernoulli_distribution& _x, const bernoulli_distribution& _y)
+
+    friend bool operator!=(const bernoulli_distribution& __x, const bernoulli_distribution& __y)
     {
-        return !(_x == _y);
+        return !(__x == __y);
     }
 
     template <class CharT, class Traits>
@@ -142,18 +143,10 @@ class bernoulli_distribution
     operator<<(::std::basic_ostream<CharT,Traits>& os,
             const bernoulli_distribution& d)
     {
-        // const std::ios_base::fmtflags _flags = os.flags();
-        // const CharT prev_fill = os.fill();
+        internal::save_stream_flags<CharT, Traits> __flags(os);
 
-        // os.setf(std::ios_base::dec|std::ios_base::left);
-        // os.fill(os.widen(' '));
-
-        // os << d.p();
-
-        // os.flags(_flags);
-        // os.fill(prev_fill);
-
-        // return os;
+        os.setf(std::ios_base::dec|std::ios_base::left);
+        os.fill(os.widen(' '));
 
         return os << d.p();
     }
@@ -167,12 +160,16 @@ class bernoulli_distribution
     template< class CharT, class Traits >
     friend ::std::basic_istream<CharT,Traits>&
     operator>>(::std::basic_istream<CharT,Traits>& is,
-                    bernoulli_distribution& d)
+               bernoulli_distribution& d)
     {
-        // is.setf(std::ios_base::dec);
+        internal::save_stream_flags<CharT, Traits> __flags(is);
+
+        is.setf(std::ios_base::dec);
+
         double __p;
         if (is >> __p)
             d.param(bernoulli_distribution::param_type(__p));
+
         return is;
     }
 

--- a/include/oneapi/dpl/internal/random_impl/bernoulli_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/bernoulli_distribution.h
@@ -128,6 +128,54 @@ class bernoulli_distribution
         return result_portion_internal<size_of_type_, _Engine>(__engine, __params, __random_nums);
     }
 
+    friend bool operator==(const bernoulli_distribution& _x, const bernoulli_distribution& _y)
+    {
+        return _x.p_ == _y.p_;
+    }
+    friend bool operator!=(const bernoulli_distribution& _x, const bernoulli_distribution& _y)
+    {
+        return !(_x == _y);
+    }
+
+    template <class CharT, class Traits>
+    friend ::std::basic_ostream<CharT, Traits>&
+    operator<<(::std::basic_ostream<CharT,Traits>& os,
+            const bernoulli_distribution& d)
+    {
+        // const std::ios_base::fmtflags _flags = os.flags();
+        // const CharT prev_fill = os.fill();
+
+        // os.setf(std::ios_base::dec|std::ios_base::left);
+        // os.fill(os.widen(' '));
+
+        // os << d.p();
+
+        // os.flags(_flags);
+        // os.fill(prev_fill);
+
+        // return os;
+
+        return os << d.p();
+    }
+
+    friend const sycl::stream&
+    operator<<(const sycl::stream& os, const bernoulli_distribution& d)
+    {
+        return os << d.p();
+    }
+
+    template< class CharT, class Traits >
+    friend ::std::basic_istream<CharT,Traits>&
+    operator>>(::std::basic_istream<CharT,Traits>& is,
+                    bernoulli_distribution& d)
+    {
+        // is.setf(std::ios_base::dec);
+        double __p;
+        if (is >> __p)
+            d.param(bernoulli_distribution::param_type(__p));
+        return is;
+    }
+
   private:
     // Size of type
     static constexpr int size_of_type_ = internal::type_traits_t<result_type>::num_elems;

--- a/include/oneapi/dpl/internal/random_impl/bernoulli_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/bernoulli_distribution.h
@@ -128,24 +128,25 @@ class bernoulli_distribution
         return result_portion_internal<size_of_type_, _Engine>(__engine, __params, __random_nums);
     }
 
-    friend bool operator==(const bernoulli_distribution& __x, const bernoulli_distribution& __y)
+    friend bool
+    operator==(const bernoulli_distribution& __x, const bernoulli_distribution& __y)
     {
         return __x.p_ == __y.p_;
     }
 
-    friend bool operator!=(const bernoulli_distribution& __x, const bernoulli_distribution& __y)
+    friend bool
+    operator!=(const bernoulli_distribution& __x, const bernoulli_distribution& __y)
     {
         return !(__x == __y);
     }
 
     template <class CharT, class Traits>
     friend ::std::basic_ostream<CharT, Traits>&
-    operator<<(::std::basic_ostream<CharT,Traits>& __os,
-            const bernoulli_distribution& __d)
+    operator<<(::std::basic_ostream<CharT, Traits>& __os, const bernoulli_distribution& __d)
     {
         internal::save_stream_flags<CharT, Traits> __flags(__os);
 
-        __os.setf(std::ios_base::dec|std::ios_base::left);
+        __os.setf(std::ios_base::dec | std::ios_base::left);
         __os.fill(__os.widen(' '));
 
         return __os << __d.p();
@@ -157,10 +158,9 @@ class bernoulli_distribution
         return __os << __d.p();
     }
 
-    template< class CharT, class Traits >
-    friend ::std::basic_istream<CharT,Traits>&
-    operator>>(::std::basic_istream<CharT,Traits>& __is,
-               bernoulli_distribution& __d)
+    template <class CharT, class Traits>
+    friend ::std::basic_istream<CharT, Traits>&
+    operator>>(::std::basic_istream<CharT, Traits>& __is, bernoulli_distribution& __d)
     {
         internal::save_stream_flags<CharT, Traits> __flags(__is);
 

--- a/include/oneapi/dpl/internal/random_impl/bernoulli_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/bernoulli_distribution.h
@@ -140,37 +140,37 @@ class bernoulli_distribution
 
     template <class CharT, class Traits>
     friend ::std::basic_ostream<CharT, Traits>&
-    operator<<(::std::basic_ostream<CharT,Traits>& os,
-            const bernoulli_distribution& d)
+    operator<<(::std::basic_ostream<CharT,Traits>& __os,
+            const bernoulli_distribution& __d)
     {
-        internal::save_stream_flags<CharT, Traits> __flags(os);
+        internal::save_stream_flags<CharT, Traits> __flags(__os);
 
-        os.setf(std::ios_base::dec|std::ios_base::left);
-        os.fill(os.widen(' '));
+        __os.setf(std::ios_base::dec|std::ios_base::left);
+        __os.fill(__os.widen(' '));
 
-        return os << d.p();
+        return __os << __d.p();
     }
 
     friend const sycl::stream&
-    operator<<(const sycl::stream& os, const bernoulli_distribution& d)
+    operator<<(const sycl::stream& __os, const bernoulli_distribution& __d)
     {
-        return os << d.p();
+        return __os << __d.p();
     }
 
     template< class CharT, class Traits >
     friend ::std::basic_istream<CharT,Traits>&
-    operator>>(::std::basic_istream<CharT,Traits>& is,
-               bernoulli_distribution& d)
+    operator>>(::std::basic_istream<CharT,Traits>& __is,
+               bernoulli_distribution& __d)
     {
-        internal::save_stream_flags<CharT, Traits> __flags(is);
+        internal::save_stream_flags<CharT, Traits> __flags(__is);
 
-        is.setf(std::ios_base::dec);
+        __is.setf(std::ios_base::dec);
 
         double __p;
-        if (is >> __p)
-            d.param(bernoulli_distribution::param_type(__p));
+        if (__is >> __p)
+            __d.param(bernoulli_distribution::param_type(__p));
 
-        return is;
+        return __is;
     }
 
   private:

--- a/include/oneapi/dpl/internal/random_impl/cauchy_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/cauchy_distribution.h
@@ -141,6 +141,54 @@ class cauchy_distribution
         return result_portion_internal<size_of_type_, _Engine>(__engine, __params, __random_nums);
     }
 
+    friend bool operator==(const cauchy_distribution& __x, const cauchy_distribution& __y)
+    {
+        return __x.param() == __y.param();
+    }
+
+    friend bool operator!=(const cauchy_distribution& __x, const cauchy_distribution& __y)
+    {
+        return !(__x == __y);
+    }
+
+    template <class CharT, class Traits>
+    friend ::std::basic_ostream<CharT, Traits>&
+    operator<<(::std::basic_ostream<CharT,Traits>& os,
+            const cauchy_distribution& d)
+    {
+        internal::save_stream_flags<CharT, Traits> __flags(os);
+
+        os.setf(std::ios_base::dec|std::ios_base::left);
+        CharT __sp = os.widen(' ');
+        os.fill(__sp);
+
+        return os << d.a() << __sp << d.b();
+    }
+
+    friend const sycl::stream&
+    operator<<(const sycl::stream& os, const cauchy_distribution& d)
+    {
+        return os << d.a() << ' ' << d.b();
+    }
+
+    template< class CharT, class Traits >
+    friend ::std::basic_istream<CharT,Traits>&
+    operator>>(::std::basic_istream<CharT,Traits>& is,
+               cauchy_distribution& d)
+    {
+        internal::save_stream_flags<CharT, Traits> __flags(is);
+
+        is.setf(std::ios_base::dec);
+
+        scalar_type __a;
+        scalar_type __b;
+
+        if (is >> __a >> __b)
+            d.param(cauchy_distribution::param_type(__a, __b));
+
+        return is;
+    }
+
   private:
     // Size of type
     static constexpr int size_of_type_ = internal::type_traits_t<result_type>::num_elems;

--- a/include/oneapi/dpl/internal/random_impl/cauchy_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/cauchy_distribution.h
@@ -141,24 +141,25 @@ class cauchy_distribution
         return result_portion_internal<size_of_type_, _Engine>(__engine, __params, __random_nums);
     }
 
-    friend bool operator==(const cauchy_distribution& __x, const cauchy_distribution& __y)
+    friend bool
+    operator==(const cauchy_distribution& __x, const cauchy_distribution& __y)
     {
         return __x.param() == __y.param();
     }
 
-    friend bool operator!=(const cauchy_distribution& __x, const cauchy_distribution& __y)
+    friend bool
+    operator!=(const cauchy_distribution& __x, const cauchy_distribution& __y)
     {
         return !(__x == __y);
     }
 
     template <class CharT, class Traits>
     friend ::std::basic_ostream<CharT, Traits>&
-    operator<<(::std::basic_ostream<CharT,Traits>& __os,
-            const cauchy_distribution& __d)
+    operator<<(::std::basic_ostream<CharT, Traits>& __os, const cauchy_distribution& __d)
     {
         internal::save_stream_flags<CharT, Traits> __flags(__os);
 
-        __os.setf(std::ios_base::dec|std::ios_base::left);
+        __os.setf(std::ios_base::dec | std::ios_base::left);
         CharT __sp = __os.widen(' ');
         __os.fill(__sp);
 
@@ -171,10 +172,9 @@ class cauchy_distribution
         return __os << __d.a() << ' ' << __d.b();
     }
 
-    template< class CharT, class Traits >
-    friend ::std::basic_istream<CharT,Traits>&
-    operator>>(::std::basic_istream<CharT,Traits>& __is,
-               cauchy_distribution& __d)
+    template <class CharT, class Traits>
+    friend ::std::basic_istream<CharT, Traits>&
+    operator>>(::std::basic_istream<CharT, Traits>& __is, cauchy_distribution& __d)
     {
         internal::save_stream_flags<CharT, Traits> __flags(__is);
 

--- a/include/oneapi/dpl/internal/random_impl/cauchy_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/cauchy_distribution.h
@@ -153,40 +153,40 @@ class cauchy_distribution
 
     template <class CharT, class Traits>
     friend ::std::basic_ostream<CharT, Traits>&
-    operator<<(::std::basic_ostream<CharT,Traits>& os,
-            const cauchy_distribution& d)
+    operator<<(::std::basic_ostream<CharT,Traits>& __os,
+            const cauchy_distribution& __d)
     {
-        internal::save_stream_flags<CharT, Traits> __flags(os);
+        internal::save_stream_flags<CharT, Traits> __flags(__os);
 
-        os.setf(std::ios_base::dec|std::ios_base::left);
-        CharT __sp = os.widen(' ');
-        os.fill(__sp);
+        __os.setf(std::ios_base::dec|std::ios_base::left);
+        CharT __sp = __os.widen(' ');
+        __os.fill(__sp);
 
-        return os << d.a() << __sp << d.b();
+        return __os << __d.a() << __sp << __d.b();
     }
 
     friend const sycl::stream&
-    operator<<(const sycl::stream& os, const cauchy_distribution& d)
+    operator<<(const sycl::stream& __os, const cauchy_distribution& __d)
     {
-        return os << d.a() << ' ' << d.b();
+        return __os << __d.a() << ' ' << __d.b();
     }
 
     template< class CharT, class Traits >
     friend ::std::basic_istream<CharT,Traits>&
-    operator>>(::std::basic_istream<CharT,Traits>& is,
-               cauchy_distribution& d)
+    operator>>(::std::basic_istream<CharT,Traits>& __is,
+               cauchy_distribution& __d)
     {
-        internal::save_stream_flags<CharT, Traits> __flags(is);
+        internal::save_stream_flags<CharT, Traits> __flags(__is);
 
-        is.setf(std::ios_base::dec);
+        __is.setf(std::ios_base::dec);
 
         scalar_type __a;
         scalar_type __b;
 
-        if (is >> __a >> __b)
-            d.param(cauchy_distribution::param_type(__a, __b));
+        if (__is >> __a >> __b)
+            __d.param(cauchy_distribution::param_type(__a, __b));
 
-        return is;
+        return __is;
     }
 
   private:

--- a/include/oneapi/dpl/internal/random_impl/discard_block_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/discard_block_engine.h
@@ -133,6 +133,57 @@ class discard_block_engine
         return engine_;
     }
 
+    friend bool
+    operator==(const discard_block_engine& __x, const discard_block_engine& __y)
+    {
+        return (__x.n_ == __y.n_ && __x.engine_ == __y.engine_);
+    }
+
+    friend bool
+    operator!=(const discard_block_engine& __x, const discard_block_engine& __y)
+    {
+        return !(__x == __y);
+    }
+
+    template<class CharT, class Traits>
+    friend ::std::basic_ostream<CharT,Traits>&
+    operator<<(::std::basic_ostream<CharT,Traits>& os,
+               const discard_block_engine& e)
+    {
+        internal::save_stream_flags<CharT, Traits> __flags(os);
+
+        os.setf(std::ios_base::dec|std::ios_base::left);
+        CharT __sp = os.widen(' ');
+        os.fill(__sp);
+
+        return os << e.engine_ << __sp << e.n_;
+    }
+
+    friend const sycl::stream&
+    operator<<(const sycl::stream& os, const discard_block_engine& e)
+    {
+        return os << e.engine_ << ' ' << e.n_;
+    }
+
+    template<class CharT, class Traits, class __Engine, std::size_t __P, std::size_t __R>
+    friend ::std::basic_istream<CharT,Traits>&
+    operator>>(::std::basic_istream<CharT,Traits>& is,
+               discard_block_engine<__Engine,__P,__R>& e)
+    {
+        internal::save_stream_flags<CharT, Traits> __flags(is);
+
+        is.setf(std::ios_base::dec);
+
+        __Engine __engine_;
+        std::size_t __n_;
+        if (is >> __engine_ >> __n_) {
+            e.engine_ = __engine_;
+            e.n_ = __n_;
+        }            
+
+        return is;
+    }
+
   private:
     // Static asserts
     static_assert((0 < _R) && (_R <= _P), "oneapi::dpl::discard_block_engine. Error: unsupported parameters");

--- a/include/oneapi/dpl/internal/random_impl/discard_block_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/discard_block_engine.h
@@ -145,14 +145,13 @@ class discard_block_engine
         return !(__x == __y);
     }
 
-    template<class CharT, class Traits>
-    friend ::std::basic_ostream<CharT,Traits>&
-    operator<<(::std::basic_ostream<CharT,Traits>& __os,
-               const discard_block_engine& __e)
+    template <class CharT, class Traits>
+    friend ::std::basic_ostream<CharT, Traits>&
+    operator<<(::std::basic_ostream<CharT, Traits>& __os, const discard_block_engine& __e)
     {
         internal::save_stream_flags<CharT, Traits> __flags(__os);
 
-        __os.setf(std::ios_base::dec|std::ios_base::left);
+        __os.setf(std::ios_base::dec | std::ios_base::left);
         CharT __sp = __os.widen(' ');
         __os.fill(__sp);
 
@@ -165,10 +164,9 @@ class discard_block_engine
         return __os << __e.engine_ << ' ' << __e.n_;
     }
 
-    template<class CharT, class Traits, class __Engine, std::size_t __P, std::size_t __R>
-    friend ::std::basic_istream<CharT,Traits>&
-    operator>>(::std::basic_istream<CharT,Traits>& __is,
-               discard_block_engine<__Engine,__P,__R>& __e)
+    template <class CharT, class Traits, class __Engine, std::size_t __P, std::size_t __R>
+    friend ::std::basic_istream<CharT, Traits>&
+    operator>>(::std::basic_istream<CharT, Traits>& __is, discard_block_engine<__Engine, __P, __R>& __e)
     {
         internal::save_stream_flags<CharT, Traits> __flags(__is);
 
@@ -176,10 +174,11 @@ class discard_block_engine
 
         __Engine __engine_;
         std::size_t __n_;
-        if (__is >> __engine_ >> __n_) {
+        if (__is >> __engine_ >> __n_)
+        {
             __e.engine_ = __engine_;
             __e.n_ = __n_;
-        }            
+        }
 
         return __is;
     }

--- a/include/oneapi/dpl/internal/random_impl/discard_block_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/discard_block_engine.h
@@ -147,41 +147,41 @@ class discard_block_engine
 
     template<class CharT, class Traits>
     friend ::std::basic_ostream<CharT,Traits>&
-    operator<<(::std::basic_ostream<CharT,Traits>& os,
-               const discard_block_engine& e)
+    operator<<(::std::basic_ostream<CharT,Traits>& __os,
+               const discard_block_engine& __e)
     {
-        internal::save_stream_flags<CharT, Traits> __flags(os);
+        internal::save_stream_flags<CharT, Traits> __flags(__os);
 
-        os.setf(std::ios_base::dec|std::ios_base::left);
-        CharT __sp = os.widen(' ');
-        os.fill(__sp);
+        __os.setf(std::ios_base::dec|std::ios_base::left);
+        CharT __sp = __os.widen(' ');
+        __os.fill(__sp);
 
-        return os << e.engine_ << __sp << e.n_;
+        return __os << __e.engine_ << __sp << __e.n_;
     }
 
     friend const sycl::stream&
-    operator<<(const sycl::stream& os, const discard_block_engine& e)
+    operator<<(const sycl::stream& __os, const discard_block_engine& __e)
     {
-        return os << e.engine_ << ' ' << e.n_;
+        return __os << __e.engine_ << ' ' << __e.n_;
     }
 
     template<class CharT, class Traits, class __Engine, std::size_t __P, std::size_t __R>
     friend ::std::basic_istream<CharT,Traits>&
-    operator>>(::std::basic_istream<CharT,Traits>& is,
-               discard_block_engine<__Engine,__P,__R>& e)
+    operator>>(::std::basic_istream<CharT,Traits>& __is,
+               discard_block_engine<__Engine,__P,__R>& __e)
     {
-        internal::save_stream_flags<CharT, Traits> __flags(is);
+        internal::save_stream_flags<CharT, Traits> __flags(__is);
 
-        is.setf(std::ios_base::dec);
+        __is.setf(std::ios_base::dec);
 
         __Engine __engine_;
         std::size_t __n_;
-        if (is >> __engine_ >> __n_) {
-            e.engine_ = __engine_;
-            e.n_ = __n_;
+        if (__is >> __engine_ >> __n_) {
+            __e.engine_ = __engine_;
+            __e.n_ = __n_;
         }            
 
-        return is;
+        return __is;
     }
 
   private:

--- a/include/oneapi/dpl/internal/random_impl/exponential_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/exponential_distribution.h
@@ -140,37 +140,37 @@ class exponential_distribution
 
     template <class CharT, class Traits>
     friend ::std::basic_ostream<CharT, Traits>&
-    operator<<(::std::basic_ostream<CharT,Traits>& os,
-            const exponential_distribution& d)
+    operator<<(::std::basic_ostream<CharT,Traits>& __os,
+            const exponential_distribution& __d)
     {
-        internal::save_stream_flags<CharT, Traits> __flags(os);
+        internal::save_stream_flags<CharT, Traits> __flags(__os);
 
-        os.setf(std::ios_base::dec|std::ios_base::left);
-        os.fill(os.widen(' '));
+        __os.setf(std::ios_base::dec|std::ios_base::left);
+        __os.fill(__os.widen(' '));
 
-        return os << d.lambda();
+        return __os << __d.lambda();
     }
 
     friend const sycl::stream&
-    operator<<(const sycl::stream& os, const exponential_distribution& d)
+    operator<<(const sycl::stream& __os, const exponential_distribution& __d)
     {
-        return os << d.lambda();
+        return __os << __d.lambda();
     }
 
     template< class CharT, class Traits >
     friend ::std::basic_istream<CharT,Traits>&
-    operator>>(::std::basic_istream<CharT,Traits>& is,
-               exponential_distribution& d)
+    operator>>(::std::basic_istream<CharT,Traits>& __is,
+               exponential_distribution& __d)
     {
-        internal::save_stream_flags<CharT, Traits> __flags(is);
+        internal::save_stream_flags<CharT, Traits> __flags(__is);
 
-        is.setf(std::ios_base::dec);
+        __is.setf(std::ios_base::dec);
 
         double __p;
-        if (is >> __p)
-            d.param(exponential_distribution::param_type(__p));
+        if (__is >> __p)
+            __d.param(exponential_distribution::param_type(__p));
 
-        return is;
+        return __is;
     }
 
   private:

--- a/include/oneapi/dpl/internal/random_impl/exponential_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/exponential_distribution.h
@@ -128,6 +128,51 @@ class exponential_distribution
         return result_portion_internal<size_of_type_, _Engine>(__engine, __params, __random_nums);
     }
 
+    friend bool operator==(const exponential_distribution& __x, const exponential_distribution& __y)
+    {
+        return __x.lambda_ == __y.lambda_;
+    }
+
+    friend bool operator!=(const exponential_distribution& __x, const exponential_distribution& __y)
+    {
+        return !(__x == __y);
+    }
+
+    template <class CharT, class Traits>
+    friend ::std::basic_ostream<CharT, Traits>&
+    operator<<(::std::basic_ostream<CharT,Traits>& os,
+            const exponential_distribution& d)
+    {
+        internal::save_stream_flags<CharT, Traits> __flags(os);
+
+        os.setf(std::ios_base::dec|std::ios_base::left);
+        os.fill(os.widen(' '));
+
+        return os << d.lambda();
+    }
+
+    friend const sycl::stream&
+    operator<<(const sycl::stream& os, const exponential_distribution& d)
+    {
+        return os << d.lambda();
+    }
+
+    template< class CharT, class Traits >
+    friend ::std::basic_istream<CharT,Traits>&
+    operator>>(::std::basic_istream<CharT,Traits>& is,
+               exponential_distribution& d)
+    {
+        internal::save_stream_flags<CharT, Traits> __flags(is);
+
+        is.setf(std::ios_base::dec);
+
+        double __p;
+        if (is >> __p)
+            d.param(exponential_distribution::param_type(__p));
+
+        return is;
+    }
+
   private:
     // Size of type
     static constexpr int size_of_type_ = internal::type_traits_t<result_type>::num_elems;

--- a/include/oneapi/dpl/internal/random_impl/exponential_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/exponential_distribution.h
@@ -128,24 +128,25 @@ class exponential_distribution
         return result_portion_internal<size_of_type_, _Engine>(__engine, __params, __random_nums);
     }
 
-    friend bool operator==(const exponential_distribution& __x, const exponential_distribution& __y)
+    friend bool
+    operator==(const exponential_distribution& __x, const exponential_distribution& __y)
     {
         return __x.lambda_ == __y.lambda_;
     }
 
-    friend bool operator!=(const exponential_distribution& __x, const exponential_distribution& __y)
+    friend bool
+    operator!=(const exponential_distribution& __x, const exponential_distribution& __y)
     {
         return !(__x == __y);
     }
 
     template <class CharT, class Traits>
     friend ::std::basic_ostream<CharT, Traits>&
-    operator<<(::std::basic_ostream<CharT,Traits>& __os,
-            const exponential_distribution& __d)
+    operator<<(::std::basic_ostream<CharT, Traits>& __os, const exponential_distribution& __d)
     {
         internal::save_stream_flags<CharT, Traits> __flags(__os);
 
-        __os.setf(std::ios_base::dec|std::ios_base::left);
+        __os.setf(std::ios_base::dec | std::ios_base::left);
         __os.fill(__os.widen(' '));
 
         return __os << __d.lambda();
@@ -157,10 +158,9 @@ class exponential_distribution
         return __os << __d.lambda();
     }
 
-    template< class CharT, class Traits >
-    friend ::std::basic_istream<CharT,Traits>&
-    operator>>(::std::basic_istream<CharT,Traits>& __is,
-               exponential_distribution& __d)
+    template <class CharT, class Traits>
+    friend ::std::basic_istream<CharT, Traits>&
+    operator>>(::std::basic_istream<CharT, Traits>& __is, exponential_distribution& __d)
     {
         internal::save_stream_flags<CharT, Traits> __flags(__is);
 

--- a/include/oneapi/dpl/internal/random_impl/extreme_value_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/extreme_value_distribution.h
@@ -141,6 +141,54 @@ class extreme_value_distribution
         return result_portion_internal<size_of_type_, _Engine>(__engine, __params, __random_nums);
     }
 
+    friend bool operator==(const extreme_value_distribution& __x, const extreme_value_distribution& __y)
+    {
+        return __x.param() == __y.param();
+    }
+
+    friend bool operator!=(const extreme_value_distribution& __x, const extreme_value_distribution& __y)
+    {
+        return !(__x == __y);
+    }
+
+    template <class CharT, class Traits>
+    friend ::std::basic_ostream<CharT, Traits>&
+    operator<<(::std::basic_ostream<CharT,Traits>& os,
+            const extreme_value_distribution& d)
+    {
+        internal::save_stream_flags<CharT, Traits> __flags(os);
+
+        os.setf(std::ios_base::dec|std::ios_base::left);
+        CharT __sp = os.widen(' ');
+        os.fill(__sp);
+
+        return os << d.a() << __sp << d.b();
+    }
+
+    friend const sycl::stream&
+    operator<<(const sycl::stream& os, const extreme_value_distribution& d)
+    {
+        return os << d.a() << ' ' << d.b();
+    }
+
+    template< class CharT, class Traits >
+    friend ::std::basic_istream<CharT,Traits>&
+    operator>>(::std::basic_istream<CharT,Traits>& is,
+               extreme_value_distribution& d)
+    {
+        internal::save_stream_flags<CharT, Traits> __flags(is);
+
+        is.setf(std::ios_base::dec);
+
+        extreme_value_distribution::scalar_type __a;
+        extreme_value_distribution::scalar_type __b;
+
+        if (is >> __a >> __b)
+            d.param(extreme_value_distribution::param_type(__a, __b));
+
+        return is;
+    }
+
   private:
     // Size of type
     static constexpr int size_of_type_ = internal::type_traits_t<result_type>::num_elems;

--- a/include/oneapi/dpl/internal/random_impl/extreme_value_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/extreme_value_distribution.h
@@ -153,40 +153,40 @@ class extreme_value_distribution
 
     template <class CharT, class Traits>
     friend ::std::basic_ostream<CharT, Traits>&
-    operator<<(::std::basic_ostream<CharT,Traits>& os,
-            const extreme_value_distribution& d)
+    operator<<(::std::basic_ostream<CharT,Traits>& __os,
+            const extreme_value_distribution& __d)
     {
-        internal::save_stream_flags<CharT, Traits> __flags(os);
+        internal::save_stream_flags<CharT, Traits> __flags(__os);
 
-        os.setf(std::ios_base::dec|std::ios_base::left);
-        CharT __sp = os.widen(' ');
-        os.fill(__sp);
+        __os.setf(std::ios_base::dec|std::ios_base::left);
+        CharT __sp = __os.widen(' ');
+        __os.fill(__sp);
 
-        return os << d.a() << __sp << d.b();
+        return __os << __d.a() << __sp << __d.b();
     }
 
     friend const sycl::stream&
-    operator<<(const sycl::stream& os, const extreme_value_distribution& d)
+    operator<<(const sycl::stream& __os, const extreme_value_distribution& __d)
     {
-        return os << d.a() << ' ' << d.b();
+        return __os << __d.a() << ' ' << __d.b();
     }
 
     template< class CharT, class Traits >
     friend ::std::basic_istream<CharT,Traits>&
-    operator>>(::std::basic_istream<CharT,Traits>& is,
-               extreme_value_distribution& d)
+    operator>>(::std::basic_istream<CharT,Traits>& __is,
+               extreme_value_distribution& __d)
     {
-        internal::save_stream_flags<CharT, Traits> __flags(is);
+        internal::save_stream_flags<CharT, Traits> __flags(__is);
 
-        is.setf(std::ios_base::dec);
+        __is.setf(std::ios_base::dec);
 
         extreme_value_distribution::scalar_type __a;
         extreme_value_distribution::scalar_type __b;
 
-        if (is >> __a >> __b)
-            d.param(extreme_value_distribution::param_type(__a, __b));
+        if (__is >> __a >> __b)
+            __d.param(extreme_value_distribution::param_type(__a, __b));
 
-        return is;
+        return __is;
     }
 
   private:

--- a/include/oneapi/dpl/internal/random_impl/extreme_value_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/extreme_value_distribution.h
@@ -141,24 +141,25 @@ class extreme_value_distribution
         return result_portion_internal<size_of_type_, _Engine>(__engine, __params, __random_nums);
     }
 
-    friend bool operator==(const extreme_value_distribution& __x, const extreme_value_distribution& __y)
+    friend bool
+    operator==(const extreme_value_distribution& __x, const extreme_value_distribution& __y)
     {
         return __x.param() == __y.param();
     }
 
-    friend bool operator!=(const extreme_value_distribution& __x, const extreme_value_distribution& __y)
+    friend bool
+    operator!=(const extreme_value_distribution& __x, const extreme_value_distribution& __y)
     {
         return !(__x == __y);
     }
 
     template <class CharT, class Traits>
     friend ::std::basic_ostream<CharT, Traits>&
-    operator<<(::std::basic_ostream<CharT,Traits>& __os,
-            const extreme_value_distribution& __d)
+    operator<<(::std::basic_ostream<CharT, Traits>& __os, const extreme_value_distribution& __d)
     {
         internal::save_stream_flags<CharT, Traits> __flags(__os);
 
-        __os.setf(std::ios_base::dec|std::ios_base::left);
+        __os.setf(std::ios_base::dec | std::ios_base::left);
         CharT __sp = __os.widen(' ');
         __os.fill(__sp);
 
@@ -171,10 +172,9 @@ class extreme_value_distribution
         return __os << __d.a() << ' ' << __d.b();
     }
 
-    template< class CharT, class Traits >
-    friend ::std::basic_istream<CharT,Traits>&
-    operator>>(::std::basic_istream<CharT,Traits>& __is,
-               extreme_value_distribution& __d)
+    template <class CharT, class Traits>
+    friend ::std::basic_istream<CharT, Traits>&
+    operator>>(::std::basic_istream<CharT, Traits>& __is, extreme_value_distribution& __d)
     {
         internal::save_stream_flags<CharT, Traits> __flags(__is);
 

--- a/include/oneapi/dpl/internal/random_impl/geometric_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/geometric_distribution.h
@@ -128,6 +128,51 @@ class geometric_distribution
         return result_portion_internal<size_of_type_, _Engine>(__engine, __params, __random_nums);
     }
 
+    friend bool operator==(const geometric_distribution& __x, const geometric_distribution& __y)
+    {
+        return __x.p_ == __y.p_;
+    }
+
+    friend bool operator!=(const geometric_distribution& __x, const geometric_distribution& __y)
+    {
+        return !(__x == __y);
+    }
+
+    template <class CharT, class Traits>
+    friend ::std::basic_ostream<CharT, Traits>&
+    operator<<(::std::basic_ostream<CharT,Traits>& os,
+            const geometric_distribution& d)
+    {
+        internal::save_stream_flags<CharT, Traits> __flags(os);
+
+        os.setf(std::ios_base::dec|std::ios_base::left);
+        os.fill(os.widen(' '));
+
+        return os << d.p();
+    }
+
+    friend const sycl::stream&
+    operator<<(const sycl::stream& os, const geometric_distribution& d)
+    {
+        return os << d.p();
+    }
+
+    template< class CharT, class Traits >
+    friend ::std::basic_istream<CharT,Traits>&
+    operator>>(::std::basic_istream<CharT,Traits>& is,
+               geometric_distribution& d)
+    {
+        internal::save_stream_flags<CharT, Traits> __flags(is);
+
+        is.setf(std::ios_base::dec);
+
+        double __p;
+        if (is >> __p)
+            d.param(geometric_distribution::param_type(__p));
+
+        return is;
+    }
+
   private:
     // Size of type
     static constexpr int size_of_type_ = internal::type_traits_t<result_type>::num_elems;

--- a/include/oneapi/dpl/internal/random_impl/geometric_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/geometric_distribution.h
@@ -128,24 +128,25 @@ class geometric_distribution
         return result_portion_internal<size_of_type_, _Engine>(__engine, __params, __random_nums);
     }
 
-    friend bool operator==(const geometric_distribution& __x, const geometric_distribution& __y)
+    friend bool
+    operator==(const geometric_distribution& __x, const geometric_distribution& __y)
     {
         return __x.p_ == __y.p_;
     }
 
-    friend bool operator!=(const geometric_distribution& __x, const geometric_distribution& __y)
+    friend bool
+    operator!=(const geometric_distribution& __x, const geometric_distribution& __y)
     {
         return !(__x == __y);
     }
 
     template <class CharT, class Traits>
     friend ::std::basic_ostream<CharT, Traits>&
-    operator<<(::std::basic_ostream<CharT,Traits>& __os,
-            const geometric_distribution& __d)
+    operator<<(::std::basic_ostream<CharT, Traits>& __os, const geometric_distribution& __d)
     {
         internal::save_stream_flags<CharT, Traits> __flags(__os);
 
-        __os.setf(std::ios_base::dec|std::ios_base::left);
+        __os.setf(std::ios_base::dec | std::ios_base::left);
         __os.fill(__os.widen(' '));
 
         return __os << __d.p();
@@ -157,10 +158,9 @@ class geometric_distribution
         return __os << __d.p();
     }
 
-    template< class CharT, class Traits >
-    friend ::std::basic_istream<CharT,Traits>&
-    operator>>(::std::basic_istream<CharT,Traits>& __is,
-               geometric_distribution& __d)
+    template <class CharT, class Traits>
+    friend ::std::basic_istream<CharT, Traits>&
+    operator>>(::std::basic_istream<CharT, Traits>& __is, geometric_distribution& __d)
     {
         internal::save_stream_flags<CharT, Traits> __flags(__is);
 

--- a/include/oneapi/dpl/internal/random_impl/geometric_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/geometric_distribution.h
@@ -140,37 +140,37 @@ class geometric_distribution
 
     template <class CharT, class Traits>
     friend ::std::basic_ostream<CharT, Traits>&
-    operator<<(::std::basic_ostream<CharT,Traits>& os,
-            const geometric_distribution& d)
+    operator<<(::std::basic_ostream<CharT,Traits>& __os,
+            const geometric_distribution& __d)
     {
-        internal::save_stream_flags<CharT, Traits> __flags(os);
+        internal::save_stream_flags<CharT, Traits> __flags(__os);
 
-        os.setf(std::ios_base::dec|std::ios_base::left);
-        os.fill(os.widen(' '));
+        __os.setf(std::ios_base::dec|std::ios_base::left);
+        __os.fill(__os.widen(' '));
 
-        return os << d.p();
+        return __os << __d.p();
     }
 
     friend const sycl::stream&
-    operator<<(const sycl::stream& os, const geometric_distribution& d)
+    operator<<(const sycl::stream& __os, const geometric_distribution& __d)
     {
-        return os << d.p();
+        return __os << __d.p();
     }
 
     template< class CharT, class Traits >
     friend ::std::basic_istream<CharT,Traits>&
-    operator>>(::std::basic_istream<CharT,Traits>& is,
-               geometric_distribution& d)
+    operator>>(::std::basic_istream<CharT,Traits>& __is,
+               geometric_distribution& __d)
     {
-        internal::save_stream_flags<CharT, Traits> __flags(is);
+        internal::save_stream_flags<CharT, Traits> __flags(__is);
 
-        is.setf(std::ios_base::dec);
+        __is.setf(std::ios_base::dec);
 
         double __p;
-        if (is >> __p)
-            d.param(geometric_distribution::param_type(__p));
+        if (__is >> __p)
+            __d.param(geometric_distribution::param_type(__p));
 
-        return is;
+        return __is;
     }
 
   private:

--- a/include/oneapi/dpl/internal/random_impl/linear_congruential_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/linear_congruential_engine.h
@@ -111,14 +111,13 @@ class linear_congruential_engine
         return !(__x == __y);
     }
 
-    template<class CharT, class Traits>
-    friend ::std::basic_ostream<CharT,Traits>&
-    operator<<(::std::basic_ostream<CharT,Traits>& __os,
-               const linear_congruential_engine& __e)
+    template <class CharT, class Traits>
+    friend ::std::basic_ostream<CharT, Traits>&
+    operator<<(::std::basic_ostream<CharT, Traits>& __os, const linear_congruential_engine& __e)
     {
         internal::save_stream_flags<CharT, Traits> __flags(__os);
 
-        __os.setf(std::ios_base::dec|std::ios_base::left);
+        __os.setf(std::ios_base::dec | std::ios_base::left);
         __os.fill(__os.widen(' '));
 
         return __os << __e.state_;
@@ -130,10 +129,9 @@ class linear_congruential_engine
         return __os << __e.state_;
     }
 
-    template<class CharT, class Traits>
-    friend ::std::basic_istream<CharT,Traits>&
-    operator>>(::std::basic_istream<CharT,Traits>& __is,
-               linear_congruential_engine& __e)
+    template <class CharT, class Traits>
+    friend ::std::basic_istream<CharT, Traits>&
+    operator>>(::std::basic_istream<CharT, Traits>& __is, linear_congruential_engine& __e)
     {
         internal::save_stream_flags<CharT, Traits> __flags(__is);
 

--- a/include/oneapi/dpl/internal/random_impl/linear_congruential_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/linear_congruential_engine.h
@@ -100,15 +100,15 @@ class linear_congruential_engine
     }
 
     friend bool
-    operator==(const linear_congruential_engine& _x, const linear_congruential_engine& _y)
+    operator==(const linear_congruential_engine& __x, const linear_congruential_engine& __y)
     {
-        return _x.state_ == _y.state_;
+        return __x.state_ == __y.state_;
     }
 
     friend bool
-    operator!=(const linear_congruential_engine& _x, const linear_congruential_engine& _y)
+    operator!=(const linear_congruential_engine& __x, const linear_congruential_engine& __y)
     {
-        return !(_x == _y);
+        return !(__x == __y);
     }
 
     template<class CharT, class Traits>
@@ -116,18 +116,12 @@ class linear_congruential_engine
     operator<<(::std::basic_ostream<CharT,Traits>& os,
                const linear_congruential_engine& e)
     {
-        const std::ios_base::fmtflags _flags = os.flags();
-        const CharT prev_fill = os.fill();
+        internal::save_stream_flags<CharT, Traits> __flags(os);
 
         os.setf(std::ios_base::dec|std::ios_base::left);
         os.fill(os.widen(' '));
 
-        os << e.state_;
-
-        os.flags(_flags);
-        os.fill(prev_fill);
-
-        return os;
+        return os << e.state_;
     }
 
     friend const sycl::stream&
@@ -141,15 +135,13 @@ class linear_congruential_engine
     operator>>(::std::basic_istream<CharT,Traits>& is,
                linear_congruential_engine& e)
     {
-        const std::ios_base::fmtflags _flags = is.flags();
+        internal::save_stream_flags<CharT, Traits> __flags(is);
 
         is.setf(std::ios_base::dec);
 
-        result_type __t;
+        linear_congruential_engine::result_type __t;
         if (is >> __t)
             e.state_ = __t;
-
-        is.flags(_flags);
 
         return is;
     }

--- a/include/oneapi/dpl/internal/random_impl/linear_congruential_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/linear_congruential_engine.h
@@ -113,37 +113,37 @@ class linear_congruential_engine
 
     template<class CharT, class Traits>
     friend ::std::basic_ostream<CharT,Traits>&
-    operator<<(::std::basic_ostream<CharT,Traits>& os,
-               const linear_congruential_engine& e)
+    operator<<(::std::basic_ostream<CharT,Traits>& __os,
+               const linear_congruential_engine& __e)
     {
-        internal::save_stream_flags<CharT, Traits> __flags(os);
+        internal::save_stream_flags<CharT, Traits> __flags(__os);
 
-        os.setf(std::ios_base::dec|std::ios_base::left);
-        os.fill(os.widen(' '));
+        __os.setf(std::ios_base::dec|std::ios_base::left);
+        __os.fill(__os.widen(' '));
 
-        return os << e.state_;
+        return __os << __e.state_;
     }
 
     friend const sycl::stream&
-    operator<<(const sycl::stream& os, const linear_congruential_engine& e)
+    operator<<(const sycl::stream& __os, const linear_congruential_engine& __e)
     {
-        return os << e.state_;
+        return __os << __e.state_;
     }
 
     template<class CharT, class Traits>
     friend ::std::basic_istream<CharT,Traits>&
-    operator>>(::std::basic_istream<CharT,Traits>& is,
-               linear_congruential_engine& e)
+    operator>>(::std::basic_istream<CharT,Traits>& __is,
+               linear_congruential_engine& __e)
     {
-        internal::save_stream_flags<CharT, Traits> __flags(is);
+        internal::save_stream_flags<CharT, Traits> __flags(__is);
 
-        is.setf(std::ios_base::dec);
+        __is.setf(std::ios_base::dec);
 
         linear_congruential_engine::result_type __t;
-        if (is >> __t)
-            e.state_ = __t;
+        if (__is >> __t)
+            __e.state_ = __t;
 
-        return is;
+        return __is;
     }
 
   private:

--- a/include/oneapi/dpl/internal/random_impl/linear_congruential_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/linear_congruential_engine.h
@@ -99,6 +99,61 @@ class linear_congruential_engine
         return result_portion_internal<internal::type_traits_t<result_type>::num_elems>(__random_nums);
     }
 
+    friend bool
+    operator==(const linear_congruential_engine& _x, const linear_congruential_engine& _y)
+    {
+        return _x.state_ == _y.state_;
+    }
+
+    friend bool
+    operator!=(const linear_congruential_engine& _x, const linear_congruential_engine& _y)
+    {
+        return !(_x == _y);
+    }
+
+    template<class CharT, class Traits>
+    friend ::std::basic_ostream<CharT,Traits>&
+    operator<<(::std::basic_ostream<CharT,Traits>& os,
+               const linear_congruential_engine& e)
+    {
+        const std::ios_base::fmtflags _flags = os.flags();
+        const CharT prev_fill = os.fill();
+
+        os.setf(std::ios_base::dec|std::ios_base::left);
+        os.fill(os.widen(' '));
+
+        os << e.state_;
+
+        os.flags(_flags);
+        os.fill(prev_fill);
+
+        return os;
+    }
+
+    friend const sycl::stream&
+    operator<<(const sycl::stream& os, const linear_congruential_engine& e)
+    {
+        return os << e.state_;
+    }
+
+    template<class CharT, class Traits>
+    friend ::std::basic_istream<CharT,Traits>&
+    operator>>(::std::basic_istream<CharT,Traits>& is,
+               linear_congruential_engine& e)
+    {
+        const std::ios_base::fmtflags _flags = is.flags();
+
+        is.setf(std::ios_base::dec);
+
+        result_type __t;
+        if (is >> __t)
+            e.state_ = __t;
+
+        is.flags(_flags);
+
+        return is;
+    }
+
   private:
     // Static asserts
     static_assert(((_M == 0) || ((_A < _M) && (_C < _M))),

--- a/include/oneapi/dpl/internal/random_impl/lognormal_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/lognormal_distribution.h
@@ -143,6 +143,38 @@ class lognormal_distribution
         return result_portion_internal<size_of_type_, _Engine>(__engine, __params, __random_nums);
     }
 
+    friend bool operator==(const lognormal_distribution& __x, const lognormal_distribution& __y)
+    {
+        return __x.nd_ == __y.nd_;
+    }
+
+    friend bool operator!=(const lognormal_distribution& __x, const lognormal_distribution& __y)
+    {
+        return !(__x == __y);
+    }
+
+    template <class CharT, class Traits>
+    friend ::std::basic_ostream<CharT, Traits>&
+    operator<<(::std::basic_ostream<CharT,Traits>& os,
+            const lognormal_distribution& d)
+    {
+        return os << d.nd_;
+    }
+
+    friend const sycl::stream&
+    operator<<(const sycl::stream& os, const lognormal_distribution& d)
+    {
+        return os << d.nd_;
+    }
+
+    template< class CharT, class Traits >
+    friend ::std::basic_istream<CharT,Traits>&
+    operator>>(::std::basic_istream<CharT,Traits>& is,
+               lognormal_distribution& d)
+    {
+        return is >> d.nd_;
+    }
+
   private:
     // Size of type
     static constexpr int size_of_type_ = internal::type_traits_t<result_type>::num_elems;

--- a/include/oneapi/dpl/internal/random_impl/lognormal_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/lognormal_distribution.h
@@ -155,24 +155,24 @@ class lognormal_distribution
 
     template <class CharT, class Traits>
     friend ::std::basic_ostream<CharT, Traits>&
-    operator<<(::std::basic_ostream<CharT,Traits>& os,
-            const lognormal_distribution& d)
+    operator<<(::std::basic_ostream<CharT,Traits>& __os,
+            const lognormal_distribution& __d)
     {
-        return os << d.nd_;
+        return __os << __d.nd_;
     }
 
     friend const sycl::stream&
-    operator<<(const sycl::stream& os, const lognormal_distribution& d)
+    operator<<(const sycl::stream& __os, const lognormal_distribution& __d)
     {
-        return os << d.nd_;
+        return __os << __d.nd_;
     }
 
     template< class CharT, class Traits >
     friend ::std::basic_istream<CharT,Traits>&
-    operator>>(::std::basic_istream<CharT,Traits>& is,
-               lognormal_distribution& d)
+    operator>>(::std::basic_istream<CharT,Traits>& __is,
+               lognormal_distribution& __d)
     {
-        return is >> d.nd_;
+        return __is >> __d.nd_;
     }
 
   private:

--- a/include/oneapi/dpl/internal/random_impl/lognormal_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/lognormal_distribution.h
@@ -143,20 +143,21 @@ class lognormal_distribution
         return result_portion_internal<size_of_type_, _Engine>(__engine, __params, __random_nums);
     }
 
-    friend bool operator==(const lognormal_distribution& __x, const lognormal_distribution& __y)
+    friend bool
+    operator==(const lognormal_distribution& __x, const lognormal_distribution& __y)
     {
         return __x.nd_ == __y.nd_;
     }
 
-    friend bool operator!=(const lognormal_distribution& __x, const lognormal_distribution& __y)
+    friend bool
+    operator!=(const lognormal_distribution& __x, const lognormal_distribution& __y)
     {
         return !(__x == __y);
     }
 
     template <class CharT, class Traits>
     friend ::std::basic_ostream<CharT, Traits>&
-    operator<<(::std::basic_ostream<CharT,Traits>& __os,
-            const lognormal_distribution& __d)
+    operator<<(::std::basic_ostream<CharT, Traits>& __os, const lognormal_distribution& __d)
     {
         return __os << __d.nd_;
     }
@@ -167,10 +168,9 @@ class lognormal_distribution
         return __os << __d.nd_;
     }
 
-    template< class CharT, class Traits >
-    friend ::std::basic_istream<CharT,Traits>&
-    operator>>(::std::basic_istream<CharT,Traits>& __is,
-               lognormal_distribution& __d)
+    template <class CharT, class Traits>
+    friend ::std::basic_istream<CharT, Traits>&
+    operator>>(::std::basic_istream<CharT, Traits>& __is, lognormal_distribution& __d)
     {
         return __is >> __d.nd_;
     }

--- a/include/oneapi/dpl/internal/random_impl/normal_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/normal_distribution.h
@@ -160,24 +160,25 @@ class normal_distribution
         return result_portion_internal<size_of_type_, _Engine>(__engine, __params, __random_nums);
     }
 
-    friend bool operator==(const normal_distribution& __x, const normal_distribution& __y)
+    friend bool
+    operator==(const normal_distribution& __x, const normal_distribution& __y)
     {
         return __x.param() == __y.param();
     }
 
-    friend bool operator!=(const normal_distribution& __x, const normal_distribution& __y)
+    friend bool
+    operator!=(const normal_distribution& __x, const normal_distribution& __y)
     {
         return !(__x == __y);
     }
 
     template <class CharT, class Traits>
     friend ::std::basic_ostream<CharT, Traits>&
-    operator<<(::std::basic_ostream<CharT,Traits>& __os,
-               const normal_distribution& __d)
+    operator<<(::std::basic_ostream<CharT, Traits>& __os, const normal_distribution& __d)
     {
         internal::save_stream_flags<CharT, Traits> __flags(__os);
 
-        __os.setf(std::ios_base::dec|std::ios_base::left);
+        __os.setf(std::ios_base::dec | std::ios_base::left);
         CharT __sp = __os.widen(' ');
         __os.fill(__sp);
 
@@ -199,10 +200,9 @@ class normal_distribution
         return __os;
     }
 
-    template< class CharT, class Traits >
-    friend ::std::basic_istream<CharT,Traits>&
-    operator>>(::std::basic_istream<CharT,Traits>& __is,
-               normal_distribution& __d)
+    template <class CharT, class Traits>
+    friend ::std::basic_istream<CharT, Traits>&
+    operator>>(::std::basic_istream<CharT, Traits>& __is, normal_distribution& __d)
     {
         using __scalar_type = normal_distribution::scalar_type;
 
@@ -218,9 +218,11 @@ class normal_distribution
 
         if (__is >> __mean >> __stddev)
             __d.param(param_type(__mean, __stddev));
-        if (__is >> __flag_) {
+        if (__is >> __flag_)
+        {
             __d.flag_ = __flag_;
-            if (__flag_ && (__is >> __saved_ln_ >> __saved_u2_)) {
+            if (__flag_ && (__is >> __saved_ln_ >> __saved_u2_))
+            {
                 __d.saved_ln_ = __saved_ln_;
                 __d.saved_u2_ = __saved_u2_;
             }

--- a/include/oneapi/dpl/internal/random_impl/normal_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/normal_distribution.h
@@ -172,43 +172,43 @@ class normal_distribution
 
     template <class CharT, class Traits>
     friend ::std::basic_ostream<CharT, Traits>&
-    operator<<(::std::basic_ostream<CharT,Traits>& os,
-               const normal_distribution& d)
+    operator<<(::std::basic_ostream<CharT,Traits>& __os,
+               const normal_distribution& __d)
     {
-        internal::save_stream_flags<CharT, Traits> __flags(os);
+        internal::save_stream_flags<CharT, Traits> __flags(__os);
 
-        os.setf(std::ios_base::dec|std::ios_base::left);
-        CharT __sp = os.widen(' ');
-        os.fill(__sp);
+        __os.setf(std::ios_base::dec|std::ios_base::left);
+        CharT __sp = __os.widen(' ');
+        __os.fill(__sp);
 
-        os << d.mean() << __sp << d.stddev() << __sp << d.flag_;
-        if (d.flag_)
-            os << __sp << d.saved_ln_ << __sp << d.saved_u2_;
+        __os << __d.mean() << __sp << __d.stddev() << __sp << __d.flag_;
+        if (__d.flag_)
+            __os << __sp << __d.saved_ln_ << __sp << __d.saved_u2_;
 
-        return os;
+        return __os;
     }
 
     friend const sycl::stream&
-    operator<<(const sycl::stream& os, const normal_distribution& d)
+    operator<<(const sycl::stream& __os, const normal_distribution& __d)
     {
-        os << d.mean() << ' ' << d.stddev() << ' ' << d.flag_;
+        __os << __d.mean() << ' ' << __d.stddev() << ' ' << __d.flag_;
 
-        if (d.flag_)
-            os << ' ' << d.saved_ln_ << ' ' << d.saved_u2_;
+        if (__d.flag_)
+            __os << ' ' << __d.saved_ln_ << ' ' << __d.saved_u2_;
 
-        return os;
+        return __os;
     }
 
     template< class CharT, class Traits >
     friend ::std::basic_istream<CharT,Traits>&
-    operator>>(::std::basic_istream<CharT,Traits>& is,
-               normal_distribution& d)
+    operator>>(::std::basic_istream<CharT,Traits>& __is,
+               normal_distribution& __d)
     {
         using __scalar_type = normal_distribution::scalar_type;
 
-        internal::save_stream_flags<CharT, Traits> __flags(is);
+        internal::save_stream_flags<CharT, Traits> __flags(__is);
 
-        is.setf(std::ios_base::dec);
+        __is.setf(std::ios_base::dec);
 
         __scalar_type __mean;
         __scalar_type __stddev;
@@ -216,17 +216,17 @@ class normal_distribution
         __scalar_type __saved_ln_;
         __scalar_type __saved_u2_;
 
-        if (is >> __mean >> __stddev)
-            d.param(param_type(__mean, __stddev));
-        if (is >> __flag_) {
-            d.flag_ = __flag_;
-            if (__flag_ && (is >> __saved_ln_ >> __saved_u2_)) {
-                d.saved_ln_ = __saved_ln_;
-                d.saved_u2_ = __saved_u2_;
+        if (__is >> __mean >> __stddev)
+            __d.param(param_type(__mean, __stddev));
+        if (__is >> __flag_) {
+            __d.flag_ = __flag_;
+            if (__flag_ && (__is >> __saved_ln_ >> __saved_u2_)) {
+                __d.saved_ln_ = __saved_ln_;
+                __d.saved_u2_ = __saved_u2_;
             }
         }
 
-        return is;
+        return __is;
     }
 
   private:

--- a/include/oneapi/dpl/internal/random_impl/random_common.h
+++ b/include/oneapi/dpl/internal/random_impl/random_common.h
@@ -52,6 +52,27 @@ typedef union {
     uint32_t hex[1];
 } sp_union_t;
 
+template <class _CharT, class _Traits>
+class save_stream_flags {
+    typedef ::std::basic_ios<_CharT, _Traits> __stream_type;
+
+public:
+    save_stream_flags(const save_stream_flags&) = delete;
+    save_stream_flags& operator=(const save_stream_flags&) = delete;
+
+    explicit save_stream_flags(__stream_type& __stream)
+        : __stream_(__stream), __fmtflags_(__stream.flags()), __fill_(__stream.fill()) {}
+    ~save_stream_flags() {
+        __stream_.flags(__fmtflags_);
+        __stream_.fill(__fill_);
+    }
+
+private:
+    typename __stream_type::fmtflags __fmtflags_;
+    __stream_type& __stream_;
+    _CharT __fill_;
+};
+
 } // namespace internal
 } // namespace dpl
 } // namespace oneapi

--- a/include/oneapi/dpl/internal/random_impl/random_common.h
+++ b/include/oneapi/dpl/internal/random_impl/random_common.h
@@ -44,30 +44,37 @@ struct type_traits_t<sycl::vec<_T, _N>>
 template <typename _T>
 using element_type_t = typename type_traits_t<_T>::element_type;
 
-typedef union {
+typedef union
+{
     uint32_t hex[2];
 } dp_union_t;
 
-typedef union {
+typedef union
+{
     uint32_t hex[1];
 } sp_union_t;
 
 template <class _CharT, class _Traits>
-class save_stream_flags {
+class save_stream_flags
+{
     typedef ::std::basic_ios<_CharT, _Traits> __stream_type;
 
-public:
+  public:
     save_stream_flags(const save_stream_flags&) = delete;
-    save_stream_flags& operator=(const save_stream_flags&) = delete;
+    save_stream_flags&
+    operator=(const save_stream_flags&) = delete;
 
     explicit save_stream_flags(__stream_type& __stream)
-        : __stream_(__stream), __fmtflags_(__stream.flags()), __fill_(__stream.fill()) {}
-    ~save_stream_flags() {
+        : __stream_(__stream), __fmtflags_(__stream.flags()), __fill_(__stream.fill())
+    {
+    }
+    ~save_stream_flags()
+    {
         __stream_.flags(__fmtflags_);
         __stream_.fill(__fill_);
     }
 
-private:
+  private:
     typename __stream_type::fmtflags __fmtflags_;
     __stream_type& __stream_;
     _CharT __fill_;

--- a/include/oneapi/dpl/internal/random_impl/subtract_with_carry_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/subtract_with_carry_engine.h
@@ -101,7 +101,8 @@ class subtract_with_carry_engine
             return false;
         if (__x.i_ == __y.i_)
             return std::equal(__x.x_, __x.x_ + _R, __y.x_);
-        if (__x.i_ == 0 || __y.i_ == 0) {
+        if (__x.i_ == 0 || __y.i_ == 0)
+        {
             size_t __j = std::min(_R - __x.i_, _R - __y.i_);
             if (!std::equal(__x.x_ + __x.i_, __x.x_ + __x.i_ + __j, __y.x_ + __y.i_))
                 return false;
@@ -109,7 +110,8 @@ class subtract_with_carry_engine
                 return std::equal(__x.x_ + __j, __x.x_ + _R, __y.x_);
             return std::equal(__x.x_, __x.x_ + (_R - __j), __y.x_ + __j);
         }
-        if (__x.i_ < __y.i_) {
+        if (__x.i_ < __y.i_)
+        {
             size_t __j = _R - __y.i_;
             if (!std::equal(__x.x_ + __x.i_, __x.x_ + (__x.i_ + __j), __y.x_ + __y.i_))
                 return false;
@@ -131,14 +133,13 @@ class subtract_with_carry_engine
         return !(__x == __y);
     }
 
-    template<class CharT, class Traits>
-    friend ::std::basic_ostream<CharT,Traits>&
-    operator<<(::std::basic_ostream<CharT,Traits>& __os,
-               const subtract_with_carry_engine& __e)
+    template <class CharT, class Traits>
+    friend ::std::basic_ostream<CharT, Traits>&
+    operator<<(::std::basic_ostream<CharT, Traits>& __os, const subtract_with_carry_engine& __e)
     {
         internal::save_stream_flags<CharT, Traits> __flags(__os);
 
-        __os.setf(std::ios_base::dec|std::ios_base::left);
+        __os.setf(std::ios_base::dec | std::ios_base::left);
         CharT __sp = __os.widen(' ');
         __os.fill(__sp);
 
@@ -167,10 +168,9 @@ class subtract_with_carry_engine
         return __os;
     }
 
-    template<class CharT, class Traits, class __UIntType, std::size_t __W, std::size_t __S, std::size_t __R>
-    friend ::std::basic_istream<CharT,Traits>&
-    operator>>(::std::basic_istream<CharT,Traits>& __is,
-               subtract_with_carry_engine<__UIntType,__W,__S,__R>& __e)
+    template <class CharT, class Traits, class __UIntType, std::size_t __W, std::size_t __S, std::size_t __R>
+    friend ::std::basic_istream<CharT, Traits>&
+    operator>>(::std::basic_istream<CharT, Traits>& __is, subtract_with_carry_engine<__UIntType, __W, __S, __R>& __e)
     {
         internal::save_stream_flags<CharT, Traits> __flags(__is);
 
@@ -179,12 +179,13 @@ class subtract_with_carry_engine
         __UIntType __t[__R + 1];
         for (size_t i = 0; i < __R + 1; ++i)
             __is >> __t[i];
-        if (!__is.fail()) {
+        if (!__is.fail())
+        {
             for (size_t i = 0; i < __R; ++i)
-            __e.x_[i] = __t[i];
+                __e.x_[i] = __t[i];
             __e.c_ = __t[__R];
             __e.i_ = 0;
-        }         
+        }
 
         return __is;
     }

--- a/include/oneapi/dpl/internal/random_impl/subtract_with_carry_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/subtract_with_carry_engine.h
@@ -133,60 +133,60 @@ class subtract_with_carry_engine
 
     template<class CharT, class Traits>
     friend ::std::basic_ostream<CharT,Traits>&
-    operator<<(::std::basic_ostream<CharT,Traits>& os,
-               const subtract_with_carry_engine& e)
+    operator<<(::std::basic_ostream<CharT,Traits>& __os,
+               const subtract_with_carry_engine& __e)
     {
-        internal::save_stream_flags<CharT, Traits> __flags(os);
+        internal::save_stream_flags<CharT, Traits> __flags(__os);
 
-        os.setf(std::ios_base::dec|std::ios_base::left);
-        CharT __sp = os.widen(' ');
-        os.fill(__sp);
+        __os.setf(std::ios_base::dec|std::ios_base::left);
+        CharT __sp = __os.widen(' ');
+        __os.fill(__sp);
 
-        os << e.x_[e.i_];
-        for (size_t j = e.i_ + 1; j < _R; ++j)
-            os << __sp << e.x_[j];
-        for (size_t j = 0; j < e.i_; ++j)
-            os << __sp << e.x_[j];
+        __os << __e.x_[__e.i_];
+        for (size_t j = __e.i_ + 1; j < _R; ++j)
+            __os << __sp << __e.x_[j];
+        for (size_t j = 0; j < __e.i_; ++j)
+            __os << __sp << __e.x_[j];
 
-        os << __sp << e.c_;
+        __os << __sp << __e.c_;
 
-        return os;
+        return __os;
     }
 
     friend const sycl::stream&
-    operator<<(const sycl::stream& os, const subtract_with_carry_engine& e)
+    operator<<(const sycl::stream& __os, const subtract_with_carry_engine& __e)
     {
-        os << e.x_[e.i_];
-        for (size_t j = e.i_ + 1; j < _R; ++j)
-            os << ' ' << e.x_[j];
-        for (size_t j = 0; j < e.i_; ++j)
-            os << ' ' << e.x_[j];
+        __os << __e.x_[__e.i_];
+        for (size_t j = __e.i_ + 1; j < _R; ++j)
+            __os << ' ' << __e.x_[j];
+        for (size_t j = 0; j < __e.i_; ++j)
+            __os << ' ' << __e.x_[j];
 
-        os << ' ' << e.c_;
+        __os << ' ' << __e.c_;
 
-        return os;
+        return __os;
     }
 
     template<class CharT, class Traits, class __UIntType, std::size_t __W, std::size_t __S, std::size_t __R>
     friend ::std::basic_istream<CharT,Traits>&
-    operator>>(::std::basic_istream<CharT,Traits>& is,
-               subtract_with_carry_engine<__UIntType,__W,__S,__R>& e)
+    operator>>(::std::basic_istream<CharT,Traits>& __is,
+               subtract_with_carry_engine<__UIntType,__W,__S,__R>& __e)
     {
-        internal::save_stream_flags<CharT, Traits> __flags(is);
+        internal::save_stream_flags<CharT, Traits> __flags(__is);
 
-        is.setf(std::ios_base::dec);
+        __is.setf(std::ios_base::dec);
 
         __UIntType __t[__R + 1];
         for (size_t i = 0; i < __R + 1; ++i)
-            is >> __t[i];
-        if (!is.fail()) {
+            __is >> __t[i];
+        if (!__is.fail()) {
             for (size_t i = 0; i < __R; ++i)
-            e.x_[i] = __t[i];
-            e.c_ = __t[__R];
-            e.i_ = 0;
+            __e.x_[i] = __t[i];
+            __e.c_ = __t[__R];
+            __e.i_ = 0;
         }         
 
-        return is;
+        return __is;
     }
 
   private:

--- a/include/oneapi/dpl/internal/random_impl/uniform_int_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/uniform_int_distribution.h
@@ -158,40 +158,40 @@ class uniform_int_distribution
 
     template <class CharT, class Traits>
     friend ::std::basic_ostream<CharT, Traits>&
-    operator<<(::std::basic_ostream<CharT,Traits>& os,
-            const uniform_int_distribution& d)
+    operator<<(::std::basic_ostream<CharT,Traits>& __os,
+            const uniform_int_distribution& __d)
     {
-        internal::save_stream_flags<CharT, Traits> __flags(os);
+        internal::save_stream_flags<CharT, Traits> __flags(__os);
 
-        os.setf(std::ios_base::dec|std::ios_base::left);
-        CharT __sp = os.widen(' ');
-        os.fill(__sp);
+        __os.setf(std::ios_base::dec|std::ios_base::left);
+        CharT __sp = __os.widen(' ');
+        __os.fill(__sp);
 
-        return os << d.a() << __sp << d.b();
+        return __os << __d.a() << __sp << __d.b();
     }
 
     friend const sycl::stream&
-    operator<<(const sycl::stream& os, const uniform_int_distribution& d)
+    operator<<(const sycl::stream& __os, const uniform_int_distribution& __d)
     {
-        return os << d.a() << ' ' << d.b();
+        return __os << __d.a() << ' ' << __d.b();
     }
 
     template< class CharT, class Traits >
     friend ::std::basic_istream<CharT,Traits>&
-    operator>>(::std::basic_istream<CharT,Traits>& is,
-               uniform_int_distribution& d)
+    operator>>(::std::basic_istream<CharT,Traits>& __is,
+               uniform_int_distribution& __d)
     {
-        internal::save_stream_flags<CharT, Traits> __flags(is);
+        internal::save_stream_flags<CharT, Traits> __flags(__is);
 
-        is.setf(std::ios_base::dec);
+        __is.setf(std::ios_base::dec);
 
         uniform_int_distribution::scalar_type __a;
         uniform_int_distribution::scalar_type __b;
 
-        if (is >> __a >> __b)
-            d.param(uniform_int_distribution::param_type(__a, __b));
+        if (__is >> __a >> __b)
+            __d.param(uniform_int_distribution::param_type(__a, __b));
 
-        return is;
+        return __is;
     }
 
   private:

--- a/include/oneapi/dpl/internal/random_impl/uniform_int_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/uniform_int_distribution.h
@@ -146,24 +146,25 @@ class uniform_int_distribution
         return result_portion_internal<size_of_type_, _Engine>(__engine, __params, __random_nums);
     }
 
-    friend bool operator==(const uniform_int_distribution& __x, const uniform_int_distribution& __y)
+    friend bool
+    operator==(const uniform_int_distribution& __x, const uniform_int_distribution& __y)
     {
         return __x.param() == __y.param();
     }
 
-    friend bool operator!=(const uniform_int_distribution& __x, const uniform_int_distribution& __y)
+    friend bool
+    operator!=(const uniform_int_distribution& __x, const uniform_int_distribution& __y)
     {
         return !(__x == __y);
     }
 
     template <class CharT, class Traits>
     friend ::std::basic_ostream<CharT, Traits>&
-    operator<<(::std::basic_ostream<CharT,Traits>& __os,
-            const uniform_int_distribution& __d)
+    operator<<(::std::basic_ostream<CharT, Traits>& __os, const uniform_int_distribution& __d)
     {
         internal::save_stream_flags<CharT, Traits> __flags(__os);
 
-        __os.setf(std::ios_base::dec|std::ios_base::left);
+        __os.setf(std::ios_base::dec | std::ios_base::left);
         CharT __sp = __os.widen(' ');
         __os.fill(__sp);
 
@@ -176,10 +177,9 @@ class uniform_int_distribution
         return __os << __d.a() << ' ' << __d.b();
     }
 
-    template< class CharT, class Traits >
-    friend ::std::basic_istream<CharT,Traits>&
-    operator>>(::std::basic_istream<CharT,Traits>& __is,
-               uniform_int_distribution& __d)
+    template <class CharT, class Traits>
+    friend ::std::basic_istream<CharT, Traits>&
+    operator>>(::std::basic_istream<CharT, Traits>& __is, uniform_int_distribution& __d)
     {
         internal::save_stream_flags<CharT, Traits> __flags(__is);
 

--- a/include/oneapi/dpl/internal/random_impl/uniform_int_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/uniform_int_distribution.h
@@ -146,6 +146,54 @@ class uniform_int_distribution
         return result_portion_internal<size_of_type_, _Engine>(__engine, __params, __random_nums);
     }
 
+    friend bool operator==(const uniform_int_distribution& __x, const uniform_int_distribution& __y)
+    {
+        return __x.param() == __y.param();
+    }
+
+    friend bool operator!=(const uniform_int_distribution& __x, const uniform_int_distribution& __y)
+    {
+        return !(__x == __y);
+    }
+
+    template <class CharT, class Traits>
+    friend ::std::basic_ostream<CharT, Traits>&
+    operator<<(::std::basic_ostream<CharT,Traits>& os,
+            const uniform_int_distribution& d)
+    {
+        internal::save_stream_flags<CharT, Traits> __flags(os);
+
+        os.setf(std::ios_base::dec|std::ios_base::left);
+        CharT __sp = os.widen(' ');
+        os.fill(__sp);
+
+        return os << d.a() << __sp << d.b();
+    }
+
+    friend const sycl::stream&
+    operator<<(const sycl::stream& os, const uniform_int_distribution& d)
+    {
+        return os << d.a() << ' ' << d.b();
+    }
+
+    template< class CharT, class Traits >
+    friend ::std::basic_istream<CharT,Traits>&
+    operator>>(::std::basic_istream<CharT,Traits>& is,
+               uniform_int_distribution& d)
+    {
+        internal::save_stream_flags<CharT, Traits> __flags(is);
+
+        is.setf(std::ios_base::dec);
+
+        uniform_int_distribution::scalar_type __a;
+        uniform_int_distribution::scalar_type __b;
+
+        if (is >> __a >> __b)
+            d.param(uniform_int_distribution::param_type(__a, __b));
+
+        return is;
+    }
+
   private:
     // Size of type
     static constexpr int size_of_type_ = internal::type_traits_t<result_type>::num_elems;

--- a/include/oneapi/dpl/internal/random_impl/uniform_real_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/uniform_real_distribution.h
@@ -156,40 +156,40 @@ class uniform_real_distribution
 
     template <class CharT, class Traits>
     friend ::std::basic_ostream<CharT, Traits>&
-    operator<<(::std::basic_ostream<CharT,Traits>& os,
-            const uniform_real_distribution& d)
+    operator<<(::std::basic_ostream<CharT,Traits>& __os,
+            const uniform_real_distribution& __d)
     {
-        internal::save_stream_flags<CharT, Traits> __flags(os);
+        internal::save_stream_flags<CharT, Traits> __flags(__os);
 
-        os.setf(std::ios_base::dec|std::ios_base::left);
-        CharT __sp = os.widen(' ');
-        os.fill(__sp);
+        __os.setf(std::ios_base::dec|std::ios_base::left);
+        CharT __sp = __os.widen(' ');
+        __os.fill(__sp);
 
-        return os << d.a() << __sp << d.b();
+        return __os << __d.a() << __sp << __d.b();
     }
 
     friend const sycl::stream&
-    operator<<(const sycl::stream& os, const uniform_real_distribution& d)
+    operator<<(const sycl::stream& __os, const uniform_real_distribution& __d)
     {
-        return os << d.a() << ' ' << d.b();
+        return __os << __d.a() << ' ' << __d.b();
     }
 
     template< class CharT, class Traits >
     friend ::std::basic_istream<CharT,Traits>&
-    operator>>(::std::basic_istream<CharT,Traits>& is,
-               uniform_real_distribution& d)
+    operator>>(::std::basic_istream<CharT,Traits>& __is,
+               uniform_real_distribution& __d)
     {
-        internal::save_stream_flags<CharT, Traits> __flags(is);
+        internal::save_stream_flags<CharT, Traits> __flags(__is);
 
-        is.setf(std::ios_base::dec);
+        __is.setf(std::ios_base::dec);
 
         uniform_real_distribution::scalar_type __a;
         uniform_real_distribution::scalar_type __b;
 
-        if (is >> __a >> __b)
-            d.param(uniform_real_distribution::param_type(__a, __b));
+        if (__is >> __a >> __b)
+            __d.param(uniform_real_distribution::param_type(__a, __b));
 
-        return is;
+        return __is;
     }
 
   private:

--- a/include/oneapi/dpl/internal/random_impl/uniform_real_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/uniform_real_distribution.h
@@ -144,6 +144,54 @@ class uniform_real_distribution
                                        _Engine>(__engine, __params, __random_nums);
     }
 
+    friend bool operator==(const uniform_real_distribution& __x, const uniform_real_distribution& __y)
+    {
+        return __x.param() == __y.param();
+    }
+
+    friend bool operator!=(const uniform_real_distribution& __x, const uniform_real_distribution& __y)
+    {
+        return !(__x == __y);
+    }
+
+    template <class CharT, class Traits>
+    friend ::std::basic_ostream<CharT, Traits>&
+    operator<<(::std::basic_ostream<CharT,Traits>& os,
+            const uniform_real_distribution& d)
+    {
+        internal::save_stream_flags<CharT, Traits> __flags(os);
+
+        os.setf(std::ios_base::dec|std::ios_base::left);
+        CharT __sp = os.widen(' ');
+        os.fill(__sp);
+
+        return os << d.a() << __sp << d.b();
+    }
+
+    friend const sycl::stream&
+    operator<<(const sycl::stream& os, const uniform_real_distribution& d)
+    {
+        return os << d.a() << ' ' << d.b();
+    }
+
+    template< class CharT, class Traits >
+    friend ::std::basic_istream<CharT,Traits>&
+    operator>>(::std::basic_istream<CharT,Traits>& is,
+               uniform_real_distribution& d)
+    {
+        internal::save_stream_flags<CharT, Traits> __flags(is);
+
+        is.setf(std::ios_base::dec);
+
+        uniform_real_distribution::scalar_type __a;
+        uniform_real_distribution::scalar_type __b;
+
+        if (is >> __a >> __b)
+            d.param(uniform_real_distribution::param_type(__a, __b));
+
+        return is;
+    }
+
   private:
     // Size of type
     static constexpr int size_of_type_ = internal::type_traits_t<result_type>::num_elems;

--- a/include/oneapi/dpl/internal/random_impl/uniform_real_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/uniform_real_distribution.h
@@ -144,24 +144,25 @@ class uniform_real_distribution
                                        _Engine>(__engine, __params, __random_nums);
     }
 
-    friend bool operator==(const uniform_real_distribution& __x, const uniform_real_distribution& __y)
+    friend bool
+    operator==(const uniform_real_distribution& __x, const uniform_real_distribution& __y)
     {
         return __x.param() == __y.param();
     }
 
-    friend bool operator!=(const uniform_real_distribution& __x, const uniform_real_distribution& __y)
+    friend bool
+    operator!=(const uniform_real_distribution& __x, const uniform_real_distribution& __y)
     {
         return !(__x == __y);
     }
 
     template <class CharT, class Traits>
     friend ::std::basic_ostream<CharT, Traits>&
-    operator<<(::std::basic_ostream<CharT,Traits>& __os,
-            const uniform_real_distribution& __d)
+    operator<<(::std::basic_ostream<CharT, Traits>& __os, const uniform_real_distribution& __d)
     {
         internal::save_stream_flags<CharT, Traits> __flags(__os);
 
-        __os.setf(std::ios_base::dec|std::ios_base::left);
+        __os.setf(std::ios_base::dec | std::ios_base::left);
         CharT __sp = __os.widen(' ');
         __os.fill(__sp);
 
@@ -174,10 +175,9 @@ class uniform_real_distribution
         return __os << __d.a() << ' ' << __d.b();
     }
 
-    template< class CharT, class Traits >
-    friend ::std::basic_istream<CharT,Traits>&
-    operator>>(::std::basic_istream<CharT,Traits>& __is,
-               uniform_real_distribution& __d)
+    template <class CharT, class Traits>
+    friend ::std::basic_istream<CharT, Traits>&
+    operator>>(::std::basic_istream<CharT, Traits>& __is, uniform_real_distribution& __d)
     {
         internal::save_stream_flags<CharT, Traits> __flags(__is);
 

--- a/include/oneapi/dpl/internal/random_impl/weibull_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/weibull_distribution.h
@@ -153,40 +153,40 @@ class weibull_distribution
 
     template <class CharT, class Traits>
     friend ::std::basic_ostream<CharT, Traits>&
-    operator<<(::std::basic_ostream<CharT,Traits>& os,
-            const weibull_distribution& d)
+    operator<<(::std::basic_ostream<CharT,Traits>& __os,
+            const weibull_distribution& __d)
     {
-        internal::save_stream_flags<CharT, Traits> __flags(os);
+        internal::save_stream_flags<CharT, Traits> __flags(__os);
 
-        os.setf(std::ios_base::dec|std::ios_base::left);
-        CharT __sp = os.widen(' ');
-        os.fill(__sp);
+        __os.setf(std::ios_base::dec|std::ios_base::left);
+        CharT __sp = __os.widen(' ');
+        __os.fill(__sp);
 
-        return os << d.a() << __sp << d.b();
+        return __os << __d.a() << __sp << __d.b();
     }
 
     friend const sycl::stream&
-    operator<<(const sycl::stream& os, const weibull_distribution& d)
+    operator<<(const sycl::stream& __os, const weibull_distribution& __d)
     {
-        return os << d.a() << ' ' << d.b();
+        return __os << __d.a() << ' ' << __d.b();
     }
 
     template< class CharT, class Traits >
     friend ::std::basic_istream<CharT,Traits>&
-    operator>>(::std::basic_istream<CharT,Traits>& is,
-               weibull_distribution& d)
+    operator>>(::std::basic_istream<CharT,Traits>& __is,
+               weibull_distribution& __d)
     {
-        internal::save_stream_flags<CharT, Traits> __flags(is);
+        internal::save_stream_flags<CharT, Traits> __flags(__is);
 
-        is.setf(std::ios_base::dec);
+        __is.setf(std::ios_base::dec);
 
         weibull_distribution::scalar_type __a;
         weibull_distribution::scalar_type __b;
 
-        if (is >> __a >> __b)
-            d.param(weibull_distribution::param_type(__a, __b));
+        if (__is >> __a >> __b)
+            __d.param(weibull_distribution::param_type(__a, __b));
 
-        return is;
+        return __is;
     }
 
   private:

--- a/include/oneapi/dpl/internal/random_impl/weibull_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/weibull_distribution.h
@@ -141,6 +141,54 @@ class weibull_distribution
         return result_portion_internal<size_of_type_, _Engine>(__engine, __params, __random_nums);
     }
 
+    friend bool operator==(const weibull_distribution& __x, const weibull_distribution& __y)
+    {
+        return __x.param() == __y.param();
+    }
+
+    friend bool operator!=(const weibull_distribution& __x, const weibull_distribution& __y)
+    {
+        return !(__x == __y);
+    }
+
+    template <class CharT, class Traits>
+    friend ::std::basic_ostream<CharT, Traits>&
+    operator<<(::std::basic_ostream<CharT,Traits>& os,
+            const weibull_distribution& d)
+    {
+        internal::save_stream_flags<CharT, Traits> __flags(os);
+
+        os.setf(std::ios_base::dec|std::ios_base::left);
+        CharT __sp = os.widen(' ');
+        os.fill(__sp);
+
+        return os << d.a() << __sp << d.b();
+    }
+
+    friend const sycl::stream&
+    operator<<(const sycl::stream& os, const weibull_distribution& d)
+    {
+        return os << d.a() << ' ' << d.b();
+    }
+
+    template< class CharT, class Traits >
+    friend ::std::basic_istream<CharT,Traits>&
+    operator>>(::std::basic_istream<CharT,Traits>& is,
+               weibull_distribution& d)
+    {
+        internal::save_stream_flags<CharT, Traits> __flags(is);
+
+        is.setf(std::ios_base::dec);
+
+        weibull_distribution::scalar_type __a;
+        weibull_distribution::scalar_type __b;
+
+        if (is >> __a >> __b)
+            d.param(weibull_distribution::param_type(__a, __b));
+
+        return is;
+    }
+
   private:
     // Size of type
     static constexpr int size_of_type_ = internal::type_traits_t<result_type>::num_elems;

--- a/include/oneapi/dpl/internal/random_impl/weibull_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/weibull_distribution.h
@@ -141,24 +141,25 @@ class weibull_distribution
         return result_portion_internal<size_of_type_, _Engine>(__engine, __params, __random_nums);
     }
 
-    friend bool operator==(const weibull_distribution& __x, const weibull_distribution& __y)
+    friend bool
+    operator==(const weibull_distribution& __x, const weibull_distribution& __y)
     {
         return __x.param() == __y.param();
     }
 
-    friend bool operator!=(const weibull_distribution& __x, const weibull_distribution& __y)
+    friend bool
+    operator!=(const weibull_distribution& __x, const weibull_distribution& __y)
     {
         return !(__x == __y);
     }
 
     template <class CharT, class Traits>
     friend ::std::basic_ostream<CharT, Traits>&
-    operator<<(::std::basic_ostream<CharT,Traits>& __os,
-            const weibull_distribution& __d)
+    operator<<(::std::basic_ostream<CharT, Traits>& __os, const weibull_distribution& __d)
     {
         internal::save_stream_flags<CharT, Traits> __flags(__os);
 
-        __os.setf(std::ios_base::dec|std::ios_base::left);
+        __os.setf(std::ios_base::dec | std::ios_base::left);
         CharT __sp = __os.widen(' ');
         __os.fill(__sp);
 
@@ -171,10 +172,9 @@ class weibull_distribution
         return __os << __d.a() << ' ' << __d.b();
     }
 
-    template< class CharT, class Traits >
-    friend ::std::basic_istream<CharT,Traits>&
-    operator>>(::std::basic_istream<CharT,Traits>& __is,
-               weibull_distribution& __d)
+    template <class CharT, class Traits>
+    friend ::std::basic_istream<CharT, Traits>&
+    operator>>(::std::basic_istream<CharT, Traits>& __is, weibull_distribution& __d)
     {
         internal::save_stream_flags<CharT, Traits> __flags(__is);
 

--- a/test/xpu_api/random/interface_tests/distributions_methods.pass.cpp
+++ b/test/xpu_api/random/interface_tests/distributions_methods.pass.cpp
@@ -223,6 +223,7 @@ std::int32_t
 check_input_output(Distr& distr)
 {
     using params_type = typename Distr::scalar_type;
+    using result_type = typename Distr::result_type;
 
     std::int32_t status = 0;
 

--- a/test/xpu_api/random/interface_tests/distributions_methods.pass.cpp
+++ b/test/xpu_api/random/interface_tests/distributions_methods.pass.cpp
@@ -218,6 +218,13 @@ make_param(typename Distr::param_type& params1, typename Distr::param_type& para
     params2 = typename Distr::param_type{-2, 10};
 }
 
+template <class T>
+bool
+check_output(oneapi::dpl::bernoulli_distribution<T>& distr, std::ostringstream& out)
+{
+    return out.str() == "0.5";
+}
+
 template <class Distr>
 bool
 test_vec(sycl::queue& queue)
@@ -296,10 +303,41 @@ test(sycl::queue& queue)
 
     // Random number generation
     {
+        {
+            Distr _d1(0.1);
+            Distr _d2(0.1);
+            if (_d1 == _d2)
+            {
+
+            }
+
+            std::ostringstream out;
+            std::istringstream in("0.5");
+
+            in >> _d1;
+            assert(check_params(_d1));
+            out << _d1;
+            assert(check_output);
+
+            if (_d1 != _d2)
+            {
+
+            }
+        }
+
         sycl::buffer<typename Distr::scalar_type> buffer(res, N_GEN);
 
         try
         {
+            queue.submit([&](sycl::handler& cgh) {
+                sycl::stream out(1024, 256, cgh);
+                cgh.single_task<>([=]() {
+                    Distr distr;
+                    out << "params: " << distr << sycl::endl;
+                });
+            });
+            queue.wait_and_throw();
+
             queue.submit([&](sycl::handler& cgh) {
                 sycl::accessor acc(buffer, cgh, sycl::write_only);
 

--- a/test/xpu_api/random/interface_tests/engines_methods.pass.cpp
+++ b/test/xpu_api/random/interface_tests/engines_methods.pass.cpp
@@ -258,15 +258,19 @@ public:
         // Random number generation
         {
             {
-                Engine engine;
+                Engine e1;
+                e1.discard(100);
 
-                std::ostringstream out;
-                std::istringstream in("1");
+                std::ostringstream os;
+                os << e1;
 
-                in >> engine;
-                out << engine;
-                assert(engine() == 1);
-                assert(out.str() == "1");
+                Engine e2;
+
+                std::istringstream in(os.str());
+                in >> e2;
+
+                if (e1 != e2)
+                    sum += 1;
             }
 
             sycl::buffer<std::int32_t> dpstd_buffer(dpstd_res.data(), dpstd_res.size());
@@ -298,18 +302,14 @@ public:
                         engine1.discard(offset);
                         if (engine0 != engine1)
                         {
-                            dpstd_acc[offset] = 1;
+                            dpstd_acc[offset] += 1;
                         }
                         typename Engine::result_type res0;
                         res0 = engine0();
                         typename Engine::result_type res1 = engine1();
                         if (res0 != res1)
                         {
-                            dpstd_acc[offset] = 1;
-                        }
-                        else
-                        {
-                            dpstd_acc[offset] = 0;
+                            dpstd_acc[offset] += 1;
                         }
                     });
                 });

--- a/test/xpu_api/random/interface_tests/engines_methods.pass.cpp
+++ b/test/xpu_api/random/interface_tests/engines_methods.pass.cpp
@@ -360,22 +360,21 @@ public:
         // Random number generation
         {
             {
-                {
-                    oneapi::dpl::ranlux24 e1;
-                    e1.discard(100);
+                oneapi::dpl::ranlux24 e1;
+                e1.discard(100);
 
-                    std::ostringstream os;
-                    os << e1;
+                std::ostringstream os;
+                os << e1;
 
-                    oneapi::dpl::ranlux24 e2;
+                oneapi::dpl::ranlux24 e2;
 
-                    std::istringstream in(os.str());
-                    in >> e2;
+                std::istringstream in(os.str());
+                in >> e2;
 
-                    if (e1 != e2)
-                        sum += 1;
-                }
+                if (e1 != e2)
+                    sum += 1;
             }
+
             sycl::buffer<std::int32_t> dpstd_buffer(dpstd_res.data(), dpstd_res.size());
 
             try


### PR DESCRIPTION
There are the following requirements for operators <<, >> in C++ standard

- **for distributions**:

![image](https://github.com/oneapi-src/oneDPL/assets/92860933/3c227f12-a7ee-4788-8c01-fa60c0433d53)

- **for engines**:

![image](https://github.com/oneapi-src/oneDPL/assets/92860933/2b2415d6-8591-4f58-b37b-5bb7b6a4ded3)
![image](https://github.com/oneapi-src/oneDPL/assets/92860933/48df0f2c-33a6-48b5-a3fb-2ed213a990a7)

**Note:** llvm and gcc comply with the same requirements for distributions as for generators

Operator support was added for Bernoulli distribution and linear_congruential engine