### PR TITLE
[RNG] Fixed failures in ranlux_24_48_base and ranlux_24_48 tests of subtract_with_carry and discard_block engines

### DIFF
--- a/include/oneapi/dpl/internal/random_impl/discard_block_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/discard_block_engine.h
@@ -35,6 +35,14 @@ template <class _Engine, ::std::size_t _P, ::std::size_t _R>
 class discard_block_engine;
 
 template <class CharT, class Traits, class __Engine, std::size_t __P, std::size_t __R>
+::std::basic_ostream<CharT, Traits>&
+operator<<(::std::basic_ostream<CharT, Traits>&, const discard_block_engine<__Engine, __P, __R>&);
+
+template <class __Engine, std::size_t __P, std::size_t __R>
+const sycl::stream&
+operator<<(const sycl::stream&, const discard_block_engine<__Engine, __P, __R>&);
+
+template <class CharT, class Traits, class __Engine, std::size_t __P, std::size_t __R>
 ::std::basic_istream<CharT, Traits>&
 operator>>(::std::basic_istream<CharT, Traits>&, discard_block_engine<__Engine, __P, __R>&);
 
@@ -152,24 +160,13 @@ class discard_block_engine
         return !(__x == __y);
     }
 
-    template <class CharT, class Traits>
+    template <class CharT, class Traits, class __Engine, std::size_t __P, std::size_t __R>
     friend ::std::basic_ostream<CharT, Traits>&
-    operator<<(::std::basic_ostream<CharT, Traits>& __os, const discard_block_engine& __e)
-    {
-        internal::save_stream_flags<CharT, Traits> __flags(__os);
+    operator<<(::std::basic_ostream<CharT, Traits>&, const discard_block_engine<__Engine, __P, __R>&);
 
-        __os.setf(std::ios_base::dec | std::ios_base::left);
-        CharT __sp = __os.widen(' ');
-        __os.fill(__sp);
-
-        return __os << __e.engine_ << __sp << __e.n_;
-    }
-
+    template <class __Engine, std::size_t __P, std::size_t __R>
     friend const sycl::stream&
-    operator<<(const sycl::stream& __os, const discard_block_engine& __e)
-    {
-        return __os << __e.engine_ << ' ' << __e.n_;
-    }
+    operator<<(const sycl::stream&, const discard_block_engine<__Engine, __P, __R>&);
 
     template <class CharT, class Traits, class __Engine, std::size_t __P, std::size_t __R>
     friend ::std::basic_istream<CharT, Traits>&
@@ -254,6 +251,26 @@ class discard_block_engine
     _Engine engine_;
     ::std::size_t n_ = 0;
 };
+
+template <class CharT, class Traits, class __Engine, std::size_t __P, std::size_t __R>
+::std::basic_ostream<CharT, Traits>&
+operator<<(::std::basic_ostream<CharT, Traits>& __os, const discard_block_engine<__Engine, __P, __R>& __e)
+{
+    internal::save_stream_flags<CharT, Traits> __flags(__os);
+
+    __os.setf(std::ios_base::dec | std::ios_base::left);
+    CharT __sp = __os.widen(' ');
+    __os.fill(__sp);
+
+    return __os << __e.engine_ << __sp << __e.n_;
+}
+
+template <class __Engine, std::size_t __P, std::size_t __R>
+const sycl::stream&
+operator<<(const sycl::stream& __os, const discard_block_engine<__Engine, __P, __R>& __e)
+{
+    return __os << __e.engine_ << ' ' << __e.n_;
+}
 
 template <class CharT, class Traits, class __Engine, std::size_t __P, std::size_t __R>
 ::std::basic_istream<CharT, Traits>&

