### PR TITLE
Introducing list of maintainers and their lead areas.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,33 +5,19 @@ for the various backends supported to allow oneDPL to run on CPU, GPU, and FPGA 
 which a developer is a lead maintainer are listed below.
 
 
-| --------------------- | ------------------- | ------------------------------------------ |
 | Name                  | Github ID           | API Area                                   |
 | --------------------- | ------------------- | ------------------------------------------ |
 | Ruslan Arutyunyan     | @rarutyun           | PSTL Offload                               |
-| --------------------- | ------------------- | ------------------------------------------ |
 | Konstantin Boyarinov  | @kboyarinov         | PSTL Offload                               |
-| --------------------- | ------------------- | ------------------------------------------ |
 | Pavel Dyakov          | @paveldyakov        | Random number generator APIs               |
-| --------------------- | ------------------- | ------------------------------------------ |
 | Mikhail Dvorskiy      | @MikeDvorskiy       | Range-based algorithms, Sort algorithms    |
-| --------------------- | ------------------- | ------------------------------------------ |
 | Adam Fidel            | @adamfidel          | Scan algorithms, Experimental Scan KT      |
-| --------------------- | ------------------- | ------------------------------------------ |
 | Dan Hoeflinger        | @danhoeflinger      | Histogram, Transform, Iterators            |
-| --------------------- | ------------------- | ------------------------------------------ |
 | Alexandr Konovalov    | @Alexandr-konovalov | PSTL Offload                               |
-| --------------------- | ------------------- | ------------------------------------------ |
 | Sergey Kopienko       | @SergeyKopienko     | Find algorithms, Experimental Sort KT      |
-| --------------------- | ------------------- | ------------------------------------------ |
 | Alexey Kukanov        | @akukanov           | oneDPL architecture, Experimental Sort KT  |
-| --------------------- | ------------------- | ------------------------------------------ |
 | Matt Michel           | @mmichel11          | By-segment algorithms, Search algorithms   |
-| --------------------- | ------------------- | ------------------------------------------ |
 | Julian Miller         | @julianmi           | Reduce algorithms                          |
-| --------------------- | ------------------- | ------------------------------------------ |
 | Dmitriy Sobolev       | @dmitriy-sobolev    | Experimental Sort KT                       |
-| --------------------- | ------------------- | ------------------------------------------ |
 | Anuya Welling         | @AnuyaWelling2801   | Experimental Dynamic Device Selection APIs | 
-| --------------------- | ------------------- | ------------------------------------------ |
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,7 +7,7 @@ This document provides a list of the maintainers for each area of development in
 | C++ standard policies and CPU backends | Dan Hoeflinger | @danhoeflinger |
 | SYCL device policies and SYCL backends | Mikhail Dvorskiy<br>Adam Fidel | @MikeDvorskiy<br>@adamfidel | 
 | Tested Standard C++ APIs & Utility Function Object Classes | Sergey Kopienko | @SergeyKopeinko |
-| C++17 standard algorithms | Mikhail Dvorskiy<br>Adam Fidel<br>SergeyKopienko<br>Julian Miller<br>Dmitriy Sobolev | @MikeDvorskiy<br>@adamfidel<br>@julianmi<br>@SergeyKopienko<br>@dmitriy-sobolev |
+| C++17 standard algorithms | Mikhail Dvorskiy<br>Adam Fidel<br>SergeyKopienko<br>Julian Miller<br>Dmitriy Sobolev | @MikeDvorskiy<br>@adamfidel<br>@SergeyKopienko<br>@julianmi<br>@dmitriy-sobolev |
 | Range-Based Algorithms | Mikhail Dvorskiy | @MikeDvorskiy |
 | Asynchronous API Algorithms | | |
 | Additional Algorithms | Dan Hoeflinger<br>Matt Michel | @danhoeflinger<br>@mmichel11 |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,7 +9,7 @@ This document provides a list of the maintainers for each area of development in
 | Tested Standard C++ APIs & Utility Function Object Classes | Sergey Kopienko | @SergeyKopeinko |
 | C++17 standard algorithms | Mikhail Dvorskiy<br>Adam Fidel<br>SergeyKopienko<br>Julian Miller<br>Dmitriy Sobolev | @MikeDvorskiy<br>@adamfidel<br>@SergeyKopienko<br>@julianmi<br>@dmitriy-sobolev |
 | Range-Based Algorithms | Mikhail Dvorskiy | @MikeDvorskiy |
