### PR TITLE
[PROTOTYPE] Two-pass scan - Support in-place exclusive scans and update tests

### DIFF
--- a/include/oneapi/dpl/experimental/kt/two_pass_scan.h
+++ b/include/oneapi/dpl/experimental/kt/two_pass_scan.h
@@ -294,7 +294,7 @@ two_pass_scan(sycl::queue q, _InRng&& __in_rng, _OutRng&& __out_rng,
                         else // The last block wrote an exclusive result, so we must make it inclusive.
                         {
                             // Grab the last element from the previous block that has been cached in temporary
-                            // storage in the first kernel.
+                            // storage in the second kernel of the previous block.
                             ValueType last_block_element = unary_op(tmp_storage[num_sub_groups_global]);
                             sub_group_carry = binary_op(__out_rng[b * blockSize - 1], last_block_element);
                         }

--- a/test/kt/two_pass_scan.cpp
+++ b/test/kt/two_pass_scan.cpp
@@ -1,5 +1,5 @@
 // -*- C++ -*-
-//===-- single_pass_scan.cpp ----------------------------------------------===//
+//===-- two_pass_scan.cpp ----------------------------------------------===//
 //
 // Copyright (C) Intel Corporation
 //
@@ -67,36 +67,58 @@ generate_scan_data(T* input, std::size_t size, std::uint32_t seed)
     }
 }
 
-template <typename T, sycl::usm::alloc _alloc_type, typename BinOp, typename KernelParam>
+template <typename T, sycl::usm::alloc _alloc_type, typename BinOp, typename KernelParam1, typename KernelParam2>
 void
