### PR TITLE
[PROTOTYPE] Generalized two pass algorithm and copy_if

### DIFF
--- a/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/exclusive_scan_by_segment_impl.h
@@ -161,7 +161,8 @@ exclusive_scan_by_segment_impl(__internal::__hetero_tag<_BackendTag>, Policy&& p
     transform_inclusive_scan(::std::move(policy2), make_zip_iterator(_temp.get(), _flags.get()),
                              make_zip_iterator(_temp.get(), _flags.get()) + n, make_zip_iterator(result, _flags.get()),
                              internal::segmented_scan_fun<ValueType, FlagType, Operator>(binary_op),
-                             oneapi::dpl::__internal::__no_op(), ::std::make_tuple(init, FlagType(1)));
+                             oneapi::dpl::__internal::__no_op(),
+                             oneapi::dpl::__internal::make_tuple(init, FlagType(1)));
     return result + n;
 }
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -395,7 +395,7 @@ __pattern_copy_if(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _R
                                                           oneapi::dpl::__par_backend_hetero::__gen_count_pred<_SizeType, _ReduceOp>{__pred},
                                                           _ReduceOp{},
                                                           oneapi::dpl::__par_backend_hetero::__gen_expand_count_pred<_SizeType, _ReduceOp>{__pred},
-                                                          oneapi::dpl::__par_backend_hetero::__scan_expanded_count<_SizeType, _ReduceOp>{},
+                                                          oneapi::dpl::__par_backend_hetero::__get_zeroth_element{},
                                                           oneapi::dpl::__par_backend_hetero::__write_to_idx_if{},
                                                           oneapi::dpl::unseq_backend::__no_init_value{},
                                                           /*_Inclusive=*/std::true_type{})

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -380,59 +380,6 @@ __pattern_scan_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range
     return __res;
 }
 
-template <typename _SizeType, typename _Predicate>
-struct __gen_count_pred
-{
-    template <typename _InRng>
-    _SizeType operator()(_InRng&& __in_rng, _SizeType __idx)
-    {
-        return __pred(__in_rng[__idx]) ? _SizeType{1} : _SizeType{0};
-    }
-    _Predicate __pred;
-};
-
-template <typename _SizeType, typename _Predicate>
-struct __gen_expand_count_pred
-{
-    template <typename _InRng>
-    auto operator()(_InRng&& __in_rng, _SizeType __idx)
-    {
-        auto ele = __in_rng[__idx];
-        bool mask = __pred(ele);
-        return std::tuple( mask ? _SizeType{1} : _SizeType{0}, mask, ele);
-    }
-    _Predicate __pred;
-};
-
-
-template <typename _BinaryOp>
-struct __scan_expanded_count
-{
-    template <typename _SizeType, typename _ValueType>
-    auto operator()(_SizeType __carry_in, const std::tuple<_SizeType, bool, _ValueType>& b)
-    {
-        return std::tuple(__binary_op(__carry_in, std::get<0>(b)), std::get<1>(b), std::get<2>(b));
-    }
-
-    template <typename _ValueType>
-    auto operator()(const std::tuple<_SizeType, bool, _ValueType>& a, const std::tuple<_SizeType, bool, _ValueType>& b)
-    {
-        return this->operator()(std::get<0>(a), b);
-    }
-
-    _BinaryOp __binary_op;
-};
-
-struct __write_to_idx_if
-{
-    template<typename _OutRng, typename _SizeType, typename ValueType>
-    void operator()(_OutRng&& __out, _SizeType __idx, const ValueType& __v) const
-    {
-        if (std::get<1>(__v))
-            __out[std::get<0>(__v)] = std::get<2>(__v);
-    }
-};
-
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Predicate,
           typename _Assign = oneapi::dpl::__internal::__pstl_assign>
 oneapi::dpl::__internal::__difference_t<_Range2>
