### PR TITLE
Implement TODO: move the loop into peer algorithms

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -343,12 +343,12 @@ enum class __peer_prefix_algo
     scan_then_broadcast
 };
 
-template <typename _OffsetT, __peer_prefix_algo _Algo>
+template <std::uint32_t __radix_bits, typename _OffsetT, __peer_prefix_algo _Algo>
 struct __peer_prefix_helper;
 
 #if (_ONEDPL_LIBSYCL_VERSION >= 50700)
-template <typename _OffsetT>
-struct __peer_prefix_helper<_OffsetT, __peer_prefix_algo::atomic_fetch_or>
+template <std::uint32_t __radix_bits, typename _OffsetT>
+struct __peer_prefix_helper<__radix_bits, _OffsetT, __peer_prefix_algo::atomic_fetch_or>
 {
     using _AtomicT = __dpl_sycl::__atomic_ref<::std::uint32_t, sycl::access::address_space::local_space>;
     using _TempStorageT = __dpl_sycl::__local_accessor<::std::uint32_t>;
@@ -357,6 +357,7 @@ struct __peer_prefix_helper<_OffsetT, __peer_prefix_algo::atomic_fetch_or>
     ::std::uint32_t __self_lidx;
     ::std::uint32_t __item_mask;
     _AtomicT __atomic_peer_mask;
+    static constexpr std::uint32_t __radix_states = 1 << __radix_bits;
 
     __peer_prefix_helper(sycl::nd_item<1> __self_item, _TempStorageT __lacc)
         : __sgroup(__self_item.get_sub_group()), __self_lidx(__self_item.get_local_linear_id()),
@@ -364,33 +365,42 @@ struct __peer_prefix_helper<_OffsetT, __peer_prefix_algo::atomic_fetch_or>
     {
     }
 
-    ::std::uint32_t
-    __peer_contribution(_OffsetT& __new_offset_idx, _OffsetT __offset_prefix, bool __is_current_bucket)
+    template <typename _OffsetHistogramAcc>
+    _OffsetT
+    __peer_contribution(std::uint32_t __bucket, _OffsetHistogramAcc& __offset_histogram)
     {
-        // reset mask for each radix state
-        if (__self_lidx == 0)
-            __atomic_peer_mask.store(0U);
-        sycl::group_barrier(__sgroup);
-        // set local id's bit to 1 if the bucket value matches the radix state
-        __atomic_peer_mask.fetch_or(__is_current_bucket << __self_lidx);
-        sycl::group_barrier(__sgroup);
-        ::std::uint32_t __peer_mask_bits = __atomic_peer_mask.load();
-        ::std::uint32_t __sg_total_offset = sycl::popcount(__peer_mask_bits);
+        _OffsetT __offset = 0;
+        _ONEDPL_PRAGMA_UNROLL
+        for (::std::uint32_t __radix_state_idx = 0; __radix_state_idx < __radix_states; ++__radix_state_idx)
+        {
+            ::std::uint32_t __is_current_bucket = (__bucket == __radix_state_idx);
+            // reset mask for each radix state
+            if (__self_lidx == 0)
+                __atomic_peer_mask.store(0U);
+            sycl::group_barrier(__sgroup);
+            // set local id's bit to 1 if the bucket value matches the radix state
+            __atomic_peer_mask.fetch_or(__is_current_bucket << __self_lidx);
+            sycl::group_barrier(__sgroup);
+            ::std::uint32_t __peer_mask_bits = __atomic_peer_mask.load();
+            ::std::uint32_t __sg_total_offset = sycl::popcount(__peer_mask_bits);
 
-        // get the local offset index from the bits set in the peer mask with index less than the work item ID
-        __peer_mask_bits &= __item_mask;
-        __new_offset_idx |= __is_current_bucket * (__offset_prefix + sycl::popcount(__peer_mask_bits));
-        return __sg_total_offset;
+            // get the local offset index from the bits set in the peer mask with index less than the work item ID
+            __peer_mask_bits &= __item_mask;
+            __offset |= __is_current_bucket * (__offset_histogram[__radix_state_idx] + sycl::popcount(__peer_mask_bits));
+            __offset_histogram[__radix_state_idx] += __sg_total_offset;
+        }
+        return __offset;
     }
 };
 #endif // (_ONEDPL_LIBSYCL_VERSION >= 50700)
 
