### PR TITLE
Resolve ESIMD sort KT compilation failures with new compiler

### DIFF
--- a/include/oneapi/dpl/experimental/kt/internal/esimd_defs.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_defs.h
@@ -21,8 +21,6 @@
 // https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_intel_esimd/sycl_ext_intel_esimd.md#static-allocation-of-slm-using-slm_init-function
 #define _ONEDPL_ESIMD_INLINE inline __attribute__((always_inline))
 
-#define _ONEDPL_SORT_KT_EXTRA_BARRIER_NEEDED (__INTEL_LLVM_COMPILER > 0 && __INTEL_LLVM_COMPILER <= 20250000)
-
 namespace oneapi::dpl::experimental::kt::gpu::esimd::__impl
 {
 

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_defs.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_defs.h
@@ -21,8 +21,7 @@
 // https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_intel_esimd/sycl_ext_intel_esimd.md#static-allocation-of-slm-using-slm_init-function
 #define _ONEDPL_ESIMD_INLINE inline __attribute__((always_inline))
 
-#define _ONEDPL_SORT_KT_EXTRA_BARRIER_NEEDED \
-    (__INTEL_LLVM_COMPILER > 0 && __INTEL_LLVM_COMPILER <= 20250000)
+#define _ONEDPL_SORT_KT_EXTRA_BARRIER_NEEDED (__INTEL_LLVM_COMPILER > 0 && __INTEL_LLVM_COMPILER <= 20250000)
 
 namespace oneapi::dpl::experimental::kt::gpu::esimd::__impl
 {

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_defs.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_defs.h
@@ -21,6 +21,9 @@
 // https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_intel_esimd/sycl_ext_intel_esimd.md#static-allocation-of-slm-using-slm_init-function
 #define _ONEDPL_ESIMD_INLINE inline __attribute__((always_inline))
 
+#define _ONEDPL_SORT_KT_EXTRA_BARRIER_NEEDED \
+    (__INTEL_LLVM_COMPILER > 0 && __INTEL_LLVM_COMPILER <= 20250000)
+
 namespace oneapi::dpl::experimental::kt::gpu::esimd::__impl
 {
 

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_kernels.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_kernels.h
@@ -197,7 +197,7 @@ __one_wg_kernel(sycl::nd_item<1> __idx, ::std::uint32_t __n, _RngPack1&& __rng_p
         {
             __dpl_esimd::__ns::simd<::std::uint16_t, __data_per_step> __bins_uw =
                 __bins.template select<__data_per_step, 1>(__s);
-            __write_addr.template select<__data_per_step, 1>(__s) += __bin_offset.template iselect(__bins_uw);
+            __write_addr.template select<__data_per_step, 1>(__s) += __bin_offset.iselect(__bins_uw);
         }
 
         // 2.6. Reorder keys in SLM.
@@ -483,7 +483,7 @@ struct __radix_sort_onesweep_kernel
         // Software barriers (here and below) are used in order to trick the compiler,
         // thus it generates memory operations with better performance
         // TODO: check if it is still necessary.
-        __dpl_esimd::__ns::fence<__dpl_esimd::__ns::fence_mask::sw_barrier>();
+        __dpl_esimd::__ns::fence();
         __dpl_esimd::__ns::simd<::std::uint32_t, 32> __matched_bins(0xffffffff);
         _ONEDPL_PRAGMA_UNROLL
         for (int __i = 0; __i < __radix_bits; __i++)
@@ -494,7 +494,7 @@ struct __radix_sort_onesweep_kernel
             ::std::uint32_t __ones = __dpl_esimd::__ns::pack_mask(__bit != 0);
             __matched_bins = __matched_bins & (__x ^ __ones);
         }
-        __dpl_esimd::__ns::fence<__dpl_esimd::__ns::fence_mask::sw_barrier>();
+        __dpl_esimd::__ns::fence();
         return __matched_bins;
     }
 
@@ -647,7 +647,7 @@ struct __radix_sort_onesweep_kernel
                     // Software barrier is used in order to motivate the compiler
                     // to generate memory operations in an order which results in better performance
                     // TODO: check if it is still necessary.
-                    __dpl_esimd::__ns::fence<__dpl_esimd::__ns::fence_mask::sw_barrier>();
+                    __dpl_esimd::__ns::fence();
                 } while (((__prev_group_hist & __hist_updated) == 0).any());
                 __prev_group_hist_sum.merge(__prev_group_hist_sum + __prev_group_hist, __is_not_accumulated);
                 __is_not_accumulated = (__prev_group_hist_sum & __global_accumulated) == 0;

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_kernels.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_kernels.h
@@ -639,7 +639,7 @@ struct __radix_sort_onesweep_kernel
                         _GlobOffsetT, __bin_width, __dpl_esimd::__ens::lsc_data_size::default_size,
                         __dpl_esimd::__ens::cache_hint::uncached, __dpl_esimd::__ens::cache_hint::cached>(
                         __p_prev_group_hist + __local_tid * __bin_width);
-                    // TODO: This barrier is added to prevent a hang that occurs otherwise. However, this barrier
+                    // TODO: This fence is added to prevent a hang that occurs otherwise. However, this fence
                     // should not logically be needed. Consider removing once this has been further investigated.
                     // This preprocessor check is set to expire and needs to be reevaluated once the SYCL major version
                     // is upgraded to 9.

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_kernels.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_kernels.h
@@ -480,9 +480,6 @@ struct __radix_sort_onesweep_kernel
     static inline __dpl_esimd::__ns::simd<::std::uint32_t, 32>
     __match_bins(const __dpl_esimd::__ns::simd<::std::uint32_t, 32>& __bins, ::std::uint32_t __local_tid)
     {
-        // Software barriers (here and below) are used in order to trick the compiler,
-        // thus it generates memory operations with better performance
-        // TODO: check if it is still necessary.
         __dpl_esimd::__ns::simd<::std::uint32_t, 32> __matched_bins(0xffffffff);
         _ONEDPL_PRAGMA_UNROLL
         for (int __i = 0; __i < __radix_bits; __i++)
@@ -642,9 +639,6 @@ struct __radix_sort_onesweep_kernel
                         _GlobOffsetT, __bin_width, __dpl_esimd::__ens::lsc_data_size::default_size,
                         __dpl_esimd::__ens::cache_hint::uncached, __dpl_esimd::__ens::cache_hint::cached>(
                         __p_prev_group_hist + __local_tid * __bin_width);
-                    // Software barrier is used in order to motivate the compiler
-                    // to generate memory operations in an order which results in better performance
-                    // TODO: check if it is still necessary.
                     __dpl_esimd::__ns::fence<__dpl_esimd::__ns::memory_kind::global>();
                 } while (((__prev_group_hist & __hist_updated) == 0).any());
                 __prev_group_hist_sum.merge(__prev_group_hist_sum + __prev_group_hist, __is_not_accumulated);

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_kernels.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_kernels.h
@@ -639,9 +639,11 @@ struct __radix_sort_onesweep_kernel
                         _GlobOffsetT, __bin_width, __dpl_esimd::__ens::lsc_data_size::default_size,
                         __dpl_esimd::__ens::cache_hint::uncached, __dpl_esimd::__ens::cache_hint::cached>(
                         __p_prev_group_hist + __local_tid * __bin_width);
-#if _ONEDPL_SORT_KT_EXTRA_BARRIER_NEEDED
                     // TODO: This barrier is added to prevent a hang that occurs otherwise. However, this barrier
                     // should not logically be needed. Consider removing once this has been further investigated.
+                    // This preprocessor check is set to expire and needs to be reevaluated once the SYCL major version
+                    // is upgraded to 9.
+#if _ONEDPL_LIBSYCL_VERSION < 90000
                     __dpl_esimd::__ns::fence<__dpl_esimd::__ns::memory_kind::local>();
 #endif
                 } while (((__prev_group_hist & __hist_updated) == 0).any());

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_kernels.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_kernels.h
@@ -639,7 +639,11 @@ struct __radix_sort_onesweep_kernel
                         _GlobOffsetT, __bin_width, __dpl_esimd::__ens::lsc_data_size::default_size,
                         __dpl_esimd::__ens::cache_hint::uncached, __dpl_esimd::__ens::cache_hint::cached>(
                         __p_prev_group_hist + __local_tid * __bin_width);
