### PR TITLE
Resolve global policy issues in a backward-compatible manner, attempt 2

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -50,16 +50,19 @@ class alignas(sycl::queue) __queue_holder
     static_assert(sizeof(sycl::queue) >= sizeof(std::pair<uintptr_t, _Queue_factory>));
     static_assert(alignof(sycl::queue) >= alignof(std::uintptr_t));
 
-    union {
+    union
+    {
         sycl::queue __q;
         std::pair<uintptr_t, _Queue_factory> __flag_and_factory;
     };
 
-    bool __has_queue() const
+    bool
+    __has_queue() const
     {
         bool res = true;
 #if _ONEDPL_PREDEFINED_POLICIES
-        res = (__flag_and_factory.first != 0); // If the first size-of-pointer bytes are zeros, we consider there is no valid queue.
+        // If the first size-of-pointer bytes are zeros, we consider there is no valid queue.
+        res = (__flag_and_factory.first != 0);
         std::atomic_signal_fence(std::memory_order_acq_rel); // to prevent possible reordering due to type punning
 #endif
         return res;
@@ -70,9 +73,9 @@ class alignas(sycl::queue) __queue_holder
     __queue_holder(_Args... __args) : __q{std::forward<_Args>(__args)...} {}
 
 #if _ONEDPL_PREDEFINED_POLICIES
-     // The ctor for predefined policy instances does not create a queue but stores a queue factory.
-     // The first size-of-pointer bytes - the "flag" - are nullified to indicate that there is no valid queue.
-     // Then a pointer to a factory function is stored.
+    // The ctor for predefined policy instances does not create a queue but stores a queue factory.
+    // The first size-of-pointer bytes - the "flag" - are nullified to indicate that there is no valid queue.
+    // Then a pointer to a factory function is stored.
     __queue_holder(_Queue_factory __f) : __flag_and_factory{0, __f} {}
 #endif
 
@@ -88,21 +91,24 @@ class alignas(sycl::queue) __queue_holder
     __queue_holder(const __queue_holder& __h) : __q{__h.__get_queue()} {}
     __queue_holder(__queue_holder&& __h) : __q{__h.__get_queue()} {}
 
-    __queue_holder& operator=(const __queue_holder& __h)
+    __queue_holder&
+    operator=(const __queue_holder& __h)
     {
         if (this != &__h)
             __q = __h.__get_queue();
         return *this;
     }
 
-    __queue_holder& operator=(__queue_holder&& __h)
+    __queue_holder&
+    operator=(__queue_holder&& __h)
     {
         if (this != &__h)
             __q = __h.__get_queue();
         return *this;
     }
 
-    sycl::queue __get_queue() const
+    sycl::queue
+    __get_queue() const
     {
         if (__has_queue())
             return __q;
@@ -148,7 +154,7 @@ class device_policy
     }
 
 #if _ONEDPL_PREDEFINED_POLICIES
-    explicit device_policy(__internal::__global_instance_tag) : q(/*factory*/__get_default_queue) {}
+    explicit device_policy(__internal::__global_instance_tag) : q(/*factory*/ __get_default_queue) {}
 
   protected:
     device_policy(__internal::_Queue_factory __f) : q(__f) {}
@@ -180,6 +186,7 @@ class fpga_policy : public device_policy<KernelName>
         };
         return __q;
     }
+
   public:
     static constexpr unsigned int unroll_factor = factor;
 
@@ -190,7 +197,7 @@ class fpga_policy : public device_policy<KernelName>
     explicit fpga_policy(sycl::queue q) : base(q) {}
     explicit fpga_policy(sycl::device d) : base(d) {}
 #if _ONEDPL_PREDEFINED_POLICIES
-    explicit fpga_policy(__internal::__global_instance_tag) : base(/*factory*/__get_fpga_default_queue) {}
+    explicit fpga_policy(__internal::__global_instance_tag) : base(/*factory*/ __get_fpga_default_queue) {}
 #endif
 };
 #endif // _ONEDPL_FPGA_DEVICE

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -160,17 +160,19 @@ class device_policy
 #if _ONEDPL_FPGA_DEVICE
 struct DefaultKernelNameFPGA;
 
