### PR TITLE
[PROTOTYPE] Optimization for unique

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -886,10 +886,10 @@ __pattern_mismatch(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterat
 //------------------------------------------------------------------------
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator1, typename _IteratorOrTuple,
-          typename _GenMask, typename _WriteOp>
+          typename _GenMask, typename _WriteOp, typename _Unique>
 ::std::pair<_IteratorOrTuple, typename ::std::iterator_traits<_Iterator1>::difference_type>
 __pattern_scan_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Iterator1 __first, _Iterator1 __last,
-                    _IteratorOrTuple __output_first, _GenMask __gen_mask, _WriteOp __write_op)
+                    _IteratorOrTuple __output_first, _GenMask __gen_mask, _WriteOp __write_op, _Unique __unique)
 {
     using _It1DifferenceType = typename ::std::iterator_traits<_Iterator1>::difference_type;
 
@@ -906,7 +906,7 @@ __pattern_scan_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Itera
 
     auto __res =
         __par_backend_hetero::__parallel_scan_copy(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
-                                                   __buf1.all_view(), __buf2.all_view(), __n, __gen_mask, __write_op);
+                                                   __buf1.all_view(), __buf2.all_view(), __n, __gen_mask, __write_op, __unique);
 
     ::std::size_t __num_copied = __res.get();
     return ::std::make_pair(__output_first + __n, __num_copied);
@@ -958,7 +958,7 @@ __pattern_partition_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __e
             __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::write>(__result1),
             __par_backend_hetero::make_iter_mode<__par_backend_hetero::access_mode::write>(__result2)),
         oneapi::dpl::__par_backend_hetero::__gen_mask<_UnaryPredicate>{__pred},
-        oneapi::dpl::__par_backend_hetero::__write_to_idx_if_else{});
+        oneapi::dpl::__par_backend_hetero::__write_to_idx_if_else{}, /*_Unique=*/std::false_type{});
 
     return ::std::make_pair(__result1 + __result.second, __result2 + (__last - __first - __result.second));
 }
@@ -978,7 +978,7 @@ __pattern_unique_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec
     auto __result =
         __pattern_scan_copy(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __result_first,
                             oneapi::dpl::__par_backend_hetero::__gen_unique_mask<_BinaryPredicate>{__pred},
-                            oneapi::dpl::__par_backend_hetero::__write_to_idx_if{});
+                            oneapi::dpl::__par_backend_hetero::__write_to_idx_if<1>{}, /*_Unique=*/std::true_type{});
 
     return __result_first + __result.second;
 }

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -335,10 +335,10 @@ __pattern_count(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&& _
 //------------------------------------------------------------------------
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _GenMask,
-          typename _WriteOp, typename _Unique>
+          typename _WriteOp, typename _IsUniquePattern>
 oneapi::dpl::__internal::__difference_t<_Range1>
 __pattern_scan_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2,
-                    _GenMask __gen_mask, _WriteOp __write_op, _Unique __unique)
+                    _GenMask __gen_mask, _WriteOp __write_op, _IsUniquePattern __is_unique_pattern)
 {
     auto __n = __rng1.size();
     if (__n == 0)
@@ -346,7 +346,7 @@ __pattern_scan_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range
 
     auto __res = __par_backend_hetero::__parallel_scan_copy(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
                                                             std::forward<_Range1>(__rng1),
-                                                            std::forward<_Range2>(__rng2), __n, __gen_mask, __write_op, __unique);
+                                                            std::forward<_Range2>(__rng2), __n, __gen_mask, __write_op, __is_unique_pattern);
     return __res.get();
 }
 
@@ -408,7 +408,7 @@ __pattern_unique_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec
     return __pattern_scan_copy(__tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng),
                                std::forward<_Range2>(__result),
                                oneapi::dpl::__par_backend_hetero::__gen_unique_mask<_BinaryPredicate>{__pred},
-                               oneapi::dpl::__par_backend_hetero::__write_to_idx_if<1>{std::forward<_Assign>(__assign)}, /*_Unique=*/std::true_type{});
+                               oneapi::dpl::__par_backend_hetero::__write_to_idx_if<1>{std::forward<_Assign>(__assign)}, /*_IsUniquePattern=*/std::true_type{});
 }
 
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -335,10 +335,10 @@ __pattern_count(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&& _
 //------------------------------------------------------------------------
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _GenMask,
-          typename _WriteOp>
+          typename _WriteOp, typename _Unique>
 oneapi::dpl::__internal::__difference_t<_Range1>
 __pattern_scan_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2,
-                    _GenMask __gen_mask, _WriteOp __write_op)
+                    _GenMask __gen_mask, _WriteOp __write_op, _Unique __unique)
 {
     auto __n = __rng1.size();
     if (__n == 0)
@@ -346,7 +346,7 @@ __pattern_scan_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range
 
     auto __res = __par_backend_hetero::__parallel_scan_copy(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
                                                             std::forward<_Range1>(__rng1),
-                                                            std::forward<_Range2>(__rng2), __n, __gen_mask, __write_op);
+                                                            std::forward<_Range2>(__rng2), __n, __gen_mask, __write_op, __unique);
     return __res.get();
 }
 
