### PR TITLE
Revert capitalization of field names to resolve syntax errors in forms.

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_ask-a-question.md
+++ b/.github/ISSUE_TEMPLATE/1_ask-a-question.md
@@ -1,10 +1,9 @@
 ---
-Name: Ask a question
-About: Use this template for everything that is not a bug or feature request.
-Title: ''
-Labels: help wanted, question
-Assignees: ''
-
+name: Ask a question
+about: Use this template for everything that is not a bug or feature request.
+title: ''
+labels: help wanted, question
+assignees: ''
 ---
 
 

--- a/.github/ISSUE_TEMPLATE/2_bug-or-performance-issue-report.md
+++ b/.github/ISSUE_TEMPLATE/2_bug-or-performance-issue-report.md
@@ -1,10 +1,9 @@
 ---
-Name: Bug or performance issue report
-About: Create a report to help us improve oneDPL.
-Title: ''
-Labels: bug
-Assignees: ''
-
+name: Bug or performance issue report
+about: Create a report to help us improve oneDPL.
+title: ''
+labels: bug
+assignees: ''
 ---
 
 **Describe the Bug:**

--- a/.github/ISSUE_TEMPLATE/3_feature_request.md
+++ b/.github/ISSUE_TEMPLATE/3_feature_request.md
@@ -1,10 +1,9 @@
 ---
-Name: Feature request
-About: Suggest an idea for oneDPL.
-Title: ''
-Labels: feature_request
-Assignees: ''
-
+name: Feature request
+about: Suggest an idea for oneDPL.
+title: ''
+labels: 'feature request'
+assignees: ''
 ---
 
 **Summary:**

--- a/.github/ISSUE_TEMPLATE/4_documentation_change.md
+++ b/.github/ISSUE_TEMPLATE/4_documentation_change.md
@@ -1,10 +1,9 @@
 ---
-Name: Documentation change request
-About: Report documentation issue or request documentation changes.
-Title: ''
-Labels: documentation
-Assignees: ''
-
+name: Documentation change request
+about: Report documentation issue or request documentation changes.
+title: ''
+labels: documentation
+assignees: ''
 ---
 
 **Summary:**


### PR DESCRIPTION
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#top-level-syntax specifies that the keys for form fields use lowercase names.  This PR changes field names back to lowercase to resolve errors in deployment of the issue templates.