### PR TITLE
[CMake] Fix cmake workaround comment for clarity

### DIFF
--- a/cmake/oneDPLWindowsIntelLLVMApply.cmake
+++ b/cmake/oneDPLWindowsIntelLLVMApply.cmake
@@ -36,6 +36,6 @@ endif()
 
 if (INTELLLVM_WIN_STD_IGNORE_FIX)
     include(Compiler/CMakeCommonCompilerMacros)
-    # Setting c++ standard default to 14, and enabling usage of CMAKE_CXX_STANDARD
+    # For IntelLLVM versions greater or equal to 2020, setting c++ standard default to 14, and enable usage of CMAKE_CXX_STANDARD
     __compiler_check_default_language_standard(CXX 2020 14)
 endif()


### PR DESCRIPTION
As discussed in :
https://github.com/oneapi-src/oneDPL/pull/1479#discussion_r1675897808

The comment for this cmake workaround was unclear, this PR should clarify things.