--- a/include/oneapi/dpl/internal/random_impl/discard_block_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/discard_block_engine.h
@@ -32,6 +32,13 @@ namespace dpl
 {
 
 template <class _Engine, ::std::size_t _P, ::std::size_t _R>
+class discard_block_engine;
+
+template <class CharT, class Traits, class __Engine, std::size_t __P, std::size_t __R>
+::std::basic_istream<CharT, Traits>&
+operator>>(::std::basic_istream<CharT, Traits>&, discard_block_engine<__Engine, __P, __R>&);
+
+template <class _Engine, ::std::size_t _P, ::std::size_t _R>
 class discard_block_engine
 {
   public:
@@ -166,22 +173,7 @@ class discard_block_engine
 
     template <class CharT, class Traits, class __Engine, std::size_t __P, std::size_t __R>
     friend ::std::basic_istream<CharT, Traits>&
-    operator>>(::std::basic_istream<CharT, Traits>& __is, discard_block_engine<__Engine, __P, __R>& __e)
-    {
-        internal::save_stream_flags<CharT, Traits> __flags(__is);
-
-        __is.setf(std::ios_base::dec);
-
-        __Engine __engine_;
-        std::size_t __n_;
-        if (__is >> __engine_ >> __n_)
-        {
-            __e.engine_ = __engine_;
-            __e.n_ = __n_;
-        }
-
-        return __is;
-    }
+    operator>>(::std::basic_istream<CharT, Traits>&, discard_block_engine<__Engine, __P, __R>&);
 
   private:
     // Static asserts
@@ -262,6 +254,25 @@ class discard_block_engine
     _Engine engine_;
     ::std::size_t n_ = 0;
 };
+
+template <class CharT, class Traits, class __Engine, std::size_t __P, std::size_t __R>
+::std::basic_istream<CharT, Traits>&
+operator>>(::std::basic_istream<CharT, Traits>& __is, discard_block_engine<__Engine, __P, __R>& __e)
+{
+    internal::save_stream_flags<CharT, Traits> __flags(__is);
+
+    __is.setf(std::ios_base::dec);
+
+    __Engine __engine_;
+    std::size_t __n_;
+    if (__is >> __engine_ >> __n_)
+    {
+        __e.engine_ = __engine_;
+        __e.n_ = __n_;
+    }
+
+    return __is;
+}
 
 } // namespace dpl
 } // namespace oneapi

--- a/include/oneapi/dpl/internal/random_impl/linear_congruential_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/linear_congruential_engine.h
@@ -25,6 +25,21 @@ namespace oneapi
 namespace dpl
 {
 
+template <class _UIntType, internal::element_type_t<_UIntType> _A, internal::element_type_t<_UIntType> _C, internal::element_type_t<_UIntType> _M>
+class linear_congruential_engine;
+
+template <class CharT, class Traits, class __UIntType, internal::element_type_t<__UIntType> __A, internal::element_type_t<__UIntType> __C, internal::element_type_t<__UIntType> __M>
+::std::basic_ostream<CharT, Traits>&
+operator<<(::std::basic_ostream<CharT, Traits>&, const linear_congruential_engine<__UIntType, __A, __C, __M>&);
+
+template <class __UIntType, internal::element_type_t<__UIntType> __A, internal::element_type_t<__UIntType> __C, internal::element_type_t<__UIntType> __M>
+const sycl::stream&
+operator<<(const sycl::stream&, const linear_congruential_engine<__UIntType, __A, __C, __M>&);
+
+template <class CharT, class Traits, class __UIntType, internal::element_type_t<__UIntType> __A, internal::element_type_t<__UIntType> __C, internal::element_type_t<__UIntType> __M>
+::std::basic_istream<CharT, Traits>&
+operator>>(::std::basic_istream<CharT, Traits>&, linear_congruential_engine<__UIntType, __A, __C, __M>&);
+
 template <class _UIntType, internal::element_type_t<_UIntType> _A, internal::element_type_t<_UIntType> _C,
           internal::element_type_t<_UIntType> _M>
 class linear_congruential_engine
@@ -111,38 +126,17 @@ class linear_congruential_engine
         return !(__x == __y);
     }
 
-    template <class CharT, class Traits>
+    template <class CharT, class Traits, class __UIntType, internal::element_type_t<__UIntType> __A, internal::element_type_t<__UIntType> __C, internal::element_type_t<__UIntType> __M>
     friend ::std::basic_ostream<CharT, Traits>&
-    operator<<(::std::basic_ostream<CharT, Traits>& __os, const linear_congruential_engine& __e)
-    {
-        internal::save_stream_flags<CharT, Traits> __flags(__os);
+    operator<<(::std::basic_ostream<CharT, Traits>& __os, const linear_congruential_engine<__UIntType, __A, __C, __M>& __e);
 
-        __os.setf(std::ios_base::dec | std::ios_base::left);
-        __os.fill(__os.widen(' '));
-
-        return __os << __e.state_;
-    }
-
+    template <class __UIntType, internal::element_type_t<__UIntType> __A, internal::element_type_t<__UIntType> __C, internal::element_type_t<__UIntType> __M>
     friend const sycl::stream&
