### PR TITLE
Single WG implementation of `__parallel_find_or`

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1332,13 +1332,6 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
     auto __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__rng_n, __wgroup_size);
     __n_groups = ::std::min(__n_groups, decltype(__n_groups)(__max_cu));
 
-    // Pass all small data into single WG implementation
-    constexpr std::size_t __max_iters_per_work_item = 32;
-    if (__rng_n <= __wgroup_size * __max_iters_per_work_item)
-    {
-        __n_groups = 1;
-    }
-
     _PRINT_INFO_IN_DEBUG_MODE(__exec, __wgroup_size, __max_cu);
 
     using _AtomicType = typename _BrickTag::_AtomicType;
@@ -1346,6 +1339,13 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
     const auto __pred = oneapi::dpl::__par_backend_hetero::__early_exit_find_or<_ExecutionPolicy, _Brick>{__f};
 
     constexpr bool __or_tag_check = std::is_same_v<_BrickTag, __parallel_or_tag>;
+
+    // Pass all small data into single WG implementation
+    constexpr std::size_t __max_iters_per_work_item = 32;
+    if (__rng_n <= __wgroup_size * __max_iters_per_work_item)
+    {
+        __n_groups = 1;
+    }
 
     _AtomicType __result;
     if (__n_groups == 1)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1203,7 +1203,7 @@ __parallel_find_or_impl_one_wg(oneapi::dpl::__internal::__device_backend_tag, _E
                     __found_local = __dpl_sycl::__reduce_over_group(__item_id.get_group(), __found_local,
                                                                     typename _BrickTag::_LocalResultsReduceOp{});
 
-                // Set local found state value value to global atomic to have correct result
+                // Set local found state value value to global state to have correct result
                 // - do not check __found_local != __init_value due __result_storage isn't initialized with __init_value on host side.
                 if (__local_idx == 0)
                 {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1181,10 +1181,7 @@ __parallel_find_or_impl_one_wg(oneapi::dpl::__internal::__device_backend_tag, _E
                 // Set local found state value value to global state to have correct result
                 if (__local_idx == 0)
                 {
-                    __FoundStateType& __found =
-                        *__result_and_scratch_storage_t::__get_usm_or_buffer_accessor_ptr(__result_acc);
-
-                    __found = __found_local;
+                    __result_and_scratch_storage_t::__get_usm_or_buffer_accessor_ptr(__result_acc)[0] = __found_local;
                 }
             });
     });

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1216,10 +1216,8 @@ __parallel_find_or_impl_one_wg(oneapi::dpl::__internal::__device_backend_tag, _E
             });
     });
 
-    __future __f_obj(__event_id, __result_storage);
-    auto __result = __f_obj.get();
-
-    return __result;
+    // Wait and return result
+    return __future(__event_id, __result_storage).get();
 }
 
 // Base pattern for __parallel_or and __parallel_find. The execution depends on tag type _BrickTag.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1190,10 +1190,7 @@ __parallel_find_or_impl_one_wg(oneapi::dpl::__internal::__device_backend_tag, _E
     });
 
     // Wait and return result
-    if (__result_storage.is_USM())
-        __event.wait_and_throw();
-
-    return __result_storage.__get_value();
+    return __future(__event, __result_storage).get();
 }
 
 // Base pattern for __parallel_or and __parallel_find. The execution depends on tag type _BrickTag.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1197,7 +1197,6 @@ __parallel_find_or_impl_one_wg(oneapi::dpl::__internal::__device_backend_tag, _E
                                                                     typename _BrickTag::_LocalResultsReduceOp{});
 
                 // Set local found state value value to global state to have correct result
-                // - do not check __found_local != __init_value due __result_storage isn't initialized with __init_value on host side.
                 if (__local_idx == 0)
                 {
                     _AtomicType& __found =

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1084,7 +1084,7 @@ struct __early_exit_find_or
 
     template <typename _NDItemId, typename _SrcDataSize, typename _IterationDataSize, typename _LocalFoundState,
               typename _BrickTag, typename... _Ranges>
-    void
+    inline void
     operator()(const _NDItemId __item_id, const _SrcDataSize __source_data_size, const std::size_t __iters_per_work_item,
                const _IterationDataSize __iteration_data_size, _LocalFoundState& __found_local, _BrickTag __brick_tag,
                _Ranges&&... __rngs) const

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1288,6 +1288,13 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
     auto __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__rng_n, __wgroup_size);
     __n_groups = ::std::min(__n_groups, decltype(__n_groups)(__max_cu));
 
