### PR TITLE
Remove local (in-group) atomic usage from __parallel_find_or (V1)

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1035,7 +1035,7 @@ struct __parallel_or_tag
 {
     using _AtomicType = int32_t;
 
-    using _LocalResultsReduceOp = __dpl_sycl::__plus<_AtomicType>;
+    using _LocalResultsReduceOp = __dpl_sycl::__bit_or<_AtomicType>;
 
     // The template parameter is intended to unify __init_value in tags.
     template <typename _DiffType>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -965,7 +965,7 @@ struct __parallel_find_forward_tag
     using _AtomicType = oneapi::dpl::__internal::__difference_t<_RangeType>;
 #endif
 
-    using FoundLocalReduceOp = __dpl_sycl::__minimum<_AtomicType>;
+    using _LocalResultsReduceOp = __dpl_sycl::__minimum<_AtomicType>;
 
     // The template parameter is intended to unify __init_value in tags.
     template <typename _DiffType>
@@ -1004,7 +1004,7 @@ struct __parallel_find_backward_tag
     using _AtomicType = oneapi::dpl::__internal::__difference_t<_RangeType>;
 #endif
 
-    using FoundLocalReduceOp = __dpl_sycl::__maximum<_AtomicType>;
+    using _LocalResultsReduceOp = __dpl_sycl::__maximum<_AtomicType>;
 
     template <typename _DiffType>
     constexpr static _AtomicType __init_value(_DiffType)
@@ -1035,7 +1035,7 @@ struct __parallel_or_tag
 {
     using _AtomicType = int32_t;
 
-    using FoundLocalReduceOp = __dpl_sycl::__plus<_AtomicType>;
+    using _LocalResultsReduceOp = __dpl_sycl::__plus<_AtomicType>;
 
     // The template parameter is intended to unify __init_value in tags.
     template <typename _DiffType>
@@ -1225,7 +1225,7 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
                     // or calculate the sum with __dpl_sycl::__plus (for the __parallel_or_tag)
                     // inside all our group items
                     __found_local = __dpl_sycl::__reduce_over_group(__item_id.get_group(), __found_local,
-                                                                    typename _BrickTag::FoundLocalReduceOp{});
+                                                                    typename _BrickTag::_LocalResultsReduceOp{});
 
                     // Set local found state value value to global atomic
                     if (__local_idx == 0 && __found_local != __init_value)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1174,7 +1174,7 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
     __wgroup_size = ::std::min(__wgroup_size, oneapi::dpl::__internal::__kernel_work_group_size(__exec, __kernel));
 #endif
 
-#if _ONEDPL_FPGA_DEVICE
+#if _ONEDPL_FPGA_EMU
     // Limit the maximum work-group size to minimize the cost of work-group reduction.
     // Limiting this also helps to avoid huge work-group sizes on some devices (e.g., FPGU emulation).
     __wgroup_size = std::min(__wgroup_size, (std::size_t)2048);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1169,9 +1169,12 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
     auto __kernel = __internal::__kernel_compiler<_FindOrKernel>::__compile(__exec);
     __wgroup_size = ::std::min(__wgroup_size, oneapi::dpl::__internal::__kernel_work_group_size(__exec, __kernel));
 #endif
+
+#if _ONEDPL_FPGA_DEVICE
     // Limit the maximum work-group size to minimize the cost of work-group reduction.
     // Limiting this also helps to avoid huge work-group sizes on some devices (e.g., FPGU emulation).
     __wgroup_size = std::min(__wgroup_size, (std::size_t)2048);
+#endif
     auto __max_cu = oneapi::dpl::__internal::__max_compute_units(__exec);
 
     auto __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__rng_n, __wgroup_size);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -975,11 +975,12 @@ struct __parallel_find_forward_tag
         return __val;
     }
 
+    // As far as we make search from begin to the end of data, we should save the first (minimal) found state in the __save_state_to methods.
+
     template <sycl::access::address_space _Space>
     static void
     __save_state_to(__dpl_sycl::__atomic_ref<_AtomicType, _Space>& __atomic, _AtomicType __new_state)
     {
-        // As far as we make search from begin to the end of data, we should save the first (minimal) found state.
         __atomic.fetch_min(__new_state);
     }
 
@@ -987,7 +988,6 @@ struct __parallel_find_forward_tag
     static void
     __save_state_to(_TFoundState& __found, _AtomicType __new_state)
     {
-        // As far as we make search from begin to the end of data, we should save the first (minimal) found state.
         __found = std::min(__found, __new_state);
     }
 };
@@ -1011,11 +1011,12 @@ struct __parallel_find_backward_tag
         return _AtomicType{-1};
     }
 
