### PR TITLE
Add spec compliant histogram API while supporting legacy extension API

### DIFF
--- a/include/oneapi/dpl/pstl/histogram_extension_defs.h
+++ b/include/oneapi/dpl/pstl/histogram_extension_defs.h
@@ -22,10 +22,18 @@ namespace oneapi
 {
 namespace dpl
 {
+template <typename _ExecutionPolicy, typename _RandomAccessIterator1, typename _Size, typename _RandomAccessIterator2>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator2>
+histogram(_ExecutionPolicy&& exec, _RandomAccessIterator1 first, _RandomAccessIterator1 last, _Size num_bins,
+          typename std::iterator_traits<_RandomAccessIterator1>::value_type first_bin_min_val,
+          typename std::iterator_traits<_RandomAccessIterator1>::value_type last_bin_max_val,
+          _RandomAccessIterator2 histogram_first);
 
 template <typename _ExecutionPolicy, typename _RandomAccessIterator1, typename _Size, typename _RandomAccessIterator2,
-          typename _ValueType = typename ::std::iterator_traits<_RandomAccessIterator1>::value_type>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator2>
+          typename _ValueType>
+std::enable_if_t<oneapi::dpl::execution::is_execution_policy_v<::std::decay_t<_ExecutionPolicy>> &&
+                     !std::is_same_v<_ValueType, typename std::iterator_traits<_RandomAccessIterator1>::value_type>,
+                 _RandomAccessIterator2>
 histogram(_ExecutionPolicy&& exec, _RandomAccessIterator1 first, _RandomAccessIterator1 last, _Size num_bins,
           _ValueType first_bin_min_val, _ValueType last_bin_max_val, _RandomAccessIterator2 histogram_first);
 

--- a/include/oneapi/dpl/pstl/histogram_impl.h
+++ b/include/oneapi/dpl/pstl/histogram_impl.h
@@ -46,9 +46,32 @@ __pattern_histogram(_Tag, _ExecutionPolicy&& exec, _RandomAccessIterator1 __firs
 
 } // namespace __internal
 
+template <typename _ExecutionPolicy, typename _RandomAccessIterator1, typename _Size, typename _RandomAccessIterator2>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator2>
+histogram(_ExecutionPolicy&& exec, _RandomAccessIterator1 first, _RandomAccessIterator1 last, _Size num_bins,
+          typename std::iterator_traits<_RandomAccessIterator1>::value_type first_bin_min_val,
+          typename std::iterator_traits<_RandomAccessIterator1>::value_type last_bin_max_val,
+          _RandomAccessIterator2 histogram_first)
+{
+    using _BoundaryType = typename std::iterator_traits<_RandomAccessIterator1>::value_type;
+    const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(exec, first, histogram_first);
+
+    oneapi::dpl::__internal::__pattern_histogram(
+        __dispatch_tag, ::std::forward<_ExecutionPolicy>(exec), first, last, num_bins,
+        oneapi::dpl::__internal::__evenly_divided_binhash<_BoundaryType>(first_bin_min_val, last_bin_max_val, num_bins),
+        histogram_first);
+    return histogram_first + num_bins;
+}
+
+// This overload is provided to support an extension to the oneDPL specification to support the original implementation
+// of the histogram API, where the boundary type _ValueType could differ from the value type of the input iterator,
+// and required `operator<` and `operator<=` to be defined between _ValueType and
+// std::iterator_traits<_RandomAccessIterator1>::value_type rather than enforcing they were the same type
 template <typename _ExecutionPolicy, typename _RandomAccessIterator1, typename _Size, typename _RandomAccessIterator2,
           typename _ValueType>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator2>
+std::enable_if_t<oneapi::dpl::execution::is_execution_policy_v<::std::decay_t<_ExecutionPolicy>> &&
+                     !std::is_same_v<_ValueType, typename std::iterator_traits<_RandomAccessIterator1>::value_type>,
+                 _RandomAccessIterator2>
 histogram(_ExecutionPolicy&& exec, _RandomAccessIterator1 first, _RandomAccessIterator1 last, _Size num_bins,
           _ValueType first_bin_min_val, _ValueType last_bin_max_val, _RandomAccessIterator2 histogram_first)
 {


### PR DESCRIPTION
This PR adjust the API overloads for histogram to create an API which complies to the current PR for [the specification](https://github.com/uxlfoundation/oneAPI-spec/pull/546), while continuing to support the existing API as an extension.

It removes an unnecessary and unused default parameter for `ValueType` which was incorrectly added in the original PR.  The new spec compliant API implements what was the intended signature originally motivated from [this discussion](https://github.com/oneapi-src/oneDPL/pull/1273#discussion_r1395697209).  

This change in overload / signature should intercept the normal usages of histogram which have matching types for the bound limits with the value type of the input iterators, and use the spec compliant signature.  

For those using histogram that provide bound limits which do not match the type, the legacy overload will still support this usage.  

We should not stop supporting any existing working cases with this change, but we will add some additional supported invocations where the type of the boundaries do not match each other.  If they are both implicitly convertible to the value type of the input iterator, they will be converted, and it should work (possibly with warnings).

Example in godbolt to play with: [Godbolt example](https://godbolt.org/z/4ePTobz4c)