### PR TITLE
[Tests] Consolidate "Latest" macros; update broken macros

### DIFF
--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -24,11 +24,11 @@
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// *** When updating we must audit each usage to ensure that the issue is still exists in the latest version ***
+//
 // This section contains macros representing the "Latest" version of compilers, STL implementations, etc. for use in
 // broken macros to represent the latest version of something which still has an ongoing issue. The intention is to
 // update this section regularly to reflect the latest version. 
-//
-// *** When updating we must audit each usage to ensure that the issue is still exists in the latest version ***
 //
 // When such an issue is fixed, we must replace the usage of these "Latest" macros with the appropriate version number
 // before updating to the newest version in this section.

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -23,6 +23,26 @@
 #   include <ciso646>
 #endif
 
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// This section contains macros representing the "Latest" version of compilers, STL implementations, etc. for use in
+// broken macros to represent the latest version of something which still has an ongoing issue. The intention is to
+// update this section regularly to reflect the latest version. 
+//
+// *** When updating we must audit each usage to ensure that the issue is still exists in the latest version ***
+//
+// When such an issue is fixed, we must replace the usage of these "Latest" macros with the appropriate version number
+// before updating to the newest version in this section.
+
+// According to https://gcc.gnu.org/develop.html#timeline use last known _GLIBCXX_ to check the version of libstdc++
+#define _PSTL_TEST_LATEST_GLIBCXX 20240426
+
+#define _PSTL_TEST_LATEST_INTEL_LLVM_COMPILER 20250000
+
+#define _PSTL_TEST_LATEST_MSVC_STL_VERSION 143
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+
 #define _PSTL_TEST_STRING(X) _PSTL_TEST_STRING_AUX(oneapi/dpl/X)
 #define _PSTL_TEST_STRING_AUX(X) #X
 //to support the optional including: <algorithm>, <memory>, <numeric> or <pstl/algorithm>, <pstl/memory>, <pstl/numeric>
@@ -130,8 +150,7 @@
 
 #define _PSTL_MSVC_LESS_THAN_CPP20_COMPLEX_CONSTEXPR_BROKEN (_MSC_VER && __cplusplus < 202002L && _MSVC_LANG < 202002L)
 
-// According to https://gcc.gnu.org/develop.html#timeline use last known _GLIBCXX_ to check the version of libstdc++ : 20240426
-#define _PSTL_TEST_COMPLEX_OP_BROKEN_GLIBCXX (__GLIBCXX__ > 0 && __GLIBCXX__ <= 20240426)
+#define _PSTL_TEST_COMPLEX_OP_BROKEN_GLIBCXX (__GLIBCXX__ > 0 && __GLIBCXX__ <= _PSTL_TEST_LATEST_GLIBCXX)
 
 #define _PSTL_ICC_TEST_COMPLEX_ASIN_MINUS_INF_NAN_BROKEN_SIGNBIT          _PSTL_TEST_COMPLEX_OP_BROKEN_GLIBCXX
 #define _PSTL_ICC_TEST_COMPLEX_COSH_MINUS_INF_MINUS_ZERO_BROKEN_SIGNBIT   _PSTL_TEST_COMPLEX_OP_BROKEN_GLIBCXX
@@ -148,7 +167,7 @@
 #define _PSTL_ICC_TEST_COMPLEX_ISINF_BROKEN (_MSVC_STL_VERSION && __INTEL_LLVM_COMPILER)
 #define _PSTL_ICC_TEST_COMPLEX_ISNAN_BROKEN (_MSVC_STL_VERSION && __INTEL_LLVM_COMPILER)
 
-#define _PSTL_TEST_COMPLEX_OP_BROKEN (_MSVC_STL_VERSION && _MSVC_STL_VERSION <= 143)
+#define _PSTL_TEST_COMPLEX_OP_BROKEN (_MSVC_STL_VERSION && _MSVC_STL_VERSION <= _PSTL_TEST_LATEST_MSVC_STL_VERSION)
 
 #define _PSTL_TEST_COMPLEX_ACOS_BROKEN  _PSTL_TEST_COMPLEX_OP_BROKEN
 #define _PSTL_TEST_COMPLEX_ACOSH_BROKEN _PSTL_TEST_COMPLEX_OP_BROKEN