+    // As far as we make search from end to the begin of data, we should save the last (maximal) found state in the __save_state_to methods.
+
     template <sycl::access::address_space _Space>
     static void
     __save_state_to(__dpl_sycl::__atomic_ref<_AtomicType, _Space>& __atomic, _AtomicType __new_state)
     {
-        // As far as we make search from end to the begin of data, we should save the last (maximal) found state.
         __atomic.fetch_max(__new_state);
     }
 
@@ -1023,7 +1024,6 @@ struct __parallel_find_backward_tag
     static void
     __save_state_to(_TFoundState& __found, _AtomicType __new_state)
     {
-        // As far as we make search from end to the begin of data, we should save the last (maximal) found state.
         __found = std::max(__found, __new_state);
     }
 };
@@ -1042,11 +1042,12 @@ struct __parallel_or_tag
         return 0;
     }
 
+    // Store that a match was found. Its position is not relevant for or semantics in the __save_state_to methods.
+
     template <sycl::access::address_space _Space>
     static void
     __save_state_to(__dpl_sycl::__atomic_ref<_AtomicType, _Space>& __atomic, _AtomicType /*__new_state*/)
     {
-        // Store that a match was found. Its position is not relevant for or semantics.
         __atomic.store(1);
     }
 
@@ -1054,7 +1055,6 @@ struct __parallel_or_tag
     static void
     __save_state_to(_TFoundState& __found, _AtomicType /*__new_state*/)
     {
-        // Store that a match was found. Its position is not relevant for or semantics.
         __found = 1;
     }
 };

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1035,7 +1035,7 @@ struct __parallel_or_tag
 {
     using _AtomicType = int32_t;
 
-    using FoundLocalReduceOp = sycl::bit_or<_AtomicType>;
+    using FoundLocalReduceOp = __dpl_sycl::__plus<_AtomicType>;
 
     // The template parameter is intended to unify __init_value in tags.
     template <typename _DiffType>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1182,7 +1182,6 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
     auto __max_cu = oneapi::dpl::__internal::__max_compute_units(__exec);
 
     auto __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__rng_n, __wgroup_size);
-    // TODO: try to change __n_groups with another formula for more perfect load balancing
     __n_groups = ::std::min(__n_groups, decltype(__n_groups)(__max_cu));
 
     auto __n_iter = oneapi::dpl::__internal::__dpl_ceiling_div(__rng_n, __n_groups * __wgroup_size);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1222,7 +1222,7 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
 
                     // 3. Reduce over group: find __dpl_sycl::__minimum (for the __parallel_find_forward_tag),
                     // find __dpl_sycl::__maximum (for the __parallel_find_backward_tag)
-                    // or calculate the sum with __dpl_sycl::__plus (for the __parallel_or_tag)
+                    // or update state with __dpl_sycl::__bit_or (for the __parallel_or_tag)
                     // inside all our group items
                     __found_local = __dpl_sycl::__reduce_over_group(__item_id.get_group(), __found_local,
                                                                     typename _BrickTag::_LocalResultsReduceOp{});

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1046,19 +1046,20 @@ struct __parallel_or_tag
 
     // Store that a match was found. Its position is not relevant for or semantics
     // in the __save_state_to (local state) / __save_state_to_atomic (global state) methods.
+    static constexpr _AtomicType __found_state = 1;
 
     template <sycl::access::address_space _Space>
     static void
     __save_state_to_atomic(__dpl_sycl::__atomic_ref<_AtomicType, _Space>& __atomic, _AtomicType /*__new_state*/)
     {
-        __atomic.store(1);
+        __atomic.store(__found_state);
     }
 
     template <typename _TFoundState>
     static void
     __save_state_to(_TFoundState& __found, _AtomicType /*__new_state*/)
     {
-        __found = 1;
+        __found = __found_state;
     }
 };
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1035,7 +1035,7 @@ struct __parallel_or_tag
 {
     using _AtomicType = int32_t;
 
-    using FoundLocalReduceOp = __dpl_sycl::__plus<_AtomicType>;
+    using FoundLocalReduceOp = sycl::bit_or<_AtomicType>;
 
     // The template parameter is intended to unify __init_value in tags.
     template <typename _DiffType>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -975,11 +975,12 @@ struct __parallel_find_forward_tag
         return __val;
     }
 
-    // As far as we make search from begin to the end of data, we should save the first (minimal) found state in the __save_state_to methods.
+    // As far as we make search from begin to the end of data, we should save the first (minimal) found state
+    // in the __save_state_to (local state) / __save_state_to_atomic (global state) methods.
 
     template <sycl::access::address_space _Space>
     static void