@@ -445,10 +392,11 @@ __pattern_copy_if(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _R
     return __future(__parallel_transform_reduce_then_scan(__tag, ::std::forward<_ExecutionPolicy>(__exec),
                                                           ::std::forward<_Range1>(__rng1),
                                                           ::std::forward<_Range2>(__rng2),
-                                                          __gen_count_pred<_SizeType, _ReduceOp>{__pred}, std::plus<std::size_t>{},
-                                                          __gen_expand_count_pred<_SizeType, _ReduceOp>{__pred},
-                                                          __scan_expanded_count<std::plus<std::size_t>>{},
-                                                          __write_to_idx_if{},
+                                                          oneapi::dpl::__par_backend_hetero::__gen_count_pred<_SizeType, _ReduceOp>{__pred},
+                                                          _ReduceOp{},
+                                                          oneapi::dpl::__par_backend_hetero::__gen_expand_count_pred<_SizeType, _ReduceOp>{__pred},
+                                                          oneapi::dpl::__par_backend_hetero::__scan_expanded_count<_SizeType, _ReduceOp>{},
+                                                          oneapi::dpl::__par_backend_hetero::__write_to_idx_if{},
                                                           oneapi::dpl::unseq_backend::__no_init_value{},
                                                           /*_Inclusive=*/std::true_type{})
                     .event());

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -389,17 +389,12 @@ __pattern_copy_if(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _R
     using _SizeType = decltype(__rng1.size());
     using _ReduceOp = ::std::plus<_SizeType>;
 
-    return __future(__parallel_transform_reduce_then_scan(__tag, ::std::forward<_ExecutionPolicy>(__exec),
-                                                          ::std::forward<_Range1>(__rng1),
-                                                          ::std::forward<_Range2>(__rng2),
-                                                          oneapi::dpl::__par_backend_hetero::__gen_count_pred<_SizeType, _ReduceOp>{__pred},
-                                                          _ReduceOp{},
-                                                          oneapi::dpl::__par_backend_hetero::__gen_expand_count_pred<_SizeType, _ReduceOp>{__pred},
-                                                          oneapi::dpl::__par_backend_hetero::__get_zeroth_element{},
-                                                          oneapi::dpl::__par_backend_hetero::__write_to_idx_if{},
-                                                          oneapi::dpl::unseq_backend::__no_init_value{},
-                                                          /*_Inclusive=*/std::true_type{})
-                    .event());
+    unseq_backend::__create_mask<_Predicate, _SizeType> __create_mask_op{__pred};
+    unseq_backend::__copy_by_mask<_ReduceOp, _Assign, /*inclusive*/ ::std::true_type, 1> __copy_by_mask_op;
+
+    return __ranges::__pattern_scan_copy(__tag, ::std::forward<_ExecutionPolicy>(__exec),
+                                         ::std::forward<_Range1>(__rng1), ::std::forward<_Range2>(__rng2),
+                                         __create_mask_op, __copy_by_mask_op);
 }
 
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -779,7 +779,7 @@ __group_scan_fits_in_slm(const sycl::queue& __queue, ::std::size_t __n, ::std::s
 template <typename _ValueType, typename _UnaryOp>
 struct __gen_transform_input
 {
-    using __out_value_type = typename std::invoke_result<_UnaryOp, _ValueType>::type;
+    using __out_value_type = std::decay_t<typename std::invoke_result<_UnaryOp, _ValueType>::type>;
     template <typename InRng>
     auto
     operator()(InRng&& __in_rng, std::size_t __idx) const

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -805,7 +805,7 @@ struct __gen_count_pred
     using __out_value_type = _SizeType;
     template <typename _InRng>
     _SizeType
-    operator()(_InRng&& __in_rng, _SizeType __idx)
+    operator()(_InRng&& __in_rng, _SizeType __idx) const
     {
         return __pred(__in_rng[__idx]) ? _SizeType{1} : _SizeType{0};
     }
@@ -817,7 +817,7 @@ struct __gen_expand_count_pred
 {
     template <typename _InRng>
     auto
-    operator()(_InRng&& __in_rng, _SizeType __idx)
+    operator()(_InRng&& __in_rng, _SizeType __idx) const
     {
         auto ele = __in_rng[__idx];
         bool mask = __pred(ele);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -779,7 +779,7 @@ __group_scan_fits_in_slm(const sycl::queue& __queue, ::std::size_t __n, ::std::s
 template <typename _ValueType, typename _UnaryOp>
 struct __gen_transform_input
 {
-    using __out_value_type = std::decay_t<decltype(::std::declval<_UnaryOp>()(::std::declval<_ValueType>()))>;
+    using __out_value_type = typename std::invoke_result<_UnaryOp, _ValueType>::type;
     template <typename InRng>
     auto
     operator()(InRng&& __in_rng, std::size_t __idx) const

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -821,23 +821,14 @@ struct __gen_expand_count_pred
     _Predicate __pred;
 };
 
-
-template <typename _SizeType, typename _BinaryOp>
-struct __scan_expanded_count
+struct __get_zeroth_element
 {
-    template <typename _ValueType>
-    auto operator()(_SizeType __carry_in, const std::tuple<_SizeType, bool, _ValueType>& b)
+    template <typename _Tp>
+    auto&
+    operator()(_Tp&& __a) const
     {
-        return std::tuple(__binary_op(__carry_in, std::get<0>(b)), std::get<1>(b), std::get<2>(b));
+        return std::get<0>(std::forward<_Tp>(__a));
     }
-
-    template <typename _ValueType>
-    auto operator()(const std::tuple<_SizeType, bool, _ValueType>& a, const std::tuple<_SizeType, bool, _ValueType>& b)
-    {
-        return this->operator()(std::get<0>(a), b);
-    }
-
-    _BinaryOp __binary_op;
 };
 
 struct __write_to_idx_if
@@ -892,8 +883,9 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag __backen
     return __future(__parallel_transform_reduce_then_scan(__backend_tag, ::std::forward<_ExecutionPolicy>(__exec),
                                                           ::std::forward<_Range1>(__in_rng),
                                                           ::std::forward<_Range2>(__out_rng),
-                                                          __gen_transform, __binary_op, __gen_transform, __binary_op,
-                                                          __simple_write_to_idx{}, __init, _Inclusive{})
+                                                          __gen_transform, __binary_op, __gen_transform,
+                                                          oneapi::dpl::__internal::__no_op{}, __simple_write_to_idx{},
+                                                          __init, _Inclusive{})
                     .event());
 }
 
@@ -1019,7 +1011,7 @@ __parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag __backend_tag, 
                                                      oneapi::dpl::__par_backend_hetero::__gen_count_pred<_Size, _Pred>{__pred},
                                                      _ReduceOp{},
                                                      oneapi::dpl::__par_backend_hetero::__gen_expand_count_pred<_Size, _Pred>{__pred},
-                                                     oneapi::dpl::__par_backend_hetero::__scan_expanded_count<_Size, _ReduceOp>{},
+                                                     oneapi::dpl::__par_backend_hetero::__get_zeroth_element{},
                                                      oneapi::dpl::__par_backend_hetero::__write_to_idx_if{},
                                                      oneapi::dpl::unseq_backend::__no_init_value<oneapi::dpl::__internal::__value_t<_InRng>>{},
                                                      /*_Inclusive=*/std::true_type{});

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -837,7 +837,8 @@ struct __write_to_idx_if
     void operator()(_OutRng&& __out, _SizeType __idx, const ValueType& __v) const
     {
         if (std::get<1>(__v))
-            __out[std::get<0>(__v)] = std::get<2>(__v);
+            __out[std::get<0>(__v) - 1] = std::get<2>(__v);
+
     }
 };
 
@@ -1013,7 +1014,7 @@ __parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag __backend_tag, 
                                                      oneapi::dpl::__par_backend_hetero::__gen_expand_count_pred<_Size, _Pred>{__pred},
                                                      oneapi::dpl::__par_backend_hetero::__get_zeroth_element{},
                                                      oneapi::dpl::__par_backend_hetero::__write_to_idx_if{},
-                                                     oneapi::dpl::unseq_backend::__no_init_value<oneapi::dpl::__internal::__value_t<_InRng>>{},
+                                                     oneapi::dpl::unseq_backend::__no_init_value<_Size>{},
                                                      /*_Inclusive=*/std::true_type{});
     }
 }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -883,11 +883,11 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag __backen
             }
         }
         oneapi::dpl::__par_backend_hetero::__gen_transform_input<_UnaryOperation> __gen_transform{__unary_op};
