### PR TITLE
[PROTOTYPE] Removing identity and default construction requirement from two_pass_scan

### DIFF
--- a/include/oneapi/dpl/experimental/kt/two_pass_scan.h
+++ b/include/oneapi/dpl/experimental/kt/two_pass_scan.h
@@ -327,17 +327,12 @@ two_pass_scan(sycl::queue q, _InRng&& __in_rng, _OutRng&& __out_rng,
                     }
                     else
                     {
-                        std::uint8_t i = 0;
                         //need to pull out first iteration tp avoid identity
-                        if (i < iters - 1)
-                        {
-                            auto v = sub_group_partials[sub_group_local_id];
-                            sub_group_scan<VL, true, false>(sub_group, v, binary_op, sub_group_carry);
-                            tmp_storage[start_idx + i * VL + sub_group_local_id] = v;
-                            i++;
-                        }
+                        auto v = sub_group_partials[sub_group_local_id];
+                        sub_group_scan<VL, true, false>(sub_group, v, binary_op, sub_group_carry);
+                        tmp_storage[start_idx + sub_group_local_id] = v;
 
-                        for (; i < iters - 1; i++)
+                        for (i = 1; i < iters - 1; i++)
                         {
                             auto v = sub_group_partials[i * VL + sub_group_local_id];
                             sub_group_scan<VL, true, true>(sub_group, v, binary_op, sub_group_carry);

--- a/include/oneapi/dpl/experimental/kt/two_pass_scan.h
+++ b/include/oneapi/dpl/experimental/kt/two_pass_scan.h
@@ -497,7 +497,6 @@ two_pass_scan(sycl::queue q, _InRng&& __in_rng, _OutRng&& __out_rng,
                 //            and apply to local sub-group prefix carries
                 if ((sub_group_id == 0) && (g > 0))
                 {
-                    ValueType adj_work_group_carry;
                     auto carry_offset = 0;
 
                     std::uint8_t iters = oneapi::dpl::__internal::__dpl_ceiling_div(active_subgroups, VL);

--- a/include/oneapi/dpl/experimental/kt/two_pass_scan.h
+++ b/include/oneapi/dpl/experimental/kt/two_pass_scan.h
@@ -230,7 +230,7 @@ two_pass_scan(sycl::queue q, _InRng&& __in_rng, _OutRng&& __out_rng,
                 std::size_t elements_in_group = std::min(M - group_start_idx, std::size_t(num_sub_groups_local * K));
                 auto active_subgroups = oneapi::dpl::__internal::__dpl_ceiling_div(elements_in_group, K);
                 std::size_t subgroup_start_idx = group_start_idx + (sub_group_id * K);
-                bool is_full_thread = subgroup_start_idx + J * VL <= M;
+                bool is_full_thread = subgroup_start_idx + J * VL < M;
                 size_t start_idx = subgroup_start_idx + sub_group_local_id;
 
                 if (sub_group_id < active_subgroups)
@@ -536,7 +536,7 @@ two_pass_scan(sycl::queue q, _InRng&& __in_rng, _OutRng&& __out_rng,
 
                 // step 5) apply global carries
                 size_t subgroup_start_idx = group_start_idx + (sub_group_id * K);
-                bool is_full_thread = subgroup_start_idx + J * VL <= M;
+                bool is_full_thread = subgroup_start_idx + J * VL < M;
                 size_t start_idx = subgroup_start_idx + sub_group_local_id;
 
                 if (is_full_thread && is_full_block)

--- a/include/oneapi/dpl/experimental/kt/two_pass_scan.h
+++ b/include/oneapi/dpl/experimental/kt/two_pass_scan.h
@@ -230,7 +230,7 @@ two_pass_scan(sycl::queue q, _InRng&& __in_rng, _OutRng&& __out_rng,
                 std::size_t elements_in_group = std::min(M - group_start_idx, std::size_t(num_sub_groups_local * K));
                 auto active_subgroups = oneapi::dpl::__internal::__dpl_ceiling_div(elements_in_group, K);
                 std::size_t subgroup_start_idx = group_start_idx + (sub_group_id * K);
-                bool is_full_thread = subgroup_start_idx + J * VL < M;
+                bool is_full_thread = subgroup_start_idx + J * VL <= M;
                 size_t start_idx = subgroup_start_idx + sub_group_local_id;
 
                 if (sub_group_id < active_subgroups)
@@ -536,7 +536,7 @@ two_pass_scan(sycl::queue q, _InRng&& __in_rng, _OutRng&& __out_rng,
 
                 // step 5) apply global carries
                 size_t subgroup_start_idx = group_start_idx + (sub_group_id * K);
-                bool is_full_thread = subgroup_start_idx + J * VL < M;
+                bool is_full_thread = subgroup_start_idx + J * VL <= M;
                 size_t start_idx = subgroup_start_idx + sub_group_local_id;
 
                 if (is_full_thread && is_full_block)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -21,6 +21,7 @@
 #include <type_traits>
 
 #include "sycl_defs.h"
+#include "../../utils.h"
 #include "parallel_backend_sycl_utils.h"
 #include "execution_sycl_defs.h"
 #include "unseq_backend_sycl.h"
@@ -68,7 +69,7 @@ __work_group_reduce_kernel(const _NDItemId __item_id, const _Size __n, const _Si
 {
     auto __local_idx = __item_id.get_local_id(0);
     const _Size __group_size = __item_id.get_local_range().size();
-    __lazy_ctor_storage<_Tp> __result;
+    oneapi::dpl::__internal::__lazy_ctor_storage<_Tp> __result;
     // 1. Initialization (transform part). Fill local memory
     __transform_pattern(__item_id, __n, __iters_per_work_item, /*global_offset*/ (_Size)0, __is_full,
                         /*__n_groups*/ (_Size)1, __result, __acc...);
@@ -96,7 +97,7 @@ __device_reduce_kernel(const _NDItemId __item_id, const _Size __n, const _Size _
     auto __local_idx = __item_id.get_local_id(0);
     auto __group_idx = __item_id.get_group(0);
     const _Size __group_size = __item_id.get_local_range().size();
-    __lazy_ctor_storage<_Tp> __result;
+    oneapi::dpl::__internal::__lazy_ctor_storage<_Tp> __result;
     // 1. Initialization (transform part). Fill local memory
     __transform_pattern(__item_id, __n, __iters_per_work_item, /*global_offset*/ (_Size)0, __is_full, __n_groups,
                         __result, __acc...);
@@ -386,7 +387,7 @@ struct __parallel_transform_reduce_impl
                         // 1. Initialization (transform part). Fill local memory
                         _Size __n_items;
                         const bool __is_full = __n == __size_per_work_group * __n_groups;
-                        __lazy_ctor_storage<_Tp> __result;
+                        oneapi::dpl::__internal::__lazy_ctor_storage<_Tp> __result;
                         if (__is_first)
                         {
                             __transform_pattern1(__item_id, __n, __iters_per_work_item, /*global_offset*/ (_Size)0,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -47,14 +47,6 @@ class __reduce_mid_work_group_kernel;
 template <typename... _Name>
 class __reduce_kernel;
 
-// Storage helper since _Tp may not have a default constructor.
-template <typename _Tp>
-union __lazy_ctor_storage
-{
-    _Tp __v;
-    __lazy_ctor_storage() {}
-};
-
 // Adjust number of sequential operations per work-item based on the vector size. Single elements are kept to
 // improve performance of small arrays or remainder loops.
 template <std::uint8_t _VecSize, typename _Size>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -767,6 +767,22 @@ class __static_monotonic_dispatcher<::std::integer_sequence<::std::uint16_t, _X,
     }
 };
 
+template <typename _Tp>
+union __lazy_ctor_storage
+{
+    using __value_type = _Tp;
+    _Tp __v;
+    __lazy_ctor_storage() {}
+    void __setup(const _Tp& init)
+    {
+        new (&__v) _Tp(init);
+    }
+    void __destroy()
+    {
+        __v.~_Tp();
+    }
+};
+
 } // namespace __par_backend_hetero
 } // namespace dpl
 } // namespace oneapi

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -767,22 +767,6 @@ class __static_monotonic_dispatcher<::std::integer_sequence<::std::uint16_t, _X,
     }
 };
 
-template <typename _Tp>
-union __lazy_ctor_storage
-{
-    using __value_type = _Tp;
-    _Tp __v;
-    __lazy_ctor_storage() {}
-    void __setup(const _Tp& init)
-    {
-        new (&__v) _Tp(init);
-    }
-    void __destroy()
-    {
-        __v.~_Tp();
-    }
-};
-
 } // namespace __par_backend_hetero
 } // namespace dpl
 } // namespace oneapi

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -765,6 +765,22 @@ struct __is_iterator_type<_T, std::void_t<typename std::iterator_traits<_T>::dif
 template <typename _T>
 static constexpr bool __is_iterator_type_v = __is_iterator_type<_T>::value;
 
+template <typename _Tp>
+union __lazy_ctor_storage
+{
+    using __value_type = _Tp;
+    _Tp __v;
+    __lazy_ctor_storage() {}
+    void __setup(const _Tp& init)
+    {
+        new (&__v) _Tp(init);
+    }
+    void __destroy()
+    {
+        __v.~_Tp();
+    }
+};
+
 } // namespace __internal
 } // namespace dpl
 } // namespace oneapi

