### PR TITLE
Fix double reference in `__device_reduce_kernel` param

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_reduce.h
@@ -90,7 +90,7 @@ template <typename _Tp, typename _NDItemId, typename _Size, typename _TransformP
 void
 __device_reduce_kernel(const _NDItemId __item_id, const _Size __n, const _Size __iters_per_work_item,
                        const bool __is_full, const _Size __n_groups, _TransformPattern __transform_pattern,
-                       _ReducePattern __reduce_pattern, const _AccLocal& __local_mem, const _Tmp& __temp_acc,
+                       _ReducePattern __reduce_pattern, const _AccLocal& __local_mem, _Tmp* __reduce_result_ptr,
                        const _Acc&... __acc)
 {
     auto __local_idx = __item_id.get_local_id(0);
@@ -105,7 +105,7 @@ __device_reduce_kernel(const _NDItemId __item_id, const _Size __n, const _Size _
     // 2. Reduce within work group using local memory
     __result.__v = __reduce_pattern(__item_id, __n_items, __result.__v, __local_mem);
     if (__local_idx == 0)
-        __temp_acc[__group_idx] = __result.__v;
+        __reduce_result_ptr[__group_idx] = __result.__v;
     __result.__destroy();
 }
 


### PR DESCRIPTION
In this PR we fix double reference in `__device_reduce_kernel` param `__temp_acc`:
 - we have only one call of `__device_reduce_kernel` and we pass into `__temp_acc` param simple pointer in all cases:
```C++
                    auto __temp_ptr =
                        __result_and_scratch_storage<_ExecutionPolicy2, _Tp>::__get_usm_or_buffer_accessor_ptr(
                            __temp_acc);
                    // ...
                    __device_reduce_kernel<_Tp>(..., __temp_ptr, ...);
```
where `__get_usm_or_buffer_accessor_ptr` is :
```C++
    template <typename _Acc>
    static auto
    __get_usm_or_buffer_accessor_ptr(const _Acc& __acc, ::std::size_t __scratch_n = 0)
    {
#if _ONEDPL_SYCL_UNIFIED_USM_BUFFER_PRESENT
        return __acc.__get_pointer();
#else
        return &__acc[__scratch_n];
#endif
    }
```
