### PR TITLE
[PROTOTYPE] Fix check for __no_init_value when __no_init_value is used with a non-void value type

### DIFF
--- a/include/oneapi/dpl/experimental/kt/two_pass_scan.h
+++ b/include/oneapi/dpl/experimental/kt/two_pass_scan.h
@@ -586,7 +586,8 @@ two_pass_scan(sycl::queue q, _InRng&& __in_rng, _OutRng&& __out_rng, BinaryOp bi
                     }
                     else
                     {
-                        if constexpr (std::is_void_v<typename InitType::__value_type>)
+                        if constexpr (std::is_same_v<InitType, oneapi::dpl::unseq_backend::__no_init_value<
+                                                                   typename InitType::__value_type>>)
                         {
                             // This is the only case where we still don't have a carry in.  No init value, 0th block,
                             // group, and subgroup. This changes the final scan through elements below.


### PR DESCRIPTION
Our current check for if there is an init value assumes that `__no_init_value` will always provide a `__value_type` of `void`. As I've been integrating this code into the oneDPL SYCL backend, it seems that this is not always the case and the `__value_type` may be the actual input iterator's value type which leads to the wrong path being taken and compile time errors.

I have updated the check to determine if `InitType` is an instance of `__no_init_value`. 