-template <typename _OffsetT>
-struct __peer_prefix_helper<_OffsetT, __peer_prefix_algo::scan_then_broadcast>
+template <std::uint32_t __radix_bits, typename _OffsetT>
+struct __peer_prefix_helper<__radix_bits, _OffsetT, __peer_prefix_algo::scan_then_broadcast>
 {
     using _TempStorageT = __empty_peer_temp_storage;
     using _ItemType = sycl::nd_item<1>;
     using _SubGroupType = decltype(::std::declval<_ItemType>().get_sub_group());
+    static constexpr std::uint32_t __radix_states = 1 << __radix_bits;
 
     _SubGroupType __sgroup;
     ::std::uint32_t __sg_size;
@@ -400,30 +410,38 @@ struct __peer_prefix_helper<_OffsetT, __peer_prefix_algo::scan_then_broadcast>
     {
     }
 
-    ::std::uint32_t
-    __peer_contribution(_OffsetT& __new_offset_idx, _OffsetT __offset_prefix, bool __is_current_bucket)
+    template <typename _OffsetHistogramAcc>
+    _OffsetT
+    __peer_contribution(std::uint32_t __bucket, _OffsetHistogramAcc& __offset_histogram)
     {
-        ::std::uint32_t __sg_item_offset = __dpl_sycl::__exclusive_scan_over_group(
-            __sgroup, static_cast<::std::uint32_t>(__is_current_bucket), __dpl_sycl::__plus<::std::uint32_t>());
+        _OffsetT __offset = 0;
+        _ONEDPL_PRAGMA_UNROLL
+        for (::std::uint32_t __radix_state_idx = 0; __radix_state_idx < __radix_states; ++__radix_state_idx)
+        {
+            ::std::uint32_t __is_current_bucket = (__bucket == __radix_state_idx);
+            ::std::uint32_t __sg_item_offset = __dpl_sycl::__exclusive_scan_over_group(
+                __sgroup, static_cast<::std::uint32_t>(__is_current_bucket), __dpl_sycl::__plus<::std::uint32_t>());
 
-        __new_offset_idx |= __is_current_bucket * (__offset_prefix + __sg_item_offset);
-        // the last scanned value may not contain number of all copies, thus adding __is_current_bucket
-        ::std::uint32_t __sg_total_offset =
-            __dpl_sycl::__group_broadcast(__sgroup, __sg_item_offset + __is_current_bucket, __sg_size - 1);
-
-        return __sg_total_offset;
+            __offset |= __is_current_bucket * (__offset_histogram[__radix_state_idx] + __sg_item_offset);
+            // the last scanned value may not contain number of all copies, thus adding __is_current_bucket
+            ::std::uint32_t __sg_total_offset =
+                __dpl_sycl::__group_broadcast(__sgroup, __sg_item_offset + __is_current_bucket, __sg_size - 1);
+            __offset_histogram[__radix_state_idx] += __sg_total_offset;
+        }
+        return __offset;
     }
 };
 
 #if _ONEDPL_SYCL_SUB_GROUP_MASK_PRESENT
