### PR TITLE
Include guards instead of pragmas

### DIFF
--- a/include/oneapi/dpl/internal/distributed_ranges_impl/concepts/concepts.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/concepts/concepts.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_CONCEPTS_CONCEPTS_HPP
+#define _ONEDPL_DR_CONCEPTS_CONCEPTS_HPP
 
 #include <oneapi/dpl/internal/distributed_ranges_impl/detail/ranges.hpp>
 
@@ -79,3 +80,5 @@ concept distributed_contiguous_iterator = distributed_iterator<Iter> && std::ran
 } && remote_contiguous_range<stdrng::range_value_t<decltype(ranges::segments(std::declval<Iter>()))>>;
 
 } // namespace oneapi::dpl::experimental::dr
+
+#endif /* _ONEDPL_DR_CONCEPTS_CONCEPTS_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/detail/enumerate.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/detail/enumerate.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_DETAIL_ENUMERATE_HPP
+#define _ONEDPL_DR_DETAIL_ENUMERATE_HPP
 
 #include <oneapi/dpl/internal/distributed_ranges_impl/detail/ranges_shim.hpp>
 
@@ -95,3 +96,5 @@ inline constexpr auto enumerate = enumerate_fn_{};
 } // namespace __detail
 
 } // namespace oneapi::dpl::experimental::dr
+
+#endif /* _ONEDPL_DR_DETAIL_ENUMERATE_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/detail/iterator_adaptor.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/detail/iterator_adaptor.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_DETAIL_ITERATOR_ADAPTOR_HPP
+#define _ONEDPL_DR_DETAIL_ITERATOR_ADAPTOR_HPP
 
 #include <iterator>
 #include <type_traits>
@@ -228,3 +229,5 @@ class iterator_adaptor
 };
 
 } // namespace oneapi::dpl::experimental::dr
+
+#endif /* _ONEDPL_DR_DETAIL_ITERATOR_ADAPTOR_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/detail/onedpl_direct_iterator.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/detail/onedpl_direct_iterator.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_DETAIL_DIRECT_ITERATOR_HPP
+#define _ONEDPL_DR_DETAIL_DIRECT_ITERATOR_HPP
 
 #include <iterator>
 
@@ -169,3 +170,5 @@ class direct_iterator
 } // namespace __detail
 
 } // namespace oneapi::dpl::experimental::dr
+
+#endif /* _ONEDPL_DR_DETAIL_DIRECT_ITERATOR_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/detail/owning_view.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/detail/owning_view.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_DETAIL_OWNING_VIEW_HPP
+#define _ONEDPL_DR_DETAIL_OWNING_VIEW_HPP
 
 #include <oneapi/dpl/internal/distributed_ranges_impl/detail/ranges_shim.hpp>
 
@@ -98,3 +99,5 @@ class owning_view : public stdrng::view_interface<owning_view<R>>
 } // namespace __detail
 
 } // namespace oneapi::dpl::experimental::dr
+
+#endif /* _ONEDPL_DR_DETAIL_OWNING_VIEW_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/detail/ranges.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/detail/ranges.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_DETAIL_RANGES_HPP
+#define _ONEDPL_DR_DETAIL_RANGES_HPP
 
 #include <any>
 #include <iterator>
@@ -372,3 +373,5 @@ inline constexpr auto local = local_fn_{};
 } // namespace ranges
 
 } // namespace oneapi::dpl::experimental::dr
+
+#endif // _ONEDPL_DR_DETAIL_RANGES_HPP

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/detail/ranges_shim.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/detail/ranges_shim.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_DETAIL_RANGES_SHIM_HPP
+#define _ONEDPL_DR_DETAIL_RANGES_SHIM_HPP
 
 #ifndef DR_USE_RANGES_V3
 
@@ -35,4 +36,6 @@ namespace stdrng = ::ranges;
 
 #    define DR_RANGES_NAMESPACE ranges
 
-#endif
+#endif /* DR_USE_RANGES_V3 */
+
+#endif /* _ONEDPL_DR_DETAIL_RANGES_SHIM_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/detail/remote_subrange.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/detail/remote_subrange.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_DETAIL_REMOTE_SUBRANGE_HPP
+#define _ONEDPL_DR_DETAIL_REMOTE_SUBRANGE_HPP
 
 #include <iterator>
 
@@ -69,3 +70,5 @@ template <typename R>
 inline constexpr bool stdrng::enable_borrowed_range<oneapi::dpl::experimental::dr::remote_subrange<R>> = true;
 
 #endif