+    // Pass all small data into single WG implementation
+    constexpr std::size_t __max_iters_per_work_item = 32;
+    if (__rng_n <= __wgroup_size * __max_iters_per_work_item)
+    {
+        __n_groups = 1;
+    }
+
     _PRINT_INFO_IN_DEBUG_MODE(__exec, __wgroup_size, __max_cu);
 
     using _AtomicType = typename _BrickTag::_AtomicType;
@@ -1295,13 +1302,6 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
     const auto __pred = oneapi::dpl::__par_backend_hetero::__early_exit_find_or<_ExecutionPolicy, _Brick>{__f};
 
     constexpr bool __or_tag_check = std::is_same_v<_BrickTag, __parallel_or_tag>;
-
-    // Pass all small data into single WG implementation
-    constexpr std::size_t __max_iters_per_work_item = 32;
-    if (__rng_n <= __wgroup_size * __max_iters_per_work_item)
-    {
-        __n_groups = 1;
-    }
 
     _AtomicType __result;
     if (__n_groups == 1)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1136,8 +1136,8 @@ struct __early_exit_find_or
 //------------------------------------------------------------------------
 
 // Base pattern for __parallel_or and __parallel_find. The execution depends on tag type _BrickTag.
-template <typename KernelName, bool __or_tag_check, typename _ExecutionPolicy, typename _BrickTag, typename __FoundStateType,
-          typename _Predicate, typename... _Ranges>
+template <typename KernelName, bool __or_tag_check, typename _ExecutionPolicy, typename _BrickTag,
+          typename __FoundStateType, typename _Predicate, typename... _Ranges>
 __FoundStateType
 __parallel_find_or_impl_one_wg(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec,
                                _BrickTag __brick_tag, const std::size_t __rng_n, const std::size_t __wgroup_size,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1309,14 +1309,8 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
         oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_generator<__find_or_kernel, _CustomName, _Brick,
                                                                                _BrickTag, _Ranges...>;
 
-    ///////////////////////////////////////////////////////////////////////////
-    // Calculate source data size
-
     auto __rng_n = oneapi::dpl::__ranges::__get_first_range_size(__rngs...);
     assert(__rng_n > 0);
-
-    ///////////////////////////////////////////////////////////////////////////
-    // Calculate work-group size
 
     // TODO: find a way to generalize getting of reliable work-group size
     std::size_t __wgroup_size = oneapi::dpl::__internal::__max_work_group_size(__exec);
@@ -1334,8 +1328,6 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
     __wgroup_size = std::min(__wgroup_size, (std::size_t)2048);
 #endif
 
-    ///////////////////////////////////////////////////////////////////////////
-    // Calculates the amount of work-groups taking into account the required number of elements per work-item
     const auto __max_cu = oneapi::dpl::__internal::__max_compute_units(__exec);
     auto __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__rng_n, __wgroup_size);
     __n_groups = ::std::min(__n_groups, decltype(__n_groups)(__max_cu));
@@ -1349,8 +1341,6 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
 
     _PRINT_INFO_IN_DEBUG_MODE(__exec, __wgroup_size, __max_cu);
 
-    ///////////////////////////////////////////////////////////////////////////
-    // Eval initial value and create predicate
     using _AtomicType = typename _BrickTag::_AtomicType;
     const _AtomicType __init_value = _BrickTag::__init_value(__rng_n);
     const auto __pred = oneapi::dpl::__par_backend_hetero::__early_exit_find_or<_ExecutionPolicy, _Brick>{__f};
@@ -1379,9 +1369,6 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
 #endif
             __rng_n, __n_groups, __wgroup_size, __init_value, __pred, std::forward<_Ranges>(__rngs)...);
     }
