### PR TITLE
Bug fix for fwd definition of __compare in sycl_traits.h

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -59,7 +59,7 @@ template <typename _Tp>
 class __not_equal_value;
 
 template <typename _Comp, typename _Proj>
-class __compare;
+struct __compare;
 
 template <typename _Pred>
 class __transform_functor;


### PR DESCRIPTION
As noted by a comment from @dmitriy-sobolev https://github.com/oneapi-src/oneDPL/pull/1621#discussion_r1739290933
after the PR was merged, there was a problem with the forward declaration of `__compare` in that is was misaligned with the definition of the struct. 

The PR resolves it.

@rarutyun  if we want to make any other changes to `__compare` here for ranges, we can.