+
+#endif /* _ONEDPL_DR_DETAIL_REMOTE_SUBRANGE_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/detail/segments_tools.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/detail/segments_tools.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_DETAIL_SEGMENT_TOOLS_HPP
+#define _ONEDPL_DR_DETAIL_SEGMENT_TOOLS_HPP
 
 #include <oneapi/dpl/internal/distributed_ranges_impl/concepts/concepts.hpp>
 #include <oneapi/dpl/internal/distributed_ranges_impl/detail/enumerate.hpp>
@@ -170,3 +171,5 @@ requires(oneapi::dpl::experimental::dr::is_subrange_view_v<std::remove_cvref_t<V
 }
 
 } // namespace DR_RANGES_NAMESPACE
+
+#endif /* _ONEDPL_DR_DETAIL_SEGMENT_TOOLS_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/detail/sycl_utils.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/detail/sycl_utils.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_DETAIL_SYCL_UTILS_HPP
+#define _ONEDPL_DR_DETAIL_SYCL_UTILS_HPP
 
 #include <limits>
 
@@ -235,3 +236,5 @@ parallel_for(sycl::queue& q, sycl::range<3> global, Fn&& fn)
 using event = sycl::event;
 
 } // namespace oneapi::dpl::experimental::dr::__detail
+
+#endif /* _ONEDPL_DR_DETAIL_SYCL_UTILS_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/detail/utils.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/detail/utils.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_DETAIL_UTILS_HPP
+#define _ONEDPL_DR_DETAIL_UTILS_HPP
 
 namespace oneapi::dpl::experimental::dr::__detail
 {
@@ -36,3 +37,5 @@ round_up(std::size_t n, std::size_t multiple)
 }
 
 } // namespace oneapi::dpl::experimental::dr::__detail
+
+#endif /* _ONEDPL_DR_DETAIL_UTILS_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/detail/view_detectors.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/detail/view_detectors.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_DETAIL_VIEW_DETECTORS_HPP
+#define _ONEDPL_DR_DETAIL_VIEW_DETECTORS_HPP
 
 #include <type_traits>
 
@@ -111,3 +112,5 @@ template <typename T>
 inline constexpr bool is_zip_view_v = is_zip_view<T>::value;
 
 } // namespace oneapi::dpl::experimental::dr
+
+#endif /* _ONEDPL_DR_DETAIL_VIEW_DETECTORS_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/sp.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/sp.hpp
@@ -12,8 +12,8 @@
 // See https://llvm.org/LICENSE.txt for license information.
 //
 //===----------------------------------------------------------------------===//
-
-#pragma once
+#ifndef _ONEDPL_DR_SP_HPP
+#define _ONEDPL_DR_SP_HPP
 
 #include "sp/algorithms/algorithms.hpp"
 #include "sp/detail.hpp"
@@ -25,3 +25,5 @@
 #include "sp/util.hpp"
 #include "sp/views/views.hpp"
 #include "views/views.hpp"
+
+#endif /* _ONEDPL_DR_SP_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/sp/algorithms/algorithms.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/sp/algorithms/algorithms.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_SP_ALGORITHMS_HPP
+#define _ONEDPL_DR_SP_ALGORITHMS_HPP
 
 #include "copy.hpp"
 #include "equal.hpp"
@@ -26,3 +27,5 @@
 #include "reduce.hpp"
 #include "sort.hpp"
 #include "transform.hpp"
+
+#endif

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/sp/algorithms/copy.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/sp/algorithms/copy.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_SP_COPY_HPP
+#define _ONEDPL_DR_SP_COPY_HPP
 
 #include <memory>
 #include <type_traits>
@@ -234,3 +235,5 @@ copy(R&& r, O result)
 }
 
 } // namespace oneapi::dpl::experimental::dr::sp
+
+#endif /* _ONEDPL_DR_SP_COPY_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/sp/algorithms/equal.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/sp/algorithms/equal.hpp
@@ -2,7 +2,8 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-#pragma once
+#ifndef _ONEDPL_DR_SP_EQUAL_HPP
+#define _ONEDPL_DR_SP_EQUAL_HPP
 
 #include <oneapi/dpl/internal/distributed_ranges_impl/sp/algorithms/fill.hpp>
 #include <oneapi/dpl/internal/distributed_ranges_impl/sp/algorithms/reduce.hpp>