-
-    ///////////////////////////////////////////////////////////////////////////
-    // Return result
 
     if constexpr (__or_tag_check)
         return __result != __init_value;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1155,8 +1155,7 @@ __parallel_find_or_impl_one_wg(oneapi::dpl::__internal::__device_backend_tag, _E
         auto __result_acc = __result_storage.__get_result_acc(__cgh);
 
         __cgh.parallel_for<KernelName>(
-            sycl::nd_range</*dim=*/1>(sycl::range</*dim=*/1>(__wgroup_size),
-                                      sycl::range</*dim=*/1>(__wgroup_size)),
+            sycl::nd_range</*dim=*/1>(sycl::range</*dim=*/1>(__wgroup_size), sycl::range</*dim=*/1>(__wgroup_size)),
             [=](sycl::nd_item</*dim=*/1> __item_id) {
                 auto __local_idx = __item_id.get_local_id(0);
 
@@ -1167,8 +1166,7 @@ __parallel_find_or_impl_one_wg(oneapi::dpl::__internal::__device_backend_tag, _E
                 //  - after this call __found_local may still have initial value:
                 //    1) if no element satisfies pred;
                 //    2) early exit from sub-group occurred: in this case the state of __found_local will updated in the next group operation (3)
-                __pred(__item_id, __rng_n, __iters_per_work_item, __wgroup_size, __found_local,
-                       __brick_tag, __rngs...);
+                __pred(__item_id, __rng_n, __iters_per_work_item, __wgroup_size, __found_local, __brick_tag, __rngs...);
 
                 // 3. Reduce over group: find __dpl_sycl::__minimum (for the __parallel_find_forward_tag),
                 // find __dpl_sycl::__maximum (for the __parallel_find_backward_tag)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1356,8 +1356,7 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
 #if _ONEDPL_COMPILE_KERNEL && _ONEDPL_KERNEL_BUNDLE_PRESENT
             __kernel_one_wg,
 #endif
-            __rng_n, __wgroup_size, // We shouldn't pass __n_groups to this call due it's single WG implementation
-            __init_value, __pred, std::forward<_Ranges>(__rngs)...);
+            __rng_n, __wgroup_size, __init_value, __pred, std::forward<_Ranges>(__rngs)...);
     }
     else
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1190,7 +1190,7 @@ __parallel_find_or_impl_one_wg(oneapi::dpl::__internal::__device_backend_tag, _E
     });
 
     // Wait and return result
-    return __future(__event, __result_storage).get();
+    return __result_storage.__wait_and_get_value(__event);
 }
 
 // Base pattern for __parallel_or and __parallel_find. The execution depends on tag type _BrickTag.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1160,7 +1160,7 @@ __parallel_find_or_impl_one_wg(oneapi::dpl::__internal::__device_backend_tag, _E
     const auto __iters_per_work_item = oneapi::dpl::__internal::__dpl_ceiling_div(__rng_n, __wgroup_size);
 
     // main parallel_for
-    auto __event_id = __exec.queue().submit([&](sycl::handler& __cgh) {
+    auto __event = __exec.queue().submit([&](sycl::handler& __cgh) {
         oneapi::dpl::__ranges::__require_access(__cgh, __rngs...);
         auto __result_acc = __result_storage.__get_result_acc(__cgh);
 
@@ -1210,7 +1210,7 @@ __parallel_find_or_impl_one_wg(oneapi::dpl::__internal::__device_backend_tag, _E
     });
 
     // Wait and return result
-    return __future(__event_id, __result_storage).get();
+    return __future(__event, __result_storage).get();
 }
 
 // Base pattern for __parallel_or and __parallel_find. The execution depends on tag type _BrickTag.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1350,6 +1350,13 @@ __parallel_find_or(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPoli
     auto __n_groups = oneapi::dpl::__internal::__dpl_ceiling_div(__rng_n, __wgroup_size);
     __n_groups = ::std::min(__n_groups, decltype(__n_groups)(__max_cu));
 
+    // Pass all small data into single WG implementation
+    constexpr std::size_t __max_iters_per_work_item = 32;
+    if (__rng_n <= __wgroup_size * __max_iters_per_work_item)
+    {
+        __n_groups = 1;
+    }
+
     _PRINT_INFO_IN_DEBUG_MODE(__exec, __wgroup_size, __max_cu);
 
     ///////////////////////////////////////////////////////////////////////////

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1190,7 +1190,10 @@ __parallel_find_or_impl_one_wg(oneapi::dpl::__internal::__device_backend_tag, _E
     });
 
     // Wait and return result
-    return __future(__event, __result_storage).get();
+    if (__result_storage.is_USM())
+        __event.wait_and_throw();
+
+    return __result_storage.__get_value();
 }
 
 // Base pattern for __parallel_or and __parallel_find. The execution depends on tag type _BrickTag.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1153,9 +1153,6 @@ __parallel_find_or_impl_one_wg(oneapi::dpl::__internal::__device_backend_tag, _E
     // We shouldn't have any restrictions for _AtomicType type here
     // because we have a single work-group and we don't need to use atomics for inter-work-group communication.
 
-    ///////////////////////////////////////////////////////////////////////////
-    // Starts main work...
-
     using __result_and_scratch_storage_t = __result_and_scratch_storage<_ExecutionPolicy, _AtomicType>;
     __result_and_scratch_storage_t __result_storage(__exec, 0);
 
