### PR TITLE
Limit the maximum work-group size

### DIFF
--- a/include/oneapi/dpl/internal/reduce_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/reduce_by_segment_impl.h
@@ -236,7 +236,8 @@ __sycl_reduce_by_segment(__internal::__hetero_tag<_BackendTag>, _ExecutionPolicy
     constexpr ::std::uint16_t __vals_per_item =
         16; // Each work item serially processes 16 items. Best observed performance on gpu
 
-    ::std::size_t __wgroup_size = oneapi::dpl::__internal::__max_work_group_size(__exec);
+    // Limit the work-group size to prevent large sizes on CPUs. Empirically found value.
+    std::size_t __wgroup_size = oneapi::dpl::__internal::__max_work_group_size(__exec, (std::size_t)2048);
 
     // adjust __wgroup_size according to local memory limit. Double the requirement on __val_type due to sycl group algorithm's use
     // of SLM.

--- a/include/oneapi/dpl/internal/reduce_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/reduce_by_segment_impl.h
@@ -237,6 +237,7 @@ __sycl_reduce_by_segment(__internal::__hetero_tag<_BackendTag>, _ExecutionPolicy
         16; // Each work item serially processes 16 items. Best observed performance on gpu
 
     // Limit the work-group size to prevent large sizes on CPUs. Empirically found value.
+    // This value exceeds the current practical limit for GPUs, but may need to be re-evaluated in the future.
     std::size_t __wgroup_size = oneapi::dpl::__internal::__max_work_group_size(__exec, (std::size_t)2048);
 
     // adjust __wgroup_size according to local memory limit. Double the requirement on __val_type due to sycl group algorithm's use

--- a/include/oneapi/dpl/internal/scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/scan_by_segment_impl.h
@@ -128,6 +128,7 @@ struct __sycl_scan_by_segment_impl
             4; // Assigning 4 elements per work item resulted in best performance on gpu.
 
         // Limit the work-group size to prevent large sizes on CPUs. Empirically found value.
+        // This value exceeds the current practical limit for GPUs, but may need to be re-evaluated in the future.
         std::size_t __wgroup_size = oneapi::dpl::__internal::__max_work_group_size(__exec, (std::size_t)2048);
 
         // We require 2 * sizeof(__val_type) * __wgroup_size of SLM for the work group segmented scan. We add

--- a/include/oneapi/dpl/internal/scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/scan_by_segment_impl.h
@@ -127,7 +127,8 @@ struct __sycl_scan_by_segment_impl
         constexpr ::std::uint16_t __vals_per_item =
             4; // Assigning 4 elements per work item resulted in best performance on gpu.
 
-        ::std::size_t __wgroup_size = oneapi::dpl::__internal::__max_work_group_size(__exec);
+        // Limit the work-group size to prevent large sizes on CPUs. Empirically found value.
+        std::size_t __wgroup_size = oneapi::dpl::__internal::__max_work_group_size(__exec, (std::size_t)2048);
 
         // We require 2 * sizeof(__val_type) * __wgroup_size of SLM for the work group segmented scan. We add
         // an additional sizeof(__val_type) * __wgroup_size requirement to ensure sufficient SLM for the group algorithms.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1278,12 +1278,6 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
     // TODO: find a way to generalize getting of reliable work-group size
     std::size_t __wgroup_size = oneapi::dpl::__internal::__max_work_group_size(__exec);
 
-#if _ONEDPL_FPGA_EMU
-    // Limit the maximum work-group size to minimize the cost of work-group reduction.
-    // Limiting this also helps to avoid huge work-group sizes on some devices (e.g., FPGU emulation).
-    __wgroup_size = std::min(__wgroup_size, (std::size_t)2048);
-#endif
-
     const auto __max_cu = oneapi::dpl::__internal::__max_compute_units(__exec);
     auto __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__rng_n, __wgroup_size);
     __n_groups = ::std::min(__n_groups, decltype(__n_groups)(__max_cu));

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1276,7 +1276,8 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
     assert(__rng_n > 0);
 
     // TODO: find a way to generalize getting of reliable work-group size
-    std::size_t __wgroup_size = oneapi::dpl::__internal::__max_work_group_size(__exec);
+    // Limit the work-group size to prevent large sizes on CPUs. Empirically found value.
+    std::size_t __wgroup_size = oneapi::dpl::__internal::__max_work_group_size(__exec, (std::size_t)4096);
 
     const auto __max_cu = oneapi::dpl::__internal::__max_compute_units(__exec);
     auto __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__rng_n, __wgroup_size);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -313,6 +313,9 @@ struct __parallel_scan_submitter<_CustomName, __internal::__optional_kernel_name
         // get the work group size adjusted to the local memory limit
         // TODO: find a way to generalize getting of reliable work-group sizes
         ::std::size_t __wgroup_size = oneapi::dpl::__internal::__slm_adjusted_work_group_size(__exec, sizeof(_Type));
