### PR TITLE
Workaround Windows correctness issue in reduce_by_segment.pass

### DIFF
--- a/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/reduce_by_segment.pass.cpp
@@ -346,13 +346,22 @@ run_test()
 int
 main()
 {
+    // On Windows, we observe incorrect results with this test with a specific compilation order of the
+    // kernels. This is being filed to the compiler team. In the meantime, we can rearrange this test
+    // to resolve the issue on our side.
+#if _PSTL_RED_BY_SEG_WINDOWS_COMPILE_ORDER_BROKEN
+    run_test<MatrixPoint<float>, UserBinaryPredicate<MatrixPoint<float>>, MaxFunctor<MatrixPoint<float>>>();
+#endif
+
 #if TEST_DPCPP_BACKEND_PRESENT
     // test with flag pred
     test_flag_pred<sycl::usm::alloc::device, class KernelName1, std::uint64_t>();
     test_flag_pred<sycl::usm::alloc::device, class KernelName2, MatrixPoint<float>>();
 #endif // TEST_DPCPP_BACKEND_PRESENT
 
+#if !_PSTL_RED_BY_SEG_WINDOWS_COMPILE_ORDER_BROKEN
     run_test<MatrixPoint<float>, UserBinaryPredicate<MatrixPoint<float>>, MaxFunctor<MatrixPoint<float>>>();
+#endif
 
     run_test<int, ::std::equal_to<int>, ::std::plus<int>>();
     run_test<float, ::std::equal_to<float>, ::std::plus<float>>();

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -224,6 +224,7 @@
 // A specific kernel compilation order causes incorrect results on Windows with the DPCPP backend. For now, we reorder
 // the test while the issue is being reported to the compiler team. Once it is resolved, this macro can be removed
 // or limited to older compiler versions.
-#define _PSTL_RED_BY_SEG_WINDOWS_COMPILE_ORDER_BROKEN (_MSC_VER && TEST_DPCPP_BACKEND_PRESENT)
+#define _PSTL_RED_BY_SEG_WINDOWS_COMPILE_ORDER_BROKEN                                                                  \
+    (_MSC_VER && TEST_DPCPP_BACKEND_PRESENT && __INTEL_LLVM_COMPILER <= 20250000)
 
 #endif // _TEST_CONFIG_H

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -221,4 +221,9 @@
 #    define _PSTL_ICPX_FPGA_TEST_USM_VECTOR_ITERATOR_BROKEN 0
 #endif
 
+// A specific kernel compilation order causes incorrect results on Windows with the DPCPP backend. For now, we reorder
+// the test while the issue is being reported to the compiler team. Once it is resolved, this macro can be removed
+// or limited to older compiler versions.
+#define _PSTL_RED_BY_SEG_WINDOWS_COMPILE_ORDER_BROKEN (_MSC_VER && TEST_DPCPP_BACKEND_PRESENT)
+
 #endif // _TEST_CONFIG_H


### PR DESCRIPTION
This PR is put up in anticipation of the reduce-then-scan implementation being committed. It can currently be produced on `dev/shared/reduce_than_scan_impl`.

When using the new reduce-then-scan implementation, a correctness issue has been identified on Windows with `reduce_by_segment.pass.cpp`. The issue can only be produced with the current ordering of test cases (and I assume ordering in which kernels are compiled). After running the two flag predicate tests, the third `MatrixPoint` test return incorrect results. We run into this issue even if the flag predicate tests are not run and their kernels only compiled. Reordering the tests to run the `MatrixPoint` test prior to the flag predicate tests, or completely removing the flag predicate tests results in a pass.

We believe this issue related to the order of kernel compilation is a compiler bug and are following up with the compiler team. For now, I have added a broken macro to reorder the tests on Windows.