-test_usm(sycl::queue q, std::size_t size, BinOp bin_op, KernelParam param)
+test_usm(sycl::queue q, std::size_t size, BinOp bin_op, KernelParam1 param1, KernelParam2 param2)
 {
 #if LOG_TEST_INFO
     std::cout << "\t\ttest_usm<" << TypeInfo().name<T>() << ", " << USMAllocPresentation().name<_alloc_type>() << ">("
               << size << ");" << std::endl;
 #endif
-    std::vector<T> expected(size);
-    generate_scan_data<BinOp>(expected.data(), size, 42);
+    std::vector<T> expected1(size);
+    std::vector<T> expected2(size);
+    generate_scan_data<BinOp>(expected1.data(), size, 42);
+    generate_scan_data<BinOp>(expected2.data(), size, 42);
 
-    TestUtils::usm_data_transfer<_alloc_type, T> dt_input(q, expected.begin(), expected.end());
+    TestUtils::usm_data_transfer<_alloc_type, T> dt_input(q, expected1.begin(), expected1.end());
+    TestUtils::usm_data_transfer<_alloc_type, T> dt_input2(q, expected2.begin(), expected2.end());
     TestUtils::usm_data_transfer<_alloc_type, T> dt_output(q, size);
 
-    inclusive_scan_serial(expected.begin(), expected.end(), expected.begin(), bin_op);
+    inclusive_scan_serial(expected1.begin(), expected1.end(), expected1.begin(), bin_op);
+    exclusive_scan_serial(expected2.begin(), expected2.end(), expected2.begin(),
+                          oneapi::dpl::unseq_backend::__known_identity<BinOp, T>, bin_op);
 
-    auto invoke_and_verify = [&](auto& dt_dst) {
-        oneapi::dpl::experimental::kt::gpu::two_pass_inclusive_scan<typename KernelParam::kernel_name>(
-            q, dt_input.get_data(), dt_input.get_data() + size, dt_dst.get_data(), bin_op, oneapi::dpl::unseq_backend::__known_identity<BinOp, T>);
+    auto invoke_and_verify = [&](auto& dt_src, auto& dt_dst, auto& expected_res, auto is_inclusive) {
+        constexpr bool is_inclusive_scan = decltype(is_inclusive)::value;
+        std::string msg;
+        if constexpr (is_inclusive_scan)
+        {
+            msg = "wrong results with USM for inclusive_scan, n: " + std::to_string(size);
+            oneapi::dpl::experimental::kt::gpu::two_pass_inclusive_scan<typename KernelParam1::kernel_name>(
+                q, dt_src.get_data(), dt_src.get_data() + size, dt_dst.get_data(), bin_op,
+                oneapi::dpl::unseq_backend::__known_identity<BinOp, T>);
+        }
+        else
+        {
+            msg = "wrong results with USM for exclusive_scan, n: " + std::to_string(size);
+            oneapi::dpl::experimental::kt::gpu::two_pass_exclusive_scan<typename KernelParam2::kernel_name>(
+                q, dt_src.get_data(), dt_src.get_data() + size, dt_dst.get_data(),
+                oneapi::dpl::unseq_backend::__known_identity<BinOp, T>, bin_op);
+        }
 
         std::vector<T> actual(size);
         dt_dst.retrieve_data(actual.begin());
 
-        std::string msg = "wrong results with USM, n: " + std::to_string(size);
-        EXPECT_EQ_N(expected.begin(), actual.begin(), size, msg.c_str());
+        EXPECT_EQ_N(expected_res.begin(), actual.begin(), size, msg.c_str());
     };
-    // Out-of-place scan
-    invoke_and_verify(dt_output);
-    // In-place scan
-    invoke_and_verify(dt_input);
+    // Out-of-place inclusive scan
+    invoke_and_verify(dt_input, dt_output, expected1, std::true_type{});
+    // In-place inclusive scan
+    invoke_and_verify(dt_input, dt_input, expected1, std::true_type{});
+    // Out-of-place exclusive scan
+    invoke_and_verify(dt_input2, dt_output, expected2, std::false_type{});
+    // In-place exclusive scan
+    invoke_and_verify(dt_input2, dt_input2, expected2, std::false_type{});
 }
 
 template <typename T, typename BinOp, typename KernelParam>
@@ -178,11 +200,13 @@ template <typename T, typename BinOp, typename KernelParam>
 void
 test_general_cases(sycl::queue q, std::size_t size, BinOp bin_op, KernelParam param)
 {
-    test_usm<T, sycl::usm::alloc::shared>(q, size, bin_op, TestUtils::get_new_kernel_params<0>(param));
-    test_usm<T, sycl::usm::alloc::device>(q, size, bin_op, TestUtils::get_new_kernel_params<1>(param));
-    test_sycl_iterators<T>(q, size, bin_op, TestUtils::get_new_kernel_params<2>(param));
-    test_all_view<T>(q, size, bin_op, TestUtils::get_new_kernel_params<3>(param));
-    test_buffer<T>(q, size, bin_op, TestUtils::get_new_kernel_params<4>(param));
+    test_usm<T, sycl::usm::alloc::shared>(q, size, bin_op, TestUtils::get_new_kernel_params<0>(param),
+                                          TestUtils::get_new_kernel_params<1>(param));
+    test_usm<T, sycl::usm::alloc::device>(q, size, bin_op, TestUtils::get_new_kernel_params<2>(param),
+                                          TestUtils::get_new_kernel_params<3>(param));
+    test_sycl_iterators<T>(q, size, bin_op, TestUtils::get_new_kernel_params<4>(param));
+    test_all_view<T>(q, size, bin_op, TestUtils::get_new_kernel_params<5>(param));
+    test_buffer<T>(q, size, bin_op, TestUtils::get_new_kernel_params<6>(param));
 }
 
 template <typename T, typename KernelParam>
@@ -219,7 +243,9 @@ test_all_types(sycl::queue q, std::size_t size, KernelParam params)
     test_all_cases<uint64_t>(q, size, params);
 
     test_all_cases<float>(q, size, params);
-    test_all_cases<double>(q, size, params);
+
+    if (TestUtils::has_type_support<double>(q.get_device()))
+        test_all_cases<double>(q, size, params);
 }
 
 int


### PR DESCRIPTION
This PR is targeted to the development branch for a new scan implementation.

I have done some evaluation of the scan implementation for the in-place case where the input and output buffers are the same. For inclusive scan, there are no issues with the current implementation. For exclusive scan, we have an issue in the multi-block case where we fetch the last element from the previous block's input to compute the current block's carry-in. In the in-place case, this input value would have been already overwritten with the exclusive scan value.

To fix this issue, the last input element in a block is written to temporary storage by the last sub-group's work item in the second kernel before the scan results are written and is then fetched by the next block. This operation does not add any additional overhead as the last sub-group would be idle either way waiting on the first sub-group to finish its work.

I have added a test-case for out-of-place and in-place inclusive / exclusive scan to the USM tests. The test build / run time is starting to grow, so I don't think we should add them to each case. 