### PR TITLE
[PROTOTYPE] partition, unique families and ranges API

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -939,9 +939,9 @@ __pattern_partition_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __e
     auto __buf2 = __keep2(__zipped_res, __zipped_res + __n);
 
     auto __result = oneapi::dpl::__par_backend_hetero::__parallel_partition_copy(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(), __buf2.all_view(), __pred);
+        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(), __buf2.all_view(), __pred);
 
-    return ::std::make_pair(__result1 + __result.get(), __result2 + (__last - __first - __result.get()));
+    return std::make_pair(__result1 + __result.get(), __result2 + (__last - __first - __result.get()));
 }
 
 //------------------------------------------------------------------------
@@ -974,7 +974,7 @@ __pattern_unique_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec
     auto __buf2 = __keep2(__result_first, __result_first + __n);
 
     auto __result = oneapi::dpl::__par_backend_hetero::__parallel_unique_copy(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(), __buf2.all_view(), __pred);
+        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(), __buf2.all_view(), __pred);
 
     return __result_first + __result.get();
 }

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -885,44 +885,6 @@ __pattern_mismatch(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterat
 // copy_if
 //------------------------------------------------------------------------
 
-template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator1, typename _IteratorOrTuple,
-          typename _GenMask, typename _WriteOp, typename _IsUniquePattern>
-::std::pair<_IteratorOrTuple, typename ::std::iterator_traits<_Iterator1>::difference_type>
-__pattern_scan_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator1 __first, _Iterator1 __last,
-                    _IteratorOrTuple __output_first, _GenMask __gen_mask, _WriteOp __write_op, _IsUniquePattern __is_unique_pattern)
-{
-    using _It1DifferenceType = typename ::std::iterator_traits<_Iterator1>::difference_type;
-
-    if (__first == __last)
-        return ::std::make_pair(__output_first, _It1DifferenceType{0});
-
-    _It1DifferenceType __n = __last - __first;
-
-    if constexpr (_IsUniquePattern::value)
-    {
-        if (__n == 1)
-        {
-            oneapi::dpl::__internal::__pattern_walk2_brick(
-                __hetero_tag<_BackendTag>{}, std::forward<_ExecutionPolicy>(__exec), __first, __last, __output_first,
-                oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>{});
-            return std::make_pair(__output_first + 1, 1);
-        }
-    }
-
-    auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
-    auto __buf1 = __keep1(__first, __last);
-    auto __keep2 =
-        oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _IteratorOrTuple>();
-    auto __buf2 = __keep2(__output_first, __output_first + __n);
-
-    auto __res = __par_backend_hetero::__parallel_scan_copy(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-                                                            __buf1.all_view(), __buf2.all_view(), __n, __gen_mask,
-                                                            __write_op, __is_unique_pattern);
-
-    ::std::size_t __num_copied = __res.get();
-    return ::std::make_pair(__output_first + __n, __num_copied);
-}
-
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2,
           typename _Predicate>
 _Iterator2
@@ -963,15 +925,22 @@ __pattern_partition_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __e
 
     using _It1DifferenceType = typename ::std::iterator_traits<_Iterator1>::difference_type;
 
-    auto __result = __pattern_scan_copy(
-        __tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
-        __par_backend_hetero::zip(
-            __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::write>(__result1),
-            __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::write>(__result2)),
-        oneapi::dpl::__par_backend_hetero::__gen_mask<_UnaryPredicate>{__pred},
-        oneapi::dpl::__par_backend_hetero::__write_to_idx_if_else{}, /*_IsUniquePattern=*/std::false_type{});
+    _It1DifferenceType __n = __last - __first;
 
-    return ::std::make_pair(__result1 + __result.second, __result2 + (__last - __first - __result.second));
+    auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
+    auto __buf1 = __keep1(__first, __last);
+
+    auto __zipped_res = __par_backend_hetero::zip(
+        __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::write>(__result1),
+        __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::write>(__result2));
+
+    auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, decltype(__zipped_res)>();
+    auto __buf2 = __keep2(__zipped_res, __zipped_res + __n);
+
+    auto __result =
+        oneapi::dpl::__par_backend_hetero::__parallel_partition_copy(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(), __buf2.all_view(), __pred);
+
+    return ::std::make_pair(__result1 + __result.get(), __result2 + (__last - __first - __result.get()));
 }
 
 //------------------------------------------------------------------------
@@ -986,12 +955,27 @@ __pattern_unique_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec
 {
     using _It1DifferenceType = typename ::std::iterator_traits<_Iterator1>::difference_type;
 
-    auto __result =
-        __pattern_scan_copy(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result_first,
-                            oneapi::dpl::__par_backend_hetero::__gen_unique_mask<_BinaryPredicate>{__pred},
-                            oneapi::dpl::__par_backend_hetero::__write_to_idx_if<1>{}, /*_IsUniquePattern=*/std::true_type{});
+    _It1DifferenceType __n = __last - __first;
 
-    return __result_first + __result.second;
+    if (__n == 0)
+        return __result_first;
+    if (__n == 1)
+    {
+        oneapi::dpl::__internal::__pattern_walk2_brick(
+            __hetero_tag<_BackendTag>{}, std::forward<_ExecutionPolicy>(__exec), __first, __last, __result_first,
+            oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>{});
+        return __result_first + 1;
+    }
+
+    auto __keep1 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _Iterator1>();
+    auto __buf1 = __keep1(__first, __last);
+    auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _Iterator2>();
+    auto __buf2 = __keep2(__result_first, __result_first + __n);
+
+    auto __result =
+        oneapi::dpl::__par_backend_hetero::__parallel_unique_copy(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(), __buf2.all_view(), __pred);
+
+    return __result_first + __result.get();
 }
 
 template <typename _Name>

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -934,11 +934,12 @@ __pattern_partition_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __e
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::write>(__result1),
         __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::write>(__result2));
 
-    auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, decltype(__zipped_res)>();
+    auto __keep2 =
+        oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, decltype(__zipped_res)>();
     auto __buf2 = __keep2(__zipped_res, __zipped_res + __n);
 
-    auto __result =
-        oneapi::dpl::__par_backend_hetero::__parallel_partition_copy(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(), __buf2.all_view(), __pred);
+    auto __result = oneapi::dpl::__par_backend_hetero::__parallel_partition_copy(
+        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(), __buf2.all_view(), __pred);
 
     return ::std::make_pair(__result1 + __result.get(), __result2 + (__last - __first - __result.get()));
 }
@@ -972,8 +973,8 @@ __pattern_unique_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec
     auto __keep2 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _Iterator2>();
     auto __buf2 = __keep2(__result_first, __result_first + __n);
 
-    auto __result =
-        oneapi::dpl::__par_backend_hetero::__parallel_unique_copy(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(), __buf2.all_view(), __pred);
+    auto __result = oneapi::dpl::__par_backend_hetero::__parallel_unique_copy(
+        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(), __buf2.all_view(), __pred);
 
     return __result_first + __result.get();
 }

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -886,10 +886,10 @@ __pattern_mismatch(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterat
 //------------------------------------------------------------------------
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator1, typename _IteratorOrTuple,
-          typename _CreateMaskOp, typename _CopyByMaskOp>
+          typename _GenMask, typename _WriteOp>
 ::std::pair<_IteratorOrTuple, typename ::std::iterator_traits<_Iterator1>::difference_type>
 __pattern_scan_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator1 __first, _Iterator1 __last,
-                    _IteratorOrTuple __output_first, _CreateMaskOp __create_mask_op, _CopyByMaskOp __copy_by_mask_op)
+                    _IteratorOrTuple __output_first, _GenMask __gen_mask, _WriteOp __write_op)
 {
     using _It1DifferenceType = typename ::std::iterator_traits<_Iterator1>::difference_type;
 
@@ -904,9 +904,9 @@ __pattern_scan_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Itera
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _IteratorOrTuple>();
     auto __buf2 = __keep2(__output_first, __output_first + __n);
 
-    auto __res = __par_backend_hetero::__parallel_scan_copy(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
-                                                            __buf1.all_view(), __buf2.all_view(), __n, __create_mask_op,
-                                                            __copy_by_mask_op);
+    auto __res =
+        __par_backend_hetero::__parallel_scan_copy(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+                                                   __buf1.all_view(), __buf2.all_view(), __n, __gen_mask, __write_op);
 
     ::std::size_t __num_copied = __res.get();
     return ::std::make_pair(__output_first + __n, __num_copied);
@@ -951,17 +951,14 @@ __pattern_partition_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __e
         return ::std::make_pair(__result1, __result2);
 
     using _It1DifferenceType = typename ::std::iterator_traits<_Iterator1>::difference_type;
-    using _ReduceOp = ::std::plus<_It1DifferenceType>;
-
-    unseq_backend::__create_mask<_UnaryPredicate, _It1DifferenceType> __create_mask_op{__pred};
-    unseq_backend::__partition_by_mask<_ReduceOp, /*inclusive*/ ::std::true_type> __copy_by_mask_op{_ReduceOp{}};
 
     auto __result = __pattern_scan_copy(
         __tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
         __par_backend_hetero::zip(
             __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::write>(__result1),
             __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::write>(__result2)),
-        __create_mask_op, __copy_by_mask_op);
+        oneapi::dpl::__par_backend_hetero::__gen_mask<_UnaryPredicate>{__pred},
+        oneapi::dpl::__par_backend_hetero::__write_to_idx_if_else{});
 
     return ::std::make_pair(__result1 + __result.second, __result2 + (__last - __first - __result.second));
 }
@@ -977,14 +974,11 @@ __pattern_unique_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec
                       _Iterator2 __result_first, _BinaryPredicate __pred)
 {
     using _It1DifferenceType = typename ::std::iterator_traits<_Iterator1>::difference_type;
-    unseq_backend::__copy_by_mask<::std::plus<_It1DifferenceType>, oneapi::dpl::__internal::__pstl_assign,
-                                  /*inclusive*/ ::std::true_type, 1>
-        __copy_by_mask_op;
-    __create_mask_unique_copy<__not_pred<_BinaryPredicate>, _It1DifferenceType> __create_mask_op{
-        __not_pred<_BinaryPredicate>{__pred}};
 
-    auto __result = __pattern_scan_copy(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
-                                        __result_first, __create_mask_op, __copy_by_mask_op);
+    auto __result =
+        __pattern_scan_copy(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result_first,
+                            oneapi::dpl::__par_backend_hetero::__gen_unique_mask<_BinaryPredicate>{__pred},
+                            oneapi::dpl::__par_backend_hetero::__write_to_idx_if{});
 
     return __result_first + __result.second;
 }

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -335,10 +335,10 @@ __pattern_count(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&& _
 //------------------------------------------------------------------------
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _GenMask,
-          typename _WriteOp>
+          typename _WriteOp, typename _IsUniquePattern>
 oneapi::dpl::__internal::__difference_t<_Range1>
 __pattern_scan_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2,
-                    _GenMask __gen_mask, _WriteOp __write_op)
+                    _GenMask __gen_mask, _WriteOp __write_op, _IsUniquePattern __is_unique_pattern)
 {
     auto __n = __rng1.size();
     if (__n == 0)
@@ -346,7 +346,7 @@ __pattern_scan_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range
 
     auto __res = __par_backend_hetero::__parallel_scan_copy(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
                                                             std::forward<_Range1>(__rng1),
-                                                            std::forward<_Range2>(__rng2), __n, __gen_mask, __write_op);
+                                                            std::forward<_Range2>(__rng2), __n, __gen_mask, __write_op, __is_unique_pattern);
     return __res.get();
 }
 
