### PR TITLE
[Perf] Break loop in __early_exit_find_or after first found element

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1051,10 +1051,7 @@ struct __early_exit_find_or
         // if our "line" is out of work group size, reduce the line to the number of the rest elements
         if (__wg_size - __leader < __shift)
             __shift = __wg_size - __leader;
-
-        bool __something_was_found = false;
-
-        for (_IterSize __i = 0; __i < __n_iter && !__something_was_found; ++__i)
+        for (_IterSize __i = 0; __i < __n_iter; ++__i)
         {
             //in case of find-semantic __shifted_idx must be the same type as the atomic for a correct comparison
             using _ShiftedIdxType = ::std::conditional_t<_OrTagType::value, decltype(__init_index + __i * __shift),
@@ -1080,7 +1077,7 @@ struct __early_exit_find_or
                     }
                 }
 
-                __something_was_found = true;
+                break;
             }
         }
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1099,7 +1099,9 @@ struct __early_exit_find_or
                 //    This means that after the first found entry there is no reason to process data anymore too.
                 // 3) __parallel_or_tag : when we search for any matching data entry, we process data from start to end (forward direction).
                 //    This means that after the first found entry there is no reason to process data anymore too.
-                __something_was_found = true; // break statement here shows poor perf then bool variable state check in the for-loop header in some cases
+                // But break statement here shows poor perf in some cases.
+                // So we use bool variable state check in the for-loop header.
+                __something_was_found = true;
             }
         }
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1075,7 +1075,8 @@ struct __early_exit_find_or
                 {
                     for (auto __old = __found_local.load(); __comp(__shifted_idx, __old); __old = __found_local.load())
                     {
-                        __found_local.compare_exchange_strong(__old, __shifted_idx);
+                        if (__found_local.compare_exchange_strong(__old, __shifted_idx))
+                            break;
                     }
                 }
 
@@ -1176,7 +1177,8 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
                             for (auto __old = __found.load(); __comp(__found_local.load(), __old);
                                  __old = __found.load())
                             {
-                                __found.compare_exchange_strong(__old, __found_local.load());
+                                if (__found.compare_exchange_strong(__old, __found_local.load()))
+                                    break;
                             }
                         }
                     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1095,7 +1095,7 @@ struct __early_exit_find_or
                 //    This means that after first found entry there is no reason to process data anymore.
                 // 2) __parallel_find_backward_tag  : when we search for the last matching data entry, we process data from end to start (backward direction).
                 //    This means that after the first found entry there is no reason to process data anymore too.
-                // 3) __parallel_or_tag : when we find any data entry we processing data we processing data from start to end (forward direction).
+                // 3) __parallel_or_tag : when we search for any matching data entry, we process data from start to end (forward direction).
                 //    This means that after the first found entry there is no reason to process data anymore too.
                 break;
             }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1036,7 +1036,7 @@ struct __early_exit_find_or
     {
         using __par_backend_hetero::__parallel_or_tag;
 
-        // There is 3 possible tag types here:
+        // There are 3 possible tag types here:
         //  - __parallel_find_forward_tag : in case when we find the first value in the data;
         //  - __parallel_find_backward_tag : in case when we find the last value in the data;
         //  - __parallel_or_tag : in case when we find any value in the data.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1077,6 +1077,7 @@ struct __early_exit_find_or
                     {
                         __found_local.compare_exchange_strong(__old, __shifted_idx);
                     }
+                    break;
                 }
             }
         }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1093,7 +1093,7 @@ struct __early_exit_find_or
                 // This break is safe for all our cases:
                 // 1) __parallel_find_forward_tag : when we find the first data entry we processing data we process data from start to end (forward direction).
                 //    This means that after first found entry there is no reason to process data anymore.
-                // 2) __parallel_find_backward_tag  : when we find the last data entry we processing data we process data from end to start (backward direction).
+                // 2) __parallel_find_backward_tag  : when we search for the last matching data entry, we process data from end to start (backward direction).
                 //    This means that after the first found entry there is no reason to process data anymore too.
                 // 3) __parallel_or_tag : when we find any data entry we processing data we processing data from start to end (forward direction).
                 //    This means that after the first found entry there is no reason to process data anymore too.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1091,7 +1091,7 @@ struct __early_exit_find_or
 
                 // This break is mandatory from the performance point of view.
                 // This break is safe for all our cases:
