### PR TITLE
Remove variant-visitor parrern from merge sort leaf

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
@@ -327,12 +327,12 @@ struct __leaf_sorter_selector
     select(const sycl::queue& __q, _Range& __rng, _Compare __comp) const
     {
         const std::size_t __n = __rng.size();
-        auto&& __d = __q.get_device();
+        auto __device = __q.get_device();
 
-        std::size_t __max_wg_size = __d.template get_info<sycl::info::device::max_work_group_size>();
+        std::size_t __max_wg_size = __device.template get_info<sycl::info::device::max_work_group_size>();
         __max_wg_size = oneapi::dpl::__internal::__dpl_bit_floor(__max_wg_size);
 
-        const auto __sg_sizes = __d.template get_info<sycl::info::device::sub_group_sizes>();
+        const auto __sg_sizes = __device.template get_info<sycl::info::device::sub_group_sizes>();
         const auto __max_sg_size = __sg_sizes.empty() ? 1 : *std::max_element(__sg_sizes.begin(), __sg_sizes.end());
         // __oversubscription is similar to "theoretical occupancy" in GPU, or "multithreading" in CPU
         // TODO: reconsider the constant if the corresponding query appears in the SYCL specification
@@ -343,36 +343,30 @@ struct __leaf_sorter_selector
         //         see: "Active Thread Blocks per Multiprocessor" (6)
         // AMD: https://rocm.docs.amd.com/en/latest/how-to/tuning-guides/mi300x/workload.html#mi300x-occupancy-vgpr-table
         //         see: "Occupancy per EU" (8)
-        const std::uint8_t __oversubscription = __d.is_gpu() ? 8 : 1;
-        const auto __max_cu = __d.template get_info<sycl::info::device::max_compute_units>();
+        const std::uint8_t __oversubscription = __device.is_gpu() ? 8 : 1;
+        const auto __max_cu = __device.template get_info<sycl::info::device::max_compute_units>();
         const auto __saturation_point = __max_cu * __max_sg_size * __oversubscription;
         const auto __desired_data_per_workitem = __n / __saturation_point;
 
         // Pessimistically double the memory requirement to take into account memory used by compiled kernel.
         // TODO: investigate if the adjustment can be less conservative
         const std::size_t __max_slm_items =
-            __d.template get_info<sycl::info::device::local_mem_size>() / (sizeof(_Tp) * 2);
+            __device.template get_info<sycl::info::device::local_mem_size>() / (sizeof(_Tp) * 2);
         if (__max_slm_items >= _Leaf8::storage_size(__max_wg_size) && __desired_data_per_workitem >= 8)
-        {
             return _Leaf8(__rng, __comp, __max_wg_size);
-        }
-        else if (__max_slm_items >= _Leaf4::storage_size(__max_wg_size) && __desired_data_per_workitem >= 4)
-        {
+
+        if (__max_slm_items >= _Leaf4::storage_size(__max_wg_size) && __desired_data_per_workitem >= 4)
             return _Leaf4(__rng, __comp, __max_wg_size);
-        }
-        else if (__max_slm_items >= _Leaf2::storage_size(__max_wg_size) && __desired_data_per_workitem >= 2)
-        {
+
+        if (__max_slm_items >= _Leaf2::storage_size(__max_wg_size) && __desired_data_per_workitem >= 2)
             return _Leaf2(__rng, __comp, __max_wg_size);
-        }
-        else
-        {
-            std::size_t __slm_max_wg_size = __max_slm_items / _Leaf2::storage_size(1);
-            // __n is taken as is because of the bit floor and processing 2 items per work-item
-            // hence the processed size always fits a single work-group if __n is chosen
-            __max_wg_size = std::min<std::size_t>({__max_wg_size, __slm_max_wg_size, __n});
-            __max_wg_size = oneapi::dpl::__internal::__dpl_bit_floor(__max_wg_size);
-            return _Leaf2(__rng, __comp, __max_wg_size);
-        }
+
+        std::size_t __slm_max_wg_size = __max_slm_items / _Leaf2::storage_size(1);
+        // __n is taken as is because of the bit floor and processing 2 items per work-item
+        // hence the processed size always fits a single work-group if __n is chosen
+        __max_wg_size = std::min<std::size_t>({__max_wg_size, __slm_max_wg_size, __n});
+        __max_wg_size = oneapi::dpl::__internal::__dpl_bit_floor(__max_wg_size);
+        return _Leaf2(__rng, __comp, __max_wg_size);
     }
 };
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
@@ -334,6 +334,7 @@ struct __leaf_sorter_selector
 
         const auto __sg_sizes = __device.template get_info<sycl::info::device::sub_group_sizes>();
         const auto __max_sg_size = __sg_sizes.empty() ? 1 : *std::max_element(__sg_sizes.begin(), __sg_sizes.end());
