### PR TITLE
[test] Marking Num device copyable for partial_sort_copy.pass

### DIFF
--- a/test/parallel_api/algorithm/alg.sorting/partial_sort_copy.pass.cpp
+++ b/test/parallel_api/algorithm/alg.sorting/partial_sort_copy.pass.cpp
@@ -49,6 +49,13 @@ struct Num
     }
 };
 
+#if TEST_DPCPP_BACKEND_PRESENT
+template <typename _T>
+struct sycl::is_device_copyable<Num<_T>> : sycl::is_device_copyable<_T>
+{
+};
+#endif //TEST_DPCPP_BACKEND_PRESENT
+
 template <typename Type>
 struct test_one_policy
 {


### PR DESCRIPTION
Making `Num<T>` device copyable.  
It obeys the rules as a type but was not specialized explicitly as device copyable.