-| Asynchronous API Algorithms | | |
+| Asynchronous API Algorithms | Pablo Reble | @reble |
 | Additional Algorithms | Dan Hoeflinger<br>Matt Michel | @danhoeflinger<br>@mmichel11 |
 | Iterators | Dan Hoeflinger | @danhoeflinger |
 | Random Number Generators | Pavel Dyakov | @paveldyakov |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,37 @@
+# Introduction
+
+The oneDPL project provides algorithms that are implemented using parallel patterns and bricks implemented
+for the various backends supported to allow oneDPL to run on CPU, GPU, and FPGA platforms. The API areas
+which a developer is a lead maintainer are listed below.
+
+
+| --------------------- | ------------------- | ------------------------------------------ |
+| Name                  | Github ID           | API Area                                   |
+| --------------------- | ------------------- | ------------------------------------------ |
+| Ruslan Arutyunyan     | @rarutyun           | PSTL Offload                               |
+| --------------------- | ------------------- | ------------------------------------------ |
+| Konstantin Boyarinov  | @kboyarinov         | PSTL Offload                               |
+| --------------------- | ------------------- | ------------------------------------------ |
+| Pavel Dyakov          | @paveldyakov        | Random number generator APIs               |
+| --------------------- | ------------------- | ------------------------------------------ |
+| Mikhail Dvorskiy      | @MikeDvorskiy       | Range-based algorithms, Sort algorithms    |
+| --------------------- | ------------------- | ------------------------------------------ |
+| Adam Fidel            | @adamfidel          | Scan algorithms, Experimental Scan KT      |
+| --------------------- | ------------------- | ------------------------------------------ |
+| Dan Hoeflinger        | @danhoeflinger      | Histogram, Transform, Iterators            |
+| --------------------- | ------------------- | ------------------------------------------ |
+| Alexandr Konovalov    | @Alexandr-konovalov | PSTL Offload                               |
+| --------------------- | ------------------- | ------------------------------------------ |
+| Sergey Kopienko       | @SergeyKopienko     | Find algorithms, Experimental Sort KT      |
+| --------------------- | ------------------- | ------------------------------------------ |
+| Alexey Kukanov        | @akukanov           | oneDPL architecture, Experimental Sort KT  |
+| --------------------- | ------------------- | ------------------------------------------ |
+| Matt Michel           | @mmichel11          | By-segment algorithms, Search algorithms   |
+| --------------------- | ------------------- | ------------------------------------------ |
+| Julian Miller         | @julianmi           | Reduce algorithms                          |
+| --------------------- | ------------------- | ------------------------------------------ |
+| Dmitriy Sobolev       | @dmitriy-sobolev    | Experimental Sort KT                       |
+| --------------------- | ------------------- | ------------------------------------------ |
+| Anuya Welling         | @AnuyaWelling2801   | Experimental Dynamic Device Selection APIs | 
+| --------------------- | ------------------- | ------------------------------------------ |
+

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,24 +1,17 @@
 # Introduction
 
-The oneDPL project provides algorithms that are implemented using parallel patterns and bricks implemented
-for the various backends supported to allow oneDPL to run on CPU, GPU, and FPGA platforms. The API areas
-which a developer is a lead maintainer are listed below. If you have questions, PRs, etc. which do not fit
-into one these categories you can check the git blame information to identify a contact or tag all maintainers.
+This document provides a list of the maintainers for each area of development in the oneDPL project.
 
-
-| Name                  | Github ID           | API Area |
+| Feature               | Maintainer          | Github ID |
 | --------------------- | ------------------- | -------- |