-    operator<<(const sycl::stream& __os, const linear_congruential_engine& __e)
-    {
-        return __os << __e.state_;
-    }
+    operator<<(const sycl::stream& __os, const linear_congruential_engine<__UIntType, __A, __C, __M>& __e);
 
-    template <class CharT, class Traits>
+    template <class CharT, class Traits, class __UIntType, internal::element_type_t<__UIntType> __A, internal::element_type_t<__UIntType> __C, internal::element_type_t<__UIntType> __M>
     friend ::std::basic_istream<CharT, Traits>&
-    operator>>(::std::basic_istream<CharT, Traits>& __is, linear_congruential_engine& __e)
-    {
-        internal::save_stream_flags<CharT, Traits> __flags(__is);
-
-        __is.setf(std::ios_base::dec);
-
-        linear_congruential_engine::result_type __t;
-        if (__is >> __t)
-            __e.state_ = __t;
-
-        return __is;
-    }
+    operator>>(::std::basic_istream<CharT, Traits>& __is, linear_congruential_engine<__UIntType, __A, __C, __M>& __e);
 
   private:
     // Static asserts
@@ -297,6 +291,40 @@ class linear_congruential_engine
 
     result_type state_;
 };
+
+template <class CharT, class Traits, class __UIntType, internal::element_type_t<__UIntType> __A, internal::element_type_t<__UIntType> __C, internal::element_type_t<__UIntType> __M>
+::std::basic_ostream<CharT, Traits>&
+operator<<(::std::basic_ostream<CharT, Traits>& __os, const linear_congruential_engine<__UIntType, __A, __C, __M>& __e)
+{
+    internal::save_stream_flags<CharT, Traits> __flags(__os);
+
+    __os.setf(std::ios_base::dec | std::ios_base::left);
+    __os.fill(__os.widen(' '));
+
+    return __os << __e.state_;
+}
+
+template <class __UIntType, internal::element_type_t<__UIntType> __A, internal::element_type_t<__UIntType> __C, internal::element_type_t<__UIntType> __M>
+const sycl::stream&
+operator<<(const sycl::stream& __os, const linear_congruential_engine<__UIntType, __A, __C, __M>& __e)
+{
+    return __os << __e.state_;
+}
+
+template <class CharT, class Traits, class __UIntType, internal::element_type_t<__UIntType> __A, internal::element_type_t<__UIntType> __C, internal::element_type_t<__UIntType> __M>
+::std::basic_istream<CharT, Traits>&
+operator>>(::std::basic_istream<CharT, Traits>& __is, linear_congruential_engine<__UIntType, __A, __C, __M>& __e)
+{
+    internal::save_stream_flags<CharT, Traits> __flags(__is);
+
+    __is.setf(std::ios_base::dec);
+
+    __UIntType __t;
+    if (__is >> __t)
+        __e.state_ = __t;
+
+    return __is;
+}
 
 } // namespace dpl
 } // namespace oneapi

--- a/include/oneapi/dpl/internal/random_impl/linear_congruential_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/linear_congruential_engine.h
@@ -25,18 +25,22 @@ namespace oneapi
 namespace dpl
 {
 
-template <class _UIntType, internal::element_type_t<_UIntType> _A, internal::element_type_t<_UIntType> _C, internal::element_type_t<_UIntType> _M>
+template <class _UIntType, internal::element_type_t<_UIntType> _A, internal::element_type_t<_UIntType> _C,
+          internal::element_type_t<_UIntType> _M>
 class linear_congruential_engine;
 
-template <class CharT, class Traits, class __UIntType, internal::element_type_t<__UIntType> __A, internal::element_type_t<__UIntType> __C, internal::element_type_t<__UIntType> __M>
+template <class CharT, class Traits, class __UIntType, internal::element_type_t<__UIntType> __A,
+          internal::element_type_t<__UIntType> __C, internal::element_type_t<__UIntType> __M>
 ::std::basic_ostream<CharT, Traits>&
 operator<<(::std::basic_ostream<CharT, Traits>&, const linear_congruential_engine<__UIntType, __A, __C, __M>&);
 
-template <class __UIntType, internal::element_type_t<__UIntType> __A, internal::element_type_t<__UIntType> __C, internal::element_type_t<__UIntType> __M>
+template <class __UIntType, internal::element_type_t<__UIntType> __A, internal::element_type_t<__UIntType> __C,
+          internal::element_type_t<__UIntType> __M>
 const sycl::stream&
 operator<<(const sycl::stream&, const linear_congruential_engine<__UIntType, __A, __C, __M>&);
 
-template <class CharT, class Traits, class __UIntType, internal::element_type_t<__UIntType> __A, internal::element_type_t<__UIntType> __C, internal::element_type_t<__UIntType> __M>
+template <class CharT, class Traits, class __UIntType, internal::element_type_t<__UIntType> __A,
+          internal::element_type_t<__UIntType> __C, internal::element_type_t<__UIntType> __M>
 ::std::basic_istream<CharT, Traits>&
 operator>>(::std::basic_istream<CharT, Traits>&, linear_congruential_engine<__UIntType, __A, __C, __M>&);
 
@@ -126,15 +130,19 @@ class linear_congruential_engine
         return !(__x == __y);
     }
 
