### PR TITLE
Using `fetch_min` / `fetch_max` in `__parallel_find_or` and in it's stuff

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -331,7 +331,7 @@ struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name
         // Practically this is the better value that was found
         constexpr decltype(__wgroup_size) __iters_per_witem = 16;
         auto __size_per_wg = __iters_per_witem * __wgroup_size;
-        auto __n_groups = (__n - 1) / __size_per_wg + 1;
+        auto __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __size_per_wg);
         // Storage for the results of scan for each workgroup
         sycl::buffer<_Type> __wg_sums(__n_groups);
 
@@ -357,7 +357,7 @@ struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name
         // 2. Scan for the entire group of values scanned from each workgroup (runs on a single workgroup)
         if (__n_groups > 1)
         {
-            auto __iters_per_single_wg = (__n_groups - 1) / __wgroup_size + 1;
+            auto __iters_per_single_wg = oneapi::dpl::__internal::__dpl_ceiling_div(__n_groups, __wgroup_size);
             __submit_event = __exec.queue().submit([&](sycl::handler& __cgh) {
                 __cgh.depends_on(__submit_event);
                 auto __wg_sums_acc = __wg_sums.template get_access<access_mode::read_write>(__cgh);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -973,12 +973,12 @@ struct __parallel_find_forward_tag
         return __val;
     }
 
-    template <sycl::access::address_space _Space>
+    template <typename _TAtomic>
     static void
-    __save_state_to_atomic(__dpl_sycl::__atomic_ref<_AtomicType, _Space>& __atomic, _AtomicType __new_state)
+    __save_state_to_atomic(_TAtomic& __found, _AtomicType __new_state)
     {
         // As far as we make search from begin to the end of data, we should save the first (minimal) found state.
-        __atomic.fetch_min(__new_state);
+        __found.fetch_min(__new_state);
     }
 };
 
@@ -999,12 +999,12 @@ struct __parallel_find_backward_tag
         return _AtomicType{-1};
     }
 
-    template <sycl::access::address_space _Space>
+    template <typename _TAtomic>
     static void
-    __save_state_to_atomic(__dpl_sycl::__atomic_ref<_AtomicType, _Space>& __atomic, _AtomicType __new_state)
+    __save_state_to_atomic(_TAtomic& __found, _AtomicType __new_state)
     {
         // As far as we make search from end to the begin of data, we should save the last (maximal) found state.
-        __atomic.fetch_max(__new_state);
+        __found.fetch_max(__new_state);
     }
 };
 
@@ -1020,12 +1020,12 @@ struct __parallel_or_tag
         return 0;
     }
 
-    template <sycl::access::address_space _Space>
+    template <typename _TAtomic>
     static void
-    __save_state_to_atomic(__dpl_sycl::__atomic_ref<_AtomicType, _Space>& __atomic, _AtomicType /*__new_state*/)
+    __save_state_to_atomic(_TAtomic& __found, _AtomicType /*__new_state*/)
     {
         // Store that a match was found. Its position is not relevant for or semantics.
-        __atomic.store(1);
+        __found.store(1);
     }
 };
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1038,7 +1038,7 @@ struct __parallel_or_tag
     static void
     __save_state_to_atomic(__dpl_sycl::__atomic_ref<_AtomicType, _Space>& __atomic, _AtomicType /*__new_state*/)
     {
-        // As far as we make search from end to the begin of data, we simple save the fact of finding.
+        // Store that a match was found. Its position is not relevant for or semantics.
         __atomic.store(1);
     }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -982,6 +982,13 @@ struct __parallel_find_forward_tag
         // As far as we make search from begin to the end of data, we should save the first (minimal) found state.
         __atomic.fetch_min(__new_state);
     }
+
+    template <typename _DiffType>
+    static auto
+    __eval_res(_AtomicType __result, _DiffType __rng_n)
+    {
+        return __result != __init_value(__rng_n) ? __result : __rng_n;
+    }
 };
 
 // Tag for __parallel_find_or to find the last element that satisfies predicate
@@ -1010,6 +1017,13 @@ struct __parallel_find_backward_tag
         // As far as we make search from end to the begin of data, we should save the last (maximal) found state.
         __atomic.fetch_max(__new_state);
     }
+
+    template <typename _DiffType>
+    static auto
+    __eval_res(_AtomicType __result, _DiffType __rng_n)
+    {
+        return __result != __init_value(__rng_n) ? __result : __rng_n;
+    }
 };
 
 // Tag for __parallel_find_or for or-semantic