-        return __parallel_transform_reduce_then_scan(
-                   __backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__in_rng),
-                   std::forward<_Range2>(__out_rng), __gen_transform, __binary_op, __gen_transform,
-                   oneapi::dpl::__internal::__no_op{}, __simple_write_to_idx{}, __init, _Inclusive{})
-            .event();
+        return __future(__parallel_transform_reduce_then_scan(
+                            __backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__in_rng),
+                            std::forward<_Range2>(__out_rng), __gen_transform, __binary_op, __gen_transform,
+                            oneapi::dpl::__internal::__no_op{}, __simple_write_to_idx{}, __init, _Inclusive{})
+                            .event());
     }
     else
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -819,7 +819,12 @@ struct __gen_expand_count_pred
     auto
     operator()(_InRng&& __in_rng, _SizeType __idx) const
     {
-        auto ele = __in_rng[__idx];
+        // Explicitly creating this element type is necessary to avoid modifying the input data when _InRng is a
+        //  zip_iterator which will return a tuple of references when dereferenced. With this explicit type, we copy
+        //  the values of zipped the input types rather than their references.
+        using _ElementType =
+            oneapi::dpl::__internal::__decay_with_tuple_specialization_t<oneapi::dpl::__internal::__value_t<_InRng>>;
+        _ElementType ele = __in_rng[__idx];
         bool mask = __pred(ele);
         return std::tuple(mask ? _SizeType{1} : _SizeType{0}, mask, ele);
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -602,7 +602,8 @@ struct __parallel_copy_if_static_single_group_submitter<_Size, _ElemsPerItem, _W
 
             __hdl.parallel_for<_ScanKernelName...>(
                 sycl::nd_range<1>(_WGSize, _WGSize), [=](sycl::nd_item<1> __self_item) {
-                    auto __res_ptr = __result_and_scratch_storage<_Policy, _Size>::__get_usm_or_buffer_accessor_ptr(__res_acc);
+                    auto __res_ptr =
+                        __result_and_scratch_storage<_Policy, _Size>::__get_usm_or_buffer_accessor_ptr(__res_acc);
                     const auto& __group = __self_item.get_group();
                     const auto& __subgroup = __self_item.get_sub_group();
                     // This kernel is only launched for sizes less than 2^16
@@ -780,7 +781,8 @@ struct __gen_transform_input
 {
     using __out_value_type = std::decay_t<decltype(::std::declval<_UnaryOp>()(::std::declval<_ValueType>()))>;
     template <typename InRng>
-    auto operator()(InRng&& __in_rng, std::size_t __idx) const
+    auto
+    operator()(InRng&& __in_rng, std::size_t __idx) const
     {
         return __unary_op(__in_rng[__idx]);
     }
@@ -789,20 +791,21 @@ struct __gen_transform_input
 
 struct __simple_write_to_idx
 {
-    template<typename _OutRng, typename ValueType>
-    void operator()(_OutRng&& __out, std::size_t __idx, const ValueType& __v) const
+    template <typename _OutRng, typename ValueType>
+    void
+    operator()(_OutRng&& __out, std::size_t __idx, const ValueType& __v) const
     {
         __out[__idx] = __v;
     }
 };
-
 
 template <typename _SizeType, typename _Predicate>
 struct __gen_count_pred
 {
     using __out_value_type = _SizeType;
     template <typename _InRng>
-    _SizeType operator()(_InRng&& __in_rng, _SizeType __idx)
+    _SizeType
+    operator()(_InRng&& __in_rng, _SizeType __idx)
     {
         return __pred(__in_rng[__idx]) ? _SizeType{1} : _SizeType{0};
     }
@@ -813,11 +816,12 @@ template <typename _SizeType, typename _Predicate>
 struct __gen_expand_count_pred
 {
     template <typename _InRng>
-    auto operator()(_InRng&& __in_rng, _SizeType __idx)
+    auto
+    operator()(_InRng&& __in_rng, _SizeType __idx)
     {
         auto ele = __in_rng[__idx];
         bool mask = __pred(ele);
-        return std::tuple( mask ? _SizeType{1} : _SizeType{0}, mask, ele);
+        return std::tuple(mask ? _SizeType{1} : _SizeType{0}, mask, ele);
     }
     _Predicate __pred;
 };
@@ -834,15 +838,14 @@ struct __get_zeroth_element
 
 struct __write_to_idx_if
 {
-    template<typename _OutRng, typename _SizeType, typename ValueType>
-    void operator()(_OutRng&& __out, _SizeType __idx, const ValueType& __v) const
+    template <typename _OutRng, typename _SizeType, typename ValueType>
+    void
+    operator()(_OutRng&& __out, _SizeType __idx, const ValueType& __v) const
     {
         if (std::get<1>(__v))
             __out[std::get<0>(__v) - 1] = std::get<2>(__v);
-
     }
 };
-
 
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _UnaryOperation, typename _InitType,
           typename _BinaryOperation, typename _Inclusive>
@@ -871,24 +874,14 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag __backen
         }
     }
 
-    // TODO: Reintegrate once support has been added
-    //// Either we can't use group scan or this input is too big for one workgroup
-    //using _Assigner = unseq_backend::__scan_assigner;
-    //using _NoAssign = unseq_backend::__scan_no_assign;
-    //using _UnaryFunctor = unseq_backend::walk_n<_ExecutionPolicy, _UnaryOperation>;
-    //using _NoOpFunctor = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;
-
-    //_Assigner __assign_op;
-    //_NoAssign __no_assign_op;
-    //_NoOpFunctor __get_data_op;
-    oneapi::dpl::__par_backend_hetero::__gen_transform_input<oneapi::dpl::__internal::__value_t<_Range1>, _UnaryOperation> __gen_transform{__unary_op};
-    return __future(__parallel_transform_reduce_then_scan(__backend_tag, ::std::forward<_ExecutionPolicy>(__exec),
-                                                          ::std::forward<_Range1>(__in_rng),
-                                                          ::std::forward<_Range2>(__out_rng),
-                                                          __gen_transform, __binary_op, __gen_transform,
-                                                          oneapi::dpl::__internal::__no_op{}, __simple_write_to_idx{},
-                                                          __init, _Inclusive{})
-                    .event());
+    oneapi::dpl::__par_backend_hetero::__gen_transform_input<oneapi::dpl::__internal::__value_t<_Range1>,
+                                                             _UnaryOperation>
+        __gen_transform{__unary_op};
+    return __future(__parallel_transform_reduce_then_scan(
+                        __backend_tag, ::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range1>(__in_rng),
+                        ::std::forward<_Range2>(__out_rng), __gen_transform, __binary_op, __gen_transform,
+                        oneapi::dpl::__internal::__no_op{}, __simple_write_to_idx{}, __init, _Inclusive{})
+                        .event());
 }
 
 template <typename _SizeType>
@@ -996,8 +989,7 @@ __parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag __backend_tag, 
     if (__n <= __single_group_upper_limit && __max_slm_size >= __req_slm_size &&
         __max_wg_size >= _SingleGroupInvoker::__targeted_wg_size)
     {
-        using _SizeBreakpoints =
-            ::std::integer_sequence<::std::uint16_t, 16, 32, 64, 128, 256, 512, 1024, 2048>;
+        using _SizeBreakpoints = ::std::integer_sequence<::std::uint16_t, 16, 32, 64, 128, 256, 512, 1024, 2048>;
 
         return __par_backend_hetero::__static_monotonic_dispatcher<_SizeBreakpoints>::__dispatch(
             _SingleGroupInvoker{}, __n, ::std::forward<_ExecutionPolicy>(__exec), __n, ::std::forward<_InRng>(__in_rng),
@@ -1007,16 +999,14 @@ __parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag __backend_tag, 
     {
         using _ReduceOp = ::std::plus<_Size>;
 
-        return __parallel_transform_reduce_then_scan(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
-                                                     std::forward<_InRng>(__in_rng),
-                                                     std::forward<_OutRng>(__out_rng),
-                                                     oneapi::dpl::__par_backend_hetero::__gen_count_pred<_Size, _Pred>{__pred},
-                                                     _ReduceOp{},
-                                                     oneapi::dpl::__par_backend_hetero::__gen_expand_count_pred<_Size, _Pred>{__pred},
-                                                     oneapi::dpl::__par_backend_hetero::__get_zeroth_element{},
-                                                     oneapi::dpl::__par_backend_hetero::__write_to_idx_if{},
-                                                     oneapi::dpl::unseq_backend::__no_init_value<_Size>{},
-                                                     /*_Inclusive=*/std::true_type{});
+        return __parallel_transform_reduce_then_scan(
+            __backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_InRng>(__in_rng),
+            std::forward<_OutRng>(__out_rng), oneapi::dpl::__par_backend_hetero::__gen_count_pred<_Size, _Pred>{__pred},
+            _ReduceOp{}, oneapi::dpl::__par_backend_hetero::__gen_expand_count_pred<_Size, _Pred>{__pred},
+            oneapi::dpl::__par_backend_hetero::__get_zeroth_element{},
+            oneapi::dpl::__par_backend_hetero::__write_to_idx_if{},
+            oneapi::dpl::unseq_backend::__no_init_value<_Size>{},
+            /*_Inclusive=*/std::true_type{});
     }
 }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -883,11 +883,11 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag __backen
             }
         }
         oneapi::dpl::__par_backend_hetero::__gen_transform_input<_UnaryOperation> __gen_transform{__unary_op};
-        return __future(__parallel_transform_reduce_then_scan(
-                            __backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__in_rng),
-                            std::forward<_Range2>(__out_rng), __gen_transform, __binary_op, __gen_transform,
-                            oneapi::dpl::__internal::__no_op{}, __simple_write_to_idx{}, __init, _Inclusive{})
-                            .event());
+        return __parallel_transform_reduce_then_scan(
+                   __backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__in_rng),
+                   std::forward<_Range2>(__out_rng), __gen_transform, __binary_op, __gen_transform,
+                   oneapi::dpl::__internal::__no_op{}, __simple_write_to_idx{}, __init, _Inclusive{})
+            .event();
     }
     else
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -989,7 +989,7 @@ __parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag __backend_tag, 
     // The kernel stores n integers for the predicate and another n integers for the offsets
     const auto __req_slm_size = sizeof(::std::uint16_t) * __n_uniform * 2;
 
-    constexpr ::std::uint16_t __single_group_upper_limit = 16384;
+    constexpr ::std::uint16_t __single_group_upper_limit = 2048;
 
     ::std::size_t __max_wg_size = oneapi::dpl::__internal::__max_work_group_size(__exec);
 