-using __fpga_default_selector =
-#if _ONEDPL_FPGA_EMU
-    __dpl_sycl::__fpga_emulator_selector;
-#else
-    __dpl_sycl::__fpga_selector;
-#endif
-
 template <unsigned int factor = 1, typename KernelName = DefaultKernelNameFPGA>
 class fpga_policy : public device_policy<KernelName>
 {
     using base = device_policy<KernelName>;
+
+    static inline auto __fpga_default_selector()
+    {
+#if _ONEDPL_FPGA_EMU
+        return __dpl_sycl::__fpga_emulator_selector();
+#else
+        return __dpl_sycl::__fpga_selector();
+#endif
+    }
 
   public:
     static constexpr unsigned int unroll_factor = factor;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -54,7 +54,7 @@ class alignas(sycl::queue) __queue_holder
 
     bool __has_queue() const
     {
-        bool res = (__buf[0] == 0); // If the first size-of-pointer bytes are zeros, we consider there is no valid queue
+        bool res = (__buf[0] != 0); // If the first size-of-pointer bytes are zeros, we consider there is no valid queue
         std::atomic_signal_fence(std::memory_order_acq_rel); // to prevent possible reordering due to type punning
         return res;
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -148,28 +148,29 @@ class device_policy
     sycl::queue
     queue() const
     {
-        return __q.__queue_ref();
+        return q.__queue_ref();
     }
 
   private:
-    static_assert(sizeof(__internal::__queue_holder)==sizeof(sycl::queue));
-    static_assert(alignof(__internal::__queue_holder)==alignof(sycl::queue));
+    static_assert(sizeof(__internal::__queue_holder) == sizeof(sycl::queue));
+    static_assert(alignof(__internal::__queue_holder) == alignof(sycl::queue));
     __internal::__queue_holder q;
 };
 
 #if _ONEDPL_FPGA_DEVICE
 struct DefaultKernelNameFPGA;
 
+using __fpga_default_selector =
+#if _ONEDPL_FPGA_EMU
+    __dpl_sycl::__fpga_emulator_selector;
+#else
+    __dpl_sycl::__fpga_selector;
+#endif
+
 template <unsigned int factor = 1, typename KernelName = DefaultKernelNameFPGA>
 class fpga_policy : public device_policy<KernelName>
 {
     using base = device_policy<KernelName>;
-    using __fpga_default_selector =
-#if _ONEDPL_FPGA_EMU
-        __dpl_sycl::__fpga_emulator_selector;
-#else
-        __dpl_sycl::__fpga_selector;
-#endif
 
   public:
     static constexpr unsigned int unroll_factor = factor;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -69,7 +69,7 @@ class alignas(sycl::queue) __queue_holder
     }
 
   public:
-    template<typename T, typename = std::enable_if_t<std::is_constructible_v<sycl::queue, T&&>>>
+    template <typename T, typename = std::enable_if_t<std::is_constructible_v<sycl::queue, T&&>>>
     __queue_holder(T&& __qarg) : __q(std::forward<T>(__qarg)) {}
 
 #if _ONEDPL_PREDEFINED_POLICIES
@@ -145,7 +145,7 @@ class device_policy
 
     device_policy() = default;
     template <typename OtherName>
-    device_policy(const device_policy<OtherName>& other) : __qh(other.__qh) {}
+    device_policy(const device_policy<OtherName>& other) : __qh(other.queue()) {}
     explicit device_policy(sycl::queue q) : __qh(q) {}
     explicit device_policy(sycl::device d) : __qh(d) {}
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -185,9 +185,6 @@ class fpga_policy : public device_policy<KernelName>
     fpga_policy(const fpga_policy<other_factor, OtherName>& other) : base(other.queue()){};
     explicit fpga_policy(sycl::queue q) : base(q) {}
     explicit fpga_policy(sycl::device d) : base(d) {}
-#if _ONEDPL_PREDEFINED_POLICIES
-    explicit fpga_policy(__internal::__global_instance_tag t) : base(t) {}
-#endif
 };
 #endif // _ONEDPL_FPGA_DEVICE
 
@@ -201,7 +198,7 @@ class fpga_policy : public device_policy<KernelName>
 
 inline device_policy<> dpcpp_default{__internal::__global_instance_tag{}};
 #        if _ONEDPL_FPGA_DEVICE
