### PR TITLE
Improvements of early exit for find-based algorithms (when we search for any matching data entry)

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1138,7 +1138,7 @@ struct __early_exit_find_or
             }
 
             // Share found into state between items in our sub-group to early exit if something was found
-            // - this approach is applicable only for __parallel_or_tag (hen we search for any matching data entry)
+            // - this approach is applicable only for __parallel_or_tag (when we search for any matching data entry)
             // - for __parallel_find_forward_tag and __parallel_find_backward_tag we should process all data
             if constexpr (_OrTagType{})
             {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1035,8 +1035,6 @@ struct __parallel_or_tag
 {
     using _AtomicType = int32_t;
 
-    using _LocalResultsReduceOp = __dpl_sycl::__bit_or<_AtomicType>;
-
     // The template parameter is intended to unify __init_value in tags.
     template <typename _DiffType>
     constexpr static _AtomicType __init_value(_DiffType)
@@ -1233,10 +1231,13 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
 
                     // 3. Reduce over group: find __dpl_sycl::__minimum (for the __parallel_find_forward_tag),
                     // find __dpl_sycl::__maximum (for the __parallel_find_backward_tag)
-                    // or update state with __dpl_sycl::__bit_or (for the __parallel_or_tag)
+                    // or update state with __dpl_sycl::__any_of_group (for the __parallel_or_tag)
                     // inside all our group items
-                    __found_local = __dpl_sycl::__reduce_over_group(__item_id.get_group(), __found_local,
-                                                                    typename _BrickTag::_LocalResultsReduceOp{});
+                    if constexpr (__or_tag_check)
+                        __found_local = __dpl_sycl::__any_of_group(__item_id.get_group(), __found_local);
+                    else
+                        __found_local = __dpl_sycl::__reduce_over_group(__item_id.get_group(), __found_local,
+                                                                        typename _BrickTag::_LocalResultsReduceOp{});
 
                     // Set local found state value value to global atomic
                     if (__local_idx == 0 && __found_local != __init_value)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1199,7 +1199,7 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
 
     _PRINT_INFO_IN_DEBUG_MODE(__exec, __wgroup_size, __max_cu);
 
-    _AtomicType __init_value = _BrickTag::__init_value(__rng_n);
+    const _AtomicType __init_value = _BrickTag::__init_value(__rng_n);
     auto __result = __init_value;
 
     auto __pred = oneapi::dpl::__par_backend_hetero::__early_exit_find_or<_ExecutionPolicy, _Brick>{__f};

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -129,9 +129,6 @@ using __maximum = sycl::maximum<_T>;
 
 template <typename _T = void>
 using __minimum = sycl::minimum<_T>;
-
-template <typename _T = void>
-using __bit_or = sycl::bit_or<_T>;
 #else  // _ONEDPL_SYCL2020_FUNCTIONAL_OBJECTS_PRESENT
 template <typename _T>
 using __plus = sycl::ONEAPI::plus<_T>;
@@ -141,9 +138,6 @@ using __maximum = sycl::ONEAPI::maximum<_T>;
 
 template <typename _T>
 using __minimum = sycl::ONEAPI::minimum<_T>;
-
-template <typename _T = void>
-using __bit_or = sycl::ONEAPI::bit_or<_T>;
 #endif // _ONEDPL_SYCL2020_FUNCTIONAL_OBJECTS_PRESENT
 
 template <typename _Buffer>


### PR DESCRIPTION
In this PR, we implemented the early exit from search inside one sub-group in all sub-group items for find-based algorithms
(when we search for any matching data entry).

It's give us some significant performance boost.