@@ -1032,6 +1046,13 @@ struct __parallel_or_tag
     {
         // As far as we make search from end to the begin of data, we simple save the fact of finding.
         __atomic.store(1);
+    }
+
+    template <typename _DiffType>
+    static auto
+    __eval_res(_AtomicType __result, _DiffType /*__rng_n*/)
+    {
+        return __result;
     }
 };
 
@@ -1138,8 +1159,6 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<__find_or_kernel, _CustomName, _Brick,
                                                                                _BrickTag, _Ranges...>;
 
-    constexpr bool __or_tag_check = ::std::is_same_v<_BrickTag, __parallel_or_tag>;
-
     assert("This device does not support 64-bit atomics" &&
            (sizeof(_AtomicType) < 64 || __exec.queue().get_device().has(sycl::aspect::atomic64)));
 
@@ -1219,10 +1238,7 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
         //The end of the scope  -  a point of synchronization (on temporary sycl buffer destruction)
     }
 
-    if constexpr (__or_tag_check)
-        return __result;
-    else
-        return __result != __init_value ? __result : __rng_n;
+    return _BrickTag::__eval_res(__result, __rng_n);
 }
 
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1058,7 +1058,8 @@ __is_backward_tag(__parallel_find_backward_tag<_RangeType>)
 }
 
 template <typename _TagType>
-constexpr bool __is_backward_tag(_TagType)
+constexpr bool
+__is_backward_tag(_TagType)
 {
     return false;
 }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1165,11 +1165,11 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
 #endif
     auto __max_cu = oneapi::dpl::__internal::__max_compute_units(__exec);
 
-    auto __n_groups = (__rng_n - 1) / __wgroup_size + 1;
+    auto __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__rng_n, __wgroup_size);
     // TODO: try to change __n_groups with another formula for more perfect load balancing
     __n_groups = ::std::min(__n_groups, decltype(__n_groups)(__max_cu));
 