@@ -44,3 +45,5 @@ equal(R1&& r1, R2&& r2)
     return equal(dr::sp::par_unseq, r1, r2);
 }
 } // namespace oneapi::dpl::experimental::dr::sp
+
+#endif /* _ONEDPL_DR_SP_EQUAL_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/sp/algorithms/exclusive_scan.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/sp/algorithms/exclusive_scan.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_SP_EXCLUSIVE_SCAN_HPP
+#define _ONEDPL_DR_SP_EXCLUSIVE_SCAN_HPP
 
 #include <sycl/sycl.hpp>
 
@@ -244,3 +245,5 @@ exclusive_scan(Iter first, Iter last, OutputIter d_first, T init)
 }
 
 } // namespace oneapi::dpl::experimental::dr::sp
+
+#endif /* _ONEDPL_DR_SP_EXCLUSIVE_SCAN_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/sp/algorithms/execution_policy.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/sp/algorithms/execution_policy.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_SP_EXECUTION_POLICY_HPP
+#define _ONEDPL_DR_SP_EXECUTION_POLICY_HPP
 
 #include <span>
 #include <sycl/sycl.hpp>
@@ -52,3 +53,5 @@ struct distributed_device_policy
 };
 
 } // namespace oneapi::dpl::experimental::dr::sp
+
+#endif /* _ONEDPL_DR_SP_EXECUTION_POLICY_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/sp/algorithms/fill.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/sp/algorithms/fill.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_SP_FILL_HPP
+#define _ONEDPL_DR_SP_FILL_HPP
 
 #include <memory>
 #include <type_traits>
@@ -112,3 +113,5 @@ fill(Iter first, Iter last, const T& value)
 }
 
 } // namespace oneapi::dpl::experimental::dr::sp
+
+#endif /* _ONEDPL_DR_SP_FILL_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/sp/algorithms/inclusive_scan.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/sp/algorithms/inclusive_scan.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_SP_INCLUSIVE_SCAN_HPP
+#define _ONEDPL_DR_SP_INCLUSIVE_SCAN_HPP
 
 #include <optional>
 
@@ -271,3 +272,5 @@ inclusive_scan(Iter first, Iter last, OutputIter d_first, BinaryOp binary_op, T 
 }
 
 } // namespace oneapi::dpl::experimental::dr::sp
+
+#endif /* _ONEDPL_DR_SP_INCLUSIVE_SCAN_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/sp/algorithms/iota.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/sp/algorithms/iota.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_SP_IOTA_HPP
+#define _ONEDPL_DR_SP_IOTA_HPP
 
 #include <limits>
 
@@ -46,3 +47,5 @@ iota(Iter begin, Iter end, T value)
 }
 
 } // namespace oneapi::dpl::experimental::dr::sp
+
+#endif /* _ONEDPL_DR_SP_IOTA_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/sp/algorithms/reduce.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/sp/algorithms/reduce.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_SP_REDUCE_HPP
+#define _ONEDPL_DR_SP_REDUCE_HPP
 
 #include <oneapi/dpl/execution>
 #include <oneapi/dpl/numeric>
@@ -194,3 +195,5 @@ reduce(Iter first, Iter last, T init, BinaryOp binary_op)
 }
 
 } // namespace oneapi::dpl::experimental::dr::sp
+
+#endif

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/sp/algorithms/sort.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/sp/algorithms/sort.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_SP_SORT_HPP
+#define _ONEDPL_DR_SP_SORT_HPP
 
 #include <oneapi/dpl/execution>
 
@@ -322,3 +323,5 @@ sort(RandomIt first, RandomIt last, Compare comp = Compare())
 }
 
 } // namespace oneapi::dpl::experimental::dr::sp
+
+#endif /* _ONEDPL_DR_SP_SORT_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/sp/algorithms/transform.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/sp/algorithms/transform.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_SP_TRANSFORM_HPP
+#define _ONEDPL_DR_SP_TRANSFORM_HPP
 
 #include <oneapi/dpl/internal/distributed_ranges_impl/sp/detail.hpp>
 #include <oneapi/dpl/internal/distributed_ranges_impl/sp/init.hpp>
@@ -105,3 +106,5 @@ transform(Iter1 in_begin, Iter1 in_end, Iter2 out_end, Fn&& fn)
 }
 
 } // namespace oneapi::dpl::experimental::dr::sp
