### PR TITLE
[RNG] Conversion fixes in uniform real distribution

### DIFF
--- a/include/oneapi/dpl/internal/random_impl/uniform_real_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/uniform_real_distribution.h
@@ -274,7 +274,7 @@ class uniform_real_distribution
             auto __engine_output = __engine();
             auto __res_tmp = __engine_output.template convert<scalar_type, sycl::rounding_mode::rte>();
             __res_tmp =
-                ((__res_tmp - __engine.min()) / (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
+                ((__res_tmp - static_cast<scalar_type>(__engine.min())) / (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
                     (__params.b() - __params.a()) +
                 __params.a();
 
@@ -288,7 +288,7 @@ class uniform_real_distribution
             auto __engine_output = __engine(__tail_size);
             auto __res_tmp = __engine_output.template convert<scalar_type, sycl::rounding_mode::rte>();
             __res_tmp =
-                ((__res_tmp - __engine.min()) / (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
+                ((__res_tmp - static_cast<scalar_type>(__engine.min())) / (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
                     (__params.b() - __params.a()) +
                 __params.a();
             for (int __j = 0; __j < __tail_size; __j++)

--- a/include/oneapi/dpl/internal/random_impl/uniform_real_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/uniform_real_distribution.h
@@ -212,11 +212,13 @@ class uniform_real_distribution
         auto __engine_output = __engine();
         result_type __res{};
 
-        for (int __i = 0; __i < _Ndistr; ++__i){
-            __res[__i] = ((__engine_output[__i] - __engine.min()) / static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
-                        (__params.b() - __params.a()) +
-                    __params.a();
-        }
+        for (int __i = 0; __i < _Ndistr; ++__i)
+        {
+            __res[__i] = ((__engine_output[__i] - __engine.min()) /
+                          static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
+                             (__params.b() - __params.a()) +
+                         __params.a();
+         }
 
         return __res;
     }
@@ -226,10 +228,10 @@ class uniform_real_distribution
     generate(_Engine& __engine, const param_type& __params)
     {
         auto __engine_output = __engine();
-        scalar_type __res = ((__engine_output - __engine.min()) /
-                 static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
-                    (__params.b() - __params.a()) +
-                __params.a();
+        scalar_type __res =
+            ((__engine_output - __engine.min()) / static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
+                (__params.b() - __params.a()) +
+            __params.a();
         return __res;
     }
 
@@ -241,10 +243,10 @@ class uniform_real_distribution
         result_type __res{};
         for (int __i = 0; __i < _Ndistr; ++__i)
         {
-            __res[__i] =
-                ((__engine_output[__i] - __engine.min()) / static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
-                    (__params.b() - __params.a()) +
-                __params.a();
+            __res[__i] = ((__engine_output[__i] - __engine.min()) /
+                          static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
+                             (__params.b() - __params.a()) +
+                         __params.a();
         }
         return __res;
     }
@@ -253,9 +255,10 @@ class uniform_real_distribution
     ::std::enable_if_t<((_Ndistr < _Nengine) & (_Ndistr == 0)), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
-        scalar_type __res = ((__engine(1)[0] - __engine.min()) / static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
-                    (__params.b() - __params.a()) +
-                __params.a();
+        scalar_type __res =
+            ((__engine(1)[0] - __engine.min()) / static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
+                (__params.b() - __params.a()) +
+            __params.a();
         return __res;
     }
 
@@ -271,10 +274,10 @@ class uniform_real_distribution
             auto __engine_output = __engine();
             for (int __j = 0; __j < _Nengine; ++__j)
             {
-                scalar_type __res_tmp =
-                    ((__engine_output[__j] - __engine.min()) / static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
-                        (__params.b() - __params.a()) +
-                    __params.a();
+                scalar_type __res_tmp = ((__engine_output[__j] - __engine.min()) /
+                                         static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
+                                            (__params.b() - __params.a()) +
+                                        __params.a();
                 __res[__i + __j] = __res_tmp;
             }
         }
@@ -283,14 +286,14 @@ class uniform_real_distribution
         {
             __i = _Ndistr - __tail_size;
             auto __engine_output = __engine(__tail_size);
-            for (int __j = 0; __j < __tail_size; __j++){
-                scalar_type __res_tmp =
-                    ((__engine_output[__j] - __engine.min()) / static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
-                        (__params.b() - __params.a()) +
-                    __params.a();
-
-                __res[__i + __j] = __res_tmp;
-            }
+            for (int __j = 0; __j < __tail_size; __j++)
+            {
+                scalar_type __res_tmp = ((__engine_output[__j] - __engine.min()) /
+                                         static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
+                                            (__params.b() - __params.a()) +
+                                        __params.a();
+                 __res[__i + __j] = __res_tmp;
+             }
         }
         return __res;
     }
@@ -319,10 +322,10 @@ class uniform_real_distribution
         result_type __res{};
         for (unsigned int __i = 0; __i < __N; ++__i)
         {
-            __res[__i] =
-                ((__engine_output[__i] - __engine.min()) / static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
-                    (__params.b() - __params.a()) +
-                __params.a();
+            __res[__i] = ((__engine_output[__i] - __engine.min()) /
+                          static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
+                             (__params.b() - __params.a()) +
+                         __params.a();
         }
         return __res;
     }
@@ -339,10 +342,10 @@ class uniform_real_distribution
             auto __engine_output = __engine(__N);
             for (__i = 0; __i < __N; ++__i)
             {
-                __res[__i] =
-                    ((__engine_output[__i] - __engine.min()) / static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
-                        (__params.b() - __params.a()) +
-                    __params.a();
+                __res[__i] = ((__engine_output[__i] - __engine.min()) /
+                              static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
+                                 (__params.b() - __params.a()) +
+                             __params.a();
             }
         }
         else
@@ -353,10 +356,10 @@ class uniform_real_distribution
                 auto __engine_output = __engine();
                 for (int __j = 0; __j < _Nengine; ++__j)
                 {
-                    auto __res_tmp =
-                        ((__engine_output[__j] - __engine.min()) / static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
-                            (__params.b() - __params.a()) +
-                        __params.a();
+                    auto __res_tmp = ((__engine_output[__j] - __engine.min()) /
+                                      static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
+                                         (__params.b() - __params.a()) +
+                                     __params.a();
                     __res[__i + __j] = __res_tmp;
                 }
             }
@@ -367,10 +370,10 @@ class uniform_real_distribution
 
                 for (unsigned int __j = 0; __j < __tail_size; ++__j)
                 {
-                    auto __res_tmp =
-                        ((__engine_output[__j] - __engine.min()) / static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
-                            (__params.b() - __params.a()) +
-                        __params.a();
+                    auto __res_tmp = ((__engine_output[__j] - __engine.min()) /
+                                      static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
+                                         (__params.b() - __params.a()) +
+                                     __params.a();
                     __res[__i + __j] = __res_tmp;
                 }
             }

--- a/include/oneapi/dpl/internal/random_impl/uniform_real_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/uniform_real_distribution.h
@@ -204,6 +204,16 @@ class uniform_real_distribution
     scalar_type a_;
     scalar_type b_;
 
+    template<typename _IntegerT, typename _Engine>
+    inline scalar_type
+    make_real_uniform(_IntegerT __int_val, _Engine& __engine, const param_type& __params)
+    {
+        return static_cast<scalar_type>(((__int_val - __engine.min()) /
+                static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
+                                            (__params.b() - __params.a()) +
+                                        __params.a());
+    }
+
     // Implementation for generate function
     template <int _Ndistr, int _Nengine, class _Engine>
     ::std::enable_if_t<((_Ndistr == _Nengine) & (_Ndistr != 0)), result_type>
@@ -214,10 +224,7 @@ class uniform_real_distribution
 
         for (int __i = 0; __i < _Ndistr; ++__i)
         {
-            __res[__i] = ((__engine_output[__i] - __engine.min()) /
-                          static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
-                             (__params.b() - __params.a()) +
-                         __params.a();
+            __res[__i] = make_real_uniform(__engine_output[__i], __engine, __params);
         }
 
         return __res;
@@ -227,12 +234,7 @@ class uniform_real_distribution
     ::std::enable_if_t<((_Ndistr == _Nengine) & (_Ndistr == 0)), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
-        auto __engine_output = __engine();
-        scalar_type __res =
-            ((__engine_output - __engine.min()) / static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
-                (__params.b() - __params.a()) +
-            __params.a();
-        return __res;
+        return make_real_uniform(__engine(), __engine, __params);
     }
 
     template <int _Ndistr, int _Nengine, class _Engine>
@@ -243,10 +245,7 @@ class uniform_real_distribution
         result_type __res{};
         for (int __i = 0; __i < _Ndistr; ++__i)
         {
-            __res[__i] = ((__engine_output[__i] - __engine.min()) /
-                          static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
-                             (__params.b() - __params.a()) +
-                         __params.a();
+            __res[__i] = make_real_uniform(__engine_output[__i], __engine, __params);
         }
         return __res;
     }
@@ -255,11 +254,7 @@ class uniform_real_distribution
     ::std::enable_if_t<((_Ndistr < _Nengine) & (_Ndistr == 0)), result_type>
     generate(_Engine& __engine, const param_type& __params)
     {
-        scalar_type __res =
-            ((__engine(1)[0] - __engine.min()) / static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
-                (__params.b() - __params.a()) +
-            __params.a();
-        return __res;
+        return make_real_uniform(__engine(1)[0], __engine, __params);
     }
 
     template <int _Ndistr, int _Nengine, class _Engine>
@@ -274,11 +269,7 @@ class uniform_real_distribution
             auto __engine_output = __engine();
             for (int __j = 0; __j < _Nengine; ++__j)
             {
-                scalar_type __res_tmp = ((__engine_output[__j] - __engine.min()) /
-                                         static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
-                                            (__params.b() - __params.a()) +
-                                        __params.a();
-                __res[__i + __j] = __res_tmp;
+                __res[__i + __j] = make_real_uniform(__engine_output[__j], __engine, __params);
             }
         }
 
@@ -288,11 +279,7 @@ class uniform_real_distribution
             auto __engine_output = __engine(__tail_size);
             for (int __j = 0; __j < __tail_size; __j++)
             {
-                scalar_type __res_tmp = ((__engine_output[__j] - __engine.min()) /
-                                         static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
-                                            (__params.b() - __params.a()) +
-                                        __params.a();
-                __res[__i + __j] = __res_tmp;
+                __res[__i + __j] = make_real_uniform(__engine_output[__j], __engine, __params);
             }
         }
         return __res;
@@ -305,10 +292,7 @@ class uniform_real_distribution
         sycl::vec<scalar_type, _Ndistr> __res{};
         for (int __i = 0; __i < _Ndistr; ++__i)
         {
-            __res[__i] =
-                ((__engine() - __engine.min()) / static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
-                    (__params.b() - __params.a()) +
-                __params.a();
+            __res[__i] = make_real_uniform(__engine(), __engine, __params);
         }
         return __res;
     }
@@ -322,10 +306,7 @@ class uniform_real_distribution
         result_type __res{};
         for (unsigned int __i = 0; __i < __N; ++__i)
         {
-            __res[__i] = ((__engine_output[__i] - __engine.min()) /
-                          static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
-                             (__params.b() - __params.a()) +
-                         __params.a();
+            __res[__i] = make_real_uniform(__engine_output[__i], __engine, __params);
         }
         return __res;
     }
@@ -342,10 +323,7 @@ class uniform_real_distribution
             auto __engine_output = __engine(__N);
             for (__i = 0; __i < __N; ++__i)
             {
-                __res[__i] = ((__engine_output[__i] - __engine.min()) /
-                              static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
-                                 (__params.b() - __params.a()) +
-                             __params.a();
+                __res[__i] = make_real_uniform(__engine_output[__i], __engine, __params);
             }
         }
         else
@@ -356,11 +334,7 @@ class uniform_real_distribution
                 auto __engine_output = __engine();
                 for (int __j = 0; __j < _Nengine; ++__j)
                 {
-                    auto __res_tmp = ((__engine_output[__j] - __engine.min()) /
-                                      static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
-                                         (__params.b() - __params.a()) +
-                                     __params.a();
-                    __res[__i + __j] = __res_tmp;
+                    __res[__i + __j] = make_real_uniform(__engine_output[__j], __engine, __params);
                 }
             }
             if (__tail_size)
@@ -370,11 +344,7 @@ class uniform_real_distribution
 
                 for (unsigned int __j = 0; __j < __tail_size; ++__j)
                 {
-                    auto __res_tmp = ((__engine_output[__j] - __engine.min()) /
-                                      static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
-                                         (__params.b() - __params.a()) +
-                                     __params.a();
-                    __res[__i + __j] = __res_tmp;
+                    __res[__i + __j] = make_real_uniform(__engine_output[__j], __engine, __params);;
                 }
             }
         }
@@ -388,10 +358,7 @@ class uniform_real_distribution
         result_type __res{};
         for (unsigned int __i = 0; __i < __N; ++__i)
         {
-            __res[__i] =
-                ((__engine() - __engine.min()) / static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
-                    (__params.b() - __params.a()) +
-                __params.a();
+            __res[__i] = make_real_uniform(__engine(), __engine, __params);
         }
         return __res;
     }

--- a/include/oneapi/dpl/internal/random_impl/uniform_real_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/uniform_real_distribution.h
@@ -218,7 +218,7 @@ class uniform_real_distribution
                           static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
                              (__params.b() - __params.a()) +
                          __params.a();
-         }
+        }
 
         return __res;
     }
@@ -292,8 +292,8 @@ class uniform_real_distribution
                                          static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
                                             (__params.b() - __params.a()) +
                                         __params.a();
-                 __res[__i + __j] = __res_tmp;
-             }
+                __res[__i + __j] = __res_tmp;
+            }
         }
         return __res;
     }

--- a/include/oneapi/dpl/internal/random_impl/uniform_real_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/uniform_real_distribution.h
@@ -204,7 +204,7 @@ class uniform_real_distribution
     scalar_type a_;
     scalar_type b_;
 
-    template<typename _IntegerT, typename _Engine>
+    template <typename _IntegerT, typename _Engine>
     inline scalar_type
     make_real_uniform(_IntegerT __int_val, _Engine& __engine, const param_type& __params)
     {

--- a/include/oneapi/dpl/internal/random_impl/uniform_real_distribution.h
+++ b/include/oneapi/dpl/internal/random_impl/uniform_real_distribution.h
@@ -208,10 +208,10 @@ class uniform_real_distribution
     inline scalar_type
     make_real_uniform(_IntegerT __int_val, _Engine& __engine, const param_type& __params)
     {
-        return static_cast<scalar_type>(((__int_val - __engine.min()) /
-                static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
-                                            (__params.b() - __params.a()) +
-                                        __params.a());
+        return static_cast<scalar_type>(
+            ((__int_val - __engine.min()) / static_cast<scalar_type>(1 + (__engine.max() - __engine.min()))) *
+                (__params.b() - __params.a()) +
+            __params.a());
     }
 
     // Implementation for generate function
@@ -344,7 +344,7 @@ class uniform_real_distribution
 
                 for (unsigned int __j = 0; __j < __tail_size; ++__j)
                 {
-                    __res[__i + __j] = make_real_uniform(__engine_output[__j], __engine, __params);;
+                    __res[__i + __j] = make_real_uniform(__engine_output[__j], __engine, __params);
                 }
             }
         }

--- a/test/xpu_api/random/device_tests/common_for_device_tests.h
+++ b/test/xpu_api/random/device_tests/common_for_device_tests.h
@@ -98,9 +98,6 @@ int device_copyable_test(sycl::queue& queue) {
         for (int j = 0; j < num_elems; j++)
             r_host[i*num_elems + j] = res[j];
     }
-    for (int j = 0; j < N; j++)
-        std::cout << r_host[j] << " ";
-    std::cout << std::endl;
 
     // compare
     return comparison(r_dev, r_host, N);

--- a/test/xpu_api/random/device_tests/common_for_device_tests.h
+++ b/test/xpu_api/random/device_tests/common_for_device_tests.h
@@ -32,7 +32,6 @@ constexpr int N = 96;
 
 template <typename Fp>
 int comparison(Fp* r0, Fp* r1, std::uint32_t length) {
-    Fp coeff;
     int numErrors = 0;
     for (size_t i = 0; i < length; ++i) {
         if constexpr (std::is_integral_v<Fp>) {
@@ -99,6 +98,9 @@ int device_copyable_test(sycl::queue& queue) {
         for (int j = 0; j < num_elems; j++)
             r_host[i*num_elems + j] = res[j];
     }
+    for (int j = 0; j < N; j++)
+        std::cout << r_host[j] << " ";
+    std::cout << std::endl;
 
     // compare
     return comparison(r_dev, r_host, N);


### PR DESCRIPTION
When trying to build the test `test/xpu_api/random/device_tests/engine_device_test.pass.cpp` with enabled macro `TEST_LONG_RUN` , the following error appears:

`...
/oneDPL/include/oneapi/dpl/internal/random_impl/uniform_real_distribution.h:277:29: error: use of overloaded operator '-' is ambiguous (with operand types 'std::enable_if_t<!std::is_same_v<vec_data_t<DataT>, vec_data_t<float>> && !std::is_same_v<detail::ConvertToOpenCLType_t<vec_data_t<DataT>>, detail::ConvertToOpenCLType_t<vec_data_t<float>>>, vec<float, 1>>' (aka 'sycl::vec<float, 1>') and 'scalar_type' (aka 'unsigned long'))
  277 |                 ((__res_tmp - __engine.min()) / (1 + static_cast<scalar_type>(__engine.max() - __engine.min()))) *
      |                   ~~~~~~~~~ ^ ~~~~~~~~~~~~~~`

