### PR TITLE
Avoid extra sycl::buffer tests

### DIFF
--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -111,7 +111,15 @@ sycl::queue get_test_queue()
     return my_queue;
 }
 
-template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName>
+template <sycl::usm::alloc alloc_type>
+constexpr bool
+required_test_sycl_buffer()
+{
+    return alloc_type == sycl::usm::alloc::shared;
+}
+
+template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName,
+          bool TestSyclBuffer = required_test_sycl_buffer<alloc_type>()>
 void
 test1buffer(float ScaleStep = 1.0f, float ScaleMax = 1.0f)
 {
@@ -140,7 +148,10 @@ test1buffer(float ScaleStep = 1.0f, float ScaleMax = 1.0f)
         }
     }
 #endif
-    { // sycl::buffer
+
+    if constexpr (TestSyclBuffer)
+    {
+        // sycl::buffer
         // 1. create buffers
         using TestBaseData = test_base_data_buffer<TestValueType>;
         TestBaseData test_base_data({ { local_max_n, inout1_offset } });
@@ -161,7 +172,8 @@ test1buffer(float ScaleStep = 1.0f, float ScaleMax = 1.0f)
     }
 }
 
-template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName>
+template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName,
+          bool TestSyclBuffer = required_test_sycl_buffer<alloc_type>()>
 void
 test2buffers(float ScaleStep = 1.0f, float ScaleMax = 1.0f)
 {
@@ -194,7 +206,10 @@ test2buffers(float ScaleStep = 1.0f, float ScaleMax = 1.0f)
         }
     }
 #endif