@@ -1234,9 +1231,6 @@ __parallel_find_or_impl_multiple_wgs(oneapi::dpl::__internal::__device_backend_t
 {
     assert("This device does not support 64-bit atomics" &&
            (sizeof(_AtomicType) < 8 || __exec.queue().get_device().has(sycl::aspect::atomic64)));
-
-    ///////////////////////////////////////////////////////////////////////////
-    // Starts main work...
 
     auto __result = __init_value;
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1136,14 +1136,14 @@ struct __early_exit_find_or
 //------------------------------------------------------------------------
 
 // Base pattern for __parallel_or and __parallel_find. The execution depends on tag type _BrickTag.
-template <typename KernelName, bool __or_tag_check, typename _ExecutionPolicy, typename _BrickTag, typename _AtomicType,
+template <typename KernelName, bool __or_tag_check, typename _ExecutionPolicy, typename _BrickTag, typename __FoundStateType,
           typename _Predicate, typename... _Ranges>
-_AtomicType
+__FoundStateType
 __parallel_find_or_impl_one_wg(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec,
                                _BrickTag __brick_tag, const std::size_t __rng_n, const std::size_t __wgroup_size,
-                               const _AtomicType __init_value, _Predicate __pred, _Ranges&&... __rngs)
+                               const __FoundStateType __init_value, _Predicate __pred, _Ranges&&... __rngs)
 {
-    using __result_and_scratch_storage_t = __result_and_scratch_storage<_ExecutionPolicy, _AtomicType>;
+    using __result_and_scratch_storage_t = __result_and_scratch_storage<_ExecutionPolicy, __FoundStateType>;
     __result_and_scratch_storage_t __result_storage(__exec, 0);
 
     // Calculate the number of elements to be processed by each work-item.
@@ -1160,7 +1160,7 @@ __parallel_find_or_impl_one_wg(oneapi::dpl::__internal::__device_backend_tag, _E
                 auto __local_idx = __item_id.get_local_id(0);
 
                 // 1. Set initial value to local found state
-                _AtomicType __found_local = __init_value;
+                __FoundStateType __found_local = __init_value;
 
                 // 2. Find any element that satisfies pred
                 //  - after this call __found_local may still have initial value:
@@ -1181,7 +1181,7 @@ __parallel_find_or_impl_one_wg(oneapi::dpl::__internal::__device_backend_tag, _E
                 // Set local found state value value to global state to have correct result
                 if (__local_idx == 0)
                 {
-                    _AtomicType& __found =
+                    __FoundStateType& __found =
                         *__result_and_scratch_storage_t::__get_usm_or_buffer_accessor_ptr(__result_acc);
 
                     __found = __found_local;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1084,7 +1084,7 @@ struct __early_exit_find_or
 
     template <typename _NDItemId, typename _SrcDataSize, typename _IterationDataSize, typename _LocalFoundState,
               typename _BrickTag, typename... _Ranges>
-    inline void
+    void
     operator()(const _NDItemId __item_id, const _SrcDataSize __source_data_size,
                const std::size_t __iters_per_work_item, const _IterationDataSize __iteration_data_size,
                _LocalFoundState& __found_local, _BrickTag __brick_tag, _Ranges&&... __rngs) const

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -1202,7 +1202,6 @@ __parallel_find_or_impl_one_wg(oneapi::dpl::__internal::__device_backend_tag, _E
                     _AtomicType& __found =
                         *__result_and_scratch_storage_t::__get_usm_or_buffer_accessor_ptr(__result_acc);
 
-                    // Update global (for all groups) non-atomic state with the found index
                     __found = __found_local;
                 }
             });

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -645,6 +645,16 @@ struct __result_and_scratch_storage
             return __sycl_buf->get_host_access(sycl::read_only)[__scratch_n];
         }
     }
+
+    template <typename _Event>
+    _T
+    __wait_and_get_value(_Event&& __event, size_t idx = 0) const
+    {
+        if (is_USM())
+            __event.wait_and_throw();
+
+        return __get_value(idx);
+    }
 };
 
 //A contract for future class: <sycl::event or other event, a value, sycl::buffers..., or __usm_host_or_buffer_storage>
@@ -666,9 +676,7 @@ class __future : private std::tuple<_Args...>
     constexpr auto
     __wait_and_get_value(__result_and_scratch_storage<_ExecutionPolicy, _T>& __storage)
     {
-        if (__storage.is_USM())
-            wait();
-        return __storage.__get_value();
+        return __storage.__wait_and_get_value(__my_event);
     }
 
     template <typename _T>


### PR DESCRIPTION
In this PR we prepare single work-group implementation of `__parallel_find_or` :
- they doesn't used `atomic`-based synchronization;
- they doesn't used `syc::buffer` for return result when USM-memory is available on device (we using `__result_and_scratch_storage` prepared by @julianmi earlier);
- kernel's compilation has been removed from `__parallel_find_or` and their staff.

This approach gives us a big performance boost for small data sizes.