### PR TITLE
Upgrade CI versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,6 +194,10 @@ jobs:
         if: (matrix.device_type == 'FPGA_EMU')
         run: |
           sudo apt-get install intel-oneapi-compiler-fpga -y
+      - name: Install OpenMP dependencies
+        if: (matrix.os == 'ubuntu-latest' && matrix.cxx_compiler == 'clang++' && matrix.backend == 'omp')
+        run: |
+          sudo apt-get install libomp5 libomp-dev -y
       - name: Run testing
         shell: bash
         run: |
@@ -214,7 +218,7 @@ jobs:
           mkdir build && cd build
           lscpu
           cmake -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-            -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DONEDPL_BACKEND=${{ matrix.backend }} -DONEDPL_DEVICE_TYPE=${{ matrix.device_type }} --debug-find --trace-expand ..
+            -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DONEDPL_BACKEND=${{ matrix.backend }} -DONEDPL_DEVICE_TYPE=${{ matrix.device_type }} ..
           make VERBOSE=1 -j${BUILD_CONCURRENCY} ${make_targets}
           ctest --timeout ${TEST_TIMEOUT} --output-on-failure ${ctest_flags}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         run: if [ -s clang-format.diff ]; then cat clang-format.diff; exit 1; fi
       - if: failure()
         name: Save artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: clang-format-diff
           path: clang-format.diff
@@ -85,7 +85,7 @@ jobs:
           mkdir html
           sphinx-build -b html documentation/library_guide/ html/
       - name: Archive build directory
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
             name: onedpl-html-docs-${{ env.GITHUB_SHA_SHORT }}
             path: html

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,25 +98,25 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             cxx_compiler: icpx
             std: 17
             build_type: release
             backend: dpcpp
             device_type: CPU
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             cxx_compiler: icpx
             std: 17
             build_type: release
             backend: dpcpp
             device_type: FPGA_EMU
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             cxx_compiler: icpx
             std: 17
             build_type: release
             backend: tbb
             device_type: HOST
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             cxx_compiler: icpx
             std: 17
             build_type: release
@@ -134,19 +134,19 @@ jobs:
             build_type: release
             backend: tbb
             device_type: HOST
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             cxx_compiler: g++
             std: 17
             build_type: release
             backend: tbb
             device_type: HOST
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             cxx_compiler: clang++
             std: 17
             build_type: release
             backend: tbb
             device_type: HOST
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             cxx_compiler: clang++
             std: 17
             build_type: release
@@ -158,13 +158,13 @@ jobs:
             build_type: release
             backend: tbb
             device_type: HOST
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             cxx_compiler: icpx
             std: 17
             build_type: release
             backend: tbb
             device_type: HOST
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             cxx_compiler: g++
             std: 17
             build_type: release
@@ -226,7 +226,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-22.04
+          - os: ubuntu-latest
             cxx_compiler: icpx
             std: 17
             build_type: release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,7 @@ jobs:
           mkdir build && cd build
           lscpu
           cmake -DCMAKE_CXX_STANDARD=${{ matrix.std }} -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-            -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DONEDPL_BACKEND=${{ matrix.backend }} -DONEDPL_DEVICE_TYPE=${{ matrix.device_type }} ..
+            -DCMAKE_CXX_COMPILER=${{ matrix.cxx_compiler }} -DONEDPL_BACKEND=${{ matrix.backend }} -DONEDPL_DEVICE_TYPE=${{ matrix.device_type }} --debug-find --trace-expand ..
           make VERBOSE=1 -j${BUILD_CONCURRENCY} ${make_targets}
           ctest --timeout ${TEST_TIMEOUT} --output-on-failure ${ctest_flags}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 permissions: read-all
 
 env:
-  BUILD_CONCURRENCY: 2
+  BUILD_CONCURRENCY: 4
   MACOS_BUILD_CONCURRENCY: 3
   TEST_TIMEOUT: 360
   WINDOWS_TBB_DOWNLOAD_LINK: https://registrationcenter-download.intel.com/akdlm/IRC_NAS/8222de4d-2c5e-41bc-bdd5-f557a9edda28/w_tbb_oneapi_p_2021.13.0.627_offline.exe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -411,7 +411,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-13
