### PR TITLE
Iterators C++20 disable `operator*` when it invalid

### DIFF
--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -106,11 +106,12 @@ class zip_forward_iterator
     zip_forward_iterator() : __my_it_() {}
     explicit zip_forward_iterator(_Types... __args) : __my_it_(__tuple_t<_Types...>{__args...}) {}
 
-    reference operator*() const
+    reference
+    operator*() const
 #if _ONEDPL_CPP20_CONCEPTS_PRESENT
         // On windows, this is required so that concepts in MSVC STL do not detect the iterator as dereferenceable when
         // a source iterator is a sycl_iterator, which is a supported type.
-        requires (std::indirectly_readable<_Types> && ...)
+        requires(std::indirectly_readable<_Types> &&...)
 #endif
     {
         return __make_references<reference>()(__my_it_, ::std::make_index_sequence<__num_types>());
@@ -291,11 +292,12 @@ class zip_iterator
     explicit zip_iterator(_Types... __args) : __my_it_(::std::make_tuple(__args...)) {}
     explicit zip_iterator(std::tuple<_Types...> __arg) : __my_it_(__arg) {}
 
-    reference operator*() const
+    reference
+    operator*() const
 #if _ONEDPL_CPP20_CONCEPTS_PRESENT
         // On windows, this is required so that concepts in MSVC STL do not detect the iterator as dereferenceable when
         // a source iterator is a sycl_iterator, which is a supported type.
-        requires (std::indirectly_readable<_Types> && ...)
+        requires(std::indirectly_readable<_Types> &&...)
 #endif
     {
         return oneapi::dpl::__internal::__make_references<reference>()(__my_it_,
@@ -470,14 +472,15 @@ class transform_iterator
         }
         return *this;
     }
-    reference operator*() const
+    reference
+    operator*() const
 #if _ONEDPL_CPP20_CONCEPTS_PRESENT
         // On windows, this is required so that concepts in MSVC STL do not detect the iterator as dereferenceable when
         // the source iterator is a sycl_iterator, which is a supported source iterator (_Iter).
         requires std::indirectly_readable<_Iter>
 #endif
     {
-        return __my_unary_func_(*__my_it_); 
+        return __my_unary_func_(*__my_it_);
     }
     reference operator[](difference_type __i) const { return *(*this + __i); }
     transform_iterator&
@@ -660,11 +663,12 @@ class permutation_iterator
             return my_index;
     }
 
-    reference operator*() const
+    reference
+    operator*() const
 #if _ONEDPL_CPP20_CONCEPTS_PRESENT
         // On windows, this is required so that concepts in MSVC STL do not detect the iterator as dereferenceable when
         // the source iterator or IndexMap is a sycl_iterator, which is a supported type for both.
-        requires std::indirectly_readable<SourceIterator> && std::indirectly_readable<IndexMap>
+        requires std::indirectly_readable<SourceIterator>&& std::indirectly_readable<IndexMap>
 #endif
     {
         return my_source_it[*my_index];

--- a/include/oneapi/dpl/pstl/iterator_impl.h
+++ b/include/oneapi/dpl/pstl/iterator_impl.h
@@ -106,13 +106,10 @@ class zip_forward_iterator
     zip_forward_iterator() : __my_it_() {}
     explicit zip_forward_iterator(_Types... __args) : __my_it_(__tuple_t<_Types...>{__args...}) {}
 
+    // On windows, this requires clause is necessary so that concepts in MSVC STL do not detect the iterator as
+    // dereferenceable when a source iterator is a sycl_iterator, which is a supported type.
     reference
-    operator*() const
-#if _ONEDPL_CPP20_CONCEPTS_PRESENT
-        // On windows, this is required so that concepts in MSVC STL do not detect the iterator as dereferenceable when
-        // a source iterator is a sycl_iterator, which is a supported type.
-        requires(std::indirectly_readable<_Types> &&...)
-#endif
+    operator*() const _ONEDPL_CPP20_REQUIRES(std::indirectly_readable<_Types> &&...)
     {
         return __make_references<reference>()(__my_it_, ::std::make_index_sequence<__num_types>());
     }
@@ -292,13 +289,10 @@ class zip_iterator
     explicit zip_iterator(_Types... __args) : __my_it_(::std::make_tuple(__args...)) {}
     explicit zip_iterator(std::tuple<_Types...> __arg) : __my_it_(__arg) {}
 
+    // On windows, this requires clause is necessary so that concepts in MSVC STL do not detect the iterator as
+    // dereferenceable when a source iterator is a sycl_iterator, which is a supported type.
     reference
-    operator*() const
-#if _ONEDPL_CPP20_CONCEPTS_PRESENT
-        // On windows, this is required so that concepts in MSVC STL do not detect the iterator as dereferenceable when
-        // a source iterator is a sycl_iterator, which is a supported type.
-        requires(std::indirectly_readable<_Types> &&...)
-#endif
+    operator*() const _ONEDPL_CPP20_REQUIRES(std::indirectly_readable<_Types> &&...)
     {
         return oneapi::dpl::__internal::__make_references<reference>()(__my_it_,
                                                                        ::std::make_index_sequence<__num_types>());
@@ -472,13 +466,11 @@ class transform_iterator
         }
         return *this;
     }