@@ -408,7 +408,7 @@ __pattern_unique_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec
     return __pattern_scan_copy(__tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng),
                                std::forward<_Range2>(__result),
                                oneapi::dpl::__par_backend_hetero::__gen_unique_mask<_BinaryPredicate>{__pred},
-                               oneapi::dpl::__par_backend_hetero::__write_to_idx_if{std::forward<_Assign>(__assign)});
+                               oneapi::dpl::__par_backend_hetero::__write_to_idx_if<1>{std::forward<_Assign>(__assign)}, /*_IsUniquePattern=*/std::true_type{});
 }
 
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -398,13 +398,16 @@ __pattern_unique_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec
         oneapi::dpl::__par_backend_hetero::__parallel_for(
             _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
             unseq_backend::walk_n<_ExecutionPolicy, CopyBrick>{CopyBrick{}}, __n, std::forward<_Range1>(__rng),
-                                  std::forward<_Range2>(__result)).get();
+            std::forward<_Range2>(__result))
+            .get();
 
         return 1;
     }
 
-    return oneapi::dpl::__par_backend_hetero::__parallel_unique_copy(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng),
-                                  std::forward<_Range2>(__result), __pred, std::forward<_Assign>(__assign)).get();
+    return oneapi::dpl::__par_backend_hetero::__parallel_unique_copy(
+               _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng),
+               std::forward<_Range2>(__result), __pred, std::forward<_Assign>(__assign))
+        .get();
 }
 
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -396,7 +396,7 @@ __pattern_unique_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec
     {
         using CopyBrick = oneapi::dpl::__internal::__brick_copy<__hetero_tag<_BackendTag>, _ExecutionPolicy>;
         oneapi::dpl::__par_backend_hetero::__parallel_for(
-            _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
+            _BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
             unseq_backend::walk_n<_ExecutionPolicy, CopyBrick>{CopyBrick{}}, __n, std::forward<_Range1>(__rng),
             std::forward<_Range2>(__result))
             .get();

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -924,7 +924,7 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag __backen
                     ::std::forward<_Range2>(__out_rng), __n, __unary_op, __init, __binary_op, _Inclusive{});
             }
         }
-        if (oneapi::dpl::__par_backend_hetero::__is_best_alg_reduce_then_scan(__exec))
+        if (oneapi::dpl::__par_backend_hetero::__prefer_reduce_then_scan(__exec))
         {
             using _GenInput = oneapi::dpl::__par_backend_hetero::__gen_transform_input<_UnaryOperation>;
             using _ScanInputTransform = oneapi::dpl::__internal::__no_op;
@@ -1074,7 +1074,7 @@ __parallel_unique_copy(oneapi::dpl::__internal::__device_backend_tag __backend_t
 {
 
     auto __n = __rng.size();
-    if (oneapi::dpl::__par_backend_hetero::__is_best_alg_reduce_then_scan(__exec))
+    if (oneapi::dpl::__par_backend_hetero::__prefer_reduce_then_scan(__exec))
     {
         using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_unique_mask<_BinaryPredicate>;
         using _WriteOp = oneapi::dpl::__par_backend_hetero::__write_to_idx_if<1, _Assign>;
@@ -1104,7 +1104,7 @@ __parallel_partition_copy(oneapi::dpl::__internal::__device_backend_tag __backen
                           _Range1&& __rng, _Range2&& __result, _UnaryPredicate __pred)
 {
     auto __n = __rng.size();
-    if (oneapi::dpl::__par_backend_hetero::__is_best_alg_reduce_then_scan(__exec))
+    if (oneapi::dpl::__par_backend_hetero::__prefer_reduce_then_scan(__exec))
     {
         using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_mask<_UnaryPredicate>;
         using _WriteOp =
@@ -1157,7 +1157,7 @@ __parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag __backend_tag, 
             _SingleGroupInvoker{}, __n, std::forward<_ExecutionPolicy>(__exec), __n, std::forward<_InRng>(__in_rng),
             std::forward<_OutRng>(__out_rng), __pred, std::forward<_Assign>(__assign));
     }
-    else if (oneapi::dpl::__par_backend_hetero::__is_best_alg_reduce_then_scan(__exec))
+    else if (oneapi::dpl::__par_backend_hetero::__prefer_reduce_then_scan(__exec))
     {
         using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_mask<_Pred>;
         using _WriteOp = oneapi::dpl::__par_backend_hetero::__write_to_idx_if<0, _Assign>;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -829,10 +829,8 @@ struct __gen_unique_mask
     bool
     operator()(_InRng&& __in_rng, std::size_t __idx) const
     {
-        if (__idx == 0)
-            return true;
-        else
-            return !__pred(__in_rng[__idx], __in_rng[__idx - 1]);
+        //starting index is offset to 1 for "unique" patterns and 0th element copy is handled separately
+        return !__pred(__in_rng[__idx], __in_rng[__idx - 1]);
     }
     _BinaryPredicate __pred;
 };
@@ -877,7 +875,7 @@ struct __get_zeroth_element
         return std::get<0>(std::forward<_Tp>(__a));
     }
 };
-template <typename Assign = oneapi::dpl::__internal::__pstl_assign>
+template <int32_t __offset = 0, typename Assign = oneapi::dpl::__internal::__pstl_assign>
 struct __write_to_idx_if
 {
     template <typename _OutRng, typename _SizeType, typename ValueType>
@@ -890,7 +888,7 @@ struct __write_to_idx_if
             typename oneapi::dpl::__internal::__get_tuple_type<std::decay_t<decltype(std::get<2>(__v))>,
                                                                std::decay_t<decltype(__out_rng[__idx])>>::__type;
         if (std::get<1>(__v))
-            __assign(static_cast<_ConvertedTupleType>(std::get<2>(__v)), __out_rng[std::get<0>(__v) - 1]);
+            __assign(static_cast<_ConvertedTupleType>(std::get<2>(__v)), __out_rng[std::get<0>(__v) - 1 + __offset]);
     }
     Assign __assign;
 };
@@ -951,7 +949,7 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag __backen
             return __parallel_transform_reduce_then_scan(
                 __backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__in_rng),
                 std::forward<_Range2>(__out_rng), __gen_transform, __binary_op, __gen_transform,
-                oneapi::dpl::__internal::__no_op{}, __simple_write_to_idx{}, __init, _Inclusive{});
+                oneapi::dpl::__internal::__no_op{}, __simple_write_to_idx{}, __init, _Inclusive{} /*_IsUniquePattern=*/std::false_type{});
         }
     }
     {
@@ -1028,10 +1026,11 @@ struct __invoke_single_group_copy_if
 };
 
 template <typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _Size, typename _GenMask,
-          typename _WriteOp>
+          typename _WriteOp, typename _IsUniquePattern>
 auto
 __parallel_scan_copy(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
-                     _InRng&& __in_rng, _OutRng&& __out_rng, _Size __n, _GenMask __generate_mask, _WriteOp __write_op)
+                     _InRng&& __in_rng, _OutRng&& __out_rng, _Size __n, _GenMask __generate_mask, _WriteOp __write_op,
+                     _IsUniquePattern __is_unique_pattern)
 {
     using _ReduceOp = ::std::plus<_Size>;
 
@@ -1042,7 +1041,7 @@ __parallel_scan_copy(oneapi::dpl::__internal::__device_backend_tag __backend_tag
         oneapi::dpl::__par_backend_hetero::__gen_expand_count_mask<_GenMask>{__generate_mask},
         oneapi::dpl::__par_backend_hetero::__get_zeroth_element{}, __write_op,
         oneapi::dpl::unseq_backend::__no_init_value<_Size>{},
-        /*_Inclusive=*/std::true_type{});
+        /*_Inclusive=*/std::true_type{}, __is_unique_pattern);
 }
 
 template <typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _Size, typename _Pred,
@@ -1090,9 +1089,9 @@ __parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag __backend_tag, 
             oneapi::dpl::__par_backend_hetero::__gen_count_mask<_GenMask>{__generate_mask}, _ReduceOp{},
             oneapi::dpl::__par_backend_hetero::__gen_expand_count_mask<_GenMask>{__generate_mask},
             oneapi::dpl::__par_backend_hetero::__get_zeroth_element{},
-            oneapi::dpl::__par_backend_hetero::__write_to_idx_if<_Assign>{std::forward<_Assign>(__assign)},
+            oneapi::dpl::__par_backend_hetero::__write_to_idx_if<0, _Assign>{std::forward<_Assign>(__assign)},
             oneapi::dpl::unseq_backend::__no_init_value<_Size>{},
