### PR TITLE
Declare predefined `dpcpp_default` and `dpcpp fpga` policies as `const`

### DIFF
--- a/documentation/CHANGES.rst
+++ b/documentation/CHANGES.rst
@@ -369,8 +369,8 @@ Changes to Existing Features
 
 - The following API elements of oneDPL were changed or removed:
 
-  - the ``default_policy`` object was renamed to ``dpcpp_default`` and declared as ``const``;
-  - the ``fpga_policy`` object was renamed to ``dpcpp_fpga`` and declared as ``const``;
+  - the ``default_policy`` object was renamed to ``dpcpp_default``;
+  - the ``fpga_policy`` object was renamed to ``dpcpp_fpga``;
   - the ``fpga_device_policy`` class was renamed to ``fpga_policy``;
   - the ``_PSTL_FPGA_DEVICE`` macro was renamed to ``ONEDPL_FPGA_DEVICE``;
   - the ``_PSTL_FPGA_EMU`` macro was renamed to ``ONEDPL_FPGA_EMULATOR``;

--- a/documentation/CHANGES.rst
+++ b/documentation/CHANGES.rst
@@ -369,8 +369,8 @@ Changes to Existing Features
 
 - The following API elements of oneDPL were changed or removed:
 
-  - the ``default_policy`` object was renamed to ``dpcpp_default``;
-  - the ``fpga_policy`` object was renamed to ``dpcpp_fpga``;
+  - the ``default_policy`` object was renamed to ``dpcpp_default`` and declared as ``const``;
+  - the ``fpga_policy`` object was renamed to ``dpcpp_fpga`` and declared as ``const``;
   - the ``fpga_device_policy`` class was renamed to ``fpga_policy``;
   - the ``_PSTL_FPGA_DEVICE`` macro was renamed to ``ONEDPL_FPGA_DEVICE``;
   - the ``_PSTL_FPGA_EMU`` macro was renamed to ``ONEDPL_FPGA_EMULATOR``;

--- a/documentation/library_guide/macros.rst
+++ b/documentation/library_guide/macros.rst
@@ -94,8 +94,8 @@ Macro                              Description
                                    such as ``dpcpp_default`` and ``dpcpp_fpga``. When the macro is not defined (by default)
                                    or evaluates to non-zero, predefined policies objects can be used.
                                    When the macro is set to 0, predefined policies objects and make functions
-                                   without arguments, when ``make_device_policy()``,
-                                   ``make_fpga_policy()``, are not available.
+                                   without arguments - ``make_device_policy()`` and
+                                   ``make_fpga_policy()`` - are not available.
 ---------------------------------- ------------------------------
 ``ONEDPL_ALLOW_DEFERRED_WAITING``  This macro allows waiting for completion of certain algorithms executed with
                                    device policies to be deferred. (Disabled by default.)

--- a/documentation/library_guide/macros.rst
+++ b/documentation/library_guide/macros.rst
@@ -94,8 +94,7 @@ Macro                              Description
                                    such as ``dpcpp_default`` and ``dpcpp_fpga``. When the macro is not defined (by default)
                                    or evaluates to non-zero, predefined policies objects can be used.
                                    When the macro is set to 0, predefined policies objects and make functions
-                                   without arguments - ``make_device_policy()`` and
-                                   ``make_fpga_policy()`` - are not available.
+                                   without arguments (``make_device_policy()`` and ``make_fpga_policy()``) are not available.
 ---------------------------------- ------------------------------
 ``ONEDPL_ALLOW_DEFERRED_WAITING``  This macro allows waiting for completion of certain algorithms executed with
                                    device policies to be deferred. (Disabled by default.)

--- a/documentation/library_guide/parallel_api/execution_policies.rst
+++ b/documentation/library_guide/parallel_api/execution_policies.rst
@@ -100,8 +100,8 @@ names for SYCL kernel functions. The |dpcpp_cpp| supports it by default;
 for other compilers it may need to be enabled with compilation options such as
 ``-fsycl-unnamed-lambda``. Refer to your compiler documentation for more information.
 
-The ``oneapi::dpl::execution::dpcpp_default`` object is a predefined object of
-the ``device_policy`` class. It is created with a default kernel name and a default queue.
+The ``oneapi::dpl::execution::dpcpp_default`` object is a predefined immutable object of
+the ``device_policy`` class. It is created with a default kernel name and uses a default queue.
 Use it to construct customized policy objects or pass directly when invoking an algorithm.
 
 If ``dpcpp_default`` is passed directly to more than one algorithm, you must ensure that the
@@ -167,14 +167,14 @@ The default constructor of ``fpga_policy`` wraps a SYCL queue created
 for ``fpga_selector``, or for ``fpga_emulator_selector``
 if the ``ONEDPL_FPGA_EMULATOR`` is defined.
 
-``oneapi::dpl::execution::dpcpp_fpga`` is a predefined object of
+``oneapi::dpl::execution::dpcpp_fpga`` is a predefined immutable object of
 the ``fpga_policy`` class created with a default unroll factor and a default kernel name.
 Use it to create customized policy objects or pass directly when invoking an algorithm.
 
 .. Note::
 
    Specifying the unroll factor for a policy enables loop unrolling in the implementation of
-   your algorithms. The default value is 1.
+   |onedpl_short| algorithms. The default value is 1.
    To find out how to choose a more precise value, refer to the `unroll Pragma <https://www.intel.com/content/www/us/en/docs/oneapi-fpga-add-on/developer-guide/current/unroll-pragma.html>`_
    and `Loop Analysis <https://www.intel.com/content/www/us/en/docs/oneapi-fpga-add-on/developer-guide/current/loop-analysis.html>`_ content in
    the `Intel® oneAPI FPGA Handbook

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -101,7 +101,7 @@ class fpga_policy : public device_policy<KernelName>
 // Starting with c++17 we can simply define sycl as inline variable.
 #    if _ONEDPL___cplusplus >= 201703L
 
-inline device_policy<> dpcpp_default{};
+inline const device_policy<> dpcpp_default{};
 #        if _ONEDPL_FPGA_DEVICE
 inline fpga_policy<> dpcpp_fpga{};
 #        endif // _ONEDPL_FPGA_DEVICE

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -103,7 +103,7 @@ class fpga_policy : public device_policy<KernelName>
 
 inline const device_policy<> dpcpp_default{};
 #        if _ONEDPL_FPGA_DEVICE
-inline fpga_policy<> dpcpp_fpga{};
+inline const fpga_policy<> dpcpp_fpga{};
 #        endif // _ONEDPL_FPGA_DEVICE
 
 #    endif // _ONEDPL___cplusplus >= 201703L


### PR DESCRIPTION
In this PR Declare predefined `dpcpp_default` and `dpcpp fpga` policies as `const`.

I hope it's may help to implement move-constructor and move-assignment in the PR https://github.com/oneapi-src/oneDPL/pull/1652 properly.

PR with the changes for oneDPL specification: https://github.com/uxlfoundation/oneAPI-spec/pull/554