-                    __dpl_esimd::__ns::fence<__dpl_esimd::__ns::memory_kind::global>();
+#if _ONEDPL_SORT_KT_EXTRA_BARRIER_NEEDED
+                    // TODO: This barrier is added to prevent a hang that occurs otherwise. However, this barrier
+                    // should not logically be needed. Consider removing once this has been further investigated.
+                    __dpl_esimd::__ns::fence<__dpl_esimd::__ns::memory_kind::local>();
+#endif
                 } while (((__prev_group_hist & __hist_updated) == 0).any());
                 __prev_group_hist_sum.merge(__prev_group_hist_sum + __prev_group_hist, __is_not_accumulated);
                 __is_not_accumulated = (__prev_group_hist_sum & __global_accumulated) == 0;

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_kernels.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_kernels.h
@@ -483,7 +483,6 @@ struct __radix_sort_onesweep_kernel
         // Software barriers (here and below) are used in order to trick the compiler,
         // thus it generates memory operations with better performance
         // TODO: check if it is still necessary.
-        __dpl_esimd::__ns::fence();
         __dpl_esimd::__ns::simd<::std::uint32_t, 32> __matched_bins(0xffffffff);
         _ONEDPL_PRAGMA_UNROLL
         for (int __i = 0; __i < __radix_bits; __i++)