-| Ruslan Arutyunyan     | @rarutyun           | PSTL Offload |
-| Konstantin Boyarinov  | @kboyarinov         | PSTL Offload |
-| Pavel Dyakov          | @paveldyakov        | Random number generator APIs |
-| Mikhail Dvorskiy      | @MikeDvorskiy       | Range-based algorithms, Sort algorithms |
-| Adam Fidel            | @adamfidel          | Scan algorithms, Experimental Scan KT |
-| Dan Hoeflinger        | @danhoeflinger      | Histogram, Transform, Iterators |
-| Alexandr Konovalov    | @Alexandr-konovalov | PSTL Offload |
-| Sergey Kopienko       | @SergeyKopienko     | Find algorithms, Experimental Sort KT, validation tests |
-| Alexey Kukanov        | @akukanov           | oneDPL architecture, Experimental Sort KT |
-| Matt Michel           | @mmichel11          | By-segment algorithms, Search algorithms |
-| Julian Miller         | @julianmi           | Reduce algorithms |
-| Dmitriy Sobolev       | @dmitriy-sobolev    | Experimental Sort KT |
-| Anuya Welling         | @AnuyaWelling2801   | Experimental Dynamic Device Selection APIs |
-
+| C++ standard policies and CPU backends | Dan Hoeflinger | @danhoelfinger |
+| SYCL device policies and SYCL backends | Mikhail Dvorskiy<br>Adam Fidel | @MikeDvorskiy<br>@adamfidel | 
+| Tested Standard C++ APIs & Utility Function Object Classes | Sergey Kopienko | @SergeyKopeinko |
+| C++17 standard algorithms | Adam Fidel | @adamfidel |
+| Range-Based Algorithms | Mikhail Dvorskiy | @MikeDvorskiy |
+| Asynchronous API Algorithms | | |
+| Additional Algorithms | Dan Hoeflinger<br>Matt Michel | @danhoeflinger<br>@mmichel11 |
+| Iterators | Dan Hoeflinger | @danhoeflinger |
+| Random Number Generators | Pavel Dyakov | @paveldyakov |
+| Dynamic Selection API | Anuya Welling | @AnuyaWelling2801 |
+| Kernel Templates API | Sergey Kopienko<br>Dmitriy Sobolev | @SergeyKopienko<br>@dmitriy-sobolev |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,7 +7,7 @@ This document provides a list of the maintainers for each area of development in
 | C++ standard policies and CPU backends | Dan Hoeflinger | @danhoeflinger |
 | SYCL device policies and SYCL backends | Mikhail Dvorskiy<br>Adam Fidel | @MikeDvorskiy<br>@adamfidel | 
 | Tested Standard C++ APIs & Utility Function Object Classes | Sergey Kopienko | @SergeyKopeinko |
-| C++17 standard algorithms | Mikhail Dvorskiy<br>Adam Fidel<br>SergeyKopienko<br>Dmitriy Sobolev | @adamfidel |
+| C++17 standard algorithms | Mikhail Dvorskiy<br>Adam Fidel<br>SergeyKopienko<br>Dmitriy Sobolev | @MikeDvorskiy<br>@adamfidel<br>@SergeyKopienko<br>@dmitriy-sobolev |
 | Range-Based Algorithms | Mikhail Dvorskiy | @MikeDvorskiy |
 | Asynchronous API Algorithms | | |
 | Additional Algorithms | Dan Hoeflinger<br>Matt Michel | @danhoeflinger<br>@mmichel11 |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,7 +2,8 @@
 
 The oneDPL project provides algorithms that are implemented using parallel patterns and bricks implemented
 for the various backends supported to allow oneDPL to run on CPU, GPU, and FPGA platforms. The API areas
-which a developer is a lead maintainer are listed below.
+which a developer is a lead maintainer are listed below. If you have questions, PRs, etc. which do not fit
+into one these categories you can check the git blame information to identify a contact or tag all maintainers.
 
 
 | Name                  | Github ID           | API Area |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,7 +7,7 @@ This document provides a list of the maintainers for each area of development in
 | C++ standard policies and CPU backends | Dan Hoeflinger | @danhoelfinger |
 | SYCL device policies and SYCL backends | Mikhail Dvorskiy<br>Adam Fidel | @MikeDvorskiy<br>@adamfidel | 
 | Tested Standard C++ APIs & Utility Function Object Classes | Sergey Kopienko | @SergeyKopeinko |
