### PR TITLE
Update scan kernel template documentation to note single-work-group is asynchronous

### DIFF
--- a/documentation/library_guide/kernel_templates/single_pass_scan.rst
+++ b/documentation/library_guide/kernel_templates/single_pass_scan.rst
@@ -78,7 +78,7 @@ Parameters
 
   Current limitations:
 
-  - Except for the case described in :ref:`scan-single-wg`, the function will internally block until the issued kernels have completed execution.
+  - Except for the case described in the :ref:`single-work-group note <scan-single-wg>`, the function will internally block until the issued kernels have completed execution.
     Although intended in the future to be an asynchronous call, the algorithm is currently synchronous.
   - The SYCL device associated with the provided queue must support 64-bit atomic operations if the element type is 64-bits.
   - There must be a known identity value for the provided combination of the element type and the binary operation. That is, ``sycl::has_known_identity_v`` must evaluate to true. Such operators are listed in the `SYCL 2020 specification <https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#table.identities>`_.

--- a/documentation/library_guide/kernel_templates/single_pass_scan.rst
+++ b/documentation/library_guide/kernel_templates/single_pass_scan.rst
@@ -78,7 +78,7 @@ Parameters
 
   Current limitations:
 
-  - The function will internally block until the issued kernels have completed execution.
+  - Except for the case described in :ref:`scan-single-wg`, the function will internally block until the issued kernels have completed execution.
     Although intended in the future to be an asynchronous call, the algorithm is currently synchronous.
   - The SYCL device associated with the provided queue must support 64-bit atomic operations if the element type is 64-bits.
   - There must be a known identity value for the provided combination of the element type and the binary operation. That is, ``sycl::has_known_identity_v`` must evaluate to true. Such operators are listed in the `SYCL 2020 specification <https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#table.identities>`_.
@@ -164,6 +164,8 @@ where V is the number of bytes needed to store the input value type.
 
 The value of N\ :sub:`flags` represents the number of work-groups and depends on ``param.data_per_workitem`` and ``param.workgroup_size``.
 It can be approximated by dividing the number of input elements N by the product of ``param.data_per_workitem`` and ``param.workgroup_size``.
+
+.. _scan-single-wg:
 
 .. note::
 

--- a/documentation/library_guide/kernel_templates/single_pass_scan.rst
+++ b/documentation/library_guide/kernel_templates/single_pass_scan.rst
@@ -78,7 +78,7 @@ Parameters
 
   Current limitations:
 
-  - Except for the case described in the :ref:`single-work-group note <scan-single-wg>`, the function will internally block until the issued kernels have completed execution.
+  - The function is intended to be asynchronous, but in some cases, the function will not return until the algorithm fully completes.
     Although intended in the future to be an asynchronous call, the algorithm is currently synchronous.
   - The SYCL device associated with the provided queue must support 64-bit atomic operations if the element type is 64-bits.
   - There must be a known identity value for the provided combination of the element type and the binary operation. That is, ``sycl::has_known_identity_v`` must evaluate to true. Such operators are listed in the `SYCL 2020 specification <https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#table.identities>`_.
@@ -164,8 +164,6 @@ where V is the number of bytes needed to store the input value type.
 
 The value of N\ :sub:`flags` represents the number of work-groups and depends on ``param.data_per_workitem`` and ``param.workgroup_size``.
 It can be approximated by dividing the number of input elements N by the product of ``param.data_per_workitem`` and ``param.workgroup_size``.
-
-.. _scan-single-wg:
 
 .. note::
 


### PR DESCRIPTION
After revisiting the code for the scan kernel template, we discovered that the algorithm is only synchronous in the non-single-work-group case. The documentation should be amended slightly to note of this discrepancy. 