@@ -494,7 +493,6 @@ struct __radix_sort_onesweep_kernel
             ::std::uint32_t __ones = __dpl_esimd::__ns::pack_mask(__bit != 0);
             __matched_bins = __matched_bins & (__x ^ __ones);
         }
-        __dpl_esimd::__ns::fence();
         return __matched_bins;
     }
 
@@ -647,7 +645,7 @@ struct __radix_sort_onesweep_kernel
                     // Software barrier is used in order to motivate the compiler
                     // to generate memory operations in an order which results in better performance
                     // TODO: check if it is still necessary.
-                    __dpl_esimd::__ns::fence();
+                    __dpl_esimd::__ns::fence<__dpl_esimd::__ns::memory_kind::global>();
                 } while (((__prev_group_hist & __hist_updated) == 0).any());
                 __prev_group_hist_sum.merge(__prev_group_hist_sum + __prev_group_hist, __is_not_accumulated);
                 __is_not_accumulated = (__prev_group_hist_sum & __global_accumulated) == 0;

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_utils.h
@@ -207,7 +207,7 @@ __create_simd(_T initial, _T step)
 {
     __dpl_esimd::__ns::simd<_T, _N> ret;
     ret.template select<16, 1>(0) = __dpl_esimd::__ns::simd<_T, 16>(0, 1) * step + initial;
-    __dpl_esimd::__ns::fence<__dpl_esimd::__ns::fence_mask::sw_barrier>();
+    __dpl_esimd::__ns::fence();
     _ONEDPL_PRAGMA_UNROLL
     for (int pos = 16; pos < _N; pos += 16)
     {

--- a/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_utils.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_radix_sort_utils.h
@@ -207,7 +207,6 @@ __create_simd(_T initial, _T step)
 {
     __dpl_esimd::__ns::simd<_T, _N> ret;
     ret.template select<16, 1>(0) = __dpl_esimd::__ns::simd<_T, 16>(0, 1) * step + initial;
-    __dpl_esimd::__ns::fence();
     _ONEDPL_PRAGMA_UNROLL
     for (int pos = 16; pos < _N; pos += 16)
     {


### PR DESCRIPTION
Our ESIMD radix sort has two issues with newer compilers:

1. We unnecessarily use the `template` keyword prior to calling a function without a template argument list. This causes compilation failures with newer compilers. This has been fixed by removing `template` in this instance.
2. The `sycl::ext::intel::esimd::sw_barrier` enumerator has been removed and as far as I am aware there is no other ESIMD equivalent. We have a note that these `sw_barrier` fences are for performance reasons. There is one fence in the inter-wg synchronization that I believe is necessary for correctness (I see a hang otherwise). However, it should use a global memory fence and not a software barrier as we need ordering of reads which are from global memory. I have removed the other sw_barrier fences and do not observe any measurable performance impact.

I can share performance data for 2 if requested.