+        // __oversubscription is similar to "theoretical occupancy" in GPU, or "multithreading" in CPU
         // TODO: reconsider the constant if the corresponding query appears in the SYCL specification
         // 8 (or 6, which is slightly less) appears to be common for modern Intel/AMD/Nvidia GPUs see:
         // Intel: https://www.intel.com/content/www/us/en/docs/oneapi/optimization-guide-gpu/2024-2/intel-xe-gpu-architecture.html:

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
@@ -22,7 +22,6 @@
 #include <cassert>     // assert
 #include <utility>     // std::swap
 #include <cstdint>     // std::uint32_t, ...
-#include <variant>     // std::variant, std::visit
 #include <algorithm>   // std::min, std::max_element
 #include <type_traits> // std::decay_t, std::integral_constant
 
@@ -323,18 +322,18 @@ struct __leaf_sorter_selector
 
     using _Tp = oneapi::dpl::__internal::__value_t<_Range>;
 
-    std::variant<_Leaf8, _Leaf4, _Leaf2>
-    select(const sycl::queue& __q, _Range& __rng, _Compare __comp) const
+    template <typename _ExecutionPolicy, typename _SubmitterT>
+    auto
+    operator()(_ExecutionPolicy&& __exec, _Range& __rng, _Compare __comp, const _SubmitterT& __submitter) const
     {
         const std::size_t __n = __rng.size();
-        auto __device = __q.get_device();
+        auto __device = __exec.queue().get_device();
 
         std::size_t __max_wg_size = __device.template get_info<sycl::info::device::max_work_group_size>();
         __max_wg_size = oneapi::dpl::__internal::__dpl_bit_floor(__max_wg_size);
 
         const auto __sg_sizes = __device.template get_info<sycl::info::device::sub_group_sizes>();
         const auto __max_sg_size = __sg_sizes.empty() ? 1 : *std::max_element(__sg_sizes.begin(), __sg_sizes.end());
-        // __oversubscription is similar to "theoretical occupancy" in GPU, or "multithreading" in CPU
         // TODO: reconsider the constant if the corresponding query appears in the SYCL specification
         // 8 (or 6, which is slightly less) appears to be common for modern Intel/AMD/Nvidia GPUs see:
         // Intel: https://www.intel.com/content/www/us/en/docs/oneapi/optimization-guide-gpu/2024-2/intel-xe-gpu-architecture.html:
@@ -353,20 +352,31 @@ struct __leaf_sorter_selector
         const std::size_t __max_slm_items =
             __device.template get_info<sycl::info::device::local_mem_size>() / (sizeof(_Tp) * 2);
         if (__max_slm_items >= _Leaf8::storage_size(__max_wg_size) && __desired_data_per_workitem >= 8)
-            return _Leaf8(__rng, __comp, __max_wg_size);
+        {
+            _Leaf8 __leaf(__rng, __comp, __max_wg_size);
+            return __submitter(__leaf);
+        }
 
         if (__max_slm_items >= _Leaf4::storage_size(__max_wg_size) && __desired_data_per_workitem >= 4)
-            return _Leaf4(__rng, __comp, __max_wg_size);
+        {
+            _Leaf4 __leaf(__rng, __comp, __max_wg_size);
+            return __submitter(__leaf);
+        }
 
         if (__max_slm_items >= _Leaf2::storage_size(__max_wg_size) && __desired_data_per_workitem >= 2)
-            return _Leaf2(__rng, __comp, __max_wg_size);
+        {
+            _Leaf2 __leaf(__rng, __comp, __max_wg_size);
+            return __submitter(__leaf);
+        }
 
-        std::size_t __slm_max_wg_size = __max_slm_items / _Leaf2::storage_size(1);
+        const std::size_t __slm_max_wg_size = __max_slm_items / _Leaf2::storage_size(1);
         // __n is taken as is because of the bit floor and processing 2 items per work-item
         // hence the processed size always fits a single work-group if __n is chosen
         __max_wg_size = std::min<std::size_t>({__max_wg_size, __slm_max_wg_size, __n});
         __max_wg_size = oneapi::dpl::__internal::__dpl_bit_floor(__max_wg_size);
-        return _Leaf2(__rng, __comp, __max_wg_size);
+
+        _Leaf2 __leaf(__rng, __comp, __max_wg_size);
+        return __submitter(__leaf);
     }
 };
 
@@ -379,46 +389,50 @@ class __sort_global_kernel;
 template <typename... _Name>
 class __sort_copy_back_kernel;
 
