### PR TITLE
[PROTOTYPE] Two-pass scan - Generalize work-group size support

### DIFF
--- a/include/oneapi/dpl/experimental/kt/two_pass_scan.h
+++ b/include/oneapi/dpl/experimental/kt/two_pass_scan.h
@@ -253,11 +253,11 @@ two_pass_scan(sycl::queue q, _InRng&& __in_rng, _OutRng&& __out_rng,
                         }
                         // If we are past the input range, then the previous value of v is passed to the sub-group scan.
                         // It does not affect the result as our sub_group_scan will use a mask to only process in-range elements.
-                        if (sub_group_local_id < num_sub_groups_local)
+                        if (i * VL + sub_group_local_id < num_sub_groups_local)
                             v = sub_group_partials[sub_group_local_id];
                         std::tie(v, sub_group_carry) = sub_group_scan<VL, true>(
                             sub_group, std::move(v), binary_op, std::move(sub_group_carry), num_sub_groups_local);
-                        if (sub_group_local_id < num_sub_groups_local)
+                        if (i * VL + sub_group_local_id < num_sub_groups_local)
                             tmp_storage[start_idx + i * VL + sub_group_local_id] = v;
                     }
                 }
@@ -338,7 +338,7 @@ two_pass_scan(sycl::queue q, _InRng&& __in_rng, _OutRng&& __out_rng,
                             sub_group_partials[i * VL + sub_group_local_id] =
                                 tmp_storage[csrc + i * VL + sub_group_local_id];
                         }