-    template <class CharT, class Traits, class __UIntType, internal::element_type_t<__UIntType> __A, internal::element_type_t<__UIntType> __C, internal::element_type_t<__UIntType> __M>
+    template <class CharT, class Traits, class __UIntType, internal::element_type_t<__UIntType> __A,
+              internal::element_type_t<__UIntType> __C, internal::element_type_t<__UIntType> __M>
     friend ::std::basic_ostream<CharT, Traits>&
-    operator<<(::std::basic_ostream<CharT, Traits>& __os, const linear_congruential_engine<__UIntType, __A, __C, __M>& __e);
+    operator<<(::std::basic_ostream<CharT, Traits>& __os,
+               const linear_congruential_engine<__UIntType, __A, __C, __M>& __e);
 
-    template <class __UIntType, internal::element_type_t<__UIntType> __A, internal::element_type_t<__UIntType> __C, internal::element_type_t<__UIntType> __M>
+    template <class __UIntType, internal::element_type_t<__UIntType> __A, internal::element_type_t<__UIntType> __C,
+              internal::element_type_t<__UIntType> __M>
     friend const sycl::stream&
     operator<<(const sycl::stream& __os, const linear_congruential_engine<__UIntType, __A, __C, __M>& __e);
 
-    template <class CharT, class Traits, class __UIntType, internal::element_type_t<__UIntType> __A, internal::element_type_t<__UIntType> __C, internal::element_type_t<__UIntType> __M>
+    template <class CharT, class Traits, class __UIntType, internal::element_type_t<__UIntType> __A,
+              internal::element_type_t<__UIntType> __C, internal::element_type_t<__UIntType> __M>
     friend ::std::basic_istream<CharT, Traits>&
     operator>>(::std::basic_istream<CharT, Traits>& __is, linear_congruential_engine<__UIntType, __A, __C, __M>& __e);
 
@@ -292,7 +300,8 @@ class linear_congruential_engine
     result_type state_;
 };
 