+          - os: macos-latest
             cxx_compiler: clang++
             std: 17
             build_type: release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,7 +281,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: windows-2019
+          - os: windows-latest
             cxx_compiler: icx-cl
             std: 17
             build_type: release
@@ -311,7 +311,7 @@ jobs:
             call "%WINDOWS_ONEAPI_PATH%\setvars.bat"
           )
           if "${{ matrix.cxx_compiler }}" == "cl" (
-            call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+            call "C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
           )
           powershell $output = cmake --version; Write-Host ::warning::CMake: $output
           powershell $output = ${{ matrix.cxx_compiler }} --version; Write-Host ::warning::Compiler: $output
@@ -339,19 +339,19 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: windows-2019
+          - os: windows-latest
             cxx_compiler: icx-cl
             std: 17
             build_type: release
             backend: tbb
             device_type: HOST
-          - os: windows-2019
+          - os: windows-latest
             cxx_compiler: cl
             std: 17
             build_type: release
             backend: tbb
             device_type: HOST
-          - os: windows-2019
+          - os: windows-latest
             cxx_compiler: icx
             std: 17
             build_type: release
@@ -381,7 +381,7 @@ jobs:
             call "%WINDOWS_ONEAPI_PATH%\setvars.bat"
           )
           if "${{ matrix.cxx_compiler }}" == "cl" (
-            call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+            call "C:\Program Files (x86)\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
           )
           powershell $output = cmake --version; Write-Host ::warning::CMake: $output
           powershell $output = ${{ matrix.cxx_compiler }} --version; Write-Host ::warning::Compiler: $output

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           fetch-depth: 0
           ref:  ${{ github.event.pull_request.head.sha }}
-      - uses: actions/setup-python@v3
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
       - name: Get clang-format
@@ -73,7 +73,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
       - name: Install prerequisites

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref:  ${{ github.event.pull_request.head.sha }}
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install prerequisites
         run: |
           sudo apt update && sudo apt install -y codespell
@@ -72,7 +72,7 @@ jobs:
   documentation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'
@@ -171,7 +171,7 @@ jobs:
             backend: serial
             device_type: HOST
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Intel APT repository
         if: (matrix.backend == 'tbb' || matrix.backend == 'dpcpp' || matrix.cxx_compiler == 'icpx' || matrix.cxx_compiler == 'icx' || matrix.cxx_compiler == 'icx-cl' || matrix.cxx_compiler == 'dpcpp' || matrix.cxx_compiler == 'dpcpp-cl')
         run: |
@@ -232,7 +232,7 @@ jobs:
             build_type: release
             device_type: cpu
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Intel APT repository
         run: |
           # https://www.intel.com/content/www/us/en/docs/oneapi/installation-guide-linux/2024-0/apt.html
@@ -288,7 +288,7 @@ jobs:
             backend: dpcpp
             device_type: cpu
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Intel® oneAPI Threading Building Blocks
         if: (matrix.backend == 'tbb' || matrix.backend == 'dpcpp')
         shell: cmd
@@ -358,7 +358,7 @@ jobs:
             backend: dpcpp
             device_type: CPU
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Intel® oneAPI Threading Building Blocks
         if: (matrix.backend == 'tbb' || matrix.backend == 'dpcpp')
         shell: cmd
@@ -417,7 +417,7 @@ jobs:
             build_type: release
             backend: omp
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install OpenMP for Clang++
         run: |
           brew install libomp


### PR DESCRIPTION
This PR proposes to upgrade the runners' versions to the latest OS to keep the CI running on current environments. This was noticed by @danhoeflinger in https://github.com/oneapi-src/oneDPL/pull/1479#discussion_r1670866048.

- Ubuntu 20.04 -> `ubuntu-latest` (currently 22.04)
- Windows Server 2019 -> `windows-latest` (currently 2022)
- macOS 13 -> `macos-latest` (currently 14)

It further upgrades the following GitHub actions:

- `actions/checkout`: warns about using deprecated Node.js 16
- `actions/setup-python`: warns about using deprecated Node.js 16
- `actions/upload-artifact`: warns about deprecation

I've also increased the build concurrency to 4 on Linux and Windows to match the core counts on the latest runners. This reduces the test times for these configurations.