@@ -408,7 +408,7 @@ __pattern_unique_copy(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec
     return __pattern_scan_copy(__tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng),
                                std::forward<_Range2>(__result),
                                oneapi::dpl::__par_backend_hetero::__gen_unique_mask<_BinaryPredicate>{__pred},
-                               oneapi::dpl::__par_backend_hetero::__write_to_idx_if{std::forward<_Assign>(__assign)});
+                               oneapi::dpl::__par_backend_hetero::__write_to_idx_if<1>{std::forward<_Assign>(__assign)}, /*_Unique=*/std::true_type{});
 }
 
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -952,7 +952,7 @@ __parallel_transform_scan(oneapi::dpl::__internal::__device_backend_tag __backen
         return __parallel_transform_reduce_then_scan(
             __backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__in_rng),
             std::forward<_Range2>(__out_rng), __gen_transform, __binary_op, __gen_transform,
-            oneapi::dpl::__internal::__no_op{}, __simple_write_to_idx{}, __init, _Inclusive{}, /*_Unique=*/std::false_type{});
+            oneapi::dpl::__internal::__no_op{}, __simple_write_to_idx{}, __init, _Inclusive{}, /*_IsUniquePattern=*/std::false_type{});
     }
     else
     {
@@ -1022,11 +1022,11 @@ struct __invoke_single_group_copy_if
 };
 
 template <typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _Size, typename _GenMask,
-          typename _WriteOp, typename _Unique>
+          typename _WriteOp, typename _IsUniquePattern>
 auto
 __parallel_scan_copy(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
                      _InRng&& __in_rng, _OutRng&& __out_rng, _Size __n, _GenMask __generate_mask, _WriteOp __write_op,
-                     _Unique __unique)
+                     _IsUniquePattern __is_unique_pattern)
 {
     using _ReduceOp = ::std::plus<_Size>;
 
@@ -1037,7 +1037,7 @@ __parallel_scan_copy(oneapi::dpl::__internal::__device_backend_tag __backend_tag
         oneapi::dpl::__par_backend_hetero::__gen_expand_count_mask<_GenMask>{__generate_mask},
         oneapi::dpl::__par_backend_hetero::__get_zeroth_element{}, __write_op,
         oneapi::dpl::unseq_backend::__no_init_value<_Size>{},
-        /*_Inclusive=*/std::true_type{}, __unique);
+        /*_Inclusive=*/std::true_type{}, __is_unique_pattern);
 }
 
 template <typename _ExecutionPolicy, typename _InRng, typename _OutRng, typename _Size, typename _Pred,

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -784,15 +784,13 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
                        oneapi::dpl::__internal::__dpl_bit_ceil(__num_remaining) / __num_sub_groups_global);
     auto __inputs_per_item =  __inputs_per_sub_group / __sub_group_size;
     const auto __block_size = (__num_remaining < __max_inputs_per_block) ? __num_remaining : __max_inputs_per_block;
-    std::size_t __num_blocks = 1;
-    if (__block_size > 0)
-        __num_blocks = __num_remaining / __block_size + (__num_remaining % __block_size != 0);
+    const auto __num_blocks = __num_remaining / __block_size + (__num_remaining % __block_size != 0);
 
     //We need temporary storage for reductions of each sub-group (__num_sub_groups_global), and also 2 for the
     // block carry-out.  We need two for the block carry-out to prevent a race condition between reading and writing
     // the block carry-out within a single kernel.
-    __result_and_scratch_storage<std::decay_t<_ExecutionPolicy>, _ValueType> __result_and_scratch{
-        __exec, __num_sub_groups_global + 2};
+    __result_and_scratch_storage<std::decay_t<_ExecutionPolicy>, _ValueType> __result_and_scratch{__exec,
+                                                                                                  __num_sub_groups_global + 2};
 
     // Reduce and scan step implementations
     using _ReduceSubmitter =