+
+#endif /* _ONEDPL_DR_SP_TRANSFORM_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/sp/allocators.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/sp/allocators.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_SP_ALLOCATORS_HPP
+#define _ONEDPL_DR_SP_ALLOCATORS_HPP
 
 #include <type_traits>
 
@@ -170,3 +171,5 @@ class buffered_allocator
 };
 
 } // namespace oneapi::dpl::experimental::dr::sp
+
+#endif /* _ONEDPL_DR_SP_ALLOCATORS_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/sp/containers/detail.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/sp/containers/detail.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_SP_CONTAINERS_DETAIL_HPP
+#define _ONEDPL_DR_SP_CONTAINERS_DETAIL_HPP
 
 #include <cmath>
 
@@ -42,3 +43,5 @@ factor(std::size_t n)
 } // namespace detail
 
 } // namespace oneapi::dpl::experimental::dr::sp
+
+#endif /* _ONEDPL_DR_SP_CONTAINERS_DETAIL_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/sp/containers/duplicated_vector.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/sp/containers/duplicated_vector.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_SP_COINTAINTERS_DUPLICATED_VECTOR_HPP
+#define _ONEDPL_DR_SP_COINTAINTERS_DUPLICATED_VECTOR_HPP
 
 #include <oneapi/dpl/internal/distributed_ranges_impl/sp/allocators.hpp>
 #include <oneapi/dpl/internal/distributed_ranges_impl/sp/remote_vector.hpp>
@@ -70,3 +71,5 @@ class duplicated_vector
 };
 
 } // namespace oneapi::dpl::experimental::dr::sp
+
+#endif /* _ONEDPL_DR_SP_DUPLICATED_VECTOR_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/sp/detail.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/sp/detail.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_SP_DETAIL_HPP
+#define _ONEDPL_DR_SP_DETAIL_HPP
 
 #include <iterator>
 #include <oneapi/dpl/internal/distributed_ranges_impl/detail/ranges.hpp>
@@ -135,3 +136,5 @@ wait(const std::vector<sycl::event>& events)
 } // namespace __detail
 
 } // namespace oneapi::dpl::experimental::dr::sp
+
+#endif /* _ONEDPL_DR_SP_DETAIL_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/sp/device_ptr.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/sp/device_ptr.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_SP_DEVICE_PTR_HPP
+#define _ONEDPL_DR_SP_DEVICE_PTR_HPP
 
 #include <type_traits>
 
@@ -205,3 +206,5 @@ requires(std::is_trivially_copyable_v<T> || std::is_void_v<T>) class device_ptr
 };
 
 } // namespace oneapi::dpl::experimental::dr::sp
+
+#endif /* _ONEDPL_DR_SP_DEVICE_PTR_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/sp/device_ref.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/sp/device_ref.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_DETAIL_SP_DEVICE_REF_HPP
+#define _ONEDPL_DR_DETAIL_SP_DEVICE_REF_HPP
 
 #include <oneapi/dpl/internal/distributed_ranges_impl/sp/init.hpp>
 #include <sycl/sycl.hpp>
@@ -74,3 +75,5 @@ requires(std::is_trivially_copyable_v<T> || std::is_void_v<T>) class device_ref
 };
 
 } // namespace oneapi::dpl::experimental::dr::sp
+
+#endif /* _ONEDPL_DR_DETAIL_SP_DEVICE_REF_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/sp/distributed_span.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/sp/distributed_span.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_SP_DISTRIBUTED_SPAN_HPP
+#define _ONEDPL_DR_SP_DISTRIBUTED_SPAN_HPP
 
 #include <vector>
 
@@ -329,3 +330,5 @@ distributed_span(R&& r) -> distributed_span<stdrng::range_value_t<R>,
                                             stdrng::iterator_t<stdrng::range_value_t<decltype(ranges::segments(r))>>>;
 
 } // namespace oneapi::dpl::experimental::dr::sp
+
+#endif /* _ONEDPL_DR_SP_DISTRIBUTED_SPAN_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/sp/distributed_vector.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/sp/distributed_vector.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_SP_DISTRIBUTED_VECTOR_HPP
+#define _ONEDPL_DR_SP_DISTRIBUTED_VECTOR_HPP
 
 #include <vector>
 
@@ -269,3 +270,5 @@ struct distributed_vector
 };
 
 } // namespace oneapi::dpl::experimental::dr::sp
