### PR TITLE
[test] Skip std::unique UserType test for dpcpp backend

### DIFF
--- a/test/parallel_api/algorithm/alg.nonmodifying/equal.pass.cpp
+++ b/test/parallel_api/algorithm/alg.nonmodifying/equal.pass.cpp
@@ -182,7 +182,13 @@ main()
     test<std::uint16_t>(8 * sizeof(std::uint16_t), [](const std::uint16_t& a, const std::uint16_t& b)   { return a == b; });
     test<float64_t>(53,                  [](const float64_t& a, const float64_t& b) { return a == b; });
     test<bool>(1,                        [](const bool& a, const bool& b)           { return a == b; });
+
+    // Avoiding UserType test for dpcpp backend, because UserType is not a device copyable type, with a custom copy
+    // assignment operator which is not the same as a bitwise copy. Therefore, a sycl::buffer with the value type
+    // UserType is not valid.
+#if !TEST_DPCPP_BACKEND_PRESENT
     test<UserType>(256,                  [](const UserType& a, const UserType& b)   { return a == b; });
+#endif
 
     test_algo_basic_double<std::int32_t>(run_for_rnd_fw<test_non_const<std::int32_t>>());
 


### PR DESCRIPTION
This PR skips the custom `UserType` test of `std::equal` for dpcpp backends.

This is done because `UserType` is not [device copyable](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec::device.copyable) (and shouldn't be explicitly specialized to be device copyable).  It has a custom copy assignment operator which is **not the same as a bitwise copy of the object**.  

Instead of changing this custom type to be device copyable, we instead skip this test to avoid conflicts with LLVM upstream.