+template <typename _ExecutionPolicy, typename _Range, typename _Compare, typename _IndexT>
+struct __parallel_sort_impl_submitter
+{
+    _ExecutionPolicy __exec;
+    _Range __rng;
+    _Compare __comp;
+
+    template <typename _LeafSorter>
+    auto
+    operator()(_LeafSorter& __leaf_sorter) const
+    {
+        using _LeafSorterT = std::decay_t<decltype(__leaf_sorter)>;
+        using _LeafDPWI    = std::integral_constant<std::uint16_t, _LeafSorterT::__data_per_workitem>;
+
+        using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
+
+        // TODO: split the submitter into multiple ones to avoid extra compilation of kernels
+        // - _LeafSortKernel does not need _IndexT
+        // - _GlobalSortKernel does not need _LeafDPWI
+        // - _CopyBackKernel does not need either of them
+        using _LeafSortKernel   = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<__sort_leaf_kernel     <_CustomName, _IndexT, _LeafDPWI>>;
+        using _GlobalSortKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<__sort_global_kernel   <_CustomName, _IndexT, _LeafDPWI>>;
+        using _CopyBackKernel   = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<__sort_copy_back_kernel<_CustomName, _IndexT, _LeafDPWI>>;
+
+        return __parallel_sort_submitter<_IndexT, _LeafSortKernel, _GlobalSortKernel, _CopyBackKernel>{}(
+            oneapi::dpl::__internal::__device_backend_tag{}, __exec, __rng, __comp, __leaf_sorter);
+    }
+};
+
 template <typename _ExecutionPolicy, typename _Range, typename _Compare>
 auto
 __parallel_sort_impl(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy&& __exec, _Range&& __rng,
                      _Compare __comp)
 {
-    using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
-
     const auto __n = __rng.size();
 
-    auto __index_selector = [__n]() -> std::variant<std::uint32_t, std::uint64_t> {
-        if (__n <= std::numeric_limits<std::uint32_t>::max())
-            return std::uint32_t{};
-        else
-            return std::uint64_t{};
-    };
-    auto __index_alternatives = __index_selector();
-    auto __leaf_sorter_alternatives = __leaf_sorter_selector<_Range, _Compare>().select(__exec.queue(), __rng, __comp);
+    if (__n <= std::numeric_limits<std::uint32_t>::max())
+    {
+        __parallel_sort_impl_submitter<_ExecutionPolicy, _Range, _Compare, std::uint32_t> __submitter{__exec, __rng, __comp};
+        return __leaf_sorter_selector<_Range, _Compare>{}(__exec, __rng, __comp, __submitter);
+    }
 
-    return std::visit(
-        [&](auto& __leaf_sorter, auto __index) {
-            using _IndexT = decltype(__index);
-            using _LeafSorterT = std::decay_t<decltype(__leaf_sorter)>;
-            using _LeafDPWI = std::integral_constant<std::uint16_t, _LeafSorterT::__data_per_workitem>;
-
-            // TODO: split the submitter into multiple ones to avoid extra compilation of kernels
-            // - _LeafSortKernel does not need _IndexT
-            // - _GlobalSortKernel does not need _LeafDPWI
-            // - _CopyBackKernel does not need either of them
-            using _LeafSortKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
-                __sort_leaf_kernel<_CustomName, _IndexT, _LeafDPWI>>;
-            using _GlobalSortKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
-                __sort_global_kernel<_CustomName, _IndexT, _LeafDPWI>>;
-            using _CopyBackKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
-                __sort_copy_back_kernel<_CustomName, _IndexT, _LeafDPWI>>;
-
-            return __parallel_sort_submitter<_IndexT, _LeafSortKernel, _GlobalSortKernel, _CopyBackKernel>()(
-                oneapi::dpl::__internal::__device_backend_tag{}, std::forward<_ExecutionPolicy>(__exec),
-                std::forward<_Range>(__rng), __comp, __leaf_sorter);
-        },
-        __leaf_sorter_alternatives, __index_alternatives);
+    __parallel_sort_impl_submitter<_ExecutionPolicy, _Range, _Compare, std::uint64_t> __submitter{__exec, __rng, __comp};
+    return __leaf_sorter_selector<_Range, _Compare>{}(__exec, __rng, __comp, __submitter);
 }
 
 } // namespace __par_backend_hetero

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
@@ -86,14 +86,14 @@ struct __group_merge_path_sorter
             const std::uint32_t __n1 = __end1 - __start1;
             const std::uint32_t __n2 = __end2 - __start2;
 
-            const auto& __in = __storage.begin() + __data_in_temp * __sorted_final;
-            const auto& __out = __storage.begin() + (!__data_in_temp) * __sorted_final;
-            const auto& __in1 = __in + __start1;
-            const auto& __in2 = __in + __start2;
+            const auto& __it_in = __storage.begin() + __data_in_temp * __sorted_final;
+            const auto& __it_out = __storage.begin() + (!__data_in_temp) * __sorted_final;
+            const auto& __in1 = __it_in + __start1;
+            const auto& __in2 = __it_in + __start2;
 
             const auto __start = __find_start_point(__in1, __in2, __id_local, __n1, __n2, __comp);
             // TODO: copy the data into registers before the merge to halve the required amount of SLM
-            __serial_merge(__in1, __in2, __out, __start.first, __start.second, __id, __data_per_workitem, __n1, __n2,
+            __serial_merge(__in1, __in2, __it_out, __start.first, __start.second, __id, __data_per_workitem, __n1, __n2,
                            __comp);
             __dpl_sycl::__group_barrier(__item);
 


### PR DESCRIPTION
I propose don't use `variant` / `visitor` pattern here due we haven't any container with different types of objects in this code.
So we are able after some refactoring to implement all required logic as I did in this PR without this pattern.