-            /*_Inclusive=*/std::true_type{});
+            /*_Inclusive=*/std::true_type{}, /*Unique=*/std::false_type{});
     }
     else
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1068,7 +1068,6 @@ __parallel_unique_copy(oneapi::dpl::__internal::__device_backend_tag __backend_t
 {
 
     auto __n = __rng.size();
-    // choice between legacy and reduce_then_scan
     if (oneapi::dpl::__par_backend_hetero::__is_best_alg_reduce_then_scan(__exec))
     {
         return __parallel_reduce_then_scan_copy(
@@ -1099,7 +1098,6 @@ __parallel_partition_copy(oneapi::dpl::__internal::__device_backend_tag __backen
                           _Range1&& __rng, _Range2&& __result, _UnaryPredicate __pred)
 {
     auto __n = __rng.size();
-    // choice between legacy and reduce_then_scan
     if (oneapi::dpl::__par_backend_hetero::__is_best_alg_reduce_then_scan(__exec))
     {
         return __parallel_reduce_then_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec),

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -726,7 +726,7 @@ __parallel_transform_scan_single_group(oneapi::dpl::__internal::__device_backend
 
         auto __event =
             __parallel_transform_scan_dynamic_single_group_submitter<_Inclusive::value, _DynamicGroupScanKernel>()(
-                ::std::forward<_ExecutionPolicy>(__exec), std::forward<_InRng>(__in_rng),
+                std::forward<_ExecutionPolicy>(__exec), std::forward<_InRng>(__in_rng),
                 std::forward<_OutRng>(__out_rng), __n, __init, __binary_op, __unary_op, __max_wg_size);
         return __future(__event, __dummy_result_and_scratch);
     }
@@ -858,7 +858,7 @@ struct __get_zeroth_element
         return std::get<0>(std::forward<_Tp>(__a));
     }
 };
-template <int32_t __offset = 0, typename Assign = oneapi::dpl::__internal::__pstl_assign>
+template <std::int32_t __offset = 0, typename Assign = oneapi::dpl::__internal::__pstl_assign>
 struct __write_to_idx_if
 {
     template <typename _OutRng, typename _SizeType, typename ValueType>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -966,10 +966,10 @@ struct __invoke_single_group_copy_if
     // Specialization for devices that have a max work-group size of at least 1024
     static constexpr ::std::uint16_t __targeted_wg_size = 1024;
 
-    template <::std::uint16_t _Size, typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _Pred,
+    template <std::uint16_t _Size, typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _Pred,
               typename _Assign = oneapi::dpl::__internal::__pstl_assign>
     auto
-    operator()(_ExecutionPolicy&& __exec, ::std::size_t __n, _InRng&& __in_rng, _OutRng&& __out_rng, _Pred&& __pred,
+    operator()(_ExecutionPolicy&& __exec, std::size_t __n, _InRng&& __in_rng, _OutRng&& __out_rng, _Pred&& __pred,
                _Assign&& __assign)
     {
         constexpr ::std::uint16_t __wg_size = ::std::min(_Size, __targeted_wg_size);
@@ -983,8 +983,8 @@ struct __invoke_single_group_copy_if
             return __par_backend_hetero::__parallel_copy_if_static_single_group_submitter<
                 _SizeType, __num_elems_per_item, __wg_size, true,
                 oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
-                    __scan_copy_single_wg_kernel<::std::integral_constant<::std::uint16_t, __wg_size>,
-                                                 ::std::integral_constant<::std::uint16_t, __num_elems_per_item>,
+                    __scan_copy_single_wg_kernel<std::integral_constant<std::uint16_t, __wg_size>,
+                                                 std::integral_constant<std::uint16_t, __num_elems_per_item>,
                                                  /* _IsFullGroup= */ std::true_type, _CustomName>>>()(
                 __exec, std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), __n, _InitType{}, _ReduceOp{},
                 std::forward<_Pred>(__pred), std::forward<_Assign>(__assign));
@@ -992,8 +992,8 @@ struct __invoke_single_group_copy_if
             return __par_backend_hetero::__parallel_copy_if_static_single_group_submitter<
                 _SizeType, __num_elems_per_item, __wg_size, false,
                 oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
-                    __scan_copy_single_wg_kernel<::std::integral_constant<::std::uint16_t, __wg_size>,
-                                                 ::std::integral_constant<::std::uint16_t, __num_elems_per_item>,
+                    __scan_copy_single_wg_kernel<std::integral_constant<std::uint16_t, __wg_size>,
+                                                 std::integral_constant<std::uint16_t, __num_elems_per_item>,
                                                  /* _IsFullGroup= */ std::false_type, _CustomName>>>()(
                 __exec, std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), __n, _InitType{}, _ReduceOp{},
                 std::forward<_Pred>(__pred), std::forward<_Assign>(__assign));
@@ -1080,14 +1080,14 @@ __parallel_unique_copy(oneapi::dpl::__internal::__device_backend_tag __backend_t
     }
     else
     {
-        unseq_backend::__copy_by_mask<::std::plus<decltype(__n)>, oneapi::dpl::__internal::__pstl_assign,
-                                      /*inclusive*/ ::std::true_type, 1>
+        unseq_backend::__copy_by_mask<std::plus<decltype(__n)>, oneapi::dpl::__internal::__pstl_assign,
+                                      /*inclusive*/ std::true_type, 1>
             __copy_by_mask_op;
         oneapi::dpl::__internal::__create_mask_unique_copy<oneapi::dpl::__internal::__not_pred<_BinaryPredicate>,
                                                            decltype(__n)>
             __create_mask_op{oneapi::dpl::__internal::__not_pred<_BinaryPredicate>{__pred}};
 
-        return __parallel_scan_copy(__backend_tag, ::std::forward<_ExecutionPolicy>(__exec),
+        return __parallel_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
                                     std::forward<_Range1>(__rng), std::forward<_Range2>(__result), __n,
                                     __create_mask_op, __copy_by_mask_op);
     }
@@ -1110,12 +1110,12 @@ __parallel_partition_copy(oneapi::dpl::__internal::__device_backend_tag __backen
     }
     else
     {
-        using _ReduceOp = ::std::plus<decltype(__n)>;
+        using _ReduceOp = std::plus<decltype(__n)>;
 
         unseq_backend::__create_mask<_UnaryPredicate, decltype(__n)> __create_mask_op{__pred};
-        unseq_backend::__partition_by_mask<_ReduceOp, /*inclusive*/ ::std::true_type> __partition_by_mask{_ReduceOp{}};
+        unseq_backend::__partition_by_mask<_ReduceOp, /*inclusive*/ std::true_type> __partition_by_mask{_ReduceOp{}};
 
-        return __parallel_scan_copy(__backend_tag, ::std::forward<_ExecutionPolicy>(__exec),
+        return __parallel_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
                                     std::forward<_Range1>(__rng), std::forward<_Range2>(__result), __n,
                                     __create_mask_op, __partition_by_mask);
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -148,8 +148,8 @@ struct iter_mode
     // for zip_iterator
     template <typename... Iters>
     auto
-    operator()(const oneapi::dpl::zip_iterator<Iters...>& it) -> decltype(oneapi::dpl::__internal::map_zip(*this,
-                                                                                                           it.base()))
+    operator()(const oneapi::dpl::zip_iterator<Iters...>& it)
+        -> decltype(oneapi::dpl::__internal::map_zip(*this, it.base()))
     {
         return oneapi::dpl::__internal::map_zip(*this, it.base());
     }
@@ -1743,8 +1743,8 @@ struct __is_radix_sort_usable_for_type
     static constexpr bool value =
 #if _USE_RADIX_SORT
         (::std::is_arithmetic_v<_T> || ::std::is_same_v<sycl::half, _T>) &&
-        (__internal::__is_comp_ascending<::std::decay_t<_Compare>>::value ||
-         __internal::__is_comp_descending<::std::decay_t<_Compare>>::value);
+            (__internal::__is_comp_ascending<::std::decay_t<_Compare>>::value ||
+            __internal::__is_comp_descending<::std::decay_t<_Compare>>::value);
 #else
         false;
 #endif

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -732,7 +732,7 @@ struct __parallel_reduce_then_scan_scan_submitter<
 // operations.  We do not want to run this can on CPU targets, as they are not performant with this algorithm.
 template <typename _ExecutionPolicy>
 bool
-__is_best_alg_reduce_then_scan(_ExecutionPolicy&& __exec)
+__is_best_alg_reduce_then_scan(const _ExecutionPolicy& __exec)
 {
     const bool __dev_has_sg32 = __par_backend_hetero::__supports_sub_group_size(__exec, 32);
     return (!__exec.queue().get_device().is_cpu() && __dev_has_sg32);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -732,7 +732,7 @@ struct __parallel_reduce_then_scan_scan_submitter<
 // operations.  We do not want to run this can on CPU targets, as they are not performant with this algorithm.
 template <typename _ExecutionPolicy>
 bool
-__is_best_alg_reduce_then_scan(const _ExecutionPolicy& __exec)
+__prefer_reduce_then_scan(const _ExecutionPolicy& __exec)
 {
     const bool __dev_has_sg32 = __par_backend_hetero::__supports_sub_group_size(__exec, 32);
     return (!__exec.queue().get_device().is_cpu() && __dev_has_sg32);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -824,15 +824,11 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
         auto __local_range = sycl::range<1>(__work_group_size);
         auto __kernel_nd_range = sycl::nd_range<1>(__global_range, __local_range);
         // 1. Reduce step - Reduce assigned input per sub-group, compute and apply intra-wg carries, and write to global memory.
-        std::cout <<"reduce\n";
         __event = __reduce_submitter(__exec, __kernel_nd_range, __in_rng, __result_and_scratch, __event,
                                      __inputs_per_sub_group, __inputs_per_item, __b);
-        __event.wait();
-        std::cout <<"scan\n";
         // 2. Scan step - Compute intra-wg carries, determine sub-group carry-ins, and perform full input block scan.
         __event = __scan_submitter(__exec, __kernel_nd_range, __in_rng, __out_rng, __result_and_scratch, __event,
                                    __inputs_per_sub_group, __inputs_per_item, __b);
-        __event.wait();
 
         if (__num_remaining > __block_size)
         {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -266,13 +266,15 @@ template <typename... _Name>
 class __reduce_then_scan_scan_kernel;
 
 template <std::size_t __sub_group_size, std::size_t __max_inputs_per_item, bool __is_inclusive,
-          typename _GenReduceInput, typename _ReduceOp, typename _InitType, typename _KernelName>
+          bool __is_unique_pattern_v, typename _GenReduceInput, typename _ReduceOp, typename _InitType,
+          typename _KernelName>
 struct __parallel_reduce_then_scan_reduce_submitter;
 
 template <std::size_t __sub_group_size, std::size_t __max_inputs_per_item, bool __is_inclusive,
-          typename _GenReduceInput, typename _ReduceOp, typename _InitType, typename... _KernelName>
+          bool __is_unique_pattern_v, typename _GenReduceInput, typename _ReduceOp, typename _InitType,
+          typename... _KernelName>
 struct __parallel_reduce_then_scan_reduce_submitter<__sub_group_size, __max_inputs_per_item, __is_inclusive,
-                                                    _GenReduceInput, _ReduceOp, _InitType,
+                                                    __is_unique_pattern_v, _GenReduceInput, _ReduceOp, _InitType,
                                                     __internal::__optional_kernel_name<_KernelName...>>
 {
     // Step 1 - SubGroupReduce is expected to perform sub-group reductions to global memory
@@ -302,7 +304,11 @@ struct __parallel_reduce_then_scan_reduce_submitter<__sub_group_size, __max_inpu
                 oneapi::dpl::__internal::__lazy_ctor_storage<_InitValueType> __sub_group_carry;
                 std::size_t __group_start_idx =
                     (__block_num * __max_block_size) + (__g * __inputs_per_sub_group * __num_sub_groups_local);
-
+                if constexpr (__is_unique_pattern_v)
+                {
+                    // for unique patterns, the first element is always copied to the output, so we need to skip it
+                    __group_start_idx += 1;
+                }
                 std::size_t __elements_in_group =
                     std::min(__n - __group_start_idx, std::size_t(__num_sub_groups_local * __inputs_per_sub_group));
                 std::uint32_t __active_subgroups =
@@ -400,16 +406,16 @@ struct __parallel_reduce_then_scan_reduce_submitter<__sub_group_size, __max_inpu
 };
 
 template <std::size_t __sub_group_size, std::size_t __max_inputs_per_item, bool __is_inclusive,
-          typename _GenReduceInput, typename _ReduceOp, typename _GenScanInput, typename _ScanInputTransform,
-          typename _WriteOp, typename _InitType, typename _KernelName>
+          bool __is_unique_pattern_v, typename _GenReduceInput, typename _ReduceOp, typename _GenScanInput,
+          typename _ScanInputTransform, typename _WriteOp, typename _InitType, typename _KernelName>
 struct __parallel_reduce_then_scan_scan_submitter;
 
 template <std::size_t __sub_group_size, std::size_t __max_inputs_per_item, bool __is_inclusive,
-          typename _GenReduceInput, typename _ReduceOp, typename _GenScanInput, typename _ScanInputTransform,
-          typename _WriteOp, typename _InitType, typename... _KernelName>
+          bool __is_unique_pattern_v, typename _GenReduceInput, typename _ReduceOp, typename _GenScanInput,
+          typename _ScanInputTransform, typename _WriteOp, typename _InitType, typename... _KernelName>
 struct __parallel_reduce_then_scan_scan_submitter<
-    __sub_group_size, __max_inputs_per_item, __is_inclusive, _GenReduceInput, _ReduceOp, _GenScanInput,
-    _ScanInputTransform, _WriteOp, _InitType, __internal::__optional_kernel_name<_KernelName...>>
+    __sub_group_size, __max_inputs_per_item, __is_inclusive, __is_unique_pattern_v, _GenReduceInput, _ReduceOp,
+    _GenScanInput, _ScanInputTransform, _WriteOp, _InitType, __internal::__optional_kernel_name<_KernelName...>>
 {
 
     template <typename _TmpPtr>
@@ -456,6 +462,11 @@ struct __parallel_reduce_then_scan_scan_submitter<
 
                 auto __group_start_idx =
                     (__block_num * __max_block_size) + (__g * __inputs_per_sub_group * __num_sub_groups_local);
+                if constexpr (__is_unique_pattern_v)
+                {
+                    // for unique patterns, the first element is always copied to the output, so we need to skip it
+                    __group_start_idx += 1;
+                }
 
                 std::size_t __elements_in_group =
                     std::min(__n - __group_start_idx, std::size_t(__num_sub_groups_local * __inputs_per_sub_group));
@@ -609,8 +620,17 @@ struct __parallel_reduce_then_scan_scan_submitter<
                         oneapi::dpl::unseq_backend::__init_processing<_InitValueType>{}(__init, __value, __reduce_op);
                         __sub_group_carry.__setup(__value);
                     }
-                    else
+                    else // zeroth block, group and subgroup
                     {
+                        if constexpr (__is_unique_pattern_v)
+                        {
+                            if (__sub_group_local_id == 0)
+                            {
+                                // For unique patterns, always copy the 0th element to the output
+                                __write_op.__assign(__in_rng[0], __out_rng[0]);
+                            }
+                        }
+
                         if constexpr (std::is_same_v<_InitType,
                                                      oneapi::dpl::unseq_backend::__no_init_value<_InitValueType>>)
                         {
@@ -673,7 +693,14 @@ struct __parallel_reduce_then_scan_scan_submitter<
                 {
                     if (__block_num + 1 == __num_blocks)
                     {
-                        __res_ptr[0] = __sub_group_carry.__v;
+                        if constexpr (__is_unique_pattern_v)
+                        {
+                            __res_ptr[0] = __sub_group_carry.__v + 1;
+                        }
+                        else
+                        {
+                            __res_ptr[0] = __sub_group_carry.__v;
+                        }
                     }
                     else
                     {
@@ -681,7 +708,6 @@ struct __parallel_reduce_then_scan_scan_submitter<
                         __set_block_carry_out(__block_num, __tmp_ptr, __sub_group_carry.__v);
                     }
                 }
-
                 __sub_group_carry.__destroy();
             });
         });
@@ -714,13 +740,13 @@ struct __parallel_reduce_then_scan_scan_submitter<
 //            and performs the final write to output operation
 template <typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _GenReduceInput, typename _ReduceOp,
           typename _GenScanInput, typename _ScanInputTransform, typename _WriteOp, typename _InitType,
-          typename _Inclusive>
+          typename _Inclusive, typename _IsUniquePattern>
 auto
 __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec,
                                       _InRng&& __in_rng, _OutRng&& __out_rng, _GenReduceInput __gen_reduce_input,
                                       _ReduceOp __reduce_op, _GenScanInput __gen_scan_input,
-                                      _ScanInputTransform __scan_input_transform, _WriteOp __write_op,
-                                      _InitType __init /*TODO mask assigners for generalization go here*/, _Inclusive)
+                                      _ScanInputTransform __scan_input_transform, _WriteOp __write_op, _InitType __init,
+                                      _Inclusive, _IsUniquePattern)
 {
     using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
     using _ReduceKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
@@ -733,6 +759,7 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
     // Empirically determined maximum. May be less for non-full blocks.
     constexpr std::uint8_t __max_inputs_per_item = 128;
     constexpr bool __inclusive = _Inclusive::value;
+    constexpr bool __is_unique_pattern_v = _IsUniquePattern::value;
 
     // TODO: Do we need to adjust for slm usage or is the amount we use reasonably small enough
     // that no check is needed?
@@ -747,14 +774,19 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
     const std::size_t __n = __in_rng.size();
     const std::size_t __max_inputs_per_block = __work_group_size * __max_inputs_per_item * __num_work_groups;
     std::size_t __num_remaining = __n;
+    if constexpr (__is_unique_pattern_v)
+    {
+        // skip scan of zeroth element in unique patterns
+        __num_remaining -= 1;
+    }
     auto __inputs_per_sub_group =
-        __n >= __max_inputs_per_block
+        __num_remaining >= __max_inputs_per_block
             ? __max_inputs_per_block / __num_sub_groups_global
             : std::max(__sub_group_size,
                        oneapi::dpl::__internal::__dpl_bit_ceil(__num_remaining) / __num_sub_groups_global);
     auto __inputs_per_item = __inputs_per_sub_group / __sub_group_size;
-    const auto __block_size = (__n < __max_inputs_per_block) ? __n : __max_inputs_per_block;
-    const auto __num_blocks = __n / __block_size + (__n % __block_size != 0);
+    const auto __block_size = (__num_remaining < __max_inputs_per_block) ? __num_remaining : __max_inputs_per_block;
+    const auto __num_blocks = __num_remaining / __block_size + (__num_remaining % __block_size != 0);
 
     //We need temporary storage for reductions of each sub-group (__num_sub_groups_global), and also 2 for the
     // block carry-out.  We need two for the block carry-out to prevent a race condition between reading and writing
@@ -764,10 +796,10 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
 
     // Reduce and scan step implementations
     using _ReduceSubmitter =
-        __parallel_reduce_then_scan_reduce_submitter<__sub_group_size, __max_inputs_per_item, __inclusive,
+        __parallel_reduce_then_scan_reduce_submitter<__sub_group_size, __max_inputs_per_item, __inclusive, __is_unique_pattern_v,
                                                      _GenReduceInput, _ReduceOp, _InitType, _ReduceKernel>;
     using _ScanSubmitter =
-        __parallel_reduce_then_scan_scan_submitter<__sub_group_size, __max_inputs_per_item, __inclusive,
+        __parallel_reduce_then_scan_scan_submitter<__sub_group_size, __max_inputs_per_item, __inclusive, __is_unique_pattern_v,
                                                    _GenReduceInput, _ReduceOp, _GenScanInput, _ScanInputTransform,
                                                    _WriteOp, _InitType, _ScanKernel>;
     // TODO: remove below before merging. used for convenience now

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -824,11 +824,16 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
         auto __local_range = sycl::range<1>(__work_group_size);
         auto __kernel_nd_range = sycl::nd_range<1>(__global_range, __local_range);
         // 1. Reduce step - Reduce assigned input per sub-group, compute and apply intra-wg carries, and write to global memory.
+        std::cout <<"reduce\n";
         __event = __reduce_submitter(__exec, __kernel_nd_range, __in_rng, __result_and_scratch, __event,
                                      __inputs_per_sub_group, __inputs_per_item, __b);
+        __event.wait();
+        std::cout <<"scan\n";
         // 2. Scan step - Compute intra-wg carries, determine sub-group carry-ins, and perform full input block scan.
         __event = __scan_submitter(__exec, __kernel_nd_range, __in_rng, __out_rng, __result_and_scratch, __event,
                                    __inputs_per_sub_group, __inputs_per_item, __b);
+        __event.wait();
+
         if (__num_remaining > __block_size)
         {
             // Resize for the next block.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -728,6 +728,16 @@ struct __parallel_reduce_then_scan_scan_submitter<
     _InitType __init;
 };
 
+// reduce_then_scan requires subgroup size of 32, and performs well only on devices with fast coordinated subgroup
+// operations.  We do not want to run this can on CPU targets, as they are not performant with this algorithm.
+template <typename _ExecutionPolicy>
+bool
+__is_best_alg_reduce_then_scan(_ExecutionPolicy&& __exec)
+{
+    const bool __dev_has_sg32 = __par_backend_hetero::__supports_sub_group_size(__exec, 32);
+    return (!__exec.queue().get_device().is_cpu() && __dev_has_sg32);
+}
+
 // General scan-like algorithm helpers
 // _GenReduceInput - a function which accepts the input range and index to generate the data needed by the main output
 //                   used in the reduction operation (to calculate the global carries)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -789,6 +789,9 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
         // skip scan of zeroth element in unique patterns
         __num_remaining -= 1;
     }
+    // reduce_then_scan kernel is not built to handle "empty" scans which includes `__n == 1` for unique patterns.
+    // These trivial end cases should be handled at a higher level.
+    assert(__num_remaining > 0);
     auto __inputs_per_sub_group =
         __num_remaining >= __max_inputs_per_block
             ? __max_inputs_per_block / __num_sub_groups_global

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -248,7 +248,7 @@ struct __gen_count_mask;
 template <typename _GenMask>
 struct __gen_expand_count_mask;
 
-template <typename Assign>
+template <int32_t __offset, typename Assign>
 struct __write_to_idx_if;
 
 template <typename Assign>
@@ -289,8 +289,8 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backen
 {
 };
 
-template <typename Assign>
-struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__write_to_idx_if, Assign)>
+template <int32_t __offset, typename Assign>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__write_to_idx_if, __offset, Assign)>
     : oneapi::dpl::__internal::__are_all_device_copyable<Assign>
 {
 };

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -273,7 +273,8 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backen
 };
 
 template <typename _BinaryPredicate>
-struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__gen_unique_mask, _BinaryPredicate)>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__gen_unique_mask,
+                                                       _BinaryPredicate)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_BinaryPredicate>
 {
 };
