### PR TITLE
Replace usage of std::complex in by_segment tests

### DIFF
--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
@@ -18,7 +18,6 @@
 #include "oneapi/dpl/execution"
 #include "oneapi/dpl/algorithm"
 #include "oneapi/dpl/iterator"
-#include "oneapi/dpl/complex"
 
 #include "support/utils.h"
 #include "support/scan_serial_impl.h"
@@ -256,7 +255,7 @@ main()
     }
 
     {
-        using ValueType = ::std::complex<float>;
+        using ValueType = MatrixPoint<float>;
         using BinaryPredicate = UserBinaryPredicate<ValueType>;
         using BinaryOperation = MaxFunctor<ValueType>;
 

--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -18,7 +18,6 @@
 #include "oneapi/dpl/execution"
 #include "oneapi/dpl/algorithm"
 #include "oneapi/dpl/iterator"
-#include "oneapi/dpl/complex"
 
 #include "support/utils.h"
 #include "support/scan_serial_impl.h"
@@ -224,7 +223,7 @@ main()
     }
 
     {
-        using ValueType = ::std::complex<float>;
+        using ValueType = MatrixPoint<float>;
         using BinaryPredicate = UserBinaryPredicate<ValueType>;
         using BinaryOperation = MaxFunctor<ValueType>;
 

--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -27,7 +27,6 @@
 #include "oneapi/dpl/algorithm"
 #include "oneapi/dpl/numeric"
 #include "oneapi/dpl/iterator"
-#include "oneapi/dpl/complex"
 
 #include "support/utils.h"
 #include "support/utils_invoke.h"
@@ -350,10 +349,10 @@ main()
 #if TEST_DPCPP_BACKEND_PRESENT
     // test with flag pred
     test_flag_pred<sycl::usm::alloc::device, class KernelName1, std::uint64_t>();
-    test_flag_pred<sycl::usm::alloc::device, class KernelName2, dpl::complex<float>>();
+    test_flag_pred<sycl::usm::alloc::device, class KernelName2, MatrixPoint<float>>();
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
-    run_test<::std::complex<float>, UserBinaryPredicate<::std::complex<float>>, MaxFunctor<::std::complex<float>>>();
+    run_test<MatrixPoint<float>, UserBinaryPredicate<MatrixPoint<float>>, MaxFunctor<MatrixPoint<float>>>();
 
     run_test<int, ::std::equal_to<int>, ::std::plus<int>>();
     run_test<float, ::std::equal_to<float>, ::std::plus<float>>();

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -822,14 +822,14 @@ template <typename _Tp>
 struct MaxFunctor<MatrixPoint<_Tp>>
 {
     auto
-    euclidean_distance(const MatrixPoint<_Tp>& __x) const
+    sum(const MatrixPoint<_Tp>& __x) const
     {
-        return std::sqrt(__x.m * __x.m + __x.n * __x.n);
+        return __x.m + __x.n;
     }
     MatrixPoint<_Tp>
     operator()(const MatrixPoint<_Tp>& __x, const MatrixPoint<_Tp>& __y) const
     {
-        return (euclidean_distance(__x) < euclidean_distance(__y)) ? __y : __x;
+        return (sum(__x) < sum(__y)) ? __y : __x;
     }
 };
 
@@ -841,14 +841,14 @@ template <typename _Tp>
 struct MaxAbsFunctor<MatrixPoint<_Tp>>
 {
     auto
-    euclidean_distance(const MatrixPoint<_Tp>& __x) const
+    abs_sum(const MatrixPoint<_Tp>& __x) const
     {
         return std::sqrt(__x.m * __x.m + __x.n * __x.n);
     }
     MatrixPoint<_Tp>
     operator()(const MatrixPoint<_Tp>& __x, const MatrixPoint<_Tp>& __y) const
     {
-        return (euclidean_distance(__x) < euclidean_distance(__y)) ? euclidean_distance(__y) : euclidean_distance(__x);
+        return (abs_sum(__x) < abs_sum(__y)) ? abs_sum(__y) : abs_sum(__x);
     }
 };
 

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -777,6 +777,37 @@ struct UserBinaryPredicate
     }
 };
 
