### PR TITLE
Fix return type of transform scan and copy if patterns

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -386,7 +386,7 @@ oneapi::dpl::__internal::__difference_t<_Range2>
 __pattern_copy_if(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2,
                   _Predicate __pred, _Assign __assign)
 {
-    oneapi::dpl::__internal::__difference_t<_Range1> __n = __rng1.size();
+    oneapi::dpl::__internal::__difference_t<_Range2> __n = __rng1.size();
     if (__n == 0)
         return 0;
 

--- a/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
@@ -91,7 +91,7 @@ oneapi::dpl::__internal::__difference_t<_Range2>
 __pattern_transform_scan_base(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2,
                               _UnaryOperation __unary_op, _InitType __init, _BinaryOperation __binary_op, _Inclusive)
 {
-    oneapi::dpl::__internal::__difference_t<_Range1> __n = __rng1.size();
+    oneapi::dpl::__internal::__difference_t<_Range2> __n = __rng1.size();
     if (__n == 0)
         return 0;
 


### PR DESCRIPTION
As discovered in https://github.com/oneapi-src/oneDPL/pull/1762#discussion_r1730044386, there is a mismatch in the return type for the transform scan pattern. A similar issue exists with `copy_if`. This PR uses the difference type of the output range as the size type for `n` to match the return type of the patterns.