@@ -284,19 +285,22 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backen
 };
 
 template <typename _GenMask>
-struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__gen_expand_count_mask, _GenMask)>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__gen_expand_count_mask,
+                                                       _GenMask)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_GenMask>
 {
 };
 
 template <int32_t __offset, typename Assign>
-struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__write_to_idx_if, __offset, Assign)>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__write_to_idx_if, __offset,
+                                                       Assign)>
     : oneapi::dpl::__internal::__are_all_device_copyable<Assign>
 {
 };
 
 template <typename Assign>
-struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__write_to_idx_if_else, Assign)>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__write_to_idx_if_else,
+                                                       Assign)>
     : oneapi::dpl::__internal::__are_all_device_copyable<Assign>
 {
 };

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -237,10 +237,22 @@ template <typename _UnaryOp>
 struct __gen_transform_input;
 
 template <typename _Predicate>
-struct __gen_count_pred;
+struct __gen_mask;
 
-template <typename _Predicate>
-struct __gen_expand_count_pred;
+template <typename _BinaryPredicate>
+struct __gen_unique_mask;
+
+template <typename _GenMask>
+struct __gen_count_mask;
+
+template <typename _GenMask>
+struct __gen_expand_count_mask;
+
+template <typename Assign>
+struct __write_to_idx_if;
+
+template <typename Assign>
+struct __write_to_idx_if_else;
 
 template <typename _ExecutionPolicy, typename _Pred>
 struct __early_exit_find_or;
