### PR TITLE
[CI] Update MacOS version, move to Clang++ from ICPC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -388,9 +388,10 @@ jobs:
           echo "::warning::CMake: $(cmake --version)"
           sysctl -a | grep machdep.cpu
           # workaround for CMake not being able to find OpenMP: see https://discourse.cmake.org/t/how-to-find-openmp-with-clang-on-macos/8860
-          export OpenMP_ROOT=$(brew --prefix)/opt/libomp 
+          # -DCMAKE_POLICY_DEFAULT_CMP0074=NEW below is forced to make sure CMake uses <PackageName>_ROOT variables.
+          export OpenMP_ROOT=$(brew --prefix)/opt/libomp
           mkdir build && cd build
           cmake -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-            -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DONEDPL_BACKEND=${{ matrix.backend }} ..
+            -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DONEDPL_BACKEND=${{ matrix.backend }} -DCMAKE_POLICY_DEFAULT_CMP0074=NEW ..
           make VERBOSE=1 build-onedpl-tests -j${MACOS_BUILD_CONCURRENCY}
           ctest --timeout ${TEST_TIMEOUT} --output-on-failure -E "${EXCLUDE_FROM_TESTING}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,6 @@ env:
   WINDOWS_ICPX_DOWNLOAD_LINK: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/a1d6c917-05ab-4883-b67b-4bd60abb74e5/w_dpcpp-cpp-compiler_p_2024.1.0.469_offline.exe
   WINDOWS_ONEAPI_PATH: C:\Program Files (x86)\Intel\oneAPI
   LINUX_ONEAPI_PATH: /opt/intel/oneapi
-  # TODO: get rid of a deprecated configuration: Intel® C++ Compiler Classic
-  MACOS_ONEAPI_DOWNLOAD_LINK: https://registrationcenter-download.intel.com/akdlm/irc_nas/18358/m_cpp-compiler-classic_p_2022.0.0.62_offline.dmg
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -373,19 +371,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-11
-            cxx_compiler: icpc
+          - os: macos-13
+            cxx_compiler: clang++
             std: 17
             build_type: release
             backend: omp
     steps:
       - uses: actions/checkout@v3
-      - name: Install Intel® oneAPI C++ Compiler Classic and Intel® oneAPI Threading Building Blocks
-        run: |
-          wget ${MACOS_ONEAPI_DOWNLOAD_LINK}
-          mkdir installer
-          hdiutil attach -mountpoint ./installer/ m_cpp-compiler*.dmg
-          sudo ./installer/bootstrapper.app/Contents/MacOS/install.sh -c --action install --eula accept
       - name: Exclude tests with known issues
         if: matrix.backend == 'omp'
         run: echo "EXCLUDE_FROM_TESTING=transform_binary.pass|transform_unary.pass" >> $GITHUB_ENV
@@ -395,9 +387,6 @@ jobs:
           set -x
           source /opt/intel/oneapi/setvars.sh
           echo "::warning::CMake: $(cmake --version)"
-          if [[ "${{ matrix.cxx_compiler }}" == "icpc" ]]; then
-            echo "::warning::Compiler: $(icpc --version)"
-          fi
           mkdir build && cd build
           cmake -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DONEDPL_BACKEND=${{ matrix.backend }} ..

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,6 +387,7 @@ jobs:
         run: |
           set -x
           echo "::warning::CMake: $(cmake --version)"
+          sysctl -a | grep machdep.cpu
           mkdir build && cd build
           cmake -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DONEDPL_BACKEND=${{ matrix.backend }} ..

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,7 +379,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install OpenMP for Clang++
-        if: (matrix.backend == 'omp' && matrix.compiler == 'clang++')
+        if: (matrix.backend == 'omp' && matrix.cxx_compiler == 'clang++')
         run: |
           brew install libomp
       - name: Run testing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,14 +378,10 @@ jobs:
             backend: omp
     steps:
       - uses: actions/checkout@v3
-      - name: Exclude tests with known issues
-        if: matrix.backend == 'omp'
-        run: echo "EXCLUDE_FROM_TESTING=transform_binary.pass|transform_unary.pass" >> $GITHUB_ENV
       - name: Run testing
         shell: bash
         run: |
           set -x
-          source /opt/intel/oneapi/setvars.sh
           echo "::warning::CMake: $(cmake --version)"
           mkdir build && cd build
           cmake -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -379,7 +379,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Install OpenMP for Clang++
-        if: (matrix.backend == 'omp' && matrix.cxx_compiler == 'clang++')
         run: |
           brew install libomp
       - name: Run testing
@@ -388,6 +387,8 @@ jobs:
           set -x
           echo "::warning::CMake: $(cmake --version)"
           sysctl -a | grep machdep.cpu
+          # workaround for CMake not being able to find OpenMP: see https://discourse.cmake.org/t/how-to-find-openmp-with-clang-on-macos/8860
+          export OpenMP_ROOT=$(brew --prefix)/opt/libomp 
           mkdir build && cd build
           cmake -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DONEDPL_BACKEND=${{ matrix.backend }} ..

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,6 +378,10 @@ jobs:
             backend: omp
     steps:
       - uses: actions/checkout@v3
+      - name: Install OpenMP for Clang++
+        if: (matrix.backend == 'omp' && matrix.compiler == 'clang++')
+        run: |
+          brew install libomp
       - name: Run testing
         shell: bash
         run: |


### PR DESCRIPTION
MacOS 11 was removed from GitHub CI on June 28 according to https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners. It has been replaced with MacOS 13.

Intel® C++ Compiler Classic Release was discontinued in the oneAPI 2024.0 release. It's been replaced with Clang++, which tends to be a default c++ compiler on MacOS.