### PR TITLE
Move the use of ranges-v3 to "standalone" DR

### DIFF
--- a/include/oneapi/dpl/internal/distributed_ranges_impl/detail/segments_tools.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/detail/segments_tools.hpp
@@ -124,7 +124,7 @@ drop_segments(R&& segments, std::size_t n)
 
 } // namespace oneapi::dpl::experimental::dr
 
-namespace __ONEDPL_DR_STD_RANGES_NAMESPACE
+namespace _ONEDPL_DR_STD_RANGES_NAMESPACE
 {
 
 // A standard library range adaptor does not change the rank of a
@@ -170,6 +170,6 @@ requires(oneapi::dpl::experimental::dr::is_subrange_view_v<std::remove_cvref_t<V
         oneapi::dpl::experimental::dr::ranges::segments(first), size);
 }
 
-} // namespace __ONEDPL_DR_STD_RANGES_NAMESPACE
+} // namespace _ONEDPL_DR_STD_RANGES_NAMESPACE
 
 #endif /* _ONEDPL_DR_DETAIL_SEGMENT_TOOLS_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/detail/std_ranges_shim.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/detail/std_ranges_shim.hpp
@@ -28,7 +28,7 @@
 
 namespace stdrng = ::std::ranges;
 
-#    define __ONEDPL_DR_STD_RANGES_NAMESPACE std::ranges
+#    define _ONEDPL_DR_STD_RANGES_NAMESPACE std::ranges
 
 #endif /* _ONEDPL_DR_STD_RANGES_SHIM_HEADER */
 

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/detail/std_ranges_shim.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/detail/std_ranges_shim.hpp
@@ -16,7 +16,7 @@
 #ifndef _ONEDPL_DR_DETAIL_RANGES_SHIM_HPP
 #define _ONEDPL_DR_DETAIL_RANGES_SHIM_HPP
 
-#ifndef DR_USE_RANGES_V3
+#if 1 // ifndef DR_USE_RANGES_V3
 
 #    include <ranges>
 

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/detail/std_ranges_shim.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/detail/std_ranges_shim.hpp
@@ -16,17 +16,19 @@
 #ifndef _ONEDPL_DR_DETAIL_RANGES_SHIM_HPP
 #define _ONEDPL_DR_DETAIL_RANGES_SHIM_HPP
 
-#ifndef _ONEDPL_DR_STD_RANGES_SHIM_HEADER
+#ifdef _ONEDPL_DR_STD_RANGES_SHIM_HEADER
 
+// The macro expands to the name of a custom ranges shim header for DR to use
+#    include _ONEDPL_DR_STD_RANGES_SHIM_HEADER
+
+#else
+
+// If no custom shim, use std::ranges
 #    include <ranges>
 
 namespace stdrng = ::std::ranges;
 
 #    define __ONEDPL_DR_STD_RANGES_NAMESPACE std::ranges
-
-#else
-
-#    include _ONEDPL_DR_STD_RANGES_SHIM_HEADER
 
 #endif /* _ONEDPL_DR_STD_RANGES_SHIM_HEADER */
 

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/detail/std_ranges_shim.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/detail/std_ranges_shim.hpp
@@ -16,7 +16,7 @@
 #ifndef _ONEDPL_DR_DETAIL_RANGES_SHIM_HPP
 #define _ONEDPL_DR_DETAIL_RANGES_SHIM_HPP
 
-#if 1 // ifndef DR_USE_RANGES_V3
+#ifndef _ONEDPL_DR_STD_RANGES_SHIM_HEADER
 
 #    include <ranges>
 
@@ -26,12 +26,8 @@ namespace stdrng = ::std::ranges;
 
 #else
 
-#    include <range/v3/all.hpp>
+#    include _ONEDPL_DR_STD_RANGES_SHIM_HEADER
 
-namespace stdrng = ::ranges;
-
-#    define __ONEDPL_DR_STD_RANGES_NAMESPACE ranges
-
-#endif /* DR_USE_RANGES_V3 */
+#endif /* _ONEDPL_DR_STD_RANGES_SHIM_HEADER */
 
 #endif /* _ONEDPL_DR_DETAIL_RANGES_SHIM_HPP */

--- a/include/oneapi/dpl/internal/distributed_ranges_impl/detail/std_ranges_shim.hpp
+++ b/include/oneapi/dpl/internal/distributed_ranges_impl/detail/std_ranges_shim.hpp
@@ -16,20 +16,14 @@
 #ifndef _ONEDPL_DR_DETAIL_RANGES_SHIM_HPP
 #define _ONEDPL_DR_DETAIL_RANGES_SHIM_HPP
 
-#ifdef _ONEDPL_DR_STD_RANGES_SHIM_HEADER
+#ifndef _ONEDPL_DR_STD_RANGES_NAMESPACE
 
-// The macro expands to the name of a custom ranges shim header for DR to use
-#    include _ONEDPL_DR_STD_RANGES_SHIM_HEADER
-
-#else
-
-// If no custom shim, use std::ranges
+// If not overridden, use std::ranges
 #    include <ranges>
-
-namespace stdrng = ::std::ranges;
-
 #    define _ONEDPL_DR_STD_RANGES_NAMESPACE std::ranges
 
-#endif /* _ONEDPL_DR_STD_RANGES_SHIM_HEADER */
+#endif
+
+namespace stdrng = ::_ONEDPL_DR_STD_RANGES_NAMESPACE;
 
 #endif /* _ONEDPL_DR_DETAIL_RANGES_SHIM_HPP */

--- a/test/distributed_ranges/include/common_tests.hpp
+++ b/test/distributed_ranges/include/common_tests.hpp
@@ -362,7 +362,9 @@ bool operator==(const distributed_vector<T> &dist_vec,
 
 } // namespace oneapi::dpl::experimental::dr::sp
 
-namespace __ONEDPL_DR_STD_RANGES_NAMESPACE {
+namespace _ONEDPL_DR_STD_RANGES_NAMESPACE {
+
+// For EXPECT_EQ to work with two arbitrary ranges, define operator== to do elementwise comparison
 
 template <stdrng::range R1, stdrng::range R2> bool operator==(R1 &&r1, R2 &&r2) {
   return is_equal(std::forward<R1>(r1), std::forward<R2>(r2));


### PR DESCRIPTION
@BenBrock @lslusarczyk

In this patch I propose to support ranges-v3 in a different manner.

The "common" DR code in oneDPL would support redefinition of the `stdrng` namespace alias, as well as the `_ONEDPL_DR_STD_RANGES_NAMESPACE` macro (the patch also removes one extra leading underscore for that macro, to fit oneDPL naming rules).

Providing alternative definitions for ranges-v3 would be done in the "standalone" DR repository, like below:
```
// File: dr/detail/ranges_v3_shim.hpp
#pragma once

// In order to use ranges-v3 instead of C++20 ranges,
// #define _ONEDPL_DR_STD_RANGES_SHIM_HEADER <dr/detail/ranges_v3_shim.hpp>
// before including oneDPL DR headers

#include <range/v3/all.hpp>

namespace stdrng = ::ranges;

#define _ONEDPL_DR_STD_RANGES_NAMESPACE ranges
```
The macro `_ONEDPL_DR_STD_RANGES_SHIM_HEADER` should name the "replacement" shim header, in this case, the one that redirects to ranges-v3. It should be defined before including the "common" part from oneDPL, so that the custom shim is included by the main shim header in oneDPL.