@@ -255,15 +267,37 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backen
 };
 
 template <typename _Predicate>
-struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__gen_count_pred, _Predicate)>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__gen_mask, _Predicate)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_Predicate>
 {
 };
 
-template <typename _Predicate>
-struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__gen_expand_count_pred,
-                                                       _Predicate)>
-    : oneapi::dpl::__internal::__are_all_device_copyable<_Predicate>
+template <typename _BinaryPredicate>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__gen_unique_mask, _BinaryPredicate)>
+    : oneapi::dpl::__internal::__are_all_device_copyable<_BinaryPredicate>
+{
+};
+template <typename _GenMask>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__gen_count_mask, _GenMask)>
+    : oneapi::dpl::__internal::__are_all_device_copyable<_GenMask>
+{
+};
+
+template <typename _GenMask>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__gen_expand_count_mask, _GenMask)>
+    : oneapi::dpl::__internal::__are_all_device_copyable<_GenMask>
+{
+};
+
+template <typename Assign>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__write_to_idx_if, Assign)>
+    : oneapi::dpl::__internal::__are_all_device_copyable<Assign>
+{
+};
+
+template <typename Assign>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__write_to_idx_if_else, Assign)>
+    : oneapi::dpl::__internal::__are_all_device_copyable<Assign>
 {
 };
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -578,10 +578,10 @@ struct __copy_by_mask
     _BinaryOp __binary_op;
     _Assigner __assigner;
 
-    template <typename _Item, typename _OutAcc, typename _InAcc, typename _WgSumsAcc, typename _Size,
+    template <typename _Item, typename _OutAcc, typename _InAcc, typename _WgSumsAcc, typename _RetAcc, typename _Size,
               typename _SizePerWg>
     void
-    operator()(_Item __item, _OutAcc& __out_acc, const _InAcc& __in_acc, const _WgSumsAcc& __wg_sums_acc, _Size __n,
+    operator()(_Item __item, _OutAcc& __out_acc, const _InAcc& __in_acc, const _WgSumsAcc& __wg_sums_acc, const _RetAcc& __ret_acc, _Size __n,
                _SizePerWg __size_per_wg) const
     {
         using ::std::get;
@@ -617,6 +617,11 @@ struct __copy_by_mask
                 // is performed(i.e. __typle_type is the same type as its operand).
                 __assigner(static_cast<__tuple_type>(get<0>(__in_acc[__item_idx])), __out_acc[__out_idx]);
         }
+        if (__item_idx == 0)
+        {
+            //copy final result to output
+            __ret_acc[0] = __wg_sums_acc[(__n-1) / __size_per_wg];
+        }
     }
 };
 
@@ -625,10 +630,10 @@ struct __partition_by_mask
 {
     _BinaryOp __binary_op;
 
-    template <typename _Item, typename _OutAcc, typename _InAcc, typename _WgSumsAcc, typename _Size,
+    template <typename _Item, typename _OutAcc, typename _InAcc, typename _WgSumsAcc, typename _RetAcc, typename _Size,
               typename _SizePerWg>
     void
-    operator()(_Item __item, _OutAcc& __out_acc, const _InAcc& __in_acc, const _WgSumsAcc& __wg_sums_acc, _Size __n,
+    operator()(_Item __item, _OutAcc& __out_acc, const _InAcc& __in_acc, const _WgSumsAcc& __wg_sums_acc, const _RetAcc& __ret_acc, _Size __n,
                _SizePerWg __size_per_wg) const
     {
         auto __item_idx = __item.get_linear_id();
@@ -660,6 +665,11 @@ struct __partition_by_mask
                 get<1>(__out_acc[__out_idx]) = static_cast<__tuple_type>(get<0>(__in_acc[__item_idx]));
             }
         }
+        if (__item_idx == 0)
+        {
+            //copy final result to output
+            __ret_acc[0] = __wg_sums_acc[(__n-1) / __size_per_wg];
+        }
     }
 };
 
@@ -669,10 +679,10 @@ struct __global_scan_functor
     _BinaryOp __binary_op;
     _InitType __init;
 
-    template <typename _Item, typename _OutAcc, typename _InAcc, typename _WgSumsAcc, typename _Size,
+    template <typename _Item, typename _OutAcc, typename _InAcc, typename _WgSumsAcc, typename _RetAcc, typename _Size,
               typename _SizePerWg>
     void