-                // 1) __parallel_find_forward_tag : when we find the first data entry we processing data we process data from start to end (forward direction).
+                // 1) __parallel_find_forward_tag : when we search for the first matching data entry, we process data from start to end (forward direction).
                 //    This means that after first found entry there is no reason to process data anymore.
                 // 2) __parallel_find_backward_tag  : when we search for the last matching data entry, we process data from end to start (backward direction).
                 //    This means that after the first found entry there is no reason to process data anymore too.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1073,13 +1073,13 @@ struct __early_exit_find_or
             {
                 if constexpr (_OrTagType::value)
                 {
-                    // As far as we find any value of the data here, we can set the atomic value to 1
+                    // As far as we found any data entry, we can set the atomic value to 1.
                     // No additional actions required.
                     __found_local.store(1);
                 }
                 else
                 {
-                    // As far as we find the first/last value of the data here, we need to set the atomic value to the index of the found data.
+                    // As far as we found the first/last data entry here, we need to set the atomic value to the index of the found data entry.
                     // But only in this case when this value is less (if we find the first value)/greater(if we find the last value) than the current value of the atomic.
                     for (auto __old = __found_local.load(); __comp(__shifted_idx, __old); __old = __found_local.load())
                     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1067,18 +1067,16 @@ struct __early_exit_find_or
             if (__shifted_idx < __n && __pred(__shifted_idx, __rngs...))
             {
                 if constexpr (_OrTagType::value)
-                {
                     __found_local.store(1);
-                    break;
-                }
                 else
                 {
                     for (auto __old = __found_local.load(); __comp(__shifted_idx, __old); __old = __found_local.load())
                     {
                         __found_local.compare_exchange_strong(__old, __shifted_idx);
                     }
-                    break;
                 }
+
+                break;
             }
         }
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1067,7 +1067,10 @@ struct __early_exit_find_or
             if (__shifted_idx < __n && __pred(__shifted_idx, __rngs...))
             {
                 if constexpr (_OrTagType::value)
+                {
                     __found_local.store(1);
+                    break;
+                }
                 else
                 {
                     for (auto __old = __found_local.load(); __comp(__shifted_idx, __old); __old = __found_local.load())

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1080,7 +1080,7 @@ struct __early_exit_find_or
                 else
                 {
                     // As far as we found the first/last data entry here, we need to set the atomic value to the index of the found data entry.
-                    // But only in this case when this value is less (if we find the first value)/greater(if we find the last value) than the current value of the atomic.
+                    // But only in this case when this value is less (if we find the first value)/greater (if we find the last value) than the current value of the atomic.
                     for (auto __old = __found_local.load(); __comp(__shifted_idx, __old); __old = __found_local.load())
                     {
                         // If we replace the atomic value successfully, we should break the loop to avoid extra operations with atomic

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1081,10 +1081,12 @@ struct __early_exit_find_or
                 {
                     // As far as we find the first/last value of the data here, we need to set the atomic value to the index of the found data.
                     // But only in this case when this value is less (if we find the first value)/greater(if we find the last value) than the current value of the atomic.
-                    if constexpr (!_BackwardTagType::value)
-                        __found_local.fetch_min(__shifted_idx);
-                    else
-                        __found_local.fetch_max(__shifted_idx);
+                    for (auto __old = __found_local.load(); __comp(__shifted_idx, __old); __old = __found_local.load())
+                    {
+                        // If we replace the atomic value successfully, we can break the loop
+                        if (__found_local.compare_exchange_strong(__old, __shifted_idx))
+                            break;
+                    }
                 }
 
                 break;
@@ -1111,9 +1113,7 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<__find_or_kernel, _CustomName, _Brick,
                                                                                _BrickTag, _Ranges...>;
 
-    constexpr bool __or_tag_check = std::is_same_v<_BrickTag, __parallel_or_tag>;
-    using _BackwardTagType = std::is_same<typename _BrickTag::_Compare, oneapi::dpl::__internal::__pstl_greater>;
-
+    constexpr bool __or_tag_check = ::std::is_same_v<_BrickTag, __parallel_or_tag>;
     auto __rng_n = oneapi::dpl::__ranges::__get_first_range_size(__rngs...);
     assert(__rng_n > 0);
 
@@ -1177,20 +1177,17 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
                     __dpl_sycl::__group_barrier(__item_id);
 
                     // Set local atomic value to global atomic
-                    if (__local_idx == 0)
+                    if (__local_idx == 0 && __comp(__found_local.load(), __found.load()))
                     {
-                        const auto __found_local_state = __found_local.load();
-
-                        if (__comp(__found_local_state, __found.load()))
+                        if constexpr (__or_tag_check)
+                            __found.store(1);
+                        else
                         {
-                            if constexpr (__or_tag_check)
-                                __found.store(1);
-                            else
+                            for (auto __old = __found.load(); __comp(__found_local.load(), __old);
+                                 __old = __found.load())
                             {
-                                if constexpr (!_BackwardTagType::value)
-                                    __found.fetch_min(__found_local_state);
-                                else
-                                    __found.fetch_max(__found_local_state);
+                                if (__found.compare_exchange_strong(__old, __found_local.load()))
+                                    break;
                             }
                         }
                     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1083,7 +1083,7 @@ struct __early_exit_find_or
                     // But only in this case when this value is less (if we find the first value)/greater(if we find the last value) than the current value of the atomic.
                     for (auto __old = __found_local.load(); __comp(__shifted_idx, __old); __old = __found_local.load())
                     {
-                        // If we replace the atomic value successfully, we can break the loop
+                        // If we replace the atomic value successfully, we should break the loop to avoid extra operations with atomic
                         if (__found_local.compare_exchange_strong(__old, __shifted_idx))
                             break;
                     }
@@ -1194,6 +1194,7 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
                             for (auto __old = __found.load(); __comp(__found_local.load(), __old);
                                  __old = __found.load())
                             {
+                                // If we replace the atomic value successfully, we should break the loop to avoid extra operations with atomic
                                 if (__found.compare_exchange_strong(__old, __found_local.load()))
                                     break;
                             }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1191,11 +1191,13 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
                             __found.store(1);
                         else
                         {
-                            for (auto __old = __found.load(); __comp(__found_local.load(), __old);
+                            const auto __found_local_state = __found_local.load();
+
+                            for (auto __old = __found.load(); __comp(__found_local_state, __old);
                                  __old = __found.load())
                             {
                                 // If we replace the atomic value successfully, we should break the loop to avoid extra operations with atomic
-                                if (__found.compare_exchange_strong(__old, __found_local.load()))
+                                if (__found.compare_exchange_strong(__old, __found_local_state))
                                     break;
                             }
                         }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1084,7 +1084,8 @@ struct __early_exit_find_or
                     // As far as we found the first/last data entry here, we need to set the atomic value to the index of the found data entry.
                     // But only in this case when this value is less (if we find the first value)/greater (if we find the last value) than the current value of the atomic.
                     bool __compare_exchange_processed = false;
-                    for (auto __old = __found_local.load(); !__compare_exchange_processed && __comp(__shifted_idx, __old); __old = __found_local.load())
+                    for (auto __old = __found_local.load();
+                         !__compare_exchange_processed && __comp(__shifted_idx, __old); __old = __found_local.load())
                     {
                         // If we replace the atomic value successfully, we should break the loop to avoid extra operations with atomic
                         __compare_exchange_processed = __found_local.compare_exchange_strong(__old, __shifted_idx);
@@ -1198,10 +1199,13 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
                             const auto __found_local_state = __found_local.load();
 
                             bool __compare_exchange_processed = false;
-                            for (auto __old = __found.load(); !__compare_exchange_processed && __comp(__found_local_state, __old); __old = __found.load())
+                            for (auto __old = __found.load();
+                                 !__compare_exchange_processed && __comp(__found_local_state, __old);
+                                 __old = __found.load())
                             {
                                 // If we replace the atomic value successfully, we should break the loop to avoid extra operations with atomic
-                                __compare_exchange_processed = __found.compare_exchange_strong(__old, __found_local_state);
+                                __compare_exchange_processed =
+                                    __found.compare_exchange_strong(__old, __found_local_state);
                             }
                         }
                     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1051,7 +1051,10 @@ struct __early_exit_find_or
         // if our "line" is out of work group size, reduce the line to the number of the rest elements
         if (__wg_size - __leader < __shift)
             __shift = __wg_size - __leader;
-        for (_IterSize __i = 0; __i < __n_iter; ++__i)
+
+        bool __something_was_found = false;
+
+        for (_IterSize __i = 0; __i < __n_iter && !__something_was_found; ++__i)
         {
             //in case of find-semantic __shifted_idx must be the same type as the atomic for a correct comparison
             using _ShiftedIdxType = ::std::conditional_t<_OrTagType::value, decltype(__init_index + __i * __shift),
@@ -1076,7 +1079,7 @@ struct __early_exit_find_or
                     }
                 }
 
-                break;
+                __something_was_found = true;
             }
         }
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1089,6 +1089,14 @@ struct __early_exit_find_or
                     }
                 }
 
+                // This break is mandatory from the performance point of view.
+                // This break is safe for all our cases:
+                // 1) __parallel_find_forward_tag : when we find the first data entry we processing data we process data from start to end (forward direction).
+                //    This means that after first found entry there is no reason to process data anymore.
+                // 2) __parallel_find_backward_tag  : when we find the last data entry we processing data we process data from end to start (backward direction).
+                //    This means that after the first found entry there is no reason to process data anymore too.
+                // 3) __parallel_or_tag : when we find any data entry we processing data we processing data from start to end (forward direction).
+                //    This means that after the first found entry there is no reason to process data anymore too.
                 break;
             }
         }

