### PR TITLE
Update to use internal version of enumerate in test

### DIFF
--- a/test/distributed-ranges/common/enumerate.cpp
+++ b/test/distributed-ranges/common/enumerate.cpp
@@ -25,13 +25,13 @@ TYPED_TEST_SUITE(Enumerate, AllTypes);
 TYPED_TEST(Enumerate, Basic) {
   Ops1<TypeParam> ops(10);
 
-  EXPECT_TRUE(check_view(rng::views::enumerate(ops.vec),
+  EXPECT_TRUE(check_view(oneapi::dpl::experimental::dr::__detail::enumerate(ops.vec),
                          xhp::views::enumerate(ops.dist_vec)));
 }
 
 TYPED_TEST(Enumerate, Mutate) {
   Ops1<TypeParam> ops(10);
-  auto local = rng::views::enumerate(ops.vec);
+  auto local = oneapi::dpl::experimental::dr::__detail::enumerate(ops.vec);
   auto dist = xhp::views::enumerate(ops.dist_vec);
 
   auto copy = [](auto &&v) { std::get<1>(v) = std::get<0>(v); };


### PR DESCRIPTION
This patch allows distributed ranges tests to be compiled with `gcc-14`.