-    operator()(_Item __item, _OutAcc& __out_acc, const _InAcc&, const _WgSumsAcc& __wg_sums_acc, _Size __n,
+    operator()(_Item __item, _OutAcc& __out_acc, const _InAcc&, const _WgSumsAcc& __wg_sums_acc, const _RetAcc&, _Size __n,
                _SizePerWg __size_per_wg) const
     {
         constexpr auto __shift = _Inclusive{} ? 0 : 1;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -529,11 +529,19 @@ struct __mask_assigner
 struct __scan_assigner
 {
     template <typename _OutAcc, typename _OutIdx, typename _InAcc, typename _InIdx>
-    void
+    std::enable_if_t<!std::is_pointer_v<_OutAcc>>
     operator()(_OutAcc& __out_acc, const _OutIdx __out_idx, const _InAcc& __in_acc, _InIdx __in_idx) const
     {
         __out_acc[__out_idx] = __in_acc[__in_idx];
     }
+
+    template <typename _OutAcc, typename _OutIdx, typename _InAcc, typename _InIdx>
+    std::enable_if_t<std::is_pointer_v<_OutAcc>>
+    operator()(_OutAcc __out_acc, const _OutIdx __out_idx, const _InAcc& __in_acc, _InIdx __in_idx) const
+    {
+        __out_acc[__out_idx] = __in_acc[__in_idx];
+    }
+
 
     template <typename _Acc, typename _OutAcc, typename _OutIdx, typename _InAcc, typename _InIdx>
     void
@@ -578,10 +586,10 @@ struct __copy_by_mask
     _BinaryOp __binary_op;
     _Assigner __assigner;
 
-    template <typename _Item, typename _OutAcc, typename _InAcc, typename _WgSumsAcc, typename _RetAcc, typename _Size,
+    template <typename _Item, typename _OutAcc, typename _InAcc, typename _WgSumsPtr, typename _RetPtr, typename _Size,
               typename _SizePerWg>
     void
-    operator()(_Item __item, _OutAcc& __out_acc, const _InAcc& __in_acc, const _WgSumsAcc& __wg_sums_acc, const _RetAcc& __ret_acc, _Size __n,
+    operator()(_Item __item, _OutAcc& __out_acc, const _InAcc& __in_acc, _WgSumsPtr* __wg_sums_ptr,  _RetPtr* __ret_ptr, _Size __n,
                _SizePerWg __size_per_wg) const
     {
         using ::std::get;
@@ -598,7 +606,7 @@ struct __copy_by_mask
             if (__item_idx >= __size_per_wg)
             {
                 auto __wg_sums_idx = __item_idx / __size_per_wg - 1;
-                __out_idx = __binary_op(__out_idx, __wg_sums_acc[__wg_sums_idx]);
+                __out_idx = __binary_op(__out_idx, __wg_sums_ptr[__wg_sums_idx]);
             }
             if (__item_idx % __size_per_wg == 0 || (get<N>(__in_acc[__item_idx]) != get<N>(__in_acc[__item_idx - 1])))
                 // If we work with tuples we might have a situation when internal tuple is assigned to ::std::tuple
@@ -620,7 +628,7 @@ struct __copy_by_mask
         if (__item_idx == 0)
         {
             //copy final result to output
-            __ret_acc[0] = __wg_sums_acc[(__n-1) / __size_per_wg];
+            __ret_ptr[0] = __wg_sums_ptr[(__n-1) / __size_per_wg];
         }
     }
 };
@@ -630,10 +638,10 @@ struct __partition_by_mask
 {
     _BinaryOp __binary_op;
 
-    template <typename _Item, typename _OutAcc, typename _InAcc, typename _WgSumsAcc, typename _RetAcc, typename _Size,
+    template <typename _Item, typename _OutAcc, typename _InAcc, typename _WgSumsPtr, typename _RetPtr, typename _Size,
               typename _SizePerWg>
     void
-    operator()(_Item __item, _OutAcc& __out_acc, const _InAcc& __in_acc, const _WgSumsAcc& __wg_sums_acc, const _RetAcc& __ret_acc, _Size __n,
+    operator()(_Item __item, _OutAcc& __out_acc, const _InAcc& __in_acc, _WgSumsPtr* __wg_sums_ptr, _RetPtr* __ret_ptr, _Size __n,
                _SizePerWg __size_per_wg) const
     {
         auto __item_idx = __item.get_linear_id();
@@ -651,7 +659,7 @@ struct __partition_by_mask
                     __in_type, ::std::decay_t<decltype(get<0>(__out_acc[__out_idx]))>>::__type;
 
                 if (__not_first_wg)
-                    __out_idx = __binary_op(__out_idx, __wg_sums_acc[__wg_sums_idx - 1]);
+                    __out_idx = __binary_op(__out_idx, __wg_sums_ptr[__wg_sums_idx - 1]);
                 get<0>(__out_acc[__out_idx]) = static_cast<__tuple_type>(get<0>(__in_acc[__item_idx]));
             }
             else
@@ -661,14 +669,14 @@ struct __partition_by_mask
                     __in_type, ::std::decay_t<decltype(get<1>(__out_acc[__out_idx]))>>::__type;
 
                 if (__not_first_wg)
-                    __out_idx -= __wg_sums_acc[__wg_sums_idx - 1];
+                    __out_idx -= __wg_sums_ptr[__wg_sums_idx - 1];
                 get<1>(__out_acc[__out_idx]) = static_cast<__tuple_type>(get<0>(__in_acc[__item_idx]));
             }
         }
         if (__item_idx == 0)
         {
             //copy final result to output
-            __ret_acc[0] = __wg_sums_acc[(__n-1) / __size_per_wg];
+            __ret_ptr[0] = __wg_sums_ptr[(__n-1) / __size_per_wg];
         }
     }
 };
@@ -679,10 +687,10 @@ struct __global_scan_functor
     _BinaryOp __binary_op;
     _InitType __init;
 
-    template <typename _Item, typename _OutAcc, typename _InAcc, typename _WgSumsAcc, typename _RetAcc, typename _Size,
+    template <typename _Item, typename _OutAcc, typename _InAcc, typename _WgSumsPtr, typename _RetPtr, typename _Size,
               typename _SizePerWg>
     void
-    operator()(_Item __item, _OutAcc& __out_acc, const _InAcc&, const _WgSumsAcc& __wg_sums_acc, const _RetAcc&, _Size __n,
+    operator()(_Item __item, _OutAcc& __out_acc, const _InAcc&, _WgSumsPtr*__wg_sums_ptr, _RetPtr*, _Size __n,
                _SizePerWg __size_per_wg) const
     {
         constexpr auto __shift = _Inclusive{} ? 0 : 1;
@@ -693,7 +701,7 @@ struct __global_scan_functor
             auto __wg_sums_idx = __item_idx / __size_per_wg - 1;
             // an initial value precedes the first group for the exclusive scan
             __item_idx += __shift;
-            auto __bin_op_result = __binary_op(__wg_sums_acc[__wg_sums_idx], __out_acc[__item_idx]);
+            auto __bin_op_result = __binary_op(__wg_sums_ptr[__wg_sums_idx], __out_acc[__item_idx]);
             using __out_type = ::std::decay_t<decltype(__out_acc[__item_idx])>;
             using __in_type = ::std::decay_t<decltype(__bin_op_result)>;
             __out_acc[__item_idx] =
@@ -722,10 +730,10 @@ struct __scan
     _DataAccessor __data_acc;
 
     template <typename _NDItemId, typename _Size, typename _AccLocal, typename _InAcc, typename _OutAcc,
-              typename _WGSumsAcc, typename _SizePerWG, typename _WGSize, typename _ItersPerWG>
+              typename _WGSumsPtr, typename _SizePerWG, typename _WGSize, typename _ItersPerWG>
     void
     scan_impl(_NDItemId __item, _Size __n, _AccLocal& __local_acc, const _InAcc& __acc, _OutAcc& __out_acc,
-              _WGSumsAcc& __wg_sums_acc, _SizePerWG __size_per_wg, _WGSize __wgroup_size, _ItersPerWG __iters_per_wg,
+              _WGSumsPtr* __wg_sums_ptr, _SizePerWG __size_per_wg, _WGSize __wgroup_size, _ItersPerWG __iters_per_wg,
               _InitType __init, std::false_type /*has_known_identity*/) const
     {
         ::std::size_t __group_id = __item.get_group(0);
@@ -795,18 +803,18 @@ struct __scan
                 __gl_assigner(__acc, __out_acc, __adjusted_global_id + __shift, __local_acc, __local_id);
 
             if (__adjusted_global_id == __n - 1)
-                __wg_assigner(__wg_sums_acc, __group_id, __local_acc, __local_id);
+                __wg_assigner(__wg_sums_ptr, __group_id, __local_acc, __local_id);
         }
 
         if (__local_id == __wgroup_size - 1 && __adjusted_global_id - __wgroup_size < __n)
-            __wg_assigner(__wg_sums_acc, __group_id, __local_acc, __local_id);
+            __wg_assigner(__wg_sums_ptr, __group_id, __local_acc, __local_id);
     }
 
     template <typename _NDItemId, typename _Size, typename _AccLocal, typename _InAcc, typename _OutAcc,
-              typename _WGSumsAcc, typename _SizePerWG, typename _WGSize, typename _ItersPerWG>
+              typename _WGSumsPtr, typename _SizePerWG, typename _WGSize, typename _ItersPerWG>
     void
     scan_impl(_NDItemId __item, _Size __n, _AccLocal& __local_acc, const _InAcc& __acc, _OutAcc& __out_acc,
-              _WGSumsAcc& __wg_sums_acc, _SizePerWG __size_per_wg, _WGSize __wgroup_size, _ItersPerWG __iters_per_wg,
+              _WGSumsPtr* __wg_sums_ptr, _SizePerWG __size_per_wg, _WGSize __wgroup_size, _ItersPerWG __iters_per_wg,
               _InitType __init, std::true_type /*has_known_identity*/) const
     {
         auto __group_id = __item.get_group(0);
@@ -841,21 +849,21 @@ struct __scan
                 __gl_assigner(__acc, __out_acc, __adjusted_global_id + __shift, __local_acc, __local_id);
 
             if (__adjusted_global_id == __n - 1)
-                __wg_assigner(__wg_sums_acc, __group_id, __local_acc, __local_id);
+                __wg_assigner(__wg_sums_ptr, __group_id, __local_acc, __local_id);
         }
 
         if (__local_id == __wgroup_size - 1 && __adjusted_global_id - __wgroup_size < __n)
-            __wg_assigner(__wg_sums_acc, __group_id, __local_acc, __local_id);
+            __wg_assigner(__wg_sums_ptr, __group_id, __local_acc, __local_id);
     }
 
     template <typename _NDItemId, typename _Size, typename _AccLocal, typename _InAcc, typename _OutAcc,
-              typename _WGSumsAcc, typename _SizePerWG, typename _WGSize, typename _ItersPerWG>
+              typename _WGSumsPtr, typename _SizePerWG, typename _WGSize, typename _ItersPerWG>
     void operator()(_NDItemId __item, _Size __n, _AccLocal& __local_acc, const _InAcc& __acc, _OutAcc& __out_acc,
-                    _WGSumsAcc& __wg_sums_acc, _SizePerWG __size_per_wg, _WGSize __wgroup_size,
+                    _WGSumsPtr* __wg_sums_ptr, _SizePerWG __size_per_wg, _WGSize __wgroup_size,
                     _ItersPerWG __iters_per_wg,
                     _InitType __init = __no_init_value<typename _InitType::__value_type>{}) const
     {
-        scan_impl(__item, __n, __local_acc, __acc, __out_acc, __wg_sums_acc, __size_per_wg, __wgroup_size,
+        scan_impl(__item, __n, __local_acc, __acc, __out_acc, __wg_sums_ptr, __size_per_wg, __wgroup_size,
                   __iters_per_wg, __init, __has_known_identity<_BinaryOperation, _Tp>{});
     }
 };

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -542,7 +542,6 @@ struct __scan_assigner
         __out_acc[__out_idx] = __in_acc[__in_idx];
     }
 
-
     template <typename _Acc, typename _OutAcc, typename _OutIdx, typename _InAcc, typename _InIdx>
     void
     operator()(_Acc&, _OutAcc& __out_acc, const _OutIdx __out_idx, const _InAcc& __in_acc, _InIdx __in_idx) const
@@ -589,8 +588,8 @@ struct __copy_by_mask
     template <typename _Item, typename _OutAcc, typename _InAcc, typename _WgSumsPtr, typename _RetPtr, typename _Size,
               typename _SizePerWg>
     void
-    operator()(_Item __item, _OutAcc& __out_acc, const _InAcc& __in_acc, _WgSumsPtr* __wg_sums_ptr,  _RetPtr* __ret_ptr, _Size __n,
-               _SizePerWg __size_per_wg) const
+    operator()(_Item __item, _OutAcc& __out_acc, const _InAcc& __in_acc, _WgSumsPtr* __wg_sums_ptr, _RetPtr* __ret_ptr,
+               _Size __n, _SizePerWg __size_per_wg) const
     {
         using ::std::get;
         auto __item_idx = __item.get_linear_id();
@@ -628,7 +627,7 @@ struct __copy_by_mask
         if (__item_idx == 0)
         {
             //copy final result to output
-            __ret_ptr[0] = __wg_sums_ptr[(__n-1) / __size_per_wg];
+            __ret_ptr[0] = __wg_sums_ptr[(__n - 1) / __size_per_wg];
         }
     }
 };
@@ -641,8 +640,8 @@ struct __partition_by_mask
     template <typename _Item, typename _OutAcc, typename _InAcc, typename _WgSumsPtr, typename _RetPtr, typename _Size,
               typename _SizePerWg>
     void
-    operator()(_Item __item, _OutAcc& __out_acc, const _InAcc& __in_acc, _WgSumsPtr* __wg_sums_ptr, _RetPtr* __ret_ptr, _Size __n,
-               _SizePerWg __size_per_wg) const
+    operator()(_Item __item, _OutAcc& __out_acc, const _InAcc& __in_acc, _WgSumsPtr* __wg_sums_ptr, _RetPtr* __ret_ptr,
+               _Size __n, _SizePerWg __size_per_wg) const
     {
         auto __item_idx = __item.get_linear_id();
         if (__item_idx < __n)
@@ -676,7 +675,7 @@ struct __partition_by_mask
         if (__item_idx == 0)
         {
             //copy final result to output
-            __ret_ptr[0] = __wg_sums_ptr[(__n-1) / __size_per_wg];
+            __ret_ptr[0] = __wg_sums_ptr[(__n - 1) / __size_per_wg];
         }
     }
 };