--- a/test/kt/CMakeLists.txt
+++ b/test/kt/CMakeLists.txt
@@ -100,7 +100,7 @@ function(_generate_esimd_sort_tests _key_value_pairs)
     set(_base_file_all "esimd_radix_sort" "esimd_radix_sort_out_of_place")
     set(_base_file_by_key_all "esimd_radix_sort_by_key" "esimd_radix_sort_by_key_out_of_place")
     set(_data_per_work_item_all "32" "64" "96" "128" "160" "192" "224" "256" "288" "320" "352" "384" "416" "448" "480" "512")
-    set(_work_group_size_all "32" "64")
+    set(_work_group_size_all "64")
     set(_type_all "char" "uint16_t" "int" "uint64_t" "float" "double")
 
     foreach (_data_per_work_item ${_data_per_work_item_all})
@@ -126,8 +126,8 @@ if (ONEDPL_TEST_ENABLE_KT_ESIMD)
     _generate_esimd_sort_tests(FALSE) # esimd_radix_sort, random
     _generate_esimd_sort_tests(TRUE) # esimd_radix_sort_by_key, random
 
-    # Pin some cases to track them, e.g. because they fail
-    _generate_esimd_sort_test("esimd_radix_sort" "256" "32" "double" "" 1000) # segfault
+    # Pin some cases to track them
+    _generate_esimd_sort_test("esimd_radix_sort_by_key_out_of_place" "96" "64" "uint32_t" "uint32_t" 1000) # common use-case
 endif()
 
 function (_generate_gpu_scan_test _data_per_work_item _work_group_size _type)


### PR DESCRIPTION
In this PR we implement break of for-loop inside `__early_exit_find_or` after first found element.
The approach from the PR https://github.com/oneapi-src/oneDPL/pull/1624 is applicable for the first/last element search.
This approach gives us a good performance boost.
Technically this `break` call implemented thought additional local variable with check inside of continue-condition in `for`-loop due performance results. 

Also in this PR, we analyze the result of `compare_exchange_strong()` call and break loop if the value of atomic has been changed correctly to avoid extra atomic value `load()` calls.