-| C++17 standard algorithms | Adam Fidel | @adamfidel |
+| C++17 standard algorithms | Mikhail Dvorskiy<br>Adam Fidel<br>SergeyKopienko<br>Dmitriy Sobolev | @adamfidel |
 | Range-Based Algorithms | Mikhail Dvorskiy | @MikeDvorskiy |
 | Asynchronous API Algorithms | | |
 | Additional Algorithms | Dan Hoeflinger<br>Matt Michel | @danhoeflinger<br>@mmichel11 |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,19 +5,19 @@ for the various backends supported to allow oneDPL to run on CPU, GPU, and FPGA 
 which a developer is a lead maintainer are listed below.
 
 
-| Name                  | Github ID           | API Area                                                |
-| --------------------- | ------------------- | ------------------------------------------------------- |
-| Ruslan Arutyunyan     | @rarutyun           | PSTL Offload                                            |
-| Konstantin Boyarinov  | @kboyarinov         | PSTL Offload                                            |
-| Pavel Dyakov          | @paveldyakov        | Random number generator APIs                            |
-| Mikhail Dvorskiy      | @MikeDvorskiy       | Range-based algorithms, Sort algorithms                 |
-| Adam Fidel            | @adamfidel          | Scan algorithms, Experimental Scan KT                   |
-| Dan Hoeflinger        | @danhoeflinger      | Histogram, Transform, Iterators                         |
-| Alexandr Konovalov    | @Alexandr-konovalov | PSTL Offload                                            |
+| Name                  | Github ID           | API Area |
+| --------------------- | ------------------- | -------- |
+| Ruslan Arutyunyan     | @rarutyun           | PSTL Offload |
+| Konstantin Boyarinov  | @kboyarinov         | PSTL Offload |
+| Pavel Dyakov          | @paveldyakov        | Random number generator APIs |
+| Mikhail Dvorskiy      | @MikeDvorskiy       | Range-based algorithms, Sort algorithms |
+| Adam Fidel            | @adamfidel          | Scan algorithms, Experimental Scan KT |
+| Dan Hoeflinger        | @danhoeflinger      | Histogram, Transform, Iterators |
+| Alexandr Konovalov    | @Alexandr-konovalov | PSTL Offload |
 | Sergey Kopienko       | @SergeyKopienko     | Find algorithms, Experimental Sort KT, validation tests |
-| Alexey Kukanov        | @akukanov           | oneDPL architecture, Experimental Sort KT               |
-| Matt Michel           | @mmichel11          | By-segment algorithms, Search algorithms                |
-| Julian Miller         | @julianmi           | Reduce algorithms                                       |
-| Dmitriy Sobolev       | @dmitriy-sobolev    | Experimental Sort KT                                    |
-| Anuya Welling         | @AnuyaWelling2801   | Experimental Dynamic Device Selection APIs              | 
+| Alexey Kukanov        | @akukanov           | oneDPL architecture, Experimental Sort KT |
+| Matt Michel           | @mmichel11          | By-segment algorithms, Search algorithms |
+| Julian Miller         | @julianmi           | Reduce algorithms |
+| Dmitriy Sobolev       | @dmitriy-sobolev    | Experimental Sort KT |
+| Anuya Welling         | @AnuyaWelling2801   | Experimental Dynamic Device Selection APIs |
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,19 +5,19 @@ for the various backends supported to allow oneDPL to run on CPU, GPU, and FPGA 
 which a developer is a lead maintainer are listed below.
 
 
