### PR TITLE
Fix double dereference in the function `__work_group_reduce_kernel`

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -72,7 +72,7 @@ template <typename _Tp, typename _NDItemId, typename _Size, typename _TransformP
 void
 __work_group_reduce_kernel(const _NDItemId __item_id, const _Size __n, const _Size __iters_per_work_item,
                            const bool __is_full, _TransformPattern __transform_pattern, _ReducePattern __reduce_pattern,
-                           _InitType __init, const _AccLocal& __local_mem, const _Res& __res_acc, const _Acc&... __acc)
+                           _InitType __init, const _AccLocal& __local_mem, _Res* __res_ptr, const _Acc&... __acc)
 {
     auto __local_idx = __item_id.get_local_id(0);
     const _Size __group_size = __item_id.get_local_range().size();
@@ -87,7 +87,7 @@ __work_group_reduce_kernel(const _NDItemId __item_id, const _Size __n, const _Si
     if (__local_idx == 0)
     {
         __reduce_pattern.apply_init(__init, __result.__v);
-        __res_acc[0] = __result.__v;
+        __res_ptr[0] = __result.__v;
     }
     __result.__v.~_Tp();
 }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -483,6 +483,8 @@ struct __usm_or_buffer_accessor
     size_t __offset = 0;
 
   public:
+    using value_type = _T;
+
     // Buffer accessor
     __usm_or_buffer_accessor(sycl::handler& __cgh, sycl::buffer<_T, 1>* __sycl_buf)
         : __acc(sycl::accessor(*__sycl_buf, __cgh, sycl::read_write, __dpl_sycl::__no_init{}))

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -585,19 +585,14 @@ struct __result_and_scratch_storage
     }
 
     template <typename _Acc>
-    static
-    std::enable_if_t<!std::is_pointer_v<_Acc>, typename _Acc::value_type*>
+    static auto
     __get_usm_or_buffer_accessor_ptr(const _Acc& __acc, ::std::size_t __scratch_n = 0)
     {
+#if _ONEDPL_SYCL_UNIFIED_USM_BUFFER_PRESENT
         return __acc.__get_pointer();
-    }
-
-    template <typename _Acc>
-    static
-    std::enable_if_t<std::is_pointer_v<_Acc>, typename std::iterator_traits<_Acc>::pointer>
-    __get_usm_or_buffer_accessor_ptr(_Acc __acc, ::std::size_t __scratch_n = 0)
-    {
+#else
         return &__acc[__scratch_n];
+#endif
     }
 
     auto

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -500,7 +500,7 @@ struct __usm_or_buffer_accessor
     {
     }
 
-    _T*
+    auto
     __get_pointer() const // should be cached within a kernel
     {
         return __usm ? __ptr + __offset : &__acc[__offset];

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -483,8 +483,6 @@ struct __usm_or_buffer_accessor
     size_t __offset = 0;
 
   public:
-    using value_type = _T;
-
     // Buffer accessor
     __usm_or_buffer_accessor(sycl::handler& __cgh, sycl::buffer<_T, 1>* __sycl_buf)
         : __acc(sycl::accessor(*__sycl_buf, __cgh, sycl::read_write, __dpl_sycl::__no_init{}))

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -500,7 +500,7 @@ struct __usm_or_buffer_accessor
     {
     }
 
-    auto
+    _T*
     __get_pointer() const // should be cached within a kernel
     {
         return __usm ? __ptr + __offset : &__acc[__offset];

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -585,14 +585,19 @@ struct __result_and_scratch_storage
     }
 
     template <typename _Acc>
-    static auto
+    static
+    std::enable_if_t<!std::is_pointer_v<_Acc>, typename _Acc::value_type*>
     __get_usm_or_buffer_accessor_ptr(const _Acc& __acc, ::std::size_t __scratch_n = 0)
     {
-#if _ONEDPL_SYCL_UNIFIED_USM_BUFFER_PRESENT
         return __acc.__get_pointer();
-#else
+    }
+
+    template <typename _Acc>
+    static
+    std::enable_if_t<std::is_pointer_v<_Acc>, typename std::iterator_traits<_Acc>::pointer>
+    __get_usm_or_buffer_accessor_ptr(_Acc __acc, ::std::size_t __scratch_n = 0)
+    {
         return &__acc[__scratch_n];
-#endif
     }
 
     auto


### PR DESCRIPTION
In this PR I propose the way how to avoid double dereference in Kernel code inside  function `__work_group_reduce_kernel` .
Double dereference has place here in Kernel's code in cases when we pass into this function simple `pointer` : we pass it by reference.

This problem also demonstrated in example, prepared by @julianmi : https://godbolt.org/z/rP7WbW94o
```C++
template <typename _Res>
void __kernel1(const _Res __res_acc){
	//  mov rax, qword ptr [rbp - 8]
	// mov dword ptr [rax], 0
    *__res_acc = 0;
}
 
template <typename _Res>
void __kernel2(const _Res& __res_acc){
    // mov rax, qword ptr [rbp - 8]
    // mov rax, qword ptr [rax]
    // mov dword ptr [rax], 1                  <<< EXTRA INSTRUCTION due we pass pointer by reference
    *__res_acc = 1;
}
 
template <typename _Res>
void __kernel3(const _Res __res_acc){
    // mov rax, qword ptr [rbp - 8]
    // mov dword ptr [rax], 2
    __res_acc[0] = 2;
}
 
template <typename _Res>
void __kernel4(const _Res& __res_acc){
    // mov rax, qword ptr [rbp - 8]
    // mov rax, qword ptr [rax]
    // mov dword ptr [rax], 3                     <<< EXTRA INSTRUCTION  due we pass pointer by reference
    __res_acc[0] = 3;
}
```