-template <typename _OffsetT>
-struct __peer_prefix_helper<_OffsetT, __peer_prefix_algo::subgroup_ballot>
+template <std::uint32_t __radix_bits, typename _OffsetT>
+struct __peer_prefix_helper<__radix_bits, _OffsetT, __peer_prefix_algo::subgroup_ballot>
 {
     using _TempStorageT = __empty_peer_temp_storage;
 
     sycl::sub_group __sgroup;
     ::std::uint32_t __self_lidx;
     sycl::ext::oneapi::sub_group_mask __item_sg_mask;
+    static constexpr std::uint32_t __radix_states = 1 << __radix_bits;
 
     __peer_prefix_helper(sycl::nd_item<1> __self_item, _TempStorageT)
         : __sgroup(__self_item.get_sub_group()), __self_lidx(__self_item.get_local_linear_id()),
@@ -432,21 +450,28 @@ struct __peer_prefix_helper<_OffsetT, __peer_prefix_algo::subgroup_ballot>
     {
     }
 
-    ::std::uint32_t
-    __peer_contribution(_OffsetT& __new_offset_idx, _OffsetT __offset_prefix, bool __is_current_bucket)
+    template <typename _OffsetHistogramAcc>
+    _OffsetT
+    __peer_contribution(std::uint32_t __bucket, _OffsetHistogramAcc& __offset_histogram)
     {
-        // set local id's bit to 1 if the bucket value matches the radix state
-        auto __peer_mask = sycl::ext::oneapi::group_ballot(__sgroup, __is_current_bucket);
-        ::std::uint32_t __peer_mask_bits{};
-        __peer_mask.extract_bits(__peer_mask_bits);
-        ::std::uint32_t __sg_total_offset = sycl::popcount(__peer_mask_bits);
+        _OffsetT __offset = 0;
+        _ONEDPL_PRAGMA_UNROLL
+        for (::std::uint32_t __radix_state_idx = 0; __radix_state_idx < __radix_states; ++__radix_state_idx)
+        {
+            ::std::uint32_t __is_current_bucket = (__bucket == __radix_state_idx);
+            // set local id's bit to 1 if the bucket value matches the radix state
+            auto __peer_mask = sycl::ext::oneapi::group_ballot(__sgroup, __is_current_bucket);
+            ::std::uint32_t __peer_mask_bits{};
+            __peer_mask.extract_bits(__peer_mask_bits);
+            ::std::uint32_t __sg_total_offset = sycl::popcount(__peer_mask_bits);
 
-        // get the local offset index from the bits set in the peer mask with index less than the work item ID
-        __peer_mask &= __item_sg_mask;
-        __peer_mask.extract_bits(__peer_mask_bits);
-        __new_offset_idx |= __is_current_bucket * (__offset_prefix + sycl::popcount(__peer_mask_bits));
-
-        return __sg_total_offset;
+            // get the local offset index from the bits set in the peer mask with index less than the work item ID
+            __peer_mask &= __item_sg_mask;
+            __peer_mask.extract_bits(__peer_mask_bits);
+            __offset |= __is_current_bucket * (__offset_histogram[__radix_state_idx] + sycl::popcount(__peer_mask_bits));
+            __offset_histogram[__radix_state_idx] += __sg_total_offset;
+        }
+        return __offset;
     }
 };
 #endif // _ONEDPL_SYCL_SUB_GROUP_MASK_PRESENT
@@ -500,7 +525,7 @@ __radix_sort_reorder_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments,
     // typedefs
     using _OffsetT = typename _OffsetBuf::value_type;
     using _ValueT = oneapi::dpl::__internal::__value_t<_InRange>;
-    using _PeerHelper = __peer_prefix_helper<_OffsetT, _PeerAlgo>;
+    using _PeerHelper = __peer_prefix_helper<__radix_bits, _OffsetT, _PeerAlgo>;
 
     assert(__input_rng.size() == __output_rng.size());
 
@@ -581,15 +606,7 @@ __radix_sort_reorder_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments,
                     ::std::uint32_t __bucket = __get_bucket<(1 << __radix_bits) - 1>(
                         __order_preserving_cast<__is_ascending>(__proj(__in_val)), __radix_offset);
 
-                    // TODO: move the whole loop to be a part of peer algorithms
-                    _OffsetT __new_offset_idx = 0;
-                    for (::std::uint32_t __radix_state_idx = 0; __radix_state_idx < __radix_states; ++__radix_state_idx)
-                    {
-                        ::std::uint32_t __is_current_bucket = (__bucket == __radix_state_idx);
-                        ::std::uint32_t __sg_total_offset = __peer_prefix_hlp.__peer_contribution(
-                            __new_offset_idx, __offset_arr[__radix_state_idx], __is_current_bucket);
-                        __offset_arr[__radix_state_idx] += __sg_total_offset;
-                    }
+                    const auto __new_offset_idx = __peer_prefix_hlp.__peer_contribution(__bucket, __offset_arr);
                     __output_rng[__new_offset_idx] = std::move(__in_val);
                 }
                 if (__residual > 0)
