### PR TITLE
[test] Fix warning in inclusive_scan_by_segment.pass.cpp

### DIFF
--- a/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/inclusive_scan_by_segment.pass.cpp
@@ -23,7 +23,7 @@
 #include "support/scan_serial_impl.h"
 
 #if TEST_DPCPP_BACKEND_PRESENT
-#    include <CL/sycl.hpp>
+#include "support/utils_sycl_defs.h"
 
 using namespace oneapi::dpl::execution;
 #endif // TEST_DPCPP_BACKEND_PRESENT


### PR DESCRIPTION
The change fixes a warning:
> #warning "CL/sycl.hpp is deprecated, use sycl/sycl.hpp"