+
+#endif /* _ONEDPL_DR_SP_DISTRIBUTED_VECTOR_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/sp/init.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/sp/init.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_SP_INIT_HPP
+#define _ONEDPL_DR_SP_INIT_HPP
 
 #include <cassert>
 #include <memory>
@@ -159,3 +160,5 @@ dpl_policy(std::size_t rank)
 } // namespace __detail
 
 } // namespace oneapi::dpl::experimental::dr::sp
+
+#endif /* _ONEDPL_DR_SP_INIT_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/sp/range.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/sp/range.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_SP_RANGE_HPP
+#define _ONEDPL_DR_SP_RANGE_HPP
 
 #include <oneapi/dpl/internal/distributed_ranges_impl/concepts/concepts.hpp>
 #include <oneapi/dpl/internal/distributed_ranges_impl/sp/distributed_span.hpp>
@@ -191,3 +192,5 @@ class segment_range
 };
 
 } // namespace oneapi::dpl::experimental::dr::sp
+
+#endif /* _ONEDPL_DR_SP_RANGE_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/sp/range_adaptors.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/sp/range_adaptors.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_SP_RANGE_ADAPTORS_HPP
+#define _ONEDPL_DR_SP_RANGE_ADAPTORS_HPP
 
 #include <oneapi/dpl/internal/distributed_ranges_impl/sp/views/standard_views.hpp>
 #include <oneapi/dpl/internal/distributed_ranges_impl/sp/zip_view.hpp>
@@ -30,3 +31,5 @@ enumerate(R&& r)
 }
 
 } // namespace oneapi::dpl::experimental::dr::sp
+
+#endif /* _ONEDPL_DR_SP_RANGE_ADAPTORS_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/sp/remote_span.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/sp/remote_span.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_SP_REMOTE_SPAN_HPP
+#define _ONEDPL_DR_SP_REMOTE_SPAN_HPP
 
 #include <oneapi/dpl/internal/distributed_ranges_impl/concepts/concepts.hpp>
 #include <oneapi/dpl/internal/distributed_ranges_impl/sp/span.hpp>
@@ -119,3 +120,5 @@ template <stdrng::random_access_range R>
 remote_span(R&&, std::size_t) -> remote_span<stdrng::range_value_t<R>, stdrng::iterator_t<R>>;
 
 } // namespace oneapi::dpl::experimental::dr::sp
+
+#endif /* _ONEDPL_DR_SP_REMOTE_SPAN_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/sp/remote_vector.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/sp/remote_vector.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_SP_REMOTE_VECTOR_HPP
+#define _ONEDPL_DR_SP_REMOTE_VECTOR_HPP
 
 #include <oneapi/dpl/internal/distributed_ranges_impl/sp/allocators.hpp>
 #include <oneapi/dpl/internal/distributed_ranges_impl/sp/vector.hpp>
@@ -56,3 +57,5 @@ template <class Alloc>
 remote_vector(std::size_t, const Alloc, std::size_t) -> remote_vector<typename Alloc::value_type, Alloc>;
 
 } // namespace oneapi::dpl::experimental::dr::sp
+
+#endif /* _ONEDPL_DR_SP_REMOTE_VECTOR_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/sp/span.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/sp/span.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_SP_SPAN_HPP
+#define _ONEDPL_DR_SP_SPAN_HPP
 
 #include <iterator>
 
@@ -117,3 +118,5 @@ template <std::random_access_iterator Iter>
 span(Iter first, std::size_t count) -> span<std::iter_value_t<Iter>, Iter>;
 
 } // namespace oneapi::dpl::experimental::dr::sp
+
+#endif /* _ONEDPL_DR_SP_SPAN_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/sp/util.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/sp/util.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_SP_UTIL_HPP
+#define _ONEDPL_DR_SP_UTIL_HPP
 
 #include <iostream>
 #include <sycl/sycl.hpp>
@@ -283,3 +284,5 @@ concept sycl_device_selector = requires(T& t, const sycl::device& device)
 } // namespace __detail
 
 } // namespace oneapi::dpl::experimental::dr::sp
+
+#endif /* _ONEDPL_DR_SP_UTIL_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/sp/vector.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/sp/vector.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_SP_VECTOR_HPP
+#define _ONEDPL_DR_SP_VECTOR_HPP
 
 #include <memory>
 
@@ -342,3 +343,5 @@ class vector
 };
 
 } // namespace oneapi::dpl::experimental::dr::sp