@@ -606,14 +623,7 @@ __radix_sort_reorder_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments,
                         __bucket = __get_bucket<(1 << __radix_bits) - 1>(
                             __order_preserving_cast<__is_ascending>(__proj(__in_val.__v)), __radix_offset);
                     }
-                    _OffsetT __new_offset_idx = 0;
-                    for (::std::uint32_t __radix_state_idx = 0; __radix_state_idx < __radix_states; ++__radix_state_idx)
-                    {
-                        ::std::uint32_t __is_current_bucket = (__bucket == __radix_state_idx);
-                        ::std::uint32_t __sg_total_offset = __peer_prefix_hlp.__peer_contribution(
-                            __new_offset_idx, __offset_arr[__radix_state_idx], __is_current_bucket);
-                        __offset_arr[__radix_state_idx] += __sg_total_offset;
-                    }
+                    const auto __new_offset_idx = __peer_prefix_hlp.__peer_contribution(__bucket, __offset_arr);
                     if (__self_lidx < __residual)
                     {
                         __output_rng[__new_offset_idx] = std::move(__in_val.__v);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -581,6 +581,7 @@ __radix_sort_reorder_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments,
                 const ::std::size_t __scan_size = __segments + 1;
                 _OffsetT __scanned_bin = 0;
                 __offset_arr[0] = __offset_rng[__segment_idx];
+                _ONEDPL_PRAGMA_UNROLL
                 for (::std::uint32_t __radix_state_idx = 1; __radix_state_idx < __radix_states; ++__radix_state_idx)
                 {
                     const ::std::uint32_t __local_offset_idx = __segment_idx + (__segments + 1) * __radix_state_idx;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -370,7 +370,6 @@ struct __peer_prefix_helper<__radix_bits, _OffsetT, __peer_prefix_algo::atomic_f
     __peer_contribution(std::uint32_t __bucket, _OffsetHistogramAcc& __histogram)
     {
         _OffsetT __offset = 0;
-        _ONEDPL_PRAGMA_UNROLL
         for (::std::uint32_t __radix_state_idx = 0; __radix_state_idx < __radix_states; ++__radix_state_idx)
         {
             ::std::uint32_t __is_current_bucket = (__bucket == __radix_state_idx);
@@ -415,7 +414,6 @@ struct __peer_prefix_helper<__radix_bits, _OffsetT, __peer_prefix_algo::scan_the
     __peer_contribution(std::uint32_t __bucket, _OffsetHistogramAcc& __histogram)
     {
         _OffsetT __offset = 0;
-        _ONEDPL_PRAGMA_UNROLL
         for (::std::uint32_t __radix_state_idx = 0; __radix_state_idx < __radix_states; ++__radix_state_idx)
         {
             ::std::uint32_t __is_current_bucket = (__bucket == __radix_state_idx);
@@ -455,7 +453,6 @@ struct __peer_prefix_helper<__radix_bits, _OffsetT, __peer_prefix_algo::subgroup
     __peer_contribution(std::uint32_t __bucket, _OffsetHistogramAcc& __histogram)
     {
         _OffsetT __offset = 0;
-        _ONEDPL_PRAGMA_UNROLL
         for (::std::uint32_t __radix_state_idx = 0; __radix_state_idx < __radix_states; ++__radix_state_idx)
         {
             ::std::uint32_t __is_current_bucket = (__bucket == __radix_state_idx);
@@ -581,7 +578,6 @@ __radix_sort_reorder_submit(_ExecutionPolicy&& __exec, ::std::size_t __segments,
                 const ::std::size_t __scan_size = __segments + 1;
                 _OffsetT __scanned_bin = 0;
                 __offset_arr[0] = __offset_rng[__segment_idx];
-                _ONEDPL_PRAGMA_UNROLL
                 for (::std::uint32_t __radix_state_idx = 1; __radix_state_idx < __radix_states; ++__radix_state_idx)
                 {
                     const ::std::uint32_t __local_offset_idx = __segment_idx + (__segments + 1) * __radix_state_idx;


### PR DESCRIPTION
This essentially implements this TODO:
> // TODO: move the whole loop to be a part of peer algorithms

This will allow adding one more peer algorithm which iterates over radix bits rather than radix states; or it will be easier to experiment at least.