### PR TITLE
[KT] radix_sort: throw bad_alloc upon memory allocation issues

### DIFF
--- a/documentation/library_guide/kernel_templates/esimd/radix_sort.rst
+++ b/documentation/library_guide/kernel_templates/esimd/radix_sort.rst
@@ -220,7 +220,7 @@ Memory Requirements
 The algorithm uses global and local device memory (see `SYCL 2020 Specification
 <https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_sycl_device_memory_model>`_)
 for intermediate data storage. For the algorithm to operate correctly, there must be enough memory on the device.
-It throws a ``std::bad_alloc`` exception if there is not enough global device memory.
+If there is not enough global device memory, a ``std::bad_alloc`` exception is thrown.
 The behavior is undefined if there is not enough local memory.
 The amount of memory that is required depends on input data and configuration parameters, as described below.
 

--- a/documentation/library_guide/kernel_templates/esimd/radix_sort.rst
+++ b/documentation/library_guide/kernel_templates/esimd/radix_sort.rst
@@ -219,9 +219,10 @@ Memory Requirements
 
 The algorithm uses global and local device memory (see `SYCL 2020 Specification
 <https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_sycl_device_memory_model>`_)
-for intermediate data storage. For the algorithm to operate correctly, there must be enough memory
-on the device; otherwise, the behavior is undefined. The amount of memory that is required
-depends on input data and configuration parameters, as described below.
+for intermediate data storage. For the algorithm to operate correctly, there must be enough memory on the device.
+It throws a ``std::bad_alloc`` exception if there is not enough global device memory.
+The behavior is undefined if there is not enough local memory.
+The amount of memory that is required depends on input data and configuration parameters, as described below.
 
 Global Memory Requirements
 --------------------------

--- a/documentation/library_guide/kernel_templates/esimd/radix_sort_by_key.rst
+++ b/documentation/library_guide/kernel_templates/esimd/radix_sort_by_key.rst
@@ -265,7 +265,7 @@ Memory Requirements
 The algorithm uses global and local device memory (see `SYCL 2020 Specification
 <https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_sycl_device_memory_model>`_)
 for intermediate data storage. For the algorithm to operate correctly, there must be enough memory on the device.
-It throws a ``std::bad_alloc`` exception if there is not enough global device memory.
+If there is not enough global device memory, a ``std::bad_alloc`` exception is thrown.
 The behavior is undefined if there is not enough local memory.
 The amount of memory that is required depends on input data and configuration parameters, as described below.
 

--- a/documentation/library_guide/kernel_templates/esimd/radix_sort_by_key.rst
+++ b/documentation/library_guide/kernel_templates/esimd/radix_sort_by_key.rst
@@ -264,9 +264,10 @@ Memory Requirements
 
 The algorithm uses global and local device memory (see `SYCL 2020 Specification
 <https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_sycl_device_memory_model>`_)
-for intermediate data storage. For the algorithm to operate correctly, there must be enough memory
-on the device; otherwise, the behavior is undefined. The amount of memory that is required
-depends on input data and configuration parameters, as described below.
+for intermediate data storage. For the algorithm to operate correctly, there must be enough memory on the device.
+It throws a ``std::bad_alloc`` exception if there is not enough global device memory.
+The behavior is undefined if there is not enough local memory.
+The amount of memory that is required depends on input data and configuration parameters, as described below.
 
 Global Memory Requirements
 --------------------------

--- a/documentation/library_guide/kernel_templates/single_pass_scan.rst
+++ b/documentation/library_guide/kernel_templates/single_pass_scan.rst
@@ -147,9 +147,10 @@ Memory Requirements
 
 The algorithm uses global and local device memory (see `SYCL 2020 Specification
 <https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_sycl_device_memory_model>`__)
-for intermediate data storage. For the algorithm to operate correctly, there must be enough memory
-on the device. It throws a ``std::bad_alloc`` exception if there is not enough global device memory. The behavior is undefined if there is not enough local memory. The amount of memory that is required
-depends on input data and configuration parameters, as described below.
+for intermediate data storage. For the algorithm to operate correctly, there must be enough memory on the device.
+If there is not enough global device memory, a ``std::bad_alloc`` exception is thrown.
+The behavior is undefined if there is not enough local memory.
+The amount of memory that is required depends on input data and configuration parameters, as described below.
 
 Global Memory Requirements
 --------------------------

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_dispatchers.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_dispatchers.h
@@ -10,6 +10,7 @@
 #ifndef _ONEDPL_KT_ESIMD_RADIX_SORT_DISPATCHERS_H
 #define _ONEDPL_KT_ESIMD_RADIX_SORT_DISPATCHERS_H
 
+#include <new>
 #include <memory>
 #include <cstdint>
 #include <cassert>

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_dispatchers.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_dispatchers.h
@@ -111,9 +111,10 @@ class __onesweep_memory_holder
     __allocate_raw_memory()
     {
         // Non-typed allocation is guaranteed to be aligned for any fundamental type according to SYCL spec
-        // TODO: handle a case when malloc_device fails to allocate the memory
         void* __mem = sycl::malloc_device(__m_raw_mem_bytes, __m_q);
         __m_raw_mem_ptr = reinterpret_cast<::std::uint8_t*>(__mem);
+        if (!__m_raw_mem_ptr)
+            throw std::bad_alloc();
     }
 
     void


### PR DESCRIPTION
This follows the same approach as the scan KT and adheres the standard c++ algorithms convention regarding memory allocation issues, for example: "If the algorithm fails to allocate memory, [std::bad_alloc](https://en.cppreference.com/w/cpp/memory/new/bad_alloc) is thrown (see https://en.cppreference.com/w/cpp/algorithm/sort)