### PR TITLE
[KT] Keep support of icpx 2023 for radix sort

### DIFF
--- a/include/oneapi/dpl/experimental/kt/internal/esimd_defs.h
+++ b/include/oneapi/dpl/experimental/kt/internal/esimd_defs.h
@@ -21,6 +21,8 @@
 // https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_intel_esimd/sycl_ext_intel_esimd.md#static-allocation-of-slm-using-slm_init-function
 #define _ONEDPL_ESIMD_INLINE inline __attribute__((always_inline))
 
+#define _ONEDPL_ESIMD_LSC_FENCE_PRESENT (_ONEDPL_LIBSYCL_VERSION >= 70200)
+
 namespace oneapi::dpl::experimental::kt::gpu::esimd::__impl
 {
 


### PR DESCRIPTION
Let's keep the radix_sort working with [Intel® oneAPI DPC++/C++ Compiler](https://www.intel.com/content/www/us/en/developer/articles/release-notes/intel-oneapi-dpc-c-compiler-release-notes.html) 2023.2. Some users may still use it.