### PR TITLE
Relocate __lazy_ctor_storage to utils header

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -20,6 +20,7 @@
 #include <memory>
 #include <type_traits>
 #include <tuple>
+#include <algorithm>
 
 #include "../../iterator_impl.h"
 
@@ -547,7 +548,8 @@ struct __result_and_scratch_storage
     }
 
   public:
-    __result_and_scratch_storage(_ExecutionPolicy& __exec, ::std::size_t __scratch_n)
+    template <typename _Policy>
+    __result_and_scratch_storage(_Policy&& __exec, ::std::size_t __scratch_n)
         : __exec{__exec}, __scratch_n{__scratch_n}, __use_USM_host{__use_USM_host_allocations(__exec.queue())},
           __supports_USM_device{__use_USM_allocations(__exec.queue())}
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_utils.h
@@ -20,7 +20,6 @@
 #include <memory>
 #include <type_traits>
 #include <tuple>
-#include <algorithm>
 
 #include "../../iterator_impl.h"
 
@@ -548,8 +547,7 @@ struct __result_and_scratch_storage
     }
 
   public:
-    template <typename _Policy>
-    __result_and_scratch_storage(_Policy&& __exec, ::std::size_t __scratch_n)
+    __result_and_scratch_storage(_ExecutionPolicy& __exec, ::std::size_t __scratch_n)
         : __exec{__exec}, __scratch_n{__scratch_n}, __use_USM_host{__use_USM_host_allocations(__exec.queue())},
           __supports_USM_device{__use_USM_allocations(__exec.queue())}
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -213,7 +213,7 @@ struct transform_reduce
     void
     vectorized_reduction_first(const _Size __start_idx, _Res& __res, const _Acc&... __acc) const
     {
-        __res.__setup(_Tp(__unary_op(__start_idx, __acc...)));
+        __res.__setup(__unary_op(__start_idx, __acc...));
         _ONEDPL_PRAGMA_UNROLL
         for (_Size __i = 1; __i < _VecSize; ++__i)
             __res.__v = __binary_op(__res.__v, __unary_op(__start_idx + __i, __acc...));
@@ -251,7 +251,7 @@ struct transform_reduce
             return;
         if (__iters_per_work_item == 1)
         {
-            __res.__setup(_Tp(__unary_op(__global_idx, __acc...)));
+            __res.__setup(__unary_op(__global_idx, __acc...));
             return;
         }
         const _Size __local_range = __item_id.get_local_range(0);
@@ -318,7 +318,7 @@ struct transform_reduce
         // Scalar remainder
         else if (__adjusted_global_id < __adjusted_n)
         {
-            __res.__setup(_Tp(__unary_op(__adjusted_global_id, __acc...)));
+            __res.__setup(__unary_op(__adjusted_global_id, __acc...));
             const _Size __adjusted_global_id_plus_one = __adjusted_global_id + 1;
             scalar_reduction_remainder(__adjusted_global_id_plus_one, __adjusted_n, __res, __acc...);
         }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/unseq_backend_sycl.h
@@ -213,7 +213,7 @@ struct transform_reduce
     void
     vectorized_reduction_first(const _Size __start_idx, _Res& __res, const _Acc&... __acc) const
     {
-        new (&__res.__v) _Tp(__unary_op(__start_idx, __acc...));
+        __res.__setup(_Tp(__unary_op(__start_idx, __acc...)));
         _ONEDPL_PRAGMA_UNROLL
         for (_Size __i = 1; __i < _VecSize; ++__i)
             __res.__v = __binary_op(__res.__v, __unary_op(__start_idx + __i, __acc...));
@@ -251,7 +251,7 @@ struct transform_reduce
             return;
         if (__iters_per_work_item == 1)
         {
-            new (&__res.__v) _Tp(__unary_op(__global_idx, __acc...));
+            __res.__setup(_Tp(__unary_op(__global_idx, __acc...)));
             return;
         }
         const _Size __local_range = __item_id.get_local_range(0);
@@ -318,7 +318,7 @@ struct transform_reduce
         // Scalar remainder
         else if (__adjusted_global_id < __adjusted_n)
         {
-            new (&__res.__v) _Tp(__unary_op(__adjusted_global_id, __acc...));
+            __res.__setup(_Tp(__unary_op(__adjusted_global_id, __acc...)));
             const _Size __adjusted_global_id_plus_one = __adjusted_global_id + 1;
             scalar_reduction_remainder(__adjusted_global_id_plus_one, __adjusted_n, __res, __acc...);
         }

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -772,10 +772,12 @@ union __lazy_ctor_storage
     using __value_type = _Tp;
     _Tp __v;
     __lazy_ctor_storage() {}
+
+    template<typename _U>
     void
-    __setup(const _Tp& init)
+    __setup(_U&& init)
     {
-        new (&__v) _Tp(init);
+        new (&__v) _Tp(std::forward<_U>(init));
     }
     void
     __destroy()

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -773,7 +773,7 @@ union __lazy_ctor_storage
     _Tp __v;
     __lazy_ctor_storage() {}
 
-    template<typename _U>
+    template <typename _U>
     void
     __setup(_U&& init)
     {

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -765,6 +765,7 @@ struct __is_iterator_type<_T, std::void_t<typename std::iterator_traits<_T>::dif
 template <typename _T>
 static constexpr bool __is_iterator_type_v = __is_iterator_type<_T>::value;
 
+// Storage helper since _Tp may not have a default constructor.
 template <typename _Tp>
 union __lazy_ctor_storage
 {

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -765,6 +765,24 @@ struct __is_iterator_type<_T, std::void_t<typename std::iterator_traits<_T>::dif
 template <typename _T>
 static constexpr bool __is_iterator_type_v = __is_iterator_type<_T>::value;
 
+template <typename _Tp>
+union __lazy_ctor_storage
+{
+    using __value_type = _Tp;
+    _Tp __v;
+    __lazy_ctor_storage() {}
+    void
+    __setup(const _Tp& init)
+    {
+        new (&__v) _Tp(init);
+    }
+    void
+    __destroy()
+    {
+        __v.~_Tp();
+    }
+};
+
 } // namespace __internal
 } // namespace dpl
 } // namespace oneapi


### PR DESCRIPTION
One of the changes to the upcoming scan rework (#1762) is to move the helper union `__lazy_ctor_storage` out of the reduce header into the main utils header, as it will eventually be used in scan as well. 

This PR makes that movement, as well as adds a few helper methods to `__lazy_ctor_storage`.

---

This PR is a part of the following sequence of PRs meant to be merged in order:

#1769 Relocate __lazy_ctor_storage to utils header (This PR)
#1770 Use __result_and_scratch_storage within scan kernels
#1762 Add reduce_then_scan algorithm for transform scan family
#1763 Make Copy_if family of APIs use reduce_then_scan algorithm
#1764 Make Partition family of APIs use reduce_then_scan algorithm
#1765 Make Unique family of APIs use reduce_then_scan algorithm

This work is a collaboration between @mmichel11 @adamfidel and @danhoeflinger, and based upon an original prototype by Ted Painter.