### PR TITLE
Reorder histogram template parameters

### DIFF
--- a/include/oneapi/dpl/pstl/histogram_extension_defs.h
+++ b/include/oneapi/dpl/pstl/histogram_extension_defs.h
@@ -23,8 +23,8 @@ namespace oneapi
 namespace dpl
 {
 
-template <typename _ExecutionPolicy, typename _RandomAccessIterator1, typename _Size, typename _RandomAccessIterator2,
-          typename _ValueType = typename ::std::iterator_traits<_RandomAccessIterator1>::value_type>
+template <typename _ExecutionPolicy, typename _RandomAccessIterator1, typename _Size, typename _ValueType,
+          typename _RandomAccessIterator2>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator2>
 histogram(_ExecutionPolicy&& exec, _RandomAccessIterator1 first, _RandomAccessIterator1 last, _Size num_bins,
           _ValueType first_bin_min_val, _ValueType last_bin_max_val, _RandomAccessIterator2 histogram_first);

--- a/include/oneapi/dpl/pstl/histogram_impl.h
+++ b/include/oneapi/dpl/pstl/histogram_impl.h
@@ -46,8 +46,8 @@ __pattern_histogram(_Tag, _ExecutionPolicy&& exec, _RandomAccessIterator1 __firs
 
 } // namespace __internal
 
-template <typename _ExecutionPolicy, typename _RandomAccessIterator1, typename _Size, typename _RandomAccessIterator2,
-          typename _ValueType>
+template <typename _ExecutionPolicy, typename _RandomAccessIterator1, typename _Size, typename _ValueType,
+          typename _RandomAccessIterator2>
 oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator2>
 histogram(_ExecutionPolicy&& exec, _RandomAccessIterator1 first, _RandomAccessIterator1 last, _Size num_bins,
           _ValueType first_bin_min_val, _ValueType last_bin_max_val, _RandomAccessIterator2 histogram_first)


### PR DESCRIPTION
Reorder histogram template parameters and remove unused default template argument.

One option for specification of histogram (version 1a from email).