+template <typename T>
+struct MatrixPoint
+{
+    T m;
+    T n;
+    MatrixPoint() = default;
+    MatrixPoint(T m, T n = {}) : m(m), n(n) {}
+    bool
+    operator==(const MatrixPoint& other) const
+    {
+        return m == other.m && n == other.n;
+    }
+    bool
+    operator!=(const MatrixPoint& other) const
+    {
+        return !(*this == other);
+    }
+    MatrixPoint
+    operator+(const MatrixPoint& other) const
+    {
+        return MatrixPoint(m + other.m, n + other.n);
+    }
+};
+
+template <typename T>
+std::ostream&
+operator<<(std::ostream& os, MatrixPoint<T> matrix_point)
+{
+    return os << "(" << matrix_point.m << ", " << matrix_point.n << ")";
+}
+
 template <typename _Tp>
 struct MaxFunctor
 {
@@ -787,20 +818,18 @@ struct MaxFunctor
     }
 };
 
-// TODO: Investigate why we cannot call ::std::abs on complex
-// types with the CUDA backend.
 template <typename _Tp>
-struct MaxFunctor<::std::complex<_Tp>>
+struct MaxFunctor<MatrixPoint<_Tp>>
 {
     auto
-    complex_abs(const ::std::complex<_Tp>& __x) const
+    euclidean_distance(const MatrixPoint<_Tp>& __x) const
     {
-        return ::std::sqrt(__x.real() * __x.real() + __x.imag() * __x.imag());
+        return std::sqrt(__x.m * __x.m + __x.n * __x.n);
     }
-    ::std::complex<_Tp>
-    operator()(const ::std::complex<_Tp>& __x, const ::std::complex<_Tp>& __y) const
+    MatrixPoint<_Tp>
+    operator()(const MatrixPoint<_Tp>& __x, const MatrixPoint<_Tp>& __y) const
     {
-        return (complex_abs(__x) < complex_abs(__y)) ? __y : __x;
+        return (euclidean_distance(__x) < euclidean_distance(__y)) ? __y : __x;
     }
 };
 
@@ -809,17 +838,17 @@ struct MaxAbsFunctor;
 
 // A modification of the functor we use in reduce_by_segment
 template <typename _Tp>
-struct MaxAbsFunctor<::std::complex<_Tp>>
+struct MaxAbsFunctor<MatrixPoint<_Tp>>
 {
     auto
-    complex_abs(const ::std::complex<_Tp>& __x) const
+    euclidean_distance(const MatrixPoint<_Tp>& __x) const
     {
-        return ::std::sqrt(__x.real() * __x.real() + __x.imag() * __x.imag());
+        return std::sqrt(__x.m * __x.m + __x.n * __x.n);
     }
-    ::std::complex<_Tp>
-    operator()(const ::std::complex<_Tp>& __x, const ::std::complex<_Tp>& __y) const
+    MatrixPoint<_Tp>
+    operator()(const MatrixPoint<_Tp>& __x, const MatrixPoint<_Tp>& __y) const
     {
-        return (complex_abs(__x) < complex_abs(__y)) ? complex_abs(__y) : complex_abs(__x);
+        return (euclidean_distance(__x) < euclidean_distance(__y)) ? euclidean_distance(__y) : euclidean_distance(__x);
     }
 };
 


### PR DESCRIPTION
Previously, we used `std::complex` in the tests for `inclusive_scan_by_segment`, `exclusive_scan_by_segment`, and `reduce_by_segment` algorithms. The purpose of this was to test with some non-fundamental type. However, `std::complex` is technically not officially supported in SYCL kernels and failures in these tests over time have reflected the state of `std::complex` support as opposed to the actual correctness of the by_segment algorithms. We already have explicit tests for current `std::complex` in our testing suite, so I believe these should be fully separated from our parallel API tests. We also do not use `std::complex` throughout our other parallel API tests.

I've replaced these tests with tests over a custom 2D point type. Essentially, a similar option is performed as before but no longer depends on `std::complex`.