-    auto __n_iter = (__rng_n - 1) / (__n_groups * __wgroup_size) + 1;
+    auto __n_iter = oneapi::dpl::__internal::__dpl_ceiling_div(__rng_n, __n_groups * __wgroup_size);
 
     _PRINT_INFO_IN_DEBUG_MODE(__exec, __wgroup_size, __max_cu);
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -958,8 +958,6 @@ __parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag __backend_tag, 
 template <typename _RangeType>
 struct __parallel_find_forward_tag
 {
-    using _RangeTypeT = _RangeType;
-
 // FPGA devices don't support 64-bit atomics
 #if _ONEDPL_FPGA_DEVICE
     using _AtomicType = uint32_t;
@@ -995,8 +993,6 @@ struct __parallel_find_forward_tag
 template <typename _RangeType>
 struct __parallel_find_backward_tag
 {
-    using _RangeTypeT = _RangeType;
-
 // FPGA devices don't support 64-bit atomics
 #if _ONEDPL_FPGA_DEVICE
     using _AtomicType = int32_t;
@@ -1029,8 +1025,6 @@ struct __parallel_find_backward_tag
 // Tag for __parallel_find_or for or-semantic
 struct __parallel_or_tag
 {
-    using _RangeTypeT = void;
-
     using _AtomicType = int32_t;
 
     // The template parameter is intended to unify __init_value in tags.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1152,7 +1152,7 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
                                                                                _BrickTag, _Ranges...>;
 
     assert("This device does not support 64-bit atomics" &&
-           (sizeof(_AtomicType) < 64 || __exec.queue().get_device().has(sycl::aspect::atomic64)));
+           (sizeof(_AtomicType) < 8 || __exec.queue().get_device().has(sycl::aspect::atomic64)));
 
     auto __rng_n = oneapi::dpl::__ranges::__get_first_range_size(__rngs...);
     assert(__rng_n > 0);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -958,13 +958,14 @@ __parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag __backend_tag, 
 template <typename _RangeType>
 struct __parallel_find_forward_tag
 {
+    using _RangeTypeT = _RangeType;
+
 // FPGA devices don't support 64-bit atomics
 #if _ONEDPL_FPGA_DEVICE
     using _AtomicType = uint32_t;
 #else
     using _AtomicType = oneapi::dpl::__internal::__difference_t<_RangeType>;
 #endif
-    using _Compare = oneapi::dpl::__internal::__pstl_less;
 
     // The template parameter is intended to unify __init_value in tags.
     template <typename _DiffType>
@@ -973,43 +974,50 @@ struct __parallel_find_forward_tag
     {
         return __val;
     }
+
+    template <sycl::access::address_space _Space>
+    static void
+    __save_state_to_atomic(__dpl_sycl::__atomic_ref<_AtomicType, _Space>& __atomic, _AtomicType __new_state)
+    {
+        // As far as we make search from begin to the end of data, we should save the first (minimal) found state.
+        __atomic.fetch_min(__new_state);
+    }
 };
 
 // Tag for __parallel_find_or to find the last element that satisfies predicate
 template <typename _RangeType>
 struct __parallel_find_backward_tag
 {
+    using _RangeTypeT = _RangeType;
+
 // FPGA devices don't support 64-bit atomics
 #if _ONEDPL_FPGA_DEVICE
     using _AtomicType = int32_t;
 #else
     using _AtomicType = oneapi::dpl::__internal::__difference_t<_RangeType>;
 #endif
-    using _Compare = oneapi::dpl::__internal::__pstl_greater;
 
     template <typename _DiffType>
     constexpr static _AtomicType __init_value(_DiffType)
     {
         return _AtomicType{-1};
     }
+
+    template <sycl::access::address_space _Space>
+    static void
+    __save_state_to_atomic(__dpl_sycl::__atomic_ref<_AtomicType, _Space>& __atomic, _AtomicType __new_state)
+    {
+        // As far as we make search from end to the begin of data, we should save the last (maximal) found state.
+        __atomic.fetch_max(__new_state);
+    }
 };
 
 // Tag for __parallel_find_or for or-semantic
 struct __parallel_or_tag
 {
-    class __atomic_compare
-    {
-      public:
-        template <typename _LocalAtomic, typename _GlobalAtomic>
-        bool
-        operator()(const _LocalAtomic& __found_local, const _GlobalAtomic& __found) const
-        {
-            return __found_local == 1 && __found == 0;
-        }
-    };
+    using _RangeTypeT = void;
 
     using _AtomicType = int32_t;
-    using _Compare = __atomic_compare;
 
     // The template parameter is intended to unify __init_value in tags.
     template <typename _DiffType>
@@ -1017,7 +1025,28 @@ struct __parallel_or_tag
     {
         return 0;
     }
+
+    template <sycl::access::address_space _Space>
+    static void
+    __save_state_to_atomic(__dpl_sycl::__atomic_ref<_AtomicType, _Space>& __atomic, _AtomicType /*__new_state*/)
+    {
+        // As far as we make search from end to the begin of data, we simple save the fact of finding.
+        __atomic.store(1);
+    }
 };
+
+template <typename _RangeType>
+constexpr bool
+__is_backward_tag(__parallel_find_backward_tag<_RangeType>)
+{
+    return true;
+}
+
+template <typename _TagType>
+constexpr bool __is_backward_tag(_TagType)
+{
+    return false;
+}
 
 //------------------------------------------------------------------------
 // early_exit (find_or)
@@ -1028,11 +1057,11 @@ struct __early_exit_find_or
 {
     _Pred __pred;
 
-    template <typename _NDItemId, typename _IterSize, typename _WgSize, typename _LocalAtomic, typename _Compare,
-              typename _BrickTag, typename... _Ranges>
+    template <typename _NDItemId, typename _IterSize, typename _WgSize, typename _LocalAtomic, typename _BrickTag,
+              typename... _Ranges>
     void
-    operator()(const _NDItemId __item_id, const _IterSize __n_iter, const _WgSize __wg_size, _Compare __comp,
-               _LocalAtomic& __found_local, _BrickTag, _Ranges&&... __rngs) const
+    operator()(const _NDItemId __item_id, const _IterSize __n_iter, const _WgSize __wg_size,
+               _LocalAtomic& __found_local, _BrickTag __brick_tag, _Ranges&&... __rngs) const
     {
         using __par_backend_hetero::__parallel_or_tag;
 
@@ -1041,7 +1070,6 @@ struct __early_exit_find_or
         //  - __parallel_find_backward_tag : in case when we find the last value in the data;
         //  - __parallel_or_tag : in case when we find any value in the data.
         using _OrTagType = ::std::is_same<_BrickTag, __par_backend_hetero::__parallel_or_tag>;
-        using _BackwardTagType = ::std::is_same<typename _BrickTag::_Compare, oneapi::dpl::__internal::__pstl_greater>;
 
         auto __n = oneapi::dpl::__ranges::__get_first_range_size(__rngs...);
 
@@ -1065,7 +1093,7 @@ struct __early_exit_find_or
                                                          decltype(__found_local.load())>;
 
             _IterSize __current_iter = __i;
-            if constexpr (_BackwardTagType::value)
+            if constexpr (__is_backward_tag(__brick_tag))
                 __current_iter = __n_iter - 1 - __i;
 
             _ShiftedIdxType __shifted_idx = __init_index + __current_iter * __shift;
@@ -1073,24 +1101,8 @@ struct __early_exit_find_or
             // should be investigated later, with other HW
             if (__shifted_idx < __n && __pred(__shifted_idx, __rngs...))
             {
-                if constexpr (_OrTagType::value)
-                {
-                    // As far as we found any data entry, we can set the atomic value to 1.
-                    // No additional actions required.
-                    __found_local.store(1);
-                }
-                else
-                {
-                    // As far as we found the first/last data entry here, we need to set the atomic value to the index of the found data entry.
-                    // But only in this case when this value is less (if we find the first value)/greater (if we find the last value) than the current value of the atomic.
-                    bool __compare_exchange_processed = false;
-                    for (auto __old = __found_local.load();
-                         !__compare_exchange_processed && __comp(__shifted_idx, __old); __old = __found_local.load())
-                    {
-                        // If we replace the atomic value successfully, we should break the loop to avoid extra operations with atomic
-                        __compare_exchange_processed = __found_local.compare_exchange_strong(__old, __shifted_idx);
-                    }
-                }
+                // Update local (for group) atomic state with the found index
+                _BrickTag::__save_state_to_atomic(__found_local, __shifted_idx);
 
                 // This break is mandatory from the performance point of view.
                 // This break is safe for all our cases:
@@ -1127,6 +1139,10 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
                                                                                _BrickTag, _Ranges...>;
 
     constexpr bool __or_tag_check = ::std::is_same_v<_BrickTag, __parallel_or_tag>;
+
+    assert("This device does not support 64-bit atomics" &&
+           (sizeof(_AtomicType) < 64 || __exec.queue().get_device().has(sycl::aspect::atomic64)));
+
     auto __rng_n = oneapi::dpl::__ranges::__get_first_range_size(__rngs...);
     assert(__rng_n > 0);
 
@@ -1185,28 +1201,17 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
                     __dpl_sycl::__group_barrier(__item_id);
 
                     // 2. Find any element that satisfies pred and set local atomic value to global atomic
-                    constexpr auto __comp = typename _BrickTag::_Compare{};
-                    __pred(__item_id, __n_iter, __wgroup_size, __comp, __found_local, __brick_tag, __rngs...);
+                    __pred(__item_id, __n_iter, __wgroup_size, __found_local, __brick_tag, __rngs...);
                     __dpl_sycl::__group_barrier(__item_id);
 
                     // Set local atomic value to global atomic
-                    if (__local_idx == 0 && __comp(__found_local.load(), __found.load()))
+                    if (__local_idx == 0)
                     {
-                        if constexpr (__or_tag_check)
-                            __found.store(1);
-                        else
+                        const auto __found_local_state = __found_local.load();
+                        if (__found_local_state != __init_value)
                         {
-                            const auto __found_local_state = __found_local.load();
-
-                            bool __compare_exchange_processed = false;
-                            for (auto __old = __found.load();
-                                 !__compare_exchange_processed && __comp(__found_local_state, __old);
-                                 __old = __found.load())
-                            {
-                                // If we replace the atomic value successfully, we should break the loop to avoid extra operations with atomic
-                                __compare_exchange_processed =
-                                    __found.compare_exchange_strong(__old, __found_local_state);
-                            }
+                            // Update global (for all groups) atomic state with the found index
+                            _BrickTag::__save_state_to_atomic(__found, __found_local_state);
                         }
                     }
                 });

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1078,8 +1078,6 @@ struct __early_exit_find_or
     operator()(const _NDItemId __item_id, const _IterSize __n_iter, const _WgSize __wg_size,
                _LocalAtomic& __found_local, _BrickTag __brick_tag, _Ranges&&... __rngs) const
     {
-        using __par_backend_hetero::__parallel_or_tag;
-
         // There are 3 possible tag types here:
         //  - __parallel_find_forward_tag : in case when we find the first value in the data;
         //  - __parallel_find_backward_tag : in case when we find the last value in the data;


### PR DESCRIPTION
In this PR we using `fetch_min` / `fetch_max` in `__parallel_find_or` and it's stuff.
This approach give us additional performance boost:
- now we shouldn't try to setup atomic states inside `for`-based loops with additional checks.

This idea was proposed by @danhoeflinger.

Also in this PR we using `__dpl_ceiling_div` function where it's applicable in the code.