-template <class CharT, class Traits, class __UIntType, internal::element_type_t<__UIntType> __A, internal::element_type_t<__UIntType> __C, internal::element_type_t<__UIntType> __M>
+template <class CharT, class Traits, class __UIntType, internal::element_type_t<__UIntType> __A,
+          internal::element_type_t<__UIntType> __C, internal::element_type_t<__UIntType> __M>
 ::std::basic_ostream<CharT, Traits>&
 operator<<(::std::basic_ostream<CharT, Traits>& __os, const linear_congruential_engine<__UIntType, __A, __C, __M>& __e)
 {
@@ -304,14 +313,16 @@ operator<<(::std::basic_ostream<CharT, Traits>& __os, const linear_congruential_
     return __os << __e.state_;
 }
 
-template <class __UIntType, internal::element_type_t<__UIntType> __A, internal::element_type_t<__UIntType> __C, internal::element_type_t<__UIntType> __M>
+template <class __UIntType, internal::element_type_t<__UIntType> __A, internal::element_type_t<__UIntType> __C,
+          internal::element_type_t<__UIntType> __M>
 const sycl::stream&
 operator<<(const sycl::stream& __os, const linear_congruential_engine<__UIntType, __A, __C, __M>& __e)
 {
     return __os << __e.state_;
 }
 
-template <class CharT, class Traits, class __UIntType, internal::element_type_t<__UIntType> __A, internal::element_type_t<__UIntType> __C, internal::element_type_t<__UIntType> __M>
+template <class CharT, class Traits, class __UIntType, internal::element_type_t<__UIntType> __A,
+          internal::element_type_t<__UIntType> __C, internal::element_type_t<__UIntType> __M>
 ::std::basic_istream<CharT, Traits>&
 operator>>(::std::basic_istream<CharT, Traits>& __is, linear_congruential_engine<__UIntType, __A, __C, __M>& __e)
 {

--- a/include/oneapi/dpl/internal/random_impl/subtract_with_carry_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/subtract_with_carry_engine.h
@@ -29,6 +29,14 @@ template <class _UIntType, size_t _W, size_t _S, size_t _R>
 class subtract_with_carry_engine;
 
 template <class CharT, class Traits, class __UIntType, std::size_t __W, std::size_t __S, std::size_t __R>
+::std::basic_ostream<CharT, Traits>&
+operator<<(::std::basic_ostream<CharT, Traits>&, const subtract_with_carry_engine<__UIntType, __W, __S, __R>&);
+
+template <class __UIntType, std::size_t __W, std::size_t __S, std::size_t __R>
+const sycl::stream&
+operator<<(const sycl::stream&, const subtract_with_carry_engine<__UIntType, __W, __S, __R>&);
+
+template <class CharT, class Traits, class __UIntType, std::size_t __W, std::size_t __S, std::size_t __R>
 ::std::basic_istream<CharT, Traits>&
 operator>>(::std::basic_istream<CharT, Traits>&, subtract_with_carry_engine<__UIntType, __W, __S, __R>&);
 
@@ -140,40 +148,13 @@ class subtract_with_carry_engine
         return !(__x == __y);
     }
 
-    template <class CharT, class Traits>
+    template <class CharT, class Traits, class __UIntType, std::size_t __W, std::size_t __S, std::size_t __R>
     friend ::std::basic_ostream<CharT, Traits>&
-    operator<<(::std::basic_ostream<CharT, Traits>& __os, const subtract_with_carry_engine& __e)
-    {
-        internal::save_stream_flags<CharT, Traits> __flags(__os);
+    operator<<(::std::basic_ostream<CharT, Traits>&, const subtract_with_carry_engine<__UIntType, __W, __S, __R>&);
 
-        __os.setf(std::ios_base::dec | std::ios_base::left);
-        CharT __sp = __os.widen(' ');
-        __os.fill(__sp);
-
-        __os << __e.x_[__e.i_];
-        for (size_t j = __e.i_ + 1; j < _R; ++j)
-            __os << __sp << __e.x_[j];
-        for (size_t j = 0; j < __e.i_; ++j)
-            __os << __sp << __e.x_[j];
-
-        __os << __sp << __e.c_;
-
-        return __os;
-    }
-
+    template <class __UIntType, std::size_t __W, std::size_t __S, std::size_t __R>
     friend const sycl::stream&
-    operator<<(const sycl::stream& __os, const subtract_with_carry_engine& __e)
-    {
-        __os << __e.x_[__e.i_];
-        for (size_t j = __e.i_ + 1; j < _R; ++j)
-            __os << ' ' << __e.x_[j];
-        for (size_t j = 0; j < __e.i_; ++j)
-            __os << ' ' << __e.x_[j];
-
-        __os << ' ' << __e.c_;
-
-        return __os;
-    }
+    operator<<(const sycl::stream&, const subtract_with_carry_engine<__UIntType, __W, __S, __R>&);
 
     template <class CharT, class Traits, class __UIntType, std::size_t __W, std::size_t __S, std::size_t __R>
     friend ::std::basic_istream<CharT, Traits>&
@@ -261,6 +242,42 @@ class subtract_with_carry_engine
     scalar_type c_;
     size_t i_ = 0;
 };