-    { // sycl::buffer
+
+    if constexpr (TestSyclBuffer)
+    {
+        // sycl::buffer
         // 1. create buffers
         using TestBaseData = test_base_data_buffer<TestValueType>;
         TestBaseData test_base_data({ { local_max_n, inout1_offset },
@@ -218,7 +233,8 @@ test2buffers(float ScaleStep = 1.0f, float ScaleMax = 1.0f)
     }
 }
 
-template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName>
+template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName,
+          bool TestSyclBuffer = required_test_sycl_buffer<alloc_type>()>
 void
 test3buffers(int mult = kDefaultMultValue, float ScaleStep = 1.0f, float ScaleMax = 1.0f)
 {
@@ -255,7 +271,10 @@ test3buffers(int mult = kDefaultMultValue, float ScaleStep = 1.0f, float ScaleMa
         }
     }
 #endif
-    { // sycl::buffer
+
+    if constexpr (TestSyclBuffer)
+    {
+        // sycl::buffer
         // 1. create buffers
         using TestBaseData = test_base_data_buffer<TestValueType>;
         TestBaseData test_base_data({ { local_max_n,        inout1_offset },
@@ -282,7 +301,8 @@ test3buffers(int mult = kDefaultMultValue, float ScaleStep = 1.0f, float ScaleMa
     }
 }
 
-template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName>
+template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName,
+          bool TestSyclBuffer = required_test_sycl_buffer<alloc_type>()>
 void
 test4buffers(int mult = kDefaultMultValue, float ScaleStep = 1.0f, float ScaleMax = 1.0f)
 {
@@ -322,7 +342,10 @@ test4buffers(int mult = kDefaultMultValue, float ScaleStep = 1.0f, float ScaleMa
         }
     }
 #endif
-    { // sycl::buffer
+
+    if constexpr (TestSyclBuffer)
+    {
+        // sycl::buffer
         // 1. create buffers
         using TestBaseData = test_base_data_buffer<TestValueType>;
         TestBaseData test_base_data({ { local_max_n,        inout1_offset },
@@ -352,32 +375,36 @@ test4buffers(int mult = kDefaultMultValue, float ScaleStep = 1.0f, float ScaleMa
     }
 }
 
-template <sycl::usm::alloc alloc_type, typename TestName>
+template <sycl::usm::alloc alloc_type, typename TestName,
+          bool TestSyclBuffer = required_test_sycl_buffer<alloc_type>()>
 ::std::enable_if_t<::std::is_base_of_v<test_base<typename TestName::UsedValueType>, TestName>>
 test1buffer()
 {
-    test1buffer<alloc_type, typename TestName::UsedValueType, TestName>(TestName::ScaleStep, TestName::ScaleMax);
+    test1buffer<alloc_type, typename TestName::UsedValueType, TestName, TestSyclBuffer>(TestName::ScaleStep, TestName::ScaleMax);
 }
 
-template <sycl::usm::alloc alloc_type, typename TestName>
+template <sycl::usm::alloc alloc_type, typename TestName,
+          bool TestSyclBuffer = required_test_sycl_buffer<alloc_type>()>
 ::std::enable_if_t<::std::is_base_of_v<test_base<typename TestName::UsedValueType>, TestName>>
 test2buffers()
 {
-    test2buffers<alloc_type, typename TestName::UsedValueType, TestName>(TestName::ScaleStep, TestName::ScaleMax);
+    test2buffers<alloc_type, typename TestName::UsedValueType, TestName, TestSyclBuffer>(TestName::ScaleStep, TestName::ScaleMax);
 }
 
-template <sycl::usm::alloc alloc_type, typename TestName>
+template <sycl::usm::alloc alloc_type, typename TestName,
+          bool TestSyclBuffer = required_test_sycl_buffer<alloc_type>()>
 ::std::enable_if_t<::std::is_base_of_v<test_base<typename TestName::UsedValueType>, TestName>>
 test3buffers(int mult = kDefaultMultValue)
 {
-    test3buffers<alloc_type, typename TestName::UsedValueType, TestName>(mult, TestName::ScaleStep, TestName::ScaleMax);
+    test3buffers<alloc_type, typename TestName::UsedValueType, TestName, TestSyclBuffer>(mult, TestName::ScaleStep, TestName::ScaleMax);
 }
 
-template <sycl::usm::alloc alloc_type, typename TestName>
+template <sycl::usm::alloc alloc_type, typename TestName,
+          bool TestSyclBuffer = required_test_sycl_buffer<alloc_type>()>
 ::std::enable_if_t<::std::is_base_of_v<test_base<typename TestName::UsedValueType>, TestName>>
 test4buffers(int mult = kDefaultMultValue)
 {
-    test4buffers<alloc_type, typename TestName::UsedValueType, TestName>(mult, TestName::ScaleStep, TestName::ScaleMax);
+    test4buffers<alloc_type, typename TestName::UsedValueType, TestName, TestSyclBuffer>(mult, TestName::ScaleStep, TestName::ScaleMax);
 }
 
 } /* namespace TestUtils */

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -118,7 +118,8 @@ required_test_sycl_buffer()
     return alloc_type == sycl::usm::alloc::shared;
 }
 
-template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName, bool TestSyclBuffer>
+template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName,
+          bool TestSyclBuffer = required_test_sycl_buffer<alloc_type>()>
 void
 test1buffer(float ScaleStep = 1.0f, float ScaleMax = 1.0f)
 {
@@ -171,7 +172,8 @@ test1buffer(float ScaleStep = 1.0f, float ScaleMax = 1.0f)
     }
 }
 
-template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName, bool TestSyclBuffer>
+template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName,
+          bool TestSyclBuffer = required_test_sycl_buffer<alloc_type>()>
 void
 test2buffers(float ScaleStep = 1.0f, float ScaleMax = 1.0f)
 {
@@ -231,7 +233,8 @@ test2buffers(float ScaleStep = 1.0f, float ScaleMax = 1.0f)
     }
 }
 
-template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName, bool TestSyclBuffer>
+template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName,
+          bool TestSyclBuffer = required_test_sycl_buffer<alloc_type>()>
 void
 test3buffers(int mult = kDefaultMultValue, float ScaleStep = 1.0f, float ScaleMax = 1.0f)
 {
@@ -298,7 +301,8 @@ test3buffers(int mult = kDefaultMultValue, float ScaleStep = 1.0f, float ScaleMa
     }
 }
 
-template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName, bool TestSyclBuffer>
+template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName,
+          bool TestSyclBuffer = required_test_sycl_buffer<alloc_type>()>
 void
 test4buffers(int mult = kDefaultMultValue, float ScaleStep = 1.0f, float ScaleMax = 1.0f)
 {

--- a/test/support/utils_sycl.h
+++ b/test/support/utils_sycl.h
@@ -118,8 +118,7 @@ required_test_sycl_buffer()
     return alloc_type == sycl::usm::alloc::shared;
 }
 
-template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName,
-          bool TestSyclBuffer = required_test_sycl_buffer<alloc_type>()>
+template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName, bool TestSyclBuffer>
 void
 test1buffer(float ScaleStep = 1.0f, float ScaleMax = 1.0f)
 {
@@ -172,8 +171,7 @@ test1buffer(float ScaleStep = 1.0f, float ScaleMax = 1.0f)
     }
 }
 
-template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName,
-          bool TestSyclBuffer = required_test_sycl_buffer<alloc_type>()>
+template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName, bool TestSyclBuffer>
 void
 test2buffers(float ScaleStep = 1.0f, float ScaleMax = 1.0f)
 {
@@ -233,8 +231,7 @@ test2buffers(float ScaleStep = 1.0f, float ScaleMax = 1.0f)
     }
 }
 
-template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName,
-          bool TestSyclBuffer = required_test_sycl_buffer<alloc_type>()>
+template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName, bool TestSyclBuffer>
 void
 test3buffers(int mult = kDefaultMultValue, float ScaleStep = 1.0f, float ScaleMax = 1.0f)
 {
@@ -301,8 +298,7 @@ test3buffers(int mult = kDefaultMultValue, float ScaleStep = 1.0f, float ScaleMa
     }
 }
 
-template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName,
-          bool TestSyclBuffer = required_test_sycl_buffer<alloc_type>()>
+template <sycl::usm::alloc alloc_type, typename TestValueType, typename TestName, bool TestSyclBuffer>
 void
 test4buffers(int mult = kDefaultMultValue, float ScaleStep = 1.0f, float ScaleMax = 1.0f)
 {


### PR DESCRIPTION
Previously `sycl::buffer` tests rans from `test1buffer`, `test2buffers`, `test3buffers` and from `test4buffers` functions for each type of `alloc_type` template param: for `sycl::usm::alloc::shared` and for `sycl::usm::alloc::device`.

It's look like as extra overhead which we should avoid to reduce CI test time.

Now `sycl::buffer` tests runs only for `alloc_type` template param equal to `sycl::usm::alloc::shared` (by default).