### PR TITLE
Do not compile `philox_test.cpp` test code if unnamed lambdas are not used

### DIFF
--- a/test/xpu_api/random/conformance_tests/philox_test.pass.cpp
+++ b/test/xpu_api/random/conformance_tests/philox_test.pass.cpp
@@ -24,6 +24,7 @@ namespace ex = oneapi::dpl::experimental;
 int
 main()
 {
+#if TEST_UNNAMED_LAMBDAS
     sycl::queue queue = TestUtils::get_test_queue();
 
     // Reference values
@@ -54,6 +55,7 @@ main()
     err += test<ex::philox4x64_vec<16>, 10000, 16>(queue) != philox4_64_ref;
 
     EXPECT_TRUE(!err, "Test FAILED");
+#endif
 
     return TestUtils::done(TEST_UNNAMED_LAMBDAS);
 }

--- a/test/xpu_api/random/conformance_tests/philox_test.pass.cpp
+++ b/test/xpu_api/random/conformance_tests/philox_test.pass.cpp
@@ -55,7 +55,7 @@ main()
     err += test<ex::philox4x64_vec<16>, 10000, 16>(queue) != philox4_64_ref;
 
     EXPECT_TRUE(!err, "Test FAILED");
-#endif
+#endif // TEST_UNNAMED_LAMBDAS
 
     return TestUtils::done(TEST_UNNAMED_LAMBDAS);
 }


### PR DESCRIPTION
The recently added `philox_test.cpp` test does not do a preprocessor check if we are testing with unnamed lambda support, so we are seeing some compilation failures in CI.

I added this check. The rest of the Philox tests seem to be compiling fine.