--- a/test/kt/two_pass_scan.cpp
+++ b/test/kt/two_pass_scan.cpp
@@ -67,6 +67,20 @@ class no_default
 };
 //add arithmetic operators
 
+template <typename T>
+struct test_is_signed
+{
+    static constexpr bool value = std::is_signed_v<T>;
+};
+
+template <typename T>
+struct test_is_signed<no_default<T>>
+{
+    static constexpr bool value = std::is_signed_v<T>;
+};
+
+template <typename T>
+static constexpr bool test_is_signed_v = test_is_signed<T>::value;
 
 template <typename BinOp, typename T>
 auto
@@ -74,9 +88,9 @@ generate_scan_data(T* input, std::size_t size, std::uint32_t seed)
 {
     // Integer numbers are generated even for floating point types in order to avoid rounding errors,
     // and simplify the final check
-    using substitute_t = std::conditional_t<std::is_signed_v<T>, std::int64_t, std::uint64_t>;
+    using substitute_t = std::conditional_t<test_is_signed_v<T>, std::int64_t, std::uint64_t>;
 
-    const substitute_t start = std::is_signed_v<T> ? -10 : 0;
+    const substitute_t start = test_is_signed_v<T> ? -10 : 0;
     const substitute_t end = 10;
 
     std::default_random_engine gen{seed};


### PR DESCRIPTION
This PR removes the identity requirement and the default constructor requirements from two_pass_scan to be more general so that it may cover more cases from mainline oneDPL.

It currently relies on a few strategies to do so:
1) Uses a lazy-constructing union in place of some value types. This allows us to avoid default construction, but allows variables to be scoped where we want them.  
2) delays creation of value type objects to interior scope, rather than reusing the same variable. 
3) Early exit for empty/ inactive workgroups, and properly avoiding empty / inactive subgroups for specific operations
 ** this seems to have the added benefit of performance improvement for small values of `n` **
4) Adapting the subgroup scan to make the `init_and_carry` parameter an optional input (as dictated by a template parameter), which lazily constructs it as an output if it does not exist, and uses and then overwrites if it is provided.  Then, first iterations of loops within a subgroup are pulled out to "skip" the input carry when it does not exist.

This PR also re-writes the "block-global" input carry calculated for `g > 0`  near the beginning of the second kernel.  The previous logic was convoluted and unnecessary, and this PR simplifies it and makes it easier to avoid the identity within the calculation.

This also adds a set of test cases which cover a type which has no default ctor, and no known identity to use. 

Performance:
It seems this PR does not generally harm performance beyond ~3% in the very large values of `n`, and improves performance for small `n` up to ~20%.  We can continue to improve those cases.  There is opportunity to make small adjustments which may regain any losses here, we will see.

Remaining work:
`std::inclusive_scan` optionally does not have an init value, whereas this code takes advantage of a guaranteed `init` value for both inclusive and exclusive scan.  Some more work is needed to specialize for the zeroth block of the cases without an incoming init.  This should be reasonably doable.  I will attempt to do it within this PR, but we can opt to do this as a follow up PR, if it takes too long.