-                        if (sub_group_local_id < num_sub_groups_local)
+                        if (i * VL + sub_group_local_id < num_sub_groups_local)
                         {
                             sub_group_partials[i * VL + sub_group_local_id] =
                                 tmp_storage[csrc + i * VL + sub_group_local_id];
@@ -399,7 +399,7 @@ two_pass_scan(sycl::queue q, _InRng&& __in_rng, _OutRng&& __out_rng,
                                 binary_op(adj_work_group_carry, sub_group_partials[carry_offset + sub_group_local_id]);
                             carry_offset += VL;
                         }
-                        if (sub_group_local_id < num_sub_groups_local)
+                        if (i * VL + sub_group_local_id < num_sub_groups_local)
                         {
                             sub_group_partials[carry_offset + sub_group_local_id] =
                                 binary_op(adj_work_group_carry, sub_group_partials[carry_offset + sub_group_local_id]);

--- a/include/oneapi/dpl/experimental/kt/two_pass_scan.h
+++ b/include/oneapi/dpl/experimental/kt/two_pass_scan.h
@@ -77,20 +77,20 @@ template <std::uint8_t VL, bool Inclusive, typename SubGroup, typename BinaryOp,
 std::tuple<ValueType, ValueType>
 sub_group_scan(const SubGroup& sub_group, ValueType value, BinaryOp binary_op, ValueType init)
 {
-    auto apply_mask_fn = [](auto sub_group_local_id, auto offset) { return sub_group_local_id >= offset; };
+    auto mask_fn = [](auto sub_group_local_id, auto offset) { return sub_group_local_id >= offset; };
     constexpr auto init_broadcast_id = VL - 1;
-    return sub_group_masked_scan<VL, Inclusive>(sub_group, apply_mask_fn, init_broadcast_id, value, binary_op, init);
+    return sub_group_masked_scan<VL, Inclusive>(sub_group, mask_fn, init_broadcast_id, value, binary_op, init);
 }
 
 template <std::uint8_t VL, bool Inclusive, typename SubGroup, typename BinaryOp, typename ValueType, typename SizeType>
 std::tuple<ValueType, ValueType>
 sub_group_scan(const SubGroup& sub_group, ValueType value, BinaryOp binary_op, ValueType init, SizeType num_remaining)
 {
-    auto apply_mask_fn = [num_remaining](auto sub_group_local_id, auto offset) {
+    auto mask_fn = [num_remaining](auto sub_group_local_id, auto offset) {
         return sub_group_local_id >= offset && sub_group_local_id < num_remaining;
     };
     auto init_broadcast_id = num_remaining - 1;
-    return sub_group_masked_scan<VL, Inclusive>(sub_group, apply_mask_fn, init_broadcast_id, value, binary_op, init);
+    return sub_group_masked_scan<VL, Inclusive>(sub_group, mask_fn, init_broadcast_id, value, binary_op, init);
 }
 
 // Named two_pass_scan for now to avoid name clash with single pass KT

--- a/include/oneapi/dpl/experimental/kt/two_pass_scan.h
+++ b/include/oneapi/dpl/experimental/kt/two_pass_scan.h
@@ -191,7 +191,6 @@ two_pass_scan(sycl::queue q, _InRng&& __in_rng, _OutRng&& __out_rng,
                 }
                 else if (is_full_thread)
                 {
-                    _ONEDPL_PRAGMA_UNROLL
                     for (int j = 0; j < J; j++)
                     {
                         v = unary_op(__in_rng[start_idx + j * VL]);
@@ -201,7 +200,6 @@ two_pass_scan(sycl::queue q, _InRng&& __in_rng, _OutRng&& __out_rng,
                 }
                 else
                 {
-                    _ONEDPL_PRAGMA_UNROLL
                     for (int j = 0; j < J; j++)
                     {
                         auto offset = start_idx + j * VL;
@@ -230,7 +228,6 @@ two_pass_scan(sycl::queue q, _InRng&& __in_rng, _OutRng&& __out_rng,
                     sub_group_carry = identity;
                     if (is_full_carry_scanner)
                     {
-                        _ONEDPL_PRAGMA_UNROLL
                         for (std::uint8_t i = 0; i < iters; i++)
                         {
                             v = sub_group_partials[i * VL + sub_group_local_id];
@@ -243,7 +240,6 @@ two_pass_scan(sycl::queue q, _InRng&& __in_rng, _OutRng&& __out_rng,
                         // In practice iters is usually 1 here when the number of sub-groups is less than the vector length.
                         // An exception would be the unlikely case where the sub-group size does not divide the work-group size
                         std::uint8_t i = 0;
-                        _ONEDPL_PRAGMA_UNROLL
                         for (; i < iters - 1; i++)
                         {
                             v = sub_group_partials[sub_group_local_id];
@@ -322,7 +318,6 @@ two_pass_scan(sycl::queue q, _InRng&& __in_rng, _OutRng&& __out_rng,
                     auto csrc = g * num_sub_groups_local;
                     if (is_full_carry_scanner)
                     {
-                        _ONEDPL_PRAGMA_UNROLL
                         for (std::uint8_t i = 0; i < iters; i++)
                         {
                             sub_group_partials[i * VL + sub_group_local_id] =
@@ -332,7 +327,6 @@ two_pass_scan(sycl::queue q, _InRng&& __in_rng, _OutRng&& __out_rng,
                     else
                     {
                         std::uint8_t i = 0;
-                        _ONEDPL_PRAGMA_UNROLL
                         for (; i < iters - 1; i++)
                         {
                             sub_group_partials[i * VL + sub_group_local_id] =
@@ -447,7 +441,6 @@ two_pass_scan(sycl::queue q, _InRng&& __in_rng, _OutRng&& __out_rng,
                 }
                 else if (is_full_thread)
                 {
-                    _ONEDPL_PRAGMA_UNROLL
                     for (int j = 0; j < J; j++)
                     {
                         v = unary_op(__in_rng[start_idx + j * VL]);
@@ -458,7 +451,6 @@ two_pass_scan(sycl::queue q, _InRng&& __in_rng, _OutRng&& __out_rng,
                 }
                 else
                 {
-                    _ONEDPL_PRAGMA_UNROLL
                     for (int j = 0; j < J; j++)
                     {
                         auto offset = start_idx + j * VL;


### PR DESCRIPTION
This PR is targeted to the prototype branch for the reduce-then-scan implementation.

Previously, the implementation was reliant on work-group sizes being >= 1024 so that the number of sub-groups is divisible by the sub-group size. This PR generalizes the work-group size requirement and allows for the case where the number of sub-groups is not divisible by the sub-group size. There is a small performance penalty when this is the case.

Additionally, support has been added for performing sub-group scans when we do not have a full sub-group size of input via the `num_remaining` parameter and avoids the need to pad with identity elements.