-    __save_state_to(__dpl_sycl::__atomic_ref<_AtomicType, _Space>& __atomic, _AtomicType __new_state)
+    __save_state_to_atomic(__dpl_sycl::__atomic_ref<_AtomicType, _Space>& __atomic, _AtomicType __new_state)
     {
         __atomic.fetch_min(__new_state);
     }
@@ -1011,11 +1012,12 @@ struct __parallel_find_backward_tag
         return _AtomicType{-1};
     }
 
-    // As far as we make search from end to the begin of data, we should save the last (maximal) found state in the __save_state_to methods.
+    // As far as we make search from end to the begin of data, we should save the last (maximal) found state
+    // in the __save_state_to (local state) / __save_state_to_atomic (global state) methods.
 
     template <sycl::access::address_space _Space>
     static void
-    __save_state_to(__dpl_sycl::__atomic_ref<_AtomicType, _Space>& __atomic, _AtomicType __new_state)
+    __save_state_to_atomic(__dpl_sycl::__atomic_ref<_AtomicType, _Space>& __atomic, _AtomicType __new_state)
     {
         __atomic.fetch_max(__new_state);
     }
@@ -1042,11 +1044,12 @@ struct __parallel_or_tag
         return 0;
     }
 
-    // Store that a match was found. Its position is not relevant for or semantics in the __save_state_to methods.
+    // Store that a match was found. Its position is not relevant for or semantics
+    // in the __save_state_to (local state) / __save_state_to_atomic (global state) methods.
 
     template <sycl::access::address_space _Space>
     static void
-    __save_state_to(__dpl_sycl::__atomic_ref<_AtomicType, _Space>& __atomic, _AtomicType /*__new_state*/)
+    __save_state_to_atomic(__dpl_sycl::__atomic_ref<_AtomicType, _Space>& __atomic, _AtomicType /*__new_state*/)
     {
         __atomic.store(1);
     }
@@ -1231,7 +1234,7 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
                             *__dpl_sycl::__get_accessor_ptr(__result_sycl_buf_acc));
 
                         // Update global (for all groups) atomic state with the found index
-                        _BrickTag::__save_state_to(__found, __found_local);
+                        _BrickTag::__save_state_to_atomic(__found, __found_local);
                     }
                 });
         });

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -130,6 +130,8 @@ using __maximum = sycl::maximum<_T>;
 template <typename _T = void>
 using __minimum = sycl::minimum<_T>;
 
+template <typename _T = void>
+using __bit_or = sycl::bit_or<_T>;
 #else  // _ONEDPL_SYCL2020_FUNCTIONAL_OBJECTS_PRESENT
 template <typename _T>
 using __plus = sycl::ONEAPI::plus<_T>;
@@ -139,6 +141,9 @@ using __maximum = sycl::ONEAPI::maximum<_T>;
 
 template <typename _T>
 using __minimum = sycl::ONEAPI::minimum<_T>;
+
+template <typename _T = void>
+using __bit_or = sycl::ONEAPI::bit_or<_T>;
 #endif // _ONEDPL_SYCL2020_FUNCTIONAL_OBJECTS_PRESENT
 
 template <typename _Buffer>


### PR DESCRIPTION
In this PR we remove local (in-group) atomic usage from `__parallel_find_or` implementation:
- `__found_local` now is local variable (for each item);
- barriers doesn't required anymore;
- we updates the state of `__found_local` within one group through `__dpl_sycl::__reduce_over_group` operation :
```C++
                    __found_local = __dpl_sycl::__reduce_over_group(__item_id.get_group(), __found_local,
                                                                    typename _BrickTag::_LocalResultsReduceOp{});
```
where `_LocalResultsReduceOp` is :
 - `__dpl_sycl::__minimum` (for the `__parallel_find_forward_tag`);
 - `__dpl_sycl::__maximum` (for the `__parallel_find_backward_tag`);
 - `__dpl_sycl::__bit_or` (for the `__parallel_or_tag`).

The new operation `__dpl_sycl::__bit_or` has been defined in the file [sycl_defs.h](https://github.com/oneapi-src/oneDPL/pull/1668/files#diff-521f7db06a55567c1a1dffa855dde585fb6bc5fbe8633d19b528356e3a501ea0) :
```C++
#if _ONEDPL_SYCL2020_FUNCTIONAL_OBJECTS_PRESENT
// ...
template <typename _T = void>
using __bit_or = sycl::bit_or<_T>;
#else  // _ONEDPL_SYCL2020_FUNCTIONAL_OBJECTS_PRESENT
// ...
template <typename _T = void>
using __bit_or = sycl::ONEAPI::bit_or<_T>;
#endif // _ONEDPL_SYCL2020_FUNCTIONAL_OBJECTS_PRESENT
```