+        // Limit the work-group size to prevent large sizes on CPUs. Empirically found value.
+        // This value matches the current practical limit for GPUs, but may need to be re-evaluated in the future.
+        __wgroup_size = std::min(__wgroup_size, (std::size_t)1024);
 
 #if _ONEDPL_COMPILE_KERNEL
         //Actually there is one kernel_bundle for the all kernels of the pattern.
@@ -1277,6 +1280,7 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
 
     // TODO: find a way to generalize getting of reliable work-group size
     // Limit the work-group size to prevent large sizes on CPUs. Empirically found value.
+    // This value exceeds the current practical limit for GPUs, but may need to be re-evaluated in the future.
     std::size_t __wgroup_size = oneapi::dpl::__internal::__max_work_group_size(__exec, (std::size_t)4096);
 
     const auto __max_cu = oneapi::dpl::__internal::__max_compute_units(__exec);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -507,8 +507,7 @@ __parallel_histogram_select_kernel(oneapi::dpl::__internal::__device_backend_tag
     using _extra_memory_type = typename _BinHashMgr::_extra_memory_type;
 
     const auto __num_bins = __bins.size();
-    ::std::size_t __max_wgroup_size = oneapi::dpl::__internal::__max_work_group_size(__exec);
-    ::std::uint16_t __work_group_size = ::std::min(::std::size_t(1024), __max_wgroup_size);
+    ::std::uint16_t __work_group_size = oneapi::dpl::__internal::__max_work_group_size(__exec, std::size_t(1024));
 
     auto __local_mem_size = __exec.queue().get_device().template get_info<sycl::info::device::local_mem_size>();
     constexpr ::std::uint8_t __max_work_item_private_bins = 16 / sizeof(_private_histogram_type);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_histogram.h
@@ -507,7 +507,8 @@ __parallel_histogram_select_kernel(oneapi::dpl::__internal::__device_backend_tag
     using _extra_memory_type = typename _BinHashMgr::_extra_memory_type;
 
     const auto __num_bins = __bins.size();
-    ::std::uint16_t __work_group_size = oneapi::dpl::__internal::__max_work_group_size(__exec, std::size_t(1024));
+    // Limit the maximum work-group size for better performance. Empirically found value.
+    std::uint16_t __work_group_size = oneapi::dpl::__internal::__max_work_group_size(__exec, std::uint16_t(1024));
 
     auto __local_mem_size = __exec.queue().get_device().template get_info<sycl::info::device::local_mem_size>();
     constexpr ::std::uint8_t __max_work_item_private_bins = 16 / sizeof(_private_histogram_type);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -668,6 +668,7 @@ struct __parallel_radix_sort_iteration
         ::std::size_t __max_sg_size = oneapi::dpl::__internal::__max_sub_group_size(__exec);
         ::std::size_t __reorder_sg_size = __max_sg_size;
         // Limit the work-group size to prevent large sizes on CPUs. Empirically found value.
+        // This value exceeds the current practical limit for GPUs, but may need to be re-evaluated in the future.
         std::size_t __scan_wg_size = oneapi::dpl::__internal::__max_work_group_size(__exec, (std::size_t)4096);
 #if _ONEDPL_RADIX_WORKLOAD_TUNING
         ::std::size_t __count_wg_size = (__in_rng.size() > (1 << 21) /*2M*/ ? 128 : __max_sg_size);
@@ -782,6 +783,7 @@ __parallel_radix_sort(oneapi::dpl::__internal::__device_backend_tag, _ExecutionP
     sycl::event __event{};
 
     // Limit the work-group size to prevent large sizes on CPUs. Empirically found value.
+    // This value exceeds the current practical limit for GPUs, but may need to be re-evaluated in the future.
     const std::size_t __max_wg_size = oneapi::dpl::__internal::__max_work_group_size(__exec, (std::size_t)4096);
 
     //TODO: 1.to reduce number of the kernels; 2.to define work group size in runtime, depending on number of elements

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -667,7 +667,8 @@ struct __parallel_radix_sort_iteration
 
         ::std::size_t __max_sg_size = oneapi::dpl::__internal::__max_sub_group_size(__exec);
         ::std::size_t __reorder_sg_size = __max_sg_size;
-        ::std::size_t __scan_wg_size = oneapi::dpl::__internal::__max_work_group_size(__exec);
+        // Limit the work-group size to prevent large sizes on CPUs. Empirically found value.
+        std::size_t __scan_wg_size = oneapi::dpl::__internal::__max_work_group_size(__exec, (std::size_t)4096);
 #if _ONEDPL_RADIX_WORKLOAD_TUNING
         ::std::size_t __count_wg_size = (__in_rng.size() > (1 << 21) /*2M*/ ? 128 : __max_sg_size);
 #else
@@ -780,10 +781,11 @@ __parallel_radix_sort(oneapi::dpl::__internal::__device_backend_tag, _ExecutionP
 
     sycl::event __event{};
 
-    const auto __max_wg_size = oneapi::dpl::__internal::__max_work_group_size(__exec);
+    // Limit the work-group size to prevent large sizes on CPUs. Empirically found value.
+    const std::size_t __max_wg_size = oneapi::dpl::__internal::__max_work_group_size(__exec, (std::size_t)4096);
 
     //TODO: 1.to reduce number of the kernels; 2.to define work group size in runtime, depending on number of elements
-    constexpr auto __wg_size = 64;
+    constexpr std::size_t __wg_size = 64;
     const auto __subgroup_sizes = __exec.queue().get_device().template get_info<sycl::info::device::sub_group_sizes>();
     const bool __dev_has_sg16 = std::find(__subgroup_sizes.begin(), __subgroup_sizes.end(),
                                           static_cast<std::size_t>(16)) != __subgroup_sizes.end();

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -56,10 +56,14 @@ __device_info(const _ExecutionPolicy& __policy)
 #endif
 
 template <typename _ExecutionPolicy>
-::std::size_t
-__max_work_group_size(const _ExecutionPolicy& __policy)
+std::size_t
+__max_work_group_size(const _ExecutionPolicy& __policy, std::size_t __wg_size_limit = 8192)
 {
-    return __policy.queue().get_device().template get_info<sycl::info::device::max_work_group_size>();
+    std::size_t __wg_size = __policy.queue().get_device().template get_info<sycl::info::device::max_work_group_size>();
+    // Limit the maximum work-group size supported by the device to optimize the throughput or minimize communication
+    // costs. This is limited to 8192 which is the highest current limit of the tested hardware (opencl:cpu devices) to
+    // prevent huge work-group sizes returned on some devices (e.g., FPGU emulation).
+    return std::min(__wg_size, __wg_size_limit);
 }
 
 template <typename _ExecutionPolicy, typename _Size>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -106,19 +106,11 @@ template <typename _ExecutionPolicy>
 __kernel_work_group_size(const _ExecutionPolicy& __policy, const sycl::kernel& __kernel)
 {
     const sycl::device& __device = __policy.queue().get_device();
-    ::std::size_t __max_wg_size =
 #if _USE_KERNEL_DEVICE_SPECIFIC_API
-        __kernel.template get_info<sycl::info::kernel_device_specific::work_group_size>(__device);
+    return __kernel.template get_info<sycl::info::kernel_device_specific::work_group_size>(__device);
 #else
-        __kernel.template get_work_group_info<sycl::info::kernel_work_group::work_group_size>(__device);
+    return __kernel.template get_work_group_info<sycl::info::kernel_work_group::work_group_size>(__device);
 #endif
-    // The variable below is needed to achieve better performance on CPU devices.
-    // Experimentally it was found that the most common divisor is 4 with all patterns.
-    // TODO: choose the divisor according to specific pattern.
-    if (__device.is_cpu() && __max_wg_size >= 4)
-        __max_wg_size /= 4;
-
-    return __max_wg_size;
 }
 
 template <typename _ExecutionPolicy>


### PR DESCRIPTION
Several algorithms query the maximum supported work-group size with `__max_work_group_size`. Some devices such as the FPGA emulator might return arbitrary numbers. This can lead to issues with huge resource usage such as SLM or increased runtimes. E.g., resulting test timeouts were observed in https://github.com/oneapi-src/oneDPL/pull/1653.

This PR proposes to limit the value returned by `__max_work_group_size` to the highest correct limit of our tested production hardware architectures. 8192 is observed for `opencl:cpu`, discrete GPUs have typically 1024, and integrated GPUs 512.

This change also allows to provide a custom limit if desired by the caller. This is useful if a specific algorithm shows higher throughputs due to less used hardware resources or reduced communication costs when using smaller work-groups.

I've tagged many people here for awareness.