-| Name                  | Github ID           | API Area                                   |
-| --------------------- | ------------------- | ------------------------------------------ |
-| Ruslan Arutyunyan     | @rarutyun           | PSTL Offload                               |
-| Konstantin Boyarinov  | @kboyarinov         | PSTL Offload                               |
-| Pavel Dyakov          | @paveldyakov        | Random number generator APIs               |
-| Mikhail Dvorskiy      | @MikeDvorskiy       | Range-based algorithms, Sort algorithms    |
-| Adam Fidel            | @adamfidel          | Scan algorithms, Experimental Scan KT      |
-| Dan Hoeflinger        | @danhoeflinger      | Histogram, Transform, Iterators            |
-| Alexandr Konovalov    | @Alexandr-konovalov | PSTL Offload                               |
-| Sergey Kopienko       | @SergeyKopienko     | Find algorithms, Experimental Sort KT      |
-| Alexey Kukanov        | @akukanov           | oneDPL architecture, Experimental Sort KT  |
-| Matt Michel           | @mmichel11          | By-segment algorithms, Search algorithms   |
-| Julian Miller         | @julianmi           | Reduce algorithms                          |
-| Dmitriy Sobolev       | @dmitriy-sobolev    | Experimental Sort KT                       |
-| Anuya Welling         | @AnuyaWelling2801   | Experimental Dynamic Device Selection APIs | 
+| Name                  | Github ID           | API Area                                                |
+| --------------------- | ------------------- | ------------------------------------------------------- |
+| Ruslan Arutyunyan     | @rarutyun           | PSTL Offload                                            |
+| Konstantin Boyarinov  | @kboyarinov         | PSTL Offload                                            |
+| Pavel Dyakov          | @paveldyakov        | Random number generator APIs                            |
+| Mikhail Dvorskiy      | @MikeDvorskiy       | Range-based algorithms, Sort algorithms                 |
+| Adam Fidel            | @adamfidel          | Scan algorithms, Experimental Scan KT                   |
+| Dan Hoeflinger        | @danhoeflinger      | Histogram, Transform, Iterators                         |
+| Alexandr Konovalov    | @Alexandr-konovalov | PSTL Offload                                            |
+| Sergey Kopienko       | @SergeyKopienko     | Find algorithms, Experimental Sort KT, validation tests |
+| Alexey Kukanov        | @akukanov           | oneDPL architecture, Experimental Sort KT               |
+| Matt Michel           | @mmichel11          | By-segment algorithms, Search algorithms                |
+| Julian Miller         | @julianmi           | Reduce algorithms                                       |
+| Dmitriy Sobolev       | @dmitriy-sobolev    | Experimental Sort KT                                    |
+| Anuya Welling         | @AnuyaWelling2801   | Experimental Dynamic Device Selection APIs              | 
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,7 +7,7 @@ This document provides a list of the maintainers for each area of development in
 | C++ standard policies and CPU backends | Dan Hoeflinger | @danhoeflinger |
 | SYCL device policies and SYCL backends | Mikhail Dvorskiy<br>Adam Fidel | @MikeDvorskiy<br>@adamfidel | 
 | Tested Standard C++ APIs & Utility Function Object Classes | Sergey Kopienko | @SergeyKopeinko |
-| C++17 standard algorithms | Mikhail Dvorskiy<br>Adam Fidel<br>SergeyKopienko<br>Dmitriy Sobolev | @MikeDvorskiy<br>@adamfidel<br>@SergeyKopienko<br>@dmitriy-sobolev |
+| C++17 standard algorithms | Mikhail Dvorskiy<br>Adam Fidel<br>SergeyKopienko<br>Julian Miller<br>Dmitriy Sobolev | @MikeDvorskiy<br>@adamfidel<br>@julianmi<br>@SergeyKopienko<br>@dmitriy-sobolev |
 | Range-Based Algorithms | Mikhail Dvorskiy | @MikeDvorskiy |
 | Asynchronous API Algorithms | | |
 | Additional Algorithms | Dan Hoeflinger<br>Matt Michel | @danhoeflinger<br>@mmichel11 |


### PR DESCRIPTION
The PR lists the lead maintainers for oneDPL and the areas for which they're primarily responsible.  Please suggest corrections to the areas as needed.

This addresses https://github.com/uxlfoundation/open-source-working-group/issues/11