+
+template <class CharT, class Traits, class __UIntType, std::size_t __W, std::size_t __S, std::size_t __R>
+::std::basic_ostream<CharT, Traits>&
+operator<<(::std::basic_ostream<CharT, Traits>& __os, const subtract_with_carry_engine<__UIntType, __W, __S, __R>& __e)
+{
+    internal::save_stream_flags<CharT, Traits> __flags(__os);
+
+    __os.setf(std::ios_base::dec | std::ios_base::left);
+    CharT __sp = __os.widen(' ');
+    __os.fill(__sp);
+
+    __os << __e.x_[__e.i_];
+    for (size_t j = __e.i_ + 1; j < __R; ++j)
+        __os << __sp << __e.x_[j];
+    for (size_t j = 0; j < __e.i_; ++j)
+        __os << __sp << __e.x_[j];
+
+    __os << __sp << __e.c_;
+
+    return __os;
+}
+
+template <class __UIntType, std::size_t __W, std::size_t __S, std::size_t __R>
+const sycl::stream&
+operator<<(const sycl::stream& __os, const subtract_with_carry_engine<__UIntType, __W, __S, __R>& __e)
+{
+    __os << __e.x_[__e.i_];
+    for (size_t j = __e.i_ + 1; j < __R; ++j)
+        __os << ' ' << __e.x_[j];
+    for (size_t j = 0; j < __e.i_; ++j)
+        __os << ' ' << __e.x_[j];
+
+    __os << ' ' << __e.c_;
+
+    return __os;
+}
 
 template <class CharT, class Traits, class __UIntType, std::size_t __W, std::size_t __S, std::size_t __R>
 ::std::basic_istream<CharT, Traits>&

--- a/include/oneapi/dpl/internal/random_impl/subtract_with_carry_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/subtract_with_carry_engine.h
@@ -26,6 +26,13 @@ namespace dpl
 {
 
 template <class _UIntType, size_t _W, size_t _S, size_t _R>
+class subtract_with_carry_engine;
+
+template <class CharT, class Traits, class __UIntType, std::size_t __W, std::size_t __S, std::size_t __R>
+::std::basic_istream<CharT, Traits>&
+operator>>(::std::basic_istream<CharT, Traits>&, subtract_with_carry_engine<__UIntType, __W, __S, __R>&);
+
+template <class _UIntType, size_t _W, size_t _S, size_t _R>
 class subtract_with_carry_engine
 {
   public:
@@ -170,25 +177,7 @@ class subtract_with_carry_engine
 
     template <class CharT, class Traits, class __UIntType, std::size_t __W, std::size_t __S, std::size_t __R>
     friend ::std::basic_istream<CharT, Traits>&
-    operator>>(::std::basic_istream<CharT, Traits>& __is, subtract_with_carry_engine<__UIntType, __W, __S, __R>& __e)
-    {
-        internal::save_stream_flags<CharT, Traits> __flags(__is);
-
-        __is.setf(std::ios_base::dec);
-
-        __UIntType __t[__R + 1];
-        for (size_t i = 0; i < __R + 1; ++i)
-            __is >> __t[i];
-        if (!__is.fail())
-        {
-            for (size_t i = 0; i < __R; ++i)
-                __e.x_[i] = __t[i];
-            __e.c_ = __t[__R];
-            __e.i_ = 0;
-        }
-
-        return __is;
-    }
+    operator>>(::std::basic_istream<CharT, Traits>&, subtract_with_carry_engine<__UIntType, __W, __S, __R>&);
 
   private:
     // Static asserts
@@ -272,6 +261,28 @@ class subtract_with_carry_engine
     scalar_type c_;
     size_t i_ = 0;
 };
+
+template <class CharT, class Traits, class __UIntType, std::size_t __W, std::size_t __S, std::size_t __R>
+::std::basic_istream<CharT, Traits>&
+operator>>(::std::basic_istream<CharT, Traits>& __is, subtract_with_carry_engine<__UIntType, __W, __S, __R>& __e)
+{
+    internal::save_stream_flags<CharT, Traits> __flags(__is);
+
+    __is.setf(std::ios_base::dec);
+
+    __UIntType __t[__R + 1];
+    for (size_t i = 0; i < __R + 1; ++i)
+        __is >> __t[i];
+    if (!__is.fail())
+    {
+        for (size_t i = 0; i < __R; ++i)
+            __e.x_[i] = __t[i];
+        __e.c_ = __t[__R];
+        __e.i_ = 0;
+    }
+
+    return __is;
+}
 
 } // namespace dpl
 } // namespace oneapi


### PR DESCRIPTION
Since `operator>>` takes the engine with template parameters for `subtract_with_carry_engine` and `discard_block_engine` classes we have multiple competing definitions in the same namespace when 2 or more of these engine types are instantiated.
Therefore, it's necessary to move the definition outside of the class, then it's only defined once, and add its declaration before the class definition.