@@ -817,7 +815,7 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
     for (std::size_t __b = 0; __b < __num_blocks; ++__b)
     {
         auto __elements_in_block = oneapi::dpl::__internal::__dpl_ceiling_div(
-                                         std::min(__num_remaining, __max_inputs_per_block), __inputs_per_item);
+            std::min(__num_remaining, __max_inputs_per_block), __inputs_per_item);
         auto __ele_in_block_round_up_workgroup =
             oneapi::dpl::__internal::__dpl_ceiling_div(__elements_in_block, __work_group_size) * __work_group_size;
         auto __global_range = sycl::range<1>(__ele_in_block_round_up_workgroup);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -693,11 +693,13 @@ struct __parallel_reduce_then_scan_scan_submitter<
                 {
                     if (__block_num + 1 == __num_blocks)
                     {
-                        __res_ptr[0] = __sub_group_carry.__v;
-
                         if constexpr (__is_unique_pattern)
                         {
-                            __res_ptr[0] += 1;
+                            __res_ptr[0] = __sub_group_carry.__v + 1;
+                        }
+                        else
+                        {
+                            __res_ptr[0] = __sub_group_carry.__v;
                         }
                     }
                     else

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce_then_scan.h
@@ -782,7 +782,7 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
             ? __max_inputs_per_block / __num_sub_groups_global
             : std::max(__sub_group_size,
                        oneapi::dpl::__internal::__dpl_bit_ceil(__num_remaining) / __num_sub_groups_global);
-    auto __inputs_per_item =  __inputs_per_sub_group / __sub_group_size;
+    auto __inputs_per_item = __inputs_per_sub_group / __sub_group_size;
     const auto __block_size = (__num_remaining < __max_inputs_per_block) ? __num_remaining : __max_inputs_per_block;
     const auto __num_blocks = __num_remaining / __block_size + (__num_remaining % __block_size != 0);
 
@@ -790,7 +790,7 @@ __parallel_transform_reduce_then_scan(oneapi::dpl::__internal::__device_backend_
     // block carry-out.  We need two for the block carry-out to prevent a race condition between reading and writing
     // the block carry-out within a single kernel.
     __result_and_scratch_storage<std::decay_t<_ExecutionPolicy>, _ValueType> __result_and_scratch{__exec,
-                                                                                                  __num_sub_groups_global + 2};
+                                                                                    __num_sub_groups_global + 2};
 
     // Reduce and scan step implementations
     using _ReduceSubmitter =

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -248,7 +248,7 @@ struct __gen_count_mask;
 template <typename _GenMask>
 struct __gen_expand_count_mask;
 
-template <typename Assign>
+template <int32_t __offset, typename Assign>
 struct __write_to_idx_if;
 
 template <typename Assign>
@@ -289,8 +289,8 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backen
 {
 };
 
-template <typename Assign>
-struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__write_to_idx_if, Assign)>
+template <int32_t __offset, typename Assign>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__write_to_idx_if, __offset, Assign)>
     : oneapi::dpl::__internal::__are_all_device_copyable<Assign>
 {
 };

--- a/test/general/implementation_details/device_copyable.pass.cpp
+++ b/test/general/implementation_details/device_copyable.pass.cpp
@@ -153,7 +153,7 @@ test_device_copyable()
     //__gen_mask
     static_assert(
         sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__gen_mask<noop_device_copyable>>,
-        // "__gen_mask is not device copyable with device copyable types");
+         "__gen_mask is not device copyable with device copyable types");
 
     //__gen_unique_mask
     static_assert(sycl::is_device_copyable_v<
@@ -172,7 +172,7 @@ test_device_copyable()
 
     //__write_to_idx_if
     static_assert(sycl::is_device_copyable_v<
-                      oneapi::dpl::__par_backend_hetero::__write_to_idx_if<assign_device_copyable>>,
+                      oneapi::dpl::__par_backend_hetero::__write_to_idx_if<0, assign_device_copyable>>,
                   "__write_to_idx_if is not device copyable with device copyable types");
 
     //__write_to_idx_if_else
@@ -404,7 +404,7 @@ test_non_device_copyable()
 
     //__write_to_idx_if
     static_assert(
-        !sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__write_to_idx_if<assign_non_device_copyable>>,
+        !sycl::is_device_copyable_v<oneapi::dpl::__par_backend_hetero::__write_to_idx_if<0, assign_non_device_copyable>>,
         "__write_to_idx_if is device copyable with non device copyable types");
 
     //__write_to_idx_if_else


### PR DESCRIPTION
Optimization for Unique.  Avoid branch at every dereference of the input range to specialize for the zeroth element. 
Ended up uglier than I expected to avoid an "empty" scan.  
We may be better off special casing the `n=1` case, which would allow us to get rid of a lot of the checks for positive `__active_subgroups`.

Draft to show for comment.  Need another pass for polish and formatting.  May want to rethink it a bit as well as mentioned above.