-inline fpga_policy<> dpcpp_fpga{__internal::__global_instance_tag{}};
+inline fpga_policy<> dpcpp_fpga{};
 #        endif // _ONEDPL_FPGA_DEVICE
 
 #    endif // _ONEDPL___cplusplus >= 201703L

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -47,13 +47,13 @@ using _QueueFactory = sycl::queue (*)();
 
 class alignas(sycl::queue) __queue_holder
 {
-    static_assert(sizeof(sycl::queue) >= sizeof(std::pair<uintptr_t, _QueueFactory>));
+    static_assert(sizeof(sycl::queue) >= sizeof(std::pair<std::uintptr_t, _QueueFactory>));
     static_assert(alignof(sycl::queue) >= alignof(std::uintptr_t));
 
     union
     {
         sycl::queue __q;
-        std::pair<uintptr_t, _QueueFactory> __flag_and_factory;
+        std::pair<std::uintptr_t, _QueueFactory> __flag_and_factory;
     };
 
     bool
@@ -70,7 +70,7 @@ class alignas(sycl::queue) __queue_holder
 
   public:
     template <typename... _Args>
-    __queue_holder(_Args... __args) : __q(std::forward<_Args>(__args)...) {}
+    __queue_holder(_Args&&... __args) : __q(std::forward<_Args>(__args)...) {}
 
 #if _ONEDPL_PREDEFINED_POLICIES
     // The ctor for predefined policy instances does not create a queue but stores a queue factory.
@@ -133,7 +133,7 @@ struct DefaultKernelName;
 template <typename KernelName = DefaultKernelName>
 class device_policy
 {
-    static inline sycl::queue
+    static sycl::queue
     __get_default_queue()
     {
         static sycl::queue __q(sycl::default_selector_v);
@@ -177,7 +177,7 @@ class fpga_policy : public device_policy<KernelName>
 {
     using base = device_policy<KernelName>;
 
-    static inline sycl::queue
+    static sycl::queue
     __get_fpga_default_queue()
     {
         static sycl::queue __q{

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -53,7 +53,7 @@ class alignas(sycl::queue) __queue_holder
 
     bool __has_queue() const
     {
-        bool res = nullptr!=reinterpret_cast<void*&>(*this);
+        bool res = nullptr!=reinterpret_cast<void* const&>(*this);
         std::atomic_signal_fence(std::memory_order_acq_rel); // mitigate possible reordering due to type punning
         return res;
     }
@@ -110,7 +110,7 @@ class alignas(sycl::queue) __queue_holder
             __queue_ref() = std::move(__h.__queue_ref());
         return *this;
     }
-    
+
     const sycl::queue& __queue_ref() const
     {
         assert(__has_queue());

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -143,7 +143,7 @@ class device_policy
   public:
     using kernel_name = KernelName;
 
-    device_policy() = default;
+    device_policy() : device_policy(__get_default_queue()) {}
     template <typename OtherName>
     device_policy(const device_policy<OtherName>& other) : __qh(other.queue()) {}
     explicit device_policy(sycl::queue q) : __qh(q) {}

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -89,7 +89,8 @@ class alignas(sycl::queue) __queue_holder
 
     // Copy and move operations have to be explicit
     __queue_holder(const __queue_holder& __h) : __q(__h.__get_queue()) {}
-    __queue_holder(__queue_holder&& __h) : __q(__h.__get_queue()) {}
+    // predefined policies should never be moved, so the move-from one must have a queue
+    __queue_holder(__queue_holder&& __h) : __q(std::move(__h.__q)) {}
 
     __queue_holder&
     operator=(const __queue_holder& __h)
@@ -102,8 +103,11 @@ class alignas(sycl::queue) __queue_holder
     __queue_holder&
     operator=(__queue_holder&& __h)
     {
-        if (this != &__h)
-            __q = __h.__get_queue();
+        if (this != &__h) {
+            // predefined policies should never be moved, so the move-from one must have a queue
+            assert(h.__has_queue());
+            __q = std::move(__h.__q);
+        }
         return *this;
     }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -106,7 +106,7 @@ class alignas(sycl::queue) __queue_holder
         if (this != &__h)
         {
             // predefined policies should never be moved, so the move-from one must have a queue
-            assert(h.__has_queue());
+            assert(__h.__has_queue());
             __q = std::move(__h.__q);
         }
         return *this;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -103,7 +103,8 @@ class alignas(sycl::queue) __queue_holder
     __queue_holder&
     operator=(__queue_holder&& __h)
     {
-        if (this != &__h) {
+        if (this != &__h)
+        {
             // predefined policies should never be moved, so the move-from one must have a queue
             assert(h.__has_queue());
             __q = std::move(__h.__q);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -43,17 +43,17 @@ namespace __internal
 #if _ONEDPL_PREDEFINED_POLICIES
 struct __global_instance_tag {};
 #endif
-using _Queue_factory = sycl::queue (*)();
+using _QueueFactory = sycl::queue (*)();
 
 class alignas(sycl::queue) __queue_holder
 {
-    static_assert(sizeof(sycl::queue) >= sizeof(std::pair<uintptr_t, _Queue_factory>));
+    static_assert(sizeof(sycl::queue) >= sizeof(std::pair<uintptr_t, _QueueFactory>));
     static_assert(alignof(sycl::queue) >= alignof(std::uintptr_t));
 
     union
     {
         sycl::queue __q;
-        std::pair<uintptr_t, _Queue_factory> __flag_and_factory;
+        std::pair<uintptr_t, _QueueFactory> __flag_and_factory;
     };
 
     bool
@@ -76,7 +76,7 @@ class alignas(sycl::queue) __queue_holder
     // The ctor for predefined policy instances does not create a queue but stores a queue factory.
     // The first size-of-pointer bytes - the "flag" - are nullified to indicate that there is no valid queue.
     // Then a pointer to a factory function is stored.
-    __queue_holder(__global_instance_tag, _Queue_factory __f) : __flag_and_factory(0, __f) {}
+    __queue_holder(__global_instance_tag, _QueueFactory __f) : __flag_and_factory(0, __f) {}
 #endif
 
     ~__queue_holder()
@@ -155,7 +155,7 @@ class device_policy
     explicit device_policy(__internal::__global_instance_tag __t) : q(__t, /*factory*/__get_default_queue) {}
 
   protected:
-    device_policy(__internal::__global_instance_tag __t, __internal::_Queue_factory __f) : q(__t, __f) {}
+    device_policy(__internal::__global_instance_tag __t, __internal::_QueueFactory __f) : q(__t, __f) {}
 #endif
 
   private:

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -69,8 +69,8 @@ class alignas(sycl::queue) __queue_holder
     }
 
   public:
-    template <typename... _Args>
-    __queue_holder(_Args&&... __args) : __q(std::forward<_Args>(__args)...) {}
+    template<typename T, typename = std::enable_if_t<std::is_constructible_v<sycl::queue, T&&>>>
+    __queue_holder(T&& __qarg) : __q(std::forward<T>(__qarg)) {}
 
 #if _ONEDPL_PREDEFINED_POLICIES
     // The ctor for predefined policy instances does not create a queue but stores a queue factory.
@@ -145,7 +145,7 @@ class device_policy
 
     device_policy() = default;
     template <typename OtherName>
-    device_policy(const device_policy<OtherName>& other) : __qh(other.queue()) {}
+    device_policy(const device_policy<OtherName>& other) : __qh(other.__qh) {}
     explicit device_policy(sycl::queue q) : __qh(q) {}
     explicit device_policy(sycl::device d) : __qh(d) {}
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -38,7 +38,8 @@ namespace execution
 inline namespace __dpl
 {
 
-namespace __internal {
+namespace __internal
+{
 
 #if _ONEDPL_PREDEFINED_POLICIES
 struct __global_instance_tag {};
@@ -53,7 +54,7 @@ class alignas(sycl::queue) __queue_holder
 
     bool __has_queue() const
     {
-        bool res = nullptr!=reinterpret_cast<void* const&>(*this);
+        bool res = (nullptr != reinterpret_cast<void* const&>(*this));
         std::atomic_signal_fence(std::memory_order_acq_rel); // mitigate possible reordering due to type punning
         return res;
     }
@@ -70,7 +71,8 @@ class alignas(sycl::queue) __queue_holder
     {
         if (!sycl::device::get_devices().empty())
             new (this) sycl::queue;
-        else {
+        else
+        {
             // an "impossible" case of SYCL providing no devices, which we however must handle
             std::memset(this, 0, sizeof(void*));
             // Since the queue holder does not have a valid queue in this case,
@@ -87,26 +89,19 @@ class alignas(sycl::queue) __queue_holder
     }
 
     // Copy and move operations have to be explicit
-    __queue_holder(const __queue_holder& __h)
-    {
-        new (this) sycl::queue(__h.__queue_ref());
-    }
-
-    __queue_holder(__queue_holder&& __h)
-    {
-        new (this) sycl::queue(std::move(__h.__queue_ref()));
-    }
+    __queue_holder(const __queue_holder& __h) { new (this) sycl::queue(__h.__queue_ref()); }
+    __queue_holder(__queue_holder&& __h)      { new (this) sycl::queue(std::move(__h.__queue_ref())); }
 
     __queue_holder& operator=(const __queue_holder& __h)
     {
-        if (this != &__h) 
+        if (this != &__h)
             __queue_ref() = __h.__queue_ref();
         return *this;
     }
 
     __queue_holder& operator=(__queue_holder&& __h)
     {
-        if (this != &__h) 
+        if (this != &__h)
             __queue_ref() = std::move(__h.__queue_ref());
         return *this;
     }
@@ -147,15 +142,13 @@ class device_policy
     explicit device_policy(sycl::device d_) : q(d_) {}
 #if _ONEDPL_PREDEFINED_POLICIES
     explicit device_policy(__internal::__global_instance_tag t_) : q(t_) {}
-#endl
+#endif
 
     operator sycl::queue() const { return queue(); }
     sycl::queue
     queue() const
     {
         return __q.__queue_ref();
-    }
-
     }
 
   private:
@@ -171,7 +164,7 @@ template <unsigned int factor = 1, typename KernelName = DefaultKernelNameFPGA>
 class fpga_policy : public device_policy<KernelName>
 {
     using base = device_policy<KernelName>;
-    using __fpga_default_selector = 
+    using __fpga_default_selector =
 #if _ONEDPL_FPGA_EMU
         __dpl_sycl::__fpga_emulator_selector;
 #else
@@ -181,9 +174,7 @@ class fpga_policy : public device_policy<KernelName>
   public:
     static constexpr unsigned int unroll_factor = factor;
 
-    fpga_policy() : base(sycl::queue(__fpga_default_selector()))
-    {
-    }
+    fpga_policy() : base(sycl::queue(__fpga_default_selector())) {}
 
     template <unsigned int other_factor, typename OtherName>
     fpga_policy(const fpga_policy<other_factor, OtherName>& other) : base(other.queue()){};
@@ -192,7 +183,6 @@ class fpga_policy : public device_policy<KernelName>
 #if _ONEDPL_PREDEFINED_POLICIES
     explicit fpga_policy(__internal::__global_instance_tag t) : base(t) {}
 #endif
-
 };
 #endif // _ONEDPL_FPGA_DEVICE
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -69,7 +69,7 @@ class alignas(sycl::queue) __queue_holder
     }
 
   public:
-    template <typename T, typename = std::enable_if_t<std::is_constructible_v<sycl::queue, T&&>>>
+    template <typename T, std::enable_if_t<std::is_constructible_v<sycl::queue, T&&>, int> = 0>
     __queue_holder(T&& __qarg) : __q(std::forward<T>(__qarg)) {}
 
 #if _ONEDPL_PREDEFINED_POLICIES
@@ -162,8 +162,8 @@ class device_policy
     device_policy() : device_policy(__internal::__get_default_queue()) {}
     template <typename OtherName>
     device_policy(const device_policy<OtherName>& other) : __qh(other.queue()) {}
-    explicit device_policy(sycl::queue q) : __qh(q) {}
-    explicit device_policy(sycl::device d) : __qh(d) {}
+    explicit device_policy(sycl::queue q) : __qh(std::move(q)) {}
+    explicit device_policy(sycl::device d) : __qh(std::move(d)) {}
 
     operator sycl::queue() const { return queue(); }
     sycl::queue

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -87,10 +87,8 @@ class alignas(sycl::queue) __queue_holder
             __flag_and_factory.second = nullptr;
     }
 
-    // Copy and move operations have to be provided explicitly
+    // Copy operations must be provided explicitly
     __queue_holder(const __queue_holder& __h) : __q(__h.__get_queue()) {}
-    // predefined policies should never be moved, so the move-from one must have a queue
-    __queue_holder(__queue_holder&& __h) : __q(std::move(__h.__q)) {}
 
     __queue_holder&
     operator=(const __queue_holder& __h)
@@ -100,15 +98,15 @@ class alignas(sycl::queue) __queue_holder
         return *this;
     }
 
+    // Move operations must be provided explicitly
+    // Predefined policies should never be moved, so the move-from object must have a valid queue
+    __queue_holder(__queue_holder&& __h) : __q(std::move(__h.__q)) {}
+
     __queue_holder&
     operator=(__queue_holder&& __h)
     {
         if (this != &__h)
-        {
-            // predefined policies should never be moved, so the move-from one must have a queue
-            assert(__h.__has_queue());
             __q = std::move(__h.__q);
-        }
         return *this;
     }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -78,8 +78,8 @@ class alignas(sycl::queue) __queue_holder
             // an "impossible" case of SYCL providing no devices, which we however must handle
             __buf[0] = 0; // nullify the first size-of-pointer bytes of the holder
             // Since the queue holder does not have a valid queue in this case,
-            // the predefined device policies are de-facto unusable.
-            // That seems OK though, because there is no device to run SYCL anyway.
+            // the predefined device policies become de-facto unusable.
+            // That seems OK though, because there is no device to use anyway.
         }
     }
 #endif

--- a/test/general/fork.pass.cpp
+++ b/test/general/fork.pass.cpp
@@ -1,13 +1,27 @@
 #include <oneapi/dpl/execution>
 #include "support/utils.h"
 
-#if __has_include(<unistd.h>)
+#if __has_include(<unistd.h>) && __has_include(<sys/wait.h>)
 #include <unistd.h>
+#include <sys/wait.h>
+#include <cerrno>
 #endif
 
 int main(){
 #ifdef _POSIX_VERSION // defined in <unistd.h>
-    [[maybe_unused]] pid_t pid = fork();
+    pid_t pid = fork();
+    if (pid < 0) // error
+        return errno;
+    if (pid == 0) // child
+        return 0;
+    int status;
+    pid_t pid2 = waitpid(pid, &status, 0);
+    if (pid2 != pid) // error
+        return errno;
+    if (WIFEXITED(status))
+        return WEXITSTATUS(status);
+    return -1;
+#else
+    return TestUtils::done(0); // skipped
 #endif
-    return TestUtils::done();
 }

--- a/test/general/fork.pass.cpp
+++ b/test/general/fork.pass.cpp
@@ -1,0 +1,13 @@
+#include <oneapi/dpl/execution>
+#include "support/utils.h"
+
+#ifndef _WIN32
+#include <unistd.h>
+#endif
+
+int main(){
+#ifndef _WIN32
+    [[maybe_unused]] pid_t pid = fork();
+#endif
+    return TestUtils::done();
+}

--- a/test/general/fork.pass.cpp
+++ b/test/general/fork.pass.cpp
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+
 #include <oneapi/dpl/execution>
 #include "support/utils.h"
 

--- a/test/general/fork.pass.cpp
+++ b/test/general/fork.pass.cpp
@@ -1,3 +1,11 @@
+// -*- C++ -*-
+//===-- fork.pass.cpp -----------------------------------------------------===//
+//
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
 #include <oneapi/dpl/execution>
 #include "support/utils.h"
 

--- a/test/general/fork.pass.cpp
+++ b/test/general/fork.pass.cpp
@@ -16,7 +16,8 @@
 #include <cerrno>
 #endif
 
-int main(){
+int main()
+{
 #ifdef _POSIX_VERSION // defined in <unistd.h>
     pid_t pid = fork();
     if (pid < 0) // error

--- a/test/general/fork.pass.cpp
+++ b/test/general/fork.pass.cpp
@@ -1,12 +1,12 @@
 #include <oneapi/dpl/execution>
 #include "support/utils.h"
 
-#ifndef _WIN32
+#if __has_include(<unistd.h>)
 #include <unistd.h>
 #endif
 
 int main(){
-#ifndef _WIN32
+#ifdef _POSIX_VERSION // defined in <unistd.h>
     [[maybe_unused]] pid_t pid = fork();
 #endif
     return TestUtils::done();

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -32,6 +32,7 @@
 #include "utils_invoke.h"
 #include "utils_test_base.h"
 
+#define TEST_USE_PREDEFINED_POLICIES (!defined(ONEDPL_USE_PREDEFINED_POLICIES) || ONEDPL_USE_PREDEFINED_POLICIES)
 #include _PSTL_TEST_HEADER(execution)
 
 namespace TestUtils
@@ -83,11 +84,11 @@ inline auto default_selector =
 #    endif // ONEDPL_FPGA_EMULATOR
 
 inline auto&& default_dpcpp_policy =
-#    if ONEDPL_USE_PREDEFINED_POLICIES
+#    if TEST_USE_PREDEFINED_POLICIES
         oneapi::dpl::execution::dpcpp_fpga;
 #    else
         TestUtils::make_fpga_policy(sycl::queue{default_selector});
-#    endif // ONEDPL_USE_PREDEFINED_POLICIES
+#    endif
 #else
 inline auto default_selector =
 #    if TEST_LIBSYCL_VERSION >= 60000
@@ -96,11 +97,11 @@ inline auto default_selector =
         sycl::default_selector{};
 #    endif
 inline auto&& default_dpcpp_policy =
-#    if ONEDPL_USE_PREDEFINED_POLICIES
+#    if TEST_USE_PREDEFINED_POLICIES
         oneapi::dpl::execution::dpcpp_default;
 #    else
-        oneapi::dpl::execution::make_device_policy(sycl::queue{default_selector});
-#    endif // ONEDPL_USE_PREDEFINED_POLICIES
+        TestUtils::make_device_policy(sycl::queue{default_selector});
+#    endif
 #endif     // ONEDPL_FPGA_DEVICE
 
 inline

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -32,7 +32,11 @@
 #include "utils_invoke.h"
 #include "utils_test_base.h"
 
-#define TEST_USE_PREDEFINED_POLICIES (!defined(ONEDPL_USE_PREDEFINED_POLICIES) || ONEDPL_USE_PREDEFINED_POLICIES)
+#ifdef ONEDPL_USE_PREDEFINED_POLICIES
+#  define TEST_USE_PREDEFINED_POLICIES ONEDPL_USE_PREDEFINED_POLICIES
+#else
+#  define TEST_USE_PREDEFINED_POLICIES 1
+#endif
 #include _PSTL_TEST_HEADER(execution)
 
 namespace TestUtils


### PR DESCRIPTION
This patch is a follow-up to #1618 (with the commit history from there) with a somewhat modified approach. It is necessary to address #1631, one more issue caused by eager initialization of a SYCL queue in oneDPL headers. It still is supposed to address #1060.

The core idea is similar: to keep layout compatibility yet have lazy behavior, store SYCL queues inside a special `__queue_holder` class with the same size and alignment, and use the first `sizeof(uintptr_t)` bytes as a flag to detect if it holds a valid queue or - in case there are only zeros in these bytes - something else. To remind, 
> the rationale is that a SYCL queue is likely implemented as a shared_ptr (that's certainly the case for DPC++), which in turn typically holds several pointers to the actual object, a service block or a reference counter, etc. It is highly unlikely therefore that the first bytes in a properly constructed queue object will be equivalent to a null pointer. 

 Special device policy constructors are used only for predefined policies and, unlike #1618, always nullify the "flag" and additionally store a pointer to a factory function that generates a proper `sycl::queue` object as a copy of an internal "magic static" instance initialized on the first call to the factory. Each time when a device policy need to return its queue the "flag" is checked and, depending on its state, either a copy of the stored queue is returned or the factory is called.

It is worth noting that the workaround only applies to the predefined policies. Any explicitly created policies as well as copies of policies created by the implementation (if it chooses so) will contain a valid queue. Propagating factories to the copies of predefined policies is deliberately not done; it is impossible to always create queues on first use without breaking class layout, so having consistent behavior for all policies except predefined ones seems the best choice.

The implementation still introduces an undefined behavior, this time by possibly using an inactive union field (the "flag", in case a valid queue was constructed).