@@ -997,7 +997,7 @@ __parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag __backend_tag, 
         __max_wg_size >= _SingleGroupInvoker::__targeted_wg_size)
     {
         using _SizeBreakpoints =
-            ::std::integer_sequence<::std::uint16_t, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384>;
+            ::std::integer_sequence<::std::uint16_t, 16, 32, 64, 128, 256, 512, 1024, 2048>;
 
         return __par_backend_hetero::__static_monotonic_dispatcher<_SizeBreakpoints>::__dispatch(
             _SingleGroupInvoker{}, __n, ::std::forward<_ExecutionPolicy>(__exec), __n, ::std::forward<_InRng>(__in_rng),

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -689,6 +689,16 @@ struct __parallel_reduce_then_scan_scan_submitter<__sub_group_size, __max_inputs
     // TODO: Add the mask functors here to generalize for scan-based algorithms
 };
 
+// General scan-like algorithm helpers
+// _GenReduceInput - a function which accepts the input range and index to generate the data needed by the main output
+//                   used in the reduction operation (to calculate the global carries)
+// _GenScanInput - a function which accepts the input range and index to generate the data needed by the final scan
+//                 and write operations, for scan patterns
+// _ScanPred - a unary function applied to the ouput of `_GenScanInput` to extract the component used in the scan, but
+//             not the part only required for the final write operation
+// _ReduceOp - a binary function which is used in the reduction and scan operations
+// _FinalOp - a function which accepts output range, index, and output of `_GenScanInput` applied to the input range
+//            and performs the final output operation
 template <typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _GenReduceInput, typename _ReduceOp,
           typename _GenScanInput, typename _ScanPred, typename _FinalOp, typename _InitType, typename _Inclusive>
 auto

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -689,8 +689,8 @@ struct __parallel_reduce_then_scan_scan_submitter<__sub_group_size, __max_inputs
                         __sub_group, __gen_scan_input, __scan_pred, __reduce_op, __final_op, __sub_group_carry, __in_rng, __out_rng,
                         __start_idx, __n, __inputs_per_item, __subgroup_start_idx, __sub_group_id, __active_subgroups);
                 }
-                //if last element in the sequence, then we need to write out the last carry out
-                if (__n - 1 == __group_start_idx + __lid)
+                //if at the last element in the sequence, then we need to write out the last carry out
+                if (__sub_group_local_id == 0 && (__n - 1) / __inputs_per_sub_group  == __sub_group_id + __block_num * __num_sub_groups_global + __g * __num_sub_groups_local)
                 {
                     __res_ptr[0] = __sub_group_carry.__v;
                 }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -394,7 +394,6 @@ struct __parallel_reduce_then_scan_reduce_submitter<__sub_group_size, __max_inpu
     const _ReduceOp __reduce_op;
     _InitType __init;
 
-    // TODO: Add the mask functors here to generalize for scan-based algorithms
 };
 
 template <std::size_t __sub_group_size, std::size_t __max_inputs_per_item, bool __is_inclusive,
@@ -682,7 +681,6 @@ struct __parallel_reduce_then_scan_scan_submitter<__sub_group_size, __max_inputs
     const _WriteOp __write_op;
     _InitType __init;
 
-    // TODO: Add the mask functors here to generalize for scan-based algorithms
 };
 
 // General scan-like algorithm helpers
@@ -737,7 +735,6 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
     const auto __block_size = (__n < __max_inputs_per_block) ? __n : __max_inputs_per_block;
     const auto __num_blocks = __n / __block_size + (__n % __block_size != 0);
 
-    // TODO: Use the trick in reduce to wrap in a shared_ptr with custom deleter to support asynchronous frees.
 
     __result_and_scratch_storage<_ExecutionPolicy, typename _GenReduceInput::__out_value_type> __result_and_scratch{
         __exec, __num_sub_groups_global + 1};
@@ -771,7 +768,6 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
         auto __global_range = sycl::range<1>(__ele_in_block_round_up_workgroup);
         auto __local_range = sycl::range<1>(__work_group_size);
         auto __kernel_nd_range = sycl::nd_range<1>(__global_range, __local_range);
-        //std::cout<<"block "<<__b<<std::endl;
         // 1. Reduce step - Reduce assigned input per sub-group, compute and apply intra-wg carries, and write to global memory.
         __event = __reduce_submitter(__exec, __kernel_nd_range, __in_rng, __result_and_scratch, __event,
                                      __inputs_per_sub_group, __inputs_per_item, __b);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -646,7 +646,8 @@ struct __parallel_reduce_then_scan_scan_submitter<__sub_group_size, __max_inputs
                         __in_rng, __out_rng, __start_idx, __n, __inputs_per_item, __subgroup_start_idx, __sub_group_id,
                         __active_subgroups);
                 }