@@ -165,7 +184,7 @@
 // within a sycl kernel which MSVC uses to allow comparisons with literal zero without warning
 #define _PSTL_TEST_COMPARISON_BROKEN                                                                                   \
     ((__cplusplus >= 202002L || _MSVC_LANG >= 202002L) && _MSVC_STL_VERSION >= 143 && _MSVC_STL_UPDATE >= 202303L &&   \
-    __INTEL_LLVM_COMPILER > 0 && __INTEL_LLVM_COMPILER <= 20250000)
+    __INTEL_LLVM_COMPILER > 0 && __INTEL_LLVM_COMPILER <= _PSTL_TEST_LATEST_INTEL_LLVM_COMPILER)
 
 #define _PSTL_TEST_COMPLEX_TIMES_COMPLEX_BROKEN (_PSTL_TEST_COMPLEX_OP_BROKEN || _PSTL_TEST_COMPLEX_OP_BROKEN_GLIBCXX)
 #define _PSTL_TEST_COMPLEX_DIV_COMPLEX_BROKEN _PSTL_TEST_COMPLEX_OP_BROKEN
@@ -225,6 +244,6 @@
 // the test while the issue is being reported to the compiler team. Once it is resolved, this macro can be removed
 // or limited to older compiler versions.
 #define _PSTL_RED_BY_SEG_WINDOWS_COMPILE_ORDER_BROKEN                                                                  \
-    (_MSC_VER && TEST_DPCPP_BACKEND_PRESENT && __INTEL_LLVM_COMPILER <= 20250000)
+    (_MSC_VER && TEST_DPCPP_BACKEND_PRESENT && __INTEL_LLVM_COMPILER <= _PSTL_TEST_LATEST_INTEL_LLVM_COMPILER)
 
 #endif // _TEST_CONFIG_H

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -24,7 +24,8 @@
 #endif
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// *** When updating we must audit each usage to ensure that the issue is still exists in the latest version ***
+// *** When updating we must audit each usage to ensure that the issue still exists in the latest version ***
+
 //
 // This section contains macros representing the "Latest" version of compilers, STL implementations, etc. for use in
 // broken macros to represent the latest version of something which still has an ongoing issue. The intention is to

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -232,9 +232,8 @@
 // oneAPI DPC++ compiler fails to compile the sum of an integer and an iterator to a usm-allocated std vector when
 // building for an FPGA device.  This prevents fpga compilation of usm-allocated std vector wrapped in zip, transform,
 // and permutation iterators (as a map).
-// TODO: Update intel llvm version number as releases are made until a fix is in place.
 #if (TEST_DPCPP_BACKEND_PRESENT && defined(ONEDPL_FPGA_DEVICE) && defined(__INTEL_LLVM_COMPILER) &&                   \
-        __INTEL_LLVM_COMPILER <= 20240200)
+        __INTEL_LLVM_COMPILER <= _PSTL_TEST_LATEST_INTEL_LLVM_COMPILER)
 #    define _PSTL_ICPX_FPGA_TEST_USM_VECTOR_ITERATOR_BROKEN 1
 #else
 #    define _PSTL_ICPX_FPGA_TEST_USM_VECTOR_ITERATOR_BROKEN 0

--- a/test/support/test_config.h
+++ b/test/support/test_config.h
@@ -34,7 +34,7 @@
 // before updating to the newest version in this section.
 
 // According to https://gcc.gnu.org/develop.html#timeline use last known _GLIBCXX_ to check the version of libstdc++
-#define _PSTL_TEST_LATEST_GLIBCXX 20240426
+#define _PSTL_TEST_LATEST_GLIBCXX 20240801
 
 #define _PSTL_TEST_LATEST_INTEL_LLVM_COMPILER 20250000
 


### PR DESCRIPTION
This PR consolidates the "Latest" macros into one place, to indicate where we currently are experiencing an issue from another library, compiler, etc.  so we want to skip certain broken tests, but not skip them indefinitely and forget about them.

The idea will be to have a task to revisit this section at least once every oneDPL release and audit the usages of these "Latest" macros to see if the issue is still present.  Any issues which have been fixed should be frozen to the last broken version.  Then once we have done this audit, we should update the macro in this location to the most recent version of the external entity.

This will help mark these "Latest" macros in the code explicitly, and also have a list of such instances to re-check prior to each release to help avoid re-interrogating the same errors in the CI.


This PR also updates the __GLIBCXX__ latest macro, for which the complex issues persist.  I will keep these as separate commits, rather than squashing upon merge.

This PR also updates the _PSTL_ICPX_FPGA_TEST_USM_VECTOR_ITERATOR_BROKEN to the latest icpx version, as it is still broken.  I plan to keep this also as a separate commit.