+
+#endif /* _ONEDPL_DR_SP_VECTOR_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/sp/views/enumerate.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/sp/views/enumerate.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_SP_VIEWS_ENUMERATE_HPP
+#define _ONEDPL_DR_SP_VIEWS_ENUMERATE_HPP
 
 #include <oneapi/dpl/internal/distributed_ranges_impl/sp/zip_view.hpp>
 
@@ -84,3 +85,5 @@ inline constexpr auto enumerate = enumerate_fn_{};
 } // namespace views
 
 } // namespace oneapi::dpl::experimental::dr::sp
+
+#endif /* _ONEDPL_DR_SP_VIEWS_ENUMERATE_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/sp/views/standard_views.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/sp/views/standard_views.hpp
@@ -13,10 +13,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_SP_VIEWS_STANDARD_VIEWS_HPP
+#define _ONEDPL_DR_SP_VIEWS_STANDARD_VIEWS_HPP
 
 #include <oneapi/dpl/internal/distributed_ranges_impl/detail/segments_tools.hpp>
 #include <oneapi/dpl/internal/distributed_ranges_impl/sp/distributed_span.hpp>
 #include <oneapi/dpl/internal/distributed_ranges_impl/sp/views/enumerate.hpp>
 #include <oneapi/dpl/internal/distributed_ranges_impl/sp/zip_view.hpp>
 #include <oneapi/dpl/internal/distributed_ranges_impl/views/transform.hpp>
+
+#endif /* _ONEDPL_DR_SP_VIEWS_STANDARD_VIEWS_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/sp/views/views.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/sp/views/views.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_SP_VIEWS_VIEWS_HPP
+#define _ONEDPL_DR_SP_VIEWS_VIEWS_HPP
 
 #include <oneapi/dpl/internal/distributed_ranges_impl/sp/views/standard_views.hpp>
 #include <oneapi/dpl/internal/distributed_ranges_impl/views/iota.hpp>
@@ -36,3 +37,5 @@ inline constexpr auto take = stdrng::views::take;
 inline constexpr auto transform = dr::views::transform;
 
 } // namespace oneapi::dpl::experimental::dr::sp::views
+
+#endif /* _ONEDPL_DR_SP_VIEWS_VIEWS_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/sp/zip_view.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/sp/zip_view.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_SP_ZIP_VIEW_HPP
+#define _ONEDPL_DR_SP_ZIP_VIEW_HPP
 
 #include <oneapi/dpl/iterator>
 
@@ -429,3 +430,5 @@ zip(Rs&&... rs)
 } // namespace views
 
 } // namespace oneapi::dpl::experimental::dr::sp
+
+#endif /* _ONEDPL_DR_SP_ZIP_VIEW_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/views/iota.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/views/iota.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_SP_VIEWS_IOTA_HPP
+#define _ONEDPL_DR_SP_VIEWS_IOTA_HPP
 
 namespace oneapi::dpl::experimental::dr::views
 {
@@ -43,3 +44,5 @@ struct iota_fn_
 inline constexpr auto iota = iota_fn_{};
 
 } // namespace oneapi::dpl::experimental::dr::views
+
+#endif /* _ONEDPL_DR_SP_VIEWS_IOTA_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/views/transform.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/views/transform.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_SP_VIEWS_TRANSFORM_HPP
+#define _ONEDPL_DR_SP_VIEWS_TRANSFORM_HPP
 
 #include <concepts>
 #include <iterator>
@@ -286,3 +287,5 @@ template <stdrng::random_access_range V, std::copy_constructible F>
 inline constexpr bool stdrng::enable_borrowed_range<oneapi::dpl::experimental::dr::transform_view<V, F>> = true;
 
 #endif
+
+#endif /* _ONEDPL_DR_SP_VIEWS_TRANSFORM_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/views/views.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/views/views.hpp
@@ -13,7 +13,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
+#ifndef _ONEDPL_DR_VIEWS_VIEWS_HPP
+#define _ONEDPL_DR_VIEWS_VIEWS_HPP
 
 #include <oneapi/dpl/internal/distributed_ranges_impl/concepts/concepts.hpp>
 #include <oneapi/dpl/internal/distributed_ranges_impl/views/transform.hpp>
@@ -32,3 +33,5 @@ ranked_view(const distributed_range auto& r)
 #endif
 
 } // namespace oneapi::dpl::experimental::dr
+
+#endif /* _ONEDPL_DR_VIEWS_VIEWS_HPP */


### PR DESCRIPTION
Include guards instead of `#pragma once`