-                //if at the last element in the sequence, then we need to write out the last carry out
+                //If within the last active group and subgroup of the block, use the 0th work item of the subgroup 
+                // to write out the last carry out for either the return value or the next block
                 if (__sub_group_local_id == 0 && (__active_groups == __g + 1) &&
                     (__active_subgroups == __sub_group_id + 1))
                 {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -280,9 +280,9 @@ struct __parallel_reduce_then_scan_reduce_submitter<__sub_group_size, __max_inpu
                const sycl::event& __prior_event, const std::size_t __inputs_per_sub_group,
                const std::size_t __inputs_per_item, const std::size_t __block_num) const
     {
-        using _InValueType = oneapi::dpl::__internal::__value_t<_InRng>;
+        using _CarryType = typename _TmpStorageAcc::__value_type;
         return __exec.queue().submit([&, this](sycl::handler& __cgh) {
-            sycl::local_accessor<_InValueType> __sub_group_partials(__num_sub_groups_local, __cgh);
+            sycl::local_accessor<_CarryType> __sub_group_partials(__num_sub_groups_local, __cgh);
             __cgh.depends_on(__prior_event);
             oneapi::dpl::__ranges::__require_access(__cgh, __in_rng);
             auto __temp_acc = __scratch_container.__get_scratch_acc(__cgh);
@@ -295,7 +295,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__sub_group_size, __max_inpu
                 auto __sub_group_id = __sub_group.get_group_linear_id();
                 auto __sub_group_local_id = __sub_group.get_local_linear_id();
 
-                oneapi::dpl::__internal::__lazy_ctor_storage<_InValueType> __sub_group_carry;
+                oneapi::dpl::__internal::__lazy_ctor_storage<_CarryType> __sub_group_carry;
                 std::size_t __group_start_idx =
                     (__block_num * __max_block_size) + (__g * __inputs_per_sub_group * __num_sub_groups_local);
                 if (__n <= __group_start_idx)
@@ -418,10 +418,10 @@ struct __parallel_reduce_then_scan_scan_submitter<__sub_group_size, __max_inputs
                const sycl::event& __prior_event, const std::size_t __inputs_per_sub_group,
                const std::size_t __inputs_per_item, const std::size_t __block_num) const
     {
-        using _InValueType = oneapi::dpl::__internal::__value_t<_InRng>;
         using _InitValueType = typename _InitType::__value_type;
+        using _CarryType = typename _TmpStorageAcc::__value_type;
         return __exec.queue().submit([&, this](sycl::handler& __cgh) {
-            sycl::local_accessor<_InValueType> __sub_group_partials(__num_sub_groups_local + 1, __cgh);
+            sycl::local_accessor<_CarryType> __sub_group_partials(__num_sub_groups_local + 1, __cgh);
             __cgh.depends_on(__prior_event);
             oneapi::dpl::__ranges::__require_access(__cgh, __in_rng, __out_rng);
             auto __temp_acc = __scratch_container.__get_scratch_acc(__cgh);
@@ -447,11 +447,11 @@ struct __parallel_reduce_then_scan_scan_submitter<__sub_group_size, __max_inputs
                     std::min(__n - __group_start_idx, std::size_t(__num_sub_groups_local * __inputs_per_sub_group));
                 std::uint32_t __active_subgroups =
                     oneapi::dpl::__internal::__dpl_ceiling_div(__elements_in_group, __inputs_per_sub_group);
-                oneapi::dpl::__internal::__lazy_ctor_storage<_InValueType> __carry_last;
-                oneapi::dpl::__internal::__lazy_ctor_storage<_InValueType> __value;
+                oneapi::dpl::__internal::__lazy_ctor_storage<_CarryType> __carry_last;
+                oneapi::dpl::__internal::__lazy_ctor_storage<_CarryType> __value;
 
                 // propogate carry in from previous block
-                oneapi::dpl::__internal::__lazy_ctor_storage<_InValueType> __sub_group_carry;
+                oneapi::dpl::__internal::__lazy_ctor_storage<_CarryType> __sub_group_carry;
 
                 // on the first sub-group in a work-group (assuming S subgroups in a work-group):
                 // 1. load S sub-group local carry pfix sums (T0..TS-1) to slm
@@ -618,7 +618,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__sub_group_size, __max_inputs
                         {
                             // Grab the last element from the previous block that has been cached in temporary
                             // storage in the second kernel of the previous block.
-                            _InValueType __last_block_element = __tmp_ptr[__num_sub_groups_global];
+                            _CarryType __last_block_element = __tmp_ptr[__num_sub_groups_global];
                             __sub_group_carry.__setup(__reduce_op(
                                 __reduce_op(__out_rng[__block_num * __max_block_size - 1], __last_block_element),
                                 __sub_group_partials[__sub_group_id - 1]));
@@ -633,7 +633,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__sub_group_size, __max_inputs
                         {
                             // Grab the last element from the previous block that has been cached in temporary
                             // storage in the second kernel of the previous block.
-                            _InValueType __last_block_element = __tmp_ptr[__num_sub_groups_global];
+                            _CarryType __last_block_element = __tmp_ptr[__num_sub_groups_global];
                             __sub_group_carry.__setup(__reduce_op(
                                 __reduce_op(__out_rng[__block_num * __max_block_size - 1], __last_block_element),
                                 __sub_group_partials[__active_subgroups]));
@@ -647,7 +647,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__sub_group_size, __max_inputs
                         {
                             // Grab the last element from the previous block that has been cached in temporary
                             // storage in the second kernel of the previous block.
-                            _InValueType __last_block_element = __tmp_ptr[__num_sub_groups_global];
+                            _CarryType __last_block_element = __tmp_ptr[__num_sub_groups_global];
                             __sub_group_carry.__setup(
                                 __reduce_op(__out_rng[__block_num * __max_block_size - 1], __last_block_element));
                         }
@@ -668,8 +668,8 @@ struct __parallel_reduce_then_scan_scan_submitter<__sub_group_size, __max_inputs
                 }
 
                 // step 5) apply global carries
-                size_t __subgroup_start_idx = __group_start_idx + (__sub_group_id * __inputs_per_sub_group);
-                size_t __start_idx = __subgroup_start_idx + __sub_group_local_id;
+                std::size_t __subgroup_start_idx = __group_start_idx + (__sub_group_id * __inputs_per_sub_group);
+                std::size_t __start_idx = __subgroup_start_idx + __sub_group_local_id;
 
                 if (__sub_group_carry_initialized)
                 {
@@ -690,7 +690,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__sub_group_size, __max_inputs
                         __start_idx, __n, __inputs_per_item, __subgroup_start_idx, __sub_group_id, __active_subgroups);
                 }
                 //if at the last element in the sequence, then we need to write out the last carry out
-                if (__sub_group_local_id == 0 && (__n - 1) / __inputs_per_sub_group  == __sub_group_id + __block_num * __num_sub_groups_global + __g * __num_sub_groups_local)
+                if (__sub_group_local_id == 0 &&  __subgroup_start_idx < __n && __subgroup_start_idx + __inputs_per_sub_group >= __n)
                 {
                     __res_ptr[0] = __sub_group_carry.__v;
                 }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -162,7 +162,8 @@ __scan_through_elements_helper(const _SubGroup& __sub_group, _GenInput __gen_inp
     if (__is_full_thread && __is_full_block)
     {
         auto __v = __gen_input(__in_rng, __start_idx);
-        __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(__sub_group, __scan_pred(__v), __binary_op,
+        auto& __v_scan = __scan_pred(__v);
+        __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(__sub_group, __v_scan, __binary_op,
                                                                            __sub_group_carry);
         if constexpr (__capture_output)
         {
@@ -173,7 +174,7 @@ __scan_through_elements_helper(const _SubGroup& __sub_group, _GenInput __gen_inp
         for (std::uint32_t __j = 1; __j < __max_inputs_per_item; __j++)
         {
             __v = __gen_input(__in_rng, __start_idx + __j * __sub_group_size);
-            __sub_group_scan<__sub_group_size, __is_inclusive, /*__init_present=*/true>(__sub_group, __scan_pred(__v),
+            __sub_group_scan<__sub_group_size, __is_inclusive, /*__init_present=*/true>(__sub_group, __v_scan,
                                                                                         __binary_op, __sub_group_carry);
             if constexpr (__capture_output)
             {
@@ -184,7 +185,8 @@ __scan_through_elements_helper(const _SubGroup& __sub_group, _GenInput __gen_inp
     else if (__is_full_thread)
     {
         auto __v = __gen_input(__in_rng, __start_idx);
-        __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(__sub_group, __scan_pred(__v), __binary_op,
+        auto& __v_scan = __scan_pred(__v);
+        __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(__sub_group, __v_scan, __binary_op,
                                                                            __sub_group_carry);
         if constexpr (__capture_output)
         {
@@ -193,7 +195,7 @@ __scan_through_elements_helper(const _SubGroup& __sub_group, _GenInput __gen_inp
         for (std::uint32_t __j = 1; __j < __iters_per_item; __j++)
         {
             __v = __gen_input(__in_rng, __start_idx + __j * __sub_group_size);
-            __sub_group_scan<__sub_group_size, __is_inclusive, /*__init_present=*/true>(__sub_group, __scan_pred(__v),
+            __sub_group_scan<__sub_group_size, __is_inclusive, /*__init_present=*/true>(__sub_group, __v_scan,
                                                                                         __binary_op, __sub_group_carry);
             if constexpr (__capture_output)
             {
@@ -210,8 +212,9 @@ __scan_through_elements_helper(const _SubGroup& __sub_group, _GenInput __gen_inp
             if (__iters == 1)
             {
                 auto __v = __gen_input(__in_rng, __start_idx);
+                auto& __v_scan = __scan_pred(__v);
                 __sub_group_scan_partial<__sub_group_size, __is_inclusive, __init_present>(
-                    __sub_group, __scan_pred(__v), __binary_op, __sub_group_carry, __n - __subgroup_start_idx);
+                    __sub_group, __v_scan, __binary_op, __sub_group_carry, __n - __subgroup_start_idx);
                 if constexpr (__capture_output)
                 {
                     if (__start_idx < __n)
@@ -221,8 +224,9 @@ __scan_through_elements_helper(const _SubGroup& __sub_group, _GenInput __gen_inp
             else
             {
                 auto __v = __gen_input(__in_rng, __start_idx);
-                __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(__sub_group, __scan_pred(__v),
-                                                                                   __binary_op, __sub_group_carry);
+                auto& __v_scan = __scan_pred(__v);
+                __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(__sub_group, __v_scan, __binary_op,
+                                                                                   __sub_group_carry);
                 if constexpr (__capture_output)
                 {
                     __final_op(__out_rng, __start_idx, __v);
@@ -233,7 +237,7 @@ __scan_through_elements_helper(const _SubGroup& __sub_group, _GenInput __gen_inp
                     auto __local_idx = __start_idx + __j * __sub_group_size;
                     __v = __gen_input(__in_rng, __local_idx);
                     __sub_group_scan<__sub_group_size, __is_inclusive, /*__init_present=*/true>(
-                        __sub_group, __scan_pred(__v), __binary_op, __sub_group_carry);
+                        __sub_group, __v_scan, __binary_op, __sub_group_carry);
                     if constexpr (__capture_output)
                     {
                         __final_op(__out_rng, __local_idx, __v);
@@ -244,7 +248,7 @@ __scan_through_elements_helper(const _SubGroup& __sub_group, _GenInput __gen_inp
                 auto __local_idx = (__offset < __n) ? __offset : __n - 1;
                 __v = __gen_input(__in_rng, __local_idx);
                 __sub_group_scan_partial<__sub_group_size, __is_inclusive, /*__init_present=*/true>(
-                    __sub_group, __scan_pred(__v), __binary_op, __sub_group_carry,
+                    __sub_group, __v_scan, __binary_op, __sub_group_carry,
                     __n - (__subgroup_start_idx + (__iters - 1) * __sub_group_size));
                 if constexpr (__capture_output)
                 {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -162,8 +162,7 @@ __scan_through_elements_helper(const _SubGroup& __sub_group, _GenInput __gen_inp
     if (__is_full_thread && __is_full_block)
     {
         auto __v = __gen_input(__in_rng, __start_idx);
-        auto& __v_scan = __scan_pred(__v);
-        __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(__sub_group, __v_scan, __binary_op,
+        __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(__sub_group, __scan_pred(__v), __binary_op,
                                                                            __sub_group_carry);
         if constexpr (__capture_output)
         {
@@ -174,7 +173,7 @@ __scan_through_elements_helper(const _SubGroup& __sub_group, _GenInput __gen_inp
         for (std::uint32_t __j = 1; __j < __max_inputs_per_item; __j++)
         {
             __v = __gen_input(__in_rng, __start_idx + __j * __sub_group_size);
-            __sub_group_scan<__sub_group_size, __is_inclusive, /*__init_present=*/true>(__sub_group, __v_scan,
+            __sub_group_scan<__sub_group_size, __is_inclusive, /*__init_present=*/true>(__sub_group, __scan_pred(__v),
                                                                                         __binary_op, __sub_group_carry);
             if constexpr (__capture_output)
             {
@@ -185,8 +184,7 @@ __scan_through_elements_helper(const _SubGroup& __sub_group, _GenInput __gen_inp
     else if (__is_full_thread)
     {
         auto __v = __gen_input(__in_rng, __start_idx);
-        auto& __v_scan = __scan_pred(__v);
-        __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(__sub_group, __v_scan, __binary_op,
+        __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(__sub_group, __scan_pred(__v), __binary_op,
                                                                            __sub_group_carry);
         if constexpr (__capture_output)
         {
@@ -195,7 +193,7 @@ __scan_through_elements_helper(const _SubGroup& __sub_group, _GenInput __gen_inp
         for (std::uint32_t __j = 1; __j < __iters_per_item; __j++)
         {
             __v = __gen_input(__in_rng, __start_idx + __j * __sub_group_size);
-            __sub_group_scan<__sub_group_size, __is_inclusive, /*__init_present=*/true>(__sub_group, __v_scan,
+            __sub_group_scan<__sub_group_size, __is_inclusive, /*__init_present=*/true>(__sub_group, __scan_pred(__v),
                                                                                         __binary_op, __sub_group_carry);
             if constexpr (__capture_output)
             {
@@ -212,9 +210,8 @@ __scan_through_elements_helper(const _SubGroup& __sub_group, _GenInput __gen_inp
             if (__iters == 1)
             {
                 auto __v = __gen_input(__in_rng, __start_idx);
-                auto& __v_scan = __scan_pred(__v);
                 __sub_group_scan_partial<__sub_group_size, __is_inclusive, __init_present>(
-                    __sub_group, __v_scan, __binary_op, __sub_group_carry, __n - __subgroup_start_idx);
+                    __sub_group, __scan_pred(__v), __binary_op, __sub_group_carry, __n - __subgroup_start_idx);
                 if constexpr (__capture_output)
                 {
                     if (__start_idx < __n)
@@ -224,9 +221,8 @@ __scan_through_elements_helper(const _SubGroup& __sub_group, _GenInput __gen_inp
             else
             {
                 auto __v = __gen_input(__in_rng, __start_idx);
-                auto& __v_scan = __scan_pred(__v);
-                __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(__sub_group, __v_scan, __binary_op,
-                                                                                   __sub_group_carry);
+                __sub_group_scan<__sub_group_size, __is_inclusive, __init_present>(__sub_group, __scan_pred(__v),
+                                                                                   __binary_op, __sub_group_carry);
                 if constexpr (__capture_output)
                 {
                     __final_op(__out_rng, __start_idx, __v);
@@ -237,7 +233,7 @@ __scan_through_elements_helper(const _SubGroup& __sub_group, _GenInput __gen_inp
                     auto __local_idx = __start_idx + __j * __sub_group_size;
                     __v = __gen_input(__in_rng, __local_idx);
                     __sub_group_scan<__sub_group_size, __is_inclusive, /*__init_present=*/true>(
-                        __sub_group, __v_scan, __binary_op, __sub_group_carry);
+                        __sub_group, __scan_pred(__v), __binary_op, __sub_group_carry);
                     if constexpr (__capture_output)
                     {
                         __final_op(__out_rng, __local_idx, __v);
@@ -248,7 +244,7 @@ __scan_through_elements_helper(const _SubGroup& __sub_group, _GenInput __gen_inp
                 auto __local_idx = (__offset < __n) ? __offset : __n - 1;
                 __v = __gen_input(__in_rng, __local_idx);
                 __sub_group_scan_partial<__sub_group_size, __is_inclusive, /*__init_present=*/true>(
-                    __sub_group, __v_scan, __binary_op, __sub_group_carry,
+                    __sub_group, __scan_pred(__v), __binary_op, __sub_group_carry,
                     __n - (__subgroup_start_idx + (__iters - 1) * __sub_group_size));
                 if constexpr (__capture_output)
                 {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -290,8 +290,6 @@ struct __parallel_reduce_then_scan_reduce_submitter<__sub_group_size, __max_inpu
                                                             *this](sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(
                                                                __sub_group_size)]] {
                 auto __temp_ptr = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__temp_acc);
-                auto __id = __ndi.get_global_id(0);
-                auto __lid = __ndi.get_local_id(0);
                 auto __g = __ndi.get_group(0);
                 auto __sub_group = __ndi.get_sub_group();
                 auto __sub_group_id = __sub_group.get_group_linear_id();
@@ -434,7 +432,6 @@ struct __parallel_reduce_then_scan_scan_submitter<__sub_group_size, __max_inputs
                                                                __sub_group_size)]] {
                 auto __tmp_ptr = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__temp_acc);
                 auto __res_ptr = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__res_acc, __num_sub_groups_global + 1);
-                auto __id = __ndi.get_global_id(0);
                 auto __lid = __ndi.get_local_id(0);
                 auto __g = __ndi.get_group(0);
                 auto __sub_group = __ndi.get_sub_group();
@@ -693,7 +690,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__sub_group_size, __max_inputs
                         __start_idx, __n, __inputs_per_item, __subgroup_start_idx, __sub_group_id, __active_subgroups);
                 }
                 //if last element in the sequence, then we need to write out the last carry out
-                if (__n - 1 == __group_start_idx + __id)
+                if (__n - 1 == __group_start_idx + __lid)
                 {
                     __res_ptr[0] = __sub_group_carry.__v;
                 }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -276,7 +276,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__sub_group_size, __max_inpu
     // input buffer
     template <typename _ExecutionPolicy, typename _InRng, typename _TmpStorageAcc>
     auto
-    operator()(_ExecutionPolicy&& __exec, _InRng&& __in_rng, _TmpStorageAcc __tmp_storage,
+    operator()(_ExecutionPolicy&& __exec, _InRng&& __in_rng, _TmpStorageAcc __scratch_container,
                const sycl::event& __prior_event, const std::size_t __inputs_per_sub_group,
                const std::size_t __inputs_per_item, const std::size_t __block_num) const
     {
@@ -285,9 +285,11 @@ struct __parallel_reduce_then_scan_reduce_submitter<__sub_group_size, __max_inpu
             sycl::local_accessor<_InValueType> __sub_group_partials(__num_sub_groups_local, __cgh);
             __cgh.depends_on(__prior_event);
             oneapi::dpl::__ranges::__require_access(__cgh, __in_rng);
+            auto __temp_acc = __scratch_container.__get_scratch_acc(__cgh);
             __cgh.parallel_for<_KernelName...>(__nd_range, [=,
                                                             *this](sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(
                                                                __sub_group_size)]] {
+                auto __temp_ptr = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__temp_acc);
                 auto __id = __ndi.get_global_id(0);
                 auto __lid = __ndi.get_local_id(0);
                 auto __g = __ndi.get_group(0);
@@ -345,7 +347,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__sub_group_size, __max_inpu
                             __sub_group, __v, __reduce_op, __sub_group_carry,
                             __active_subgroups - __subgroup_start_idx);
                         if (__sub_group_local_id < __active_subgroups)
-                            __tmp_storage[__start_idx + __sub_group_local_id] = __v;
+                            __temp_ptr[__start_idx + __sub_group_local_id] = __v;
                     }
                     else
                     {
@@ -353,14 +355,14 @@ struct __parallel_reduce_then_scan_reduce_submitter<__sub_group_size, __max_inpu
                         auto __v = __sub_group_partials[__sub_group_local_id];
                         __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
                             __sub_group, __v, __reduce_op, __sub_group_carry);
-                        __tmp_storage[__start_idx + __sub_group_local_id] = __v;
+                        __temp_ptr[__start_idx + __sub_group_local_id] = __v;
 
                         for (int __i = 1; __i < __iters - 1; __i++)
                         {
                             __v = __sub_group_partials[__i * __sub_group_size + __sub_group_local_id];
                             __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
                                 __sub_group, __v, __reduce_op, __sub_group_carry);
-                            __tmp_storage[__start_idx + __i * __sub_group_size + __sub_group_local_id] = __v;
+                            __temp_ptr[__start_idx + __i * __sub_group_size + __sub_group_local_id] = __v;
                         }
                         // If we are past the input range, then the previous value of v is passed to the sub-group scan.
                         // It does not affect the result as our sub_group_scan will use a mask to only process in-range elements.
@@ -374,7 +376,7 @@ struct __parallel_reduce_then_scan_reduce_submitter<__sub_group_size, __max_inpu
                         __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
                             __sub_group, __v, __reduce_op, __sub_group_carry, __num_sub_groups_local);
                         if (__proposed_idx < __num_sub_groups_local)
-                            __tmp_storage[__start_idx + __proposed_idx] = __v;
+                            __temp_ptr[__start_idx + __proposed_idx] = __v;
                     }
 
                     __sub_group_carry.__destroy();
@@ -413,7 +415,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__sub_group_size, __max_inputs
 {
     template <typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _TmpStorageAcc>
     auto
-    operator()(_ExecutionPolicy&& __exec, _InRng&& __in_rng, _OutRng&& __out_rng, _TmpStorageAcc __tmp_storage,
+    operator()(_ExecutionPolicy&& __exec, _InRng&& __in_rng, _OutRng&& __out_rng, _TmpStorageAcc __scratch_container,
                const sycl::event& __prior_event, const std::size_t __inputs_per_sub_group,
                const std::size_t __inputs_per_item, const std::size_t __block_num) const
     {
@@ -423,9 +425,14 @@ struct __parallel_reduce_then_scan_scan_submitter<__sub_group_size, __max_inputs
             sycl::local_accessor<_InValueType> __sub_group_partials(__num_sub_groups_local + 1, __cgh);
             __cgh.depends_on(__prior_event);
             oneapi::dpl::__ranges::__require_access(__cgh, __in_rng, __out_rng);
+            auto __temp_acc = __scratch_container.__get_scratch_acc(__cgh);
+            auto __res_acc = __scratch_container.__get_result_acc(__cgh);
+
             __cgh.parallel_for<_KernelName...>(__nd_range, [=,
                                                             *this](sycl::nd_item<1> __ndi) [[sycl::reqd_sub_group_size(
                                                                __sub_group_size)]] {
+                auto __tmp_ptr = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__temp_acc);
+                auto __res_ptr = _TmpStorageAcc::__get_usm_or_buffer_accessor_ptr(__res_acc, __num_sub_groups_global + 1);
                 auto __id = __ndi.get_global_id(0);
                 auto __lid = __ndi.get_local_id(0);
                 auto __g = __ndi.get_group(0);
@@ -471,12 +478,12 @@ struct __parallel_reduce_then_scan_scan_submitter<__sub_group_size, __max_inputs
                     for (; __i < __iters - 1; __i++)
                     {
                         __sub_group_partials[__i * __sub_group_size + __sub_group_local_id] =
-                            __tmp_storage[__subgroups_before_my_group + __i * __sub_group_size + __sub_group_local_id];
+                            __tmp_ptr[__subgroups_before_my_group + __i * __sub_group_size + __sub_group_local_id];
                     }
                     if (__i * __sub_group_size + __sub_group_local_id < __active_subgroups)
                     {
                         __sub_group_partials[__i * __sub_group_size + __sub_group_local_id] =
-                            __tmp_storage[__subgroups_before_my_group + __i * __sub_group_size + __sub_group_local_id];
+                            __tmp_ptr[__subgroups_before_my_group + __i * __sub_group_size + __sub_group_local_id];
                     }
 
                     // step 2) load 32, 64, 96, etc. work-group carry outs on every work-group; then
@@ -498,7 +505,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__sub_group_size, __max_inputs
                             auto __reduction_idx = (__proposed_idx < __subgroups_before_my_group)
                                                        ? __proposed_idx
                                                        : __subgroups_before_my_group - 1;
-                            __value.__setup(__tmp_storage[__reduction_idx]);
+                            __value.__setup(__tmp_ptr[__reduction_idx]);
                             __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
                                                      /*__init_present=*/false>(__sub_group, __value.__v, __reduce_op,
                                                                                __carry_last, __remaining_elements);
@@ -507,7 +514,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__sub_group_size, __max_inputs
                         {
                             // multiple iterations
                             // first 1 full
-                            __value.__setup(__tmp_storage[__num_sub_groups_local * __sub_group_local_id + __offset]);
+                            __value.__setup(__tmp_ptr[__num_sub_groups_local * __sub_group_local_id + __offset]);
                             __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/false>(
                                 __sub_group, __value.__v, __reduce_op, __carry_last);
 
@@ -516,7 +523,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__sub_group_size, __max_inputs
                             {
                                 auto __reduction_idx = __i * __num_sub_groups_local * __sub_group_size +
                                                        __num_sub_groups_local * __sub_group_local_id + __offset;
-                                __value.__v = __tmp_storage[__reduction_idx];
+                                __value.__v = __tmp_ptr[__reduction_idx];
                                 __sub_group_scan<__sub_group_size, /*__is_inclusive=*/true, /*__init_present=*/true>(
                                     __sub_group, __value.__v, __reduce_op, __carry_last);
                             }
@@ -529,7 +536,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__sub_group_size, __max_inputs
                             auto __reduction_idx = (__proposed_idx < __subgroups_before_my_group)
                                                        ? __proposed_idx
                                                        : __subgroups_before_my_group - 1;
-                            __value.__v = __tmp_storage[__reduction_idx];
+                            __value.__v = __tmp_ptr[__reduction_idx];
                             __sub_group_scan_partial<__sub_group_size, /*__is_inclusive=*/true,
                                                      /*__init_present=*/true>(__sub_group, __value.__v, __reduce_op,
                                                                               __carry_last, __remaining_elements);
@@ -613,7 +620,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__sub_group_size, __max_inputs
                         {
                             // Grab the last element from the previous block that has been cached in temporary
                             // storage in the second kernel of the previous block.
-                            _InValueType __last_block_element = __tmp_storage[__num_sub_groups_global];
+                            _InValueType __last_block_element = __tmp_ptr[__num_sub_groups_global];
                             __sub_group_carry.__setup(__reduce_op(
                                 __reduce_op(__out_rng[__block_num * __max_block_size - 1], __last_block_element),
                                 __sub_group_partials[__sub_group_id - 1]));
@@ -628,7 +635,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__sub_group_size, __max_inputs
                         {
                             // Grab the last element from the previous block that has been cached in temporary
                             // storage in the second kernel of the previous block.
-                            _InValueType __last_block_element = __tmp_storage[__num_sub_groups_global];
+                            _InValueType __last_block_element = __tmp_ptr[__num_sub_groups_global];
                             __sub_group_carry.__setup(__reduce_op(
                                 __reduce_op(__out_rng[__block_num * __max_block_size - 1], __last_block_element),
                                 __sub_group_partials[__active_subgroups]));
@@ -642,7 +649,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__sub_group_size, __max_inputs
                         {
                             // Grab the last element from the previous block that has been cached in temporary
                             // storage in the second kernel of the previous block.
-                            _InValueType __last_block_element = __tmp_storage[__num_sub_groups_global];
+                            _InValueType __last_block_element = __tmp_ptr[__num_sub_groups_global];
                             __sub_group_carry.__setup(
                                 __reduce_op(__out_rng[__block_num * __max_block_size - 1], __last_block_element));
                         }
@@ -658,7 +665,7 @@ struct __parallel_reduce_then_scan_scan_submitter<__sub_group_size, __max_inputs
                     if (__global_id == __num_work_items - 1)
                     {
                         std::size_t __last_idx_in_block = std::min(__n - 1, __max_block_size * (__block_num + 1) - 1);
-                        __tmp_storage[__num_sub_groups_global] = __gen_reduce_input(__in_rng, __last_idx_in_block);
+                        __tmp_ptr[__num_sub_groups_global] = __gen_reduce_input(__in_rng, __last_idx_in_block);
                     }
                 }
 
@@ -675,7 +682,6 @@ struct __parallel_reduce_then_scan_scan_submitter<__sub_group_size, __max_inputs
                         __out_rng, __start_idx, __n, __inputs_per_item, __subgroup_start_idx, __sub_group_id,
                         __active_subgroups);
 
-                    __sub_group_carry.__destroy();
                 }
                 else // first group first block, no subgroup carry
                 {
@@ -685,6 +691,13 @@ struct __parallel_reduce_then_scan_scan_submitter<__sub_group_size, __max_inputs
                         __sub_group, __gen_scan_input, __scan_op, __final_op, __sub_group_carry, __in_rng, __out_rng,
                         __start_idx, __n, __inputs_per_item, __subgroup_start_idx, __sub_group_id, __active_subgroups);
                 }
+                //if last element in the sequence, then we need to write out the last carry out
+                if (__n == __group_start_idx + __id)
+                {
+                    __res_ptr[0] = __sub_group_carry.__v;
+                }
+
+                __sub_group_carry.__destroy();
             });
         });
     }
@@ -753,7 +766,8 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
     const auto __num_blocks = __n / __block_size + (__n % __block_size != 0);
 
     // TODO: Use the trick in reduce to wrap in a shared_ptr with custom deleter to support asynchronous frees.
-    _ValueType* __tmp_storage = sycl::malloc_device<_ValueType>(__num_sub_groups_global + 1, __exec.queue());
+
+    __result_and_scratch_storage<_ExecutionPolicy, typename _GenReduceInput::__out_value_type> __result_and_scratch{__exec, __num_sub_groups_global + 1};
 
     // Reduce and scan step implementations
     using _ReduceSubmitter =
@@ -778,10 +792,10 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
     for (std::size_t __b = 0; __b < __num_blocks; ++__b)
     {
         // 1. Reduce step - Reduce assigned input per sub-group, compute and apply intra-wg carries, and write to global memory.
-        __event = __reduce_submitter(__exec, __in_rng, __tmp_storage, __event, __inputs_per_sub_group,
+        __event = __reduce_submitter(__exec, __in_rng, __result_and_scratch, __event, __inputs_per_sub_group,
                                      __inputs_per_item, __b);
         // 2. Scan step - Compute intra-wg carries, determine sub-group carry-ins, and perform full input block scan.
-        __event = __scan_submitter(__exec, __in_rng, __out_rng, __tmp_storage, __event, __inputs_per_sub_group,
+        __event = __scan_submitter(__exec, __in_rng, __out_rng, __result_and_scratch, __event, __inputs_per_sub_group,
                                    __inputs_per_item, __b);
         if (__num_remaining > __block_size)
         {
@@ -799,8 +813,7 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
     }
     // TODO: Remove to make asynchronous. Depends on completing async USM free TODO.
     __event.wait();
-    sycl::free(__tmp_storage, __exec.queue());
-    return __future(__event);
+    return __future(__event, __result_and_scratch);
 }
 
 } // namespace __par_backend_hetero

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -735,7 +735,7 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
 
     // TODO: Use the trick in reduce to wrap in a shared_ptr with custom deleter to support asynchronous frees.
 
-    __result_and_scratch_storage<_ExecutionPolicy, typename _GenReduceInput::__out_value_type> __result_and_scratch{__exec, __num_sub_groups_global + 2};
+    __result_and_scratch_storage<_ExecutionPolicy, typename _GenReduceInput::__out_value_type> __result_and_scratch{__exec, __num_sub_groups_global + 1};
 
     // Reduce and scan step implementations
     using _ReduceSubmitter =

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -510,6 +510,7 @@ struct __usm_or_buffer_accessor
 template <typename _ExecutionPolicy, typename _T>
 struct __result_and_scratch_storage
 {
+    using __value_type = _T;
   private:
     using __sycl_buffer_t = sycl::buffer<_T, 1>;
 


### PR DESCRIPTION
Summary
---
This PR changes the two pass algorithm to be more generalized for use with other scan-like algorithms like copy_if.

This PR adds copy_if as an example.  partition and unique patterns should follow easily.  Set algorithms have not been evaluated, but should also be possible.


Structural changes
---
The "bridge" between blocks now uses a saved carry-out value from the previous block (where it used to depend on the output of the previous block).  The output of the previous block only applies to transform_scan patterns, and not scan_copy algorithms.  It also required different logic for inclusive and exclusive scans.  The change to use the carry unifies this logic between inclusive and exclusive scans. 

The following operations have been defined to encode a generalized scan-like pattern:
* `_GenReduceInput` : a function which accepts the input range and index to generate the data needed by the main output used in the reduction operation (to calculate the global carries)
* `_GenScanInput` :  a function which accepts the input range and index to generate the data needed by the final scan and write operations, for scan patterns
* `_ScanPred` : a unary function applied to the ouput of `_GenScanInput` to extract the component used in the scan, but not the part only required for the final write operation
* `_ReduceOp` : a binary function which is used in the reduction and scan operations
* `_FinalOp`: A function which accepts output range, index, and output of `_GenScanInput` applied to the input range.

For transform_scan, these are defined as follows:

* `_GenReduceInput` : apply the transfom to input at index and return
* `_GenScanInput` :  apply the transfom to input at index and return
* `_ScanPred` : no_op passthrough
* `_ReduceOp` : user supplied binary scan operation
* `_FinalOp`: Simple write value to output range at index

For copy_if these are defined as follows:
* `_GenReduceInput` : apply user supplied predicate to input at index and return `1` for true, `0` for false
* `_GenScanInput` :  a tuple with 3 elements:
                            1) apply user supplied predicate to input at index and return `1` for true, `0` for false (contribution to count)
                            2) apply user supplied predicate to input at index (condition for final copy)
                            3) original value (value for final copy)
* `_ScanPred` : `std::get<0>(input)`
* `_ReduceOp` : `std::plus`
* `_FinalOp`: if the second element of the tuple is true, write the third element to the output range using the index found in the first element of the tuple

Odds and ends
---
* Makes the two pass scan pattern asynchronous, depending on `__result_and_scratch_space` for async deallocation

* Changes the single workgroup copy_if to have a smaller threshold, and to use the `__result_and_scratch_space` struct to match return future type with the copy_if implementation.

* Limits range to only launch non-empty workgroups (removed early exit for empty workgroups)


TODO next:
---
Replace usages of  `__parallel_transform_scan_base` to route to `__parallel_transform_reduce_then_scan` instead.  Modify the calling code as necessary.  This should cover the rest of the scan-like patterns.  Prioritize partition, then unique, then finally, set algorithms as time allows.
