### PR TITLE
using CPU instead of HOST in Distributed Ranges CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
             std: 23
             build_type: release
             backend: dpcpp
-            device_type: HOST
+            device_type: CPU
     steps:
       - uses: actions/checkout@v3
       - name: Set up Intel APT repository


### PR DESCRIPTION
applied https://github.com/oneapi-src/oneDPL/pull/1479#discussion_r1670678370