@@ -690,7 +689,7 @@ struct __global_scan_functor
     template <typename _Item, typename _OutAcc, typename _InAcc, typename _WgSumsPtr, typename _RetPtr, typename _Size,
               typename _SizePerWg>
     void
-    operator()(_Item __item, _OutAcc& __out_acc, const _InAcc&, _WgSumsPtr*__wg_sums_ptr, _RetPtr*, _Size __n,
+    operator()(_Item __item, _OutAcc& __out_acc, const _InAcc&, _WgSumsPtr* __wg_sums_ptr, _RetPtr*, _Size __n,
                _SizePerWg __size_per_wg) const
     {
         constexpr auto __shift = _Inclusive{} ? 0 : 1;
@@ -858,10 +857,10 @@ struct __scan
 
     template <typename _NDItemId, typename _Size, typename _AccLocal, typename _InAcc, typename _OutAcc,
               typename _WGSumsPtr, typename _SizePerWG, typename _WGSize, typename _ItersPerWG>
-    void operator()(_NDItemId __item, _Size __n, _AccLocal& __local_acc, const _InAcc& __acc, _OutAcc& __out_acc,
-                    _WGSumsPtr* __wg_sums_ptr, _SizePerWG __size_per_wg, _WGSize __wgroup_size,
-                    _ItersPerWG __iters_per_wg,
-                    _InitType __init = __no_init_value<typename _InitType::__value_type>{}) const
+    void
+    operator()(_NDItemId __item, _Size __n, _AccLocal& __local_acc, const _InAcc& __acc, _OutAcc& __out_acc,
+               _WGSumsPtr* __wg_sums_ptr, _SizePerWG __size_per_wg, _WGSize __wgroup_size, _ItersPerWG __iters_per_wg,
+               _InitType __init = __no_init_value<typename _InitType::__value_type>{}) const
     {
         scan_impl(__item, __n, __local_acc, __acc, __out_acc, __wg_sums_ptr, __size_per_wg, __wgroup_size,
                   __iters_per_wg, __init, __has_known_identity<_BinaryOperation, _Tp>{});

--- a/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
@@ -95,11 +95,10 @@ __pattern_transform_scan_base(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __ex
     if (__n == 0)
         return 0;
 
-    oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(_BackendTag{},
-                                                                 std::forward<_ExecutionPolicy>(__exec),
-                                                                 std::forward<_Range1>(__rng1),
-                                                                 std::forward<_Range2>(__rng2), __n, __unary_op,
-                                                                 __init, __binary_op, _Inclusive{}).wait();
+    oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(
+        _BackendTag{}, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng1),
+        std::forward<_Range2>(__rng2), __n, __unary_op, __init, __binary_op, _Inclusive{})
+        .wait();
     return __n;
 }
 

--- a/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
@@ -91,35 +91,16 @@ oneapi::dpl::__internal::__difference_t<_Range2>
 __pattern_transform_scan_base(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2,
                               _UnaryOperation __unary_op, _InitType __init, _BinaryOperation __binary_op, _Inclusive)
 {
-    if (__rng1.empty())
+    auto __n = __rng1.size();
+    if (__n == 0)
         return 0;
-    oneapi::dpl::__internal::__difference_t<_Range2> __rng1_size = __rng1.size();
 
-    using _Type = typename _InitType::__value_type;
-    using _Assigner = unseq_backend::__scan_assigner;
-    using _NoAssign = unseq_backend::__scan_no_assign;
-    using _UnaryFunctor = unseq_backend::walk_n<_ExecutionPolicy, _UnaryOperation>;
-    using _NoOpFunctor = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;
-
-    _Assigner __assign_op;
-    _NoAssign __no_assign_op;
-    _NoOpFunctor __get_data_op;
-
-    oneapi::dpl::__par_backend_hetero::__parallel_transform_scan_base(
-        _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec), ::std::forward<_Range1>(__rng1),
-        ::std::forward<_Range2>(__rng2), __binary_op, __init,
-        // local scan
-        unseq_backend::__scan<_Inclusive, _ExecutionPolicy, _BinaryOperation, _UnaryFunctor, _Assigner, _Assigner,
-                              _NoOpFunctor, _InitType>{__binary_op, _UnaryFunctor{__unary_op}, __assign_op, __assign_op,
-                                                       __get_data_op},
-        // scan between groups
-        unseq_backend::__scan</*inclusive=*/::std::true_type, _ExecutionPolicy, _BinaryOperation, _NoOpFunctor,
-                              _NoAssign, _Assigner, _NoOpFunctor, unseq_backend::__no_init_value<_Type>>{
-            __binary_op, _NoOpFunctor{}, __no_assign_op, __assign_op, __get_data_op},
-        // global scan
-        unseq_backend::__global_scan_functor<_Inclusive, _BinaryOperation, _InitType>{__binary_op, __init})
-        .wait();
-    return __rng1_size;
+    oneapi::dpl::__par_backend_hetero::__parallel_transform_scan(_BackendTag{},
+                                                                 std::forward<_ExecutionPolicy>(__exec),
+                                                                 std::forward<_Range1>(__rng1),
+                                                                 std::forward<_Range2>(__rng2), __n, __unary_op,
+                                                                 __init, __binary_op, _Inclusive{}).wait();
+    return __n;
 }
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _UnaryOperation,

--- a/test/general/implementation_details/device_copyable.pass.cpp
+++ b/test/general/implementation_details/device_copyable.pass.cpp
@@ -150,14 +150,35 @@ test_device_copyable()
         sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_transform_input<noop_device_copyable>>,
         "__gen_transform_input is not device copyable with device copyable types");
 
-    //__gen_count_pred
-    static_assert(sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_count_pred<noop_device_copyable>>,
-                  "__gen_count_pred is not device copyable with device copyable types");
-
-    //__gen_expand_count_pred
+    //__gen_mask
     static_assert(
-        sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_expand_count_pred<noop_device_copyable>>,
-        "__gen_expand_count_pred is not device copyable with device copyable types");
+        sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_mask<noop_device_copyable>>,
+        // "__gen_mask is not device copyable with device copyable types");
+
+    //__gen_unique_mask
+    static_assert(sycl::is_device_copyable_v<
+                      oneapi::dpl::__par_backend_hetero::__gen_unique_mask<binary_op_device_copyable>>,
+                  "__gen_unique_mask is not device copyable with device copyable types");
+
+    //__gen_count_mask
+    static_assert(sycl::is_device_copyable_v<
+                      oneapi::dpl::__par_backend_hetero::__gen_count_mask<oneapi::dpl::__par_backend_hetero::__gen_mask<noop_device_copyable>>>,
+                  "__gen_count_mask is not device copyable with device copyable types");
+
+    //__gen_expand_count_mask
+    static_assert(sycl::is_device_copyable_v<
+                      oneapi::dpl::__par_backend_hetero::__gen_expand_count_mask<oneapi::dpl::__par_backend_hetero::__gen_mask<noop_device_copyable>>>,
+                  "__gen_expand_count_mask is not device copyable with device copyable types");
+
+    //__write_to_idx_if
+    static_assert(sycl::is_device_copyable_v<
+                      oneapi::dpl::__par_backend_hetero::__write_to_idx_if<assign_device_copyable>>,
+                  "__write_to_idx_if is not device copyable with device copyable types");
+
+    //__write_to_idx_if_else
+    static_assert(sycl::is_device_copyable_v<
+                      oneapi::dpl::__par_backend_hetero::__write_to_idx_if_else<assign_device_copyable>>,
+                  "__write_to_idx_if_else is not device copyable with device copyable types");
 
     // __early_exit_find_or
     static_assert(
@@ -357,20 +378,39 @@ test_non_device_copyable()
                       oneapi::dpl::unseq_backend::__brick_reduce_idx<noop_device_copyable, int_non_device_copyable>>,
                   "__brick_reduce_idx is device copyable with non device copyable types");
 
-    // //__gen_transform_input
+    //__gen_transform_input
     static_assert(
         !sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_transform_input<noop_non_device_copyable>>,
         "__gen_transform_input is device copyable with non device copyable types");
 
-    //__gen_count_pred
-    static_assert(
-        !sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_count_pred<noop_non_device_copyable>>,
-        "__gen_count_pred is device copyable with non device copyable types");
+    //__gen_mask
+    static_assert(!sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_mask<noop_non_device_copyable>>,
+                  "__gen_mask is device copyable with non device copyable types");
 
