### PR TITLE
Addressing static analysis errors

### DIFF
--- a/include/oneapi/dpl/pstl/algorithm_fwd.h
+++ b/include/oneapi/dpl/pstl/algorithm_fwd.h
@@ -56,7 +56,7 @@ __pattern_any_of(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIte
 
 template <class _ForwardIterator, class _Function>
 void __brick_walk1(_ForwardIterator, _ForwardIterator, _Function,
-                   /*vector=*/::std::false_type) noexcept;
+                   /*vector=*/::std::false_type);
 
 template <class _RandomAccessIterator, class _Function>
 void __brick_walk1(_RandomAccessIterator, _RandomAccessIterator, _Function,

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -104,7 +104,7 @@ __for_each_n_it_serial(_ForwardIterator __first, _Size __n, _Function __f)
 //------------------------------------------------------------------------
 template <class _ForwardIterator, class _Function>
 void
-__brick_walk1(_ForwardIterator __first, _ForwardIterator __last, _Function __f, /*vector=*/::std::false_type) noexcept
+__brick_walk1(_ForwardIterator __first, _ForwardIterator __last, _Function __f, /*vector=*/::std::false_type)
 {
     ::std::for_each(__first, __last, __f);
 }

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -661,10 +661,7 @@ __simd_min_element(_ForwardIterator __first, _Size __n, _Compare __comp) noexcep
             : __min_val(val), __min_ind(0), __min_comp(const_cast<_Compare*>(comp))
         {
         }
-        _ComplexType(const _ComplexType& __obj)
-            : __min_val(__obj.__min_val), __min_ind(__obj.__min_ind), __min_comp(__obj.__min_comp)
-        {
-        }
+        _ComplexType(const _ComplexType& __obj) = default;
 
         _ONEDPL_PRAGMA_DECLARE_SIMD
         void
@@ -725,11 +722,7 @@ __simd_minmax_element(_ForwardIterator __first, _Size __n, _Compare __comp) noex
               __minmax_comp(const_cast<_Compare*>(comp))
         {
         }
-        _ComplexType(const _ComplexType& __obj)
-            : __min_val(__obj.__min_val), __max_val(__obj.__max_val), __min_ind(__obj.__min_ind),
-              __max_ind(__obj.__max_ind), __minmax_comp(__obj.__minmax_comp)
-        {
-        }
+        _ComplexType(const _ComplexType& __obj) = default;
 
         _ONEDPL_PRAGMA_DECLARE_SIMD
         void

--- a/include/oneapi/dpl/pstl/unseq_backend_simd.h
+++ b/include/oneapi/dpl/pstl/unseq_backend_simd.h
@@ -34,7 +34,7 @@ const ::std::size_t __lane_size = 64;
 
 template <class _Iterator, class _DifferenceType, class _Function>
 _Iterator
-__simd_walk_1(_Iterator __first, _DifferenceType __n, _Function __f) noexcept
+__simd_walk_1(_Iterator __first, _DifferenceType __n, _Function __f)
 {
     _ONEDPL_PRAGMA_SIMD
     for (_DifferenceType __i = 0; __i < __n; ++__i)


### PR DESCRIPTION
Scanning oneDPL code with a static analysis tool identified the two versions of a complex comparator in the SIMD unseq backend.  This PR removes the user-defined copy constructors since they are explicit versions of the default copy constructor to address the errors from the static analysis tool.

In addition the scans also identified two functions used in the implementation of uninitialized memory algorithms that were tagged with the noexcept keyword.  In the case of the uninitialized memory functors new may be called, in which case an exception could be thrown.