### PR TITLE
[PROTOTYPE] Resolve conversion issues between internal tuple and std::tuple in zip_iterator.pass

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -856,8 +856,13 @@ struct __write_to_idx_if
     void
     operator()(_OutRng&& __out, _SizeType __idx, const ValueType& __v) const
     {
+        // Use of an explicit cast to our internal tuple type is required to resolve conversion issues between our
+        // internal tuple and std::tuple. If the underlying type is not a tuple, then the type will just be passed through.
+        using _ConvertedTupleType =
+            typename oneapi::dpl::__internal::__get_tuple_type<std::decay_t<decltype(std::get<2>(__v))>,
+                                                               std::decay_t<decltype(__out[__idx])>>::__type;
         if (std::get<1>(__v))
-            __out[std::get<0>(__v) - 1] = std::get<2>(__v);
+            __out[std::get<0>(__v) - 1] = static_cast<_ConvertedTupleType>(std::get<2>(__v));
     }
 };
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -805,7 +805,12 @@ struct __simple_write_to_idx
     void
     operator()(_OutRng&& __out, std::size_t __idx, const ValueType& __v) const
     {
-        __out[__idx] = __v;
+        // Use of an explicit cast to our internal tuple type is required to resolve conversion issues between our
+        // internal tuple and std::tuple. If the underlying type is not a tuple, then the type will just be passed through.
+        using _ConvertedTupleType =
+            typename oneapi::dpl::__internal::__get_tuple_type<std::decay_t<decltype(__v)>,
+                                                               std::decay_t<decltype(__out[__idx])>>::__type;
+        __out[__idx] = static_cast<_ConvertedTupleType>(__v);
     }
 };
 


### PR DESCRIPTION
`zip_iterator.pass` runs into some compilation issues currently due to conversion issues between `std::tuple` and our internal tuple in cases in which they should be convertible but a compilation failure is still encountered. 

To fix this issue, we apply the same trick applied in the legacy `copy_if` implementation:  https://github.com/oneapi-src/oneDPL/blob/e3ebb58c1cc97261909c3bb3b47e4b3747be8dde/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h#L618