### PR TITLE
Resolve compilation errors with sycl::queue default device selection for older icpx compilers

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/execution_sycl_defs.h
@@ -123,7 +123,7 @@ class alignas(sycl::queue) __queue_holder
 inline sycl::queue
 __get_default_queue()
 {
-    static sycl::queue __q(sycl::default_selector_v);
+    static sycl::queue __q;
     return __q;
 }
 


### PR DESCRIPTION
Currently, we create our default  `sycl::queue` through providing `sycl::default_selector_v` to its constructor. Despite being apart of SYCL2020, this is problematic for some older compilers we still support and test with where this feature has not been implemented (e.g. icpx 2022.3):
```
error: no type named 'default_selector_v' in namespace 'sycl'; did you mean 'default_selector'?
    static sycl::queue __q(sycl::default_selector_v);
```
The default constructor of `sycl::queue` guarantees that the default device will be selected, so relying on this resolves our issue.