-    //__gen_expand_count_pred
+    //__gen_unique_mask
     static_assert(!sycl::is_device_copyable_v<
-                      oneapi::dpl::__par_backend_hetero::__gen_expand_count_pred<noop_non_device_copyable>>,
-                  "__gen_expand_count_pred is device copyable with non device copyable types");
+                      oneapi::dpl::__par_backend_hetero::__gen_unique_mask<binary_op_non_device_copyable>>,
+                  "__gen_unique_mask is device copyable with non device copyable types");
+
+    //__gen_count_mask
+    static_assert(!sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_count_mask<
+                      oneapi::dpl::__par_backend_hetero::__gen_mask<noop_non_device_copyable>>>,
+                  "__gen_count_mask is device copyable with non device copyable types");
+
+    //__gen_expand_count_mask
+    static_assert(!sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_expand_count_mask<
+                      oneapi::dpl::__par_backend_hetero::__gen_mask<noop_non_device_copyable>>>,
+                  "__gen_expand_count_mask is device copyable with non device copyable types");
+
+    //__write_to_idx_if
+    static_assert(
+        !sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__write_to_idx_if<assign_non_device_copyable>>,
+        "__write_to_idx_if is device copyable with non device copyable types");
+
+    //__write_to_idx_if_else
+    static_assert(!sycl::is_device_copyable_v<
+                      oneapi::dpl::__par_backend_hetero::__write_to_idx_if_else<assign_non_device_copyable>>,
+                  "__write_to_idx_if_else is device copyable with non device copyable types");
 
     // __early_exit_find_or
     static_assert(

--- a/test/general/implementation_details/device_copyable.pass.cpp
+++ b/test/general/implementation_details/device_copyable.pass.cpp
@@ -153,7 +153,7 @@ test_device_copyable()
     //__gen_mask
     static_assert(
         sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_mask<noop_device_copyable>>,
-        // "__gen_mask is not device copyable with device copyable types");
+         "__gen_mask is not device copyable with device copyable types");
 
     //__gen_unique_mask
     static_assert(sycl::is_device_copyable_v<
@@ -172,7 +172,7 @@ test_device_copyable()
 
     //__write_to_idx_if
     static_assert(sycl::is_device_copyable_v<
-                      oneapi::dpl::__par_backend_hetero::__write_to_idx_if<assign_device_copyable>>,
+                      oneapi::dpl::__par_backend_hetero::__write_to_idx_if<0, assign_device_copyable>>,
                   "__write_to_idx_if is not device copyable with device copyable types");
 
     //__write_to_idx_if_else
@@ -404,7 +404,7 @@ test_non_device_copyable()
 
     //__write_to_idx_if
     static_assert(
-        !sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__write_to_idx_if<assign_non_device_copyable>>,
+        !sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__write_to_idx_if<0, assign_non_device_copyable>>,
         "__write_to_idx_if is device copyable with non device copyable types");
 
     //__write_to_idx_if_else

--- a/test/general/implementation_details/device_copyable.pass.cpp
+++ b/test/general/implementation_details/device_copyable.pass.cpp
@@ -151,34 +151,33 @@ test_device_copyable()
         "__gen_transform_input is not device copyable with device copyable types");
 
     //__gen_mask
-    static_assert(
-        sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_mask<noop_device_copyable>>,
-         "__gen_mask is not device copyable with device copyable types");
+    static_assert(sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_mask<noop_device_copyable>>,
+                  "__gen_mask is not device copyable with device copyable types");
 
     //__gen_unique_mask
-    static_assert(sycl::is_device_copyable_v<
-                      oneapi::dpl::__par_backend_hetero::__gen_unique_mask<binary_op_device_copyable>>,
-                  "__gen_unique_mask is not device copyable with device copyable types");
+    static_assert(
+        sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_unique_mask<binary_op_device_copyable>>,
+        "__gen_unique_mask is not device copyable with device copyable types");
 
     //__gen_count_mask
-    static_assert(sycl::is_device_copyable_v<
-                      oneapi::dpl::__par_backend_hetero::__gen_count_mask<oneapi::dpl::__par_backend_hetero::__gen_mask<noop_device_copyable>>>,
+    static_assert(sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_count_mask<
+                      oneapi::dpl::__par_backend_hetero::__gen_mask<noop_device_copyable>>>,
                   "__gen_count_mask is not device copyable with device copyable types");
 
     //__gen_expand_count_mask
-    static_assert(sycl::is_device_copyable_v<
-                      oneapi::dpl::__par_backend_hetero::__gen_expand_count_mask<oneapi::dpl::__par_backend_hetero::__gen_mask<noop_device_copyable>>>,
+    static_assert(sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_expand_count_mask<
+                      oneapi::dpl::__par_backend_hetero::__gen_mask<noop_device_copyable>>>,
                   "__gen_expand_count_mask is not device copyable with device copyable types");
 
     //__write_to_idx_if
-    static_assert(sycl::is_device_copyable_v<
-                      oneapi::dpl::__par_backend_hetero::__write_to_idx_if<0, assign_device_copyable>>,
-                  "__write_to_idx_if is not device copyable with device copyable types");
+    static_assert(
+        sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__write_to_idx_if<0, assign_device_copyable>>,
+        "__write_to_idx_if is not device copyable with device copyable types");
 
     //__write_to_idx_if_else
-    static_assert(sycl::is_device_copyable_v<
-                      oneapi::dpl::__par_backend_hetero::__write_to_idx_if_else<assign_device_copyable>>,
-                  "__write_to_idx_if_else is not device copyable with device copyable types");
+    static_assert(
+        sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__write_to_idx_if_else<assign_device_copyable>>,
+        "__write_to_idx_if_else is not device copyable with device copyable types");
 
     // __early_exit_find_or
     static_assert(
@@ -403,9 +402,9 @@ test_non_device_copyable()
                   "__gen_expand_count_mask is device copyable with non device copyable types");
 
     //__write_to_idx_if
-    static_assert(
-        !sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__write_to_idx_if<0, assign_non_device_copyable>>,
-        "__write_to_idx_if is device copyable with non device copyable types");
+    static_assert(!sycl::is_device_copyable_v<
+                      oneapi::dpl::__par_backend_hetero::__write_to_idx_if<0, assign_non_device_copyable>>,
+                  "__write_to_idx_if is device copyable with non device copyable types");
 
     //__write_to_idx_if_else
     static_assert(!sycl::is_device_copyable_v<

--- a/test/parallel_api/algorithm/alg.modifying.operations/unique.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/unique.pass.cpp
@@ -40,7 +40,7 @@ struct run_unique
         ForwardIt k = unique(exec, first2, last2);
 
         auto n = ::std::distance(first1, i);
-        EXPECT_EQ(::std::distance(first2, k), n, "wrong return value from unique without predicate");
+        EXPECT_TRUE(::std::distance(first2, k) == n, "wrong return value from unique without predicate");
         EXPECT_EQ_N(first1, first2, n, "wrong effect from unique without predicate");
     }
 };
@@ -63,7 +63,7 @@ struct run_unique_predicate
         ForwardIt k = unique(exec, first2, last2, pred);
 
         auto n = ::std::distance(first1, i);
-        EXPECT_EQ(::std::distance(first2, k),  n, "wrong return value from unique with predicate");
+        EXPECT_TRUE(::std::distance(first2, k) == n, "wrong return value from unique with predicate");
         EXPECT_EQ_N(first1, first2, n, "wrong effect from unique with predicate");
     }
 };

--- a/test/parallel_api/algorithm/alg.modifying.operations/unique.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/unique.pass.cpp
@@ -40,7 +40,7 @@ struct run_unique
         ForwardIt k = unique(exec, first2, last2);
 
         auto n = ::std::distance(first1, i);
-        EXPECT_TRUE(::std::distance(first2, k) == n, "wrong return value from unique without predicate");
+        EXPECT_EQ(::std::distance(first2, k), n, "wrong return value from unique without predicate");
         EXPECT_EQ_N(first1, first2, n, "wrong effect from unique without predicate");
     }
 };
@@ -63,7 +63,7 @@ struct run_unique_predicate
         ForwardIt k = unique(exec, first2, last2, pred);
 
         auto n = ::std::distance(first1, i);
-        EXPECT_TRUE(::std::distance(first2, k) == n, "wrong return value from unique with predicate");
+        EXPECT_EQ(::std::distance(first2, k),  n, "wrong return value from unique with predicate");
         EXPECT_EQ_N(first1, first2, n, "wrong effect from unique with predicate");
     }
 };

--- a/test/support/utils_device_copyable.h
+++ b/test/support/utils_device_copyable.h
@@ -78,8 +78,11 @@ struct assign_device_copyable
 // relying on trivial copyability
 struct binary_op_non_device_copyable
 {
-    binary_op_non_device_copyable(const binary_op_non_device_copyable& other) { std::cout << " non trivial copy ctor\n"; }
-    int 
+    binary_op_non_device_copyable(const binary_op_non_device_copyable& other)
+    {
+        std::cout << " non trivial copy ctor\n";
+    }
+    int
     operator()(int a, int b) const
     {
         return a;
@@ -89,7 +92,7 @@ struct binary_op_non_device_copyable
 struct binary_op_device_copyable
 {
     binary_op_device_copyable(const binary_op_device_copyable& other) { std::cout << " non trivial copy ctor\n"; }
-    int 
+    int
     operator()(int a, int b) const
     {
         return a;

--- a/test/support/utils_device_copyable.h
+++ b/test/support/utils_device_copyable.h
@@ -48,6 +48,54 @@ struct noop_non_device_copyable
     }
 };
 
+// Device copyable assignment callable.
+// Intentionally non-trivially copyable to test that device_copyable speciailzation works and we are not
+// relying on trivial copyability
+struct assign_non_device_copyable
+{
+    assign_non_device_copyable(const assign_non_device_copyable& other) { std::cout << "non trivial copy ctor\n"; }
+    template <typename _Xp, typename _Yp>
+    void
+    operator()(const _Xp& __x, _Yp&& __y) const
+    {
+        ::std::forward<_Yp>(__y) = __x;
+    }
+};
+
+struct assign_device_copyable
+{
+    assign_device_copyable(const assign_device_copyable& other) { std::cout << "non trivial copy ctor\n"; }
+    template <typename _Xp, typename _Yp>
+    void
+    operator()(const _Xp& __x, _Yp&& __y) const
+    {
+        ::std::forward<_Yp>(__y) = __x;
+    }
+};
+
+// Device copyable binary operator binary operators.
+// Intentionally non-trivially copyable to test that device_copyable speciailzation works and we are not
+// relying on trivial copyability
+struct binary_op_non_device_copyable
+{
+    binary_op_non_device_copyable(const binary_op_non_device_copyable& other) { std::cout << " non trivial copy ctor\n"; }
+    int 
+    operator()(int a, int b) const
+    {
+        return a;
+    }
+};
+
+struct binary_op_device_copyable
+{
+    binary_op_device_copyable(const binary_op_device_copyable& other) { std::cout << " non trivial copy ctor\n"; }
+    int 
+    operator()(int a, int b) const
+    {
+        return a;
+    }
+};
+
 // Device copyable int wrapper struct used in testing as surrogate for values, value types, etc.
 // Intentionally non-trivially copyable to test that device_copyable speciailzation works and we are not
 // relying on trivial copyability
@@ -157,6 +205,16 @@ struct constant_iterator_non_device_copyable
 
 template <>
 struct sycl::is_device_copyable<TestUtils::noop_device_copyable> : std::true_type
+{
+};
+
+template <>
+struct sycl::is_device_copyable<TestUtils::assign_device_copyable> : std::true_type
+{
+};
+
+template <>
+struct sycl::is_device_copyable<TestUtils::binary_op_device_copyable> : std::true_type
 {
 };
 

--- a/test/support/utils_device_copyable.h
+++ b/test/support/utils_device_copyable.h
@@ -58,7 +58,7 @@ struct assign_non_device_copyable
     void
     operator()(const _Xp& __x, _Yp&& __y) const
     {
-        ::std::forward<_Yp>(__y) = __x;
+        std::forward<_Yp>(__y) = __x;
     }
 };
 
@@ -69,7 +69,7 @@ struct assign_device_copyable
     void
     operator()(const _Xp& __x, _Yp&& __y) const
     {
-        ::std::forward<_Yp>(__y) = __x;
+        std::forward<_Yp>(__y) = __x;
     }
 };
 


### PR DESCRIPTION
Adds partition, unique families as well as the ranges API to use two pass scan.

There is some refactoring to the generalized helpers, to simplify sharing between families of scan-like algorithms using this.  
Otherwise, this just adds other entry points to use two pass scan.

This also standardizes / adds some zero element short circuits in the ranges API

Note:  for the ranges API, I try to hook in to the path to re-use what we have in the main APIs.  Specifically, this enables ranges API copy_if to be able to use single workgroup copy_if as well, where it was not previously exposed to that.

Tentative performance results for these families of algorithms are similar to what we have seen with copy_if.