+
+    // On windows, this requires clause is necessary so that concepts in MSVC STL do not detect the iterator as
+    // dereferenceable when the source iterator is a sycl_iterator, which is a supported type.
     reference
-    operator*() const
-#if _ONEDPL_CPP20_CONCEPTS_PRESENT
-        // On windows, this is required so that concepts in MSVC STL do not detect the iterator as dereferenceable when
-        // the source iterator is a sycl_iterator, which is a supported source iterator (_Iter).
-        requires std::indirectly_readable<_Iter>
-#endif
+    operator*() const _ONEDPL_CPP20_REQUIRES(std::indirectly_readable<_Iter>)
     {
         return __my_unary_func_(*__my_it_);
     }
@@ -663,13 +655,11 @@ class permutation_iterator
             return my_index;
     }
 
+    // On windows, this requires clause is necessary so that concepts in MSVC STL do not detect the iterator as
+    // dereferenceable when the source or map iterator is a sycl_iterator, which is a supported type for both.
     reference
     operator*() const
-#if _ONEDPL_CPP20_CONCEPTS_PRESENT
-        // On windows, this is required so that concepts in MSVC STL do not detect the iterator as dereferenceable when
-        // the source iterator or IndexMap is a sycl_iterator, which is a supported type for both.
-        requires std::indirectly_readable<SourceIterator>&& std::indirectly_readable<IndexMap>
-#endif
+        _ONEDPL_CPP20_REQUIRES(std::indirectly_readable<SourceIterator> && std::indirectly_readable<IndexMap>)
     {
         return my_source_it[*my_index];
     }

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -318,6 +318,12 @@
     (!_ONEDPL_CPP20_CONCEPTS_PRESENT ||                                                                                \
      (_ONEDPL_CPP23_RANGES_ZIP_PRESENT && _ONEDPL_CPP23_TUPLE_LIKE_COMMON_REFERENCE_PRESENT))
 
+#if _ONEDPL_CPP20_CONCEPTS_PRESENT
+    #define _ONEDPL_CPP20_REQUIRES(req) requires (req)
+#else
+    #define _ONEDPL_CPP20_REQUIRES(req)
+#endif
+
 #define _ONEDPL_BUILT_IN_STABLE_NAME_PRESENT __has_builtin(__builtin_sycl_unique_stable_name)
 
 #if defined(_MSC_VER) && __INTEL_LLVM_COMPILER < 20240100

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -319,9 +319,9 @@
      (_ONEDPL_CPP23_RANGES_ZIP_PRESENT && _ONEDPL_CPP23_TUPLE_LIKE_COMMON_REFERENCE_PRESENT))
 
 #if _ONEDPL_CPP20_CONCEPTS_PRESENT
-    #define _ONEDPL_CPP20_REQUIRES(req) requires (req)
+#    define _ONEDPL_CPP20_REQUIRES(req) requires(req)
 #else
-    #define _ONEDPL_CPP20_REQUIRES(req)
+#    define _ONEDPL_CPP20_REQUIRES(req)
 #endif
 
 #define _ONEDPL_BUILT_IN_STABLE_NAME_PRESENT __has_builtin(__builtin_sycl_unique_stable_name)


### PR DESCRIPTION
oneDPL's iterators like `zip_iterator`, `transform_iterator`, `permutation_iterator` can all use `sycl_iterator` as a source iterator, but `sycl_iterator` does not allow dereference.  
This PR makes the `operator*` require `std::indirectly_readable` for our iterators when c++20 concepts exist.  This fixes a bug in windows MSVC STL which was previously unable to correctly determine if a `transform_iterator<sycl_iterator>` is dereferenceable.

In practice, we never use the dereference because it is converted to the appropriate accessor for use within a kernel by our input data processing.  However, we do not control if STL implementations might try to use dereference, so we must make sure they can correctly determine if it is available.