### PR TITLE
use internal version of enumerate in test to support gcc14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,6 @@ jobs:
         if: (matrix.std == '23')
         run: |
           sudo apt-get install libgtest-dev libfmt-dev -y
-          sudo apt-get remove libgcc-14-dev cpp-14-x86-64-linux-gnu -y  # gcc14 toolkit not supported yet by DR
       - name: Run testing
         shell: bash
         run: |

--- a/test/distributed_ranges/common/enumerate.cpp
+++ b/test/distributed_ranges/common/enumerate.cpp
@@ -25,13 +25,13 @@ TYPED_TEST_SUITE(Enumerate, AllTypes);
 TYPED_TEST(Enumerate, Basic) {
   Ops1<TypeParam> ops(10);
 
-  EXPECT_TRUE(check_view(stdrng::views::enumerate(ops.vec),
+  EXPECT_TRUE(check_view(oneapi::dpl::experimental::dr::__detail::enumerate(ops.vec),
                          xp::views::enumerate(ops.dist_vec)));
 }
 
 TYPED_TEST(Enumerate, Mutate) {
   Ops1<TypeParam> ops(10);
-  auto local = stdrng::views::enumerate(ops.vec);
+  auto local = oneapi::dpl::experimental::dr::__detail::enumerate(ops.vec);
   auto dist = xp::views::enumerate(ops.dist_vec);
 
   auto copy = [](auto &&v) { std::get<1>(v) = std::get<0>(v); };


### PR DESCRIPTION
This patch allows distributed ranges tests to be compiled with gcc-14. This is conflict fixed version of https://github.com/oneapi-src/oneDPL/pull/1697 PR from @BenBrock + removed workaround in CI