### PR TITLE
[RNG] Added compilation guards for `philox_test.pass` and `philox_unit_test.pass`

### DIFF
--- a/test/xpu_api/random/conformance_tests/philox_test.pass.cpp
+++ b/test/xpu_api/random/conformance_tests/philox_test.pass.cpp
@@ -12,18 +12,20 @@
 // Test for Philox random number generation engine - comparison of 10 000th element
 
 #include "support/utils.h"
-#include "support/test_config.h"
+
+#if TEST_UNNAMED_LAMBDAS
 #include "common_for_conformance_tests.hpp"
-
-#include <random>
-
 #include <oneapi/dpl/random>
+#endif // TEST_UNNAMED_LAMBDAS
 
 namespace ex = oneapi::dpl::experimental;
 
 int
 main()
 {
+
+#if TEST_UNNAMED_LAMBDAS
+
     sycl::queue queue = TestUtils::get_test_queue();
 
     // Reference values
@@ -33,6 +35,7 @@ main()
 
     // Generate 10 000th element for philox4_32
     err += test<ex::philox4x32, 10000, 1>(queue) != philox4_32_ref;
+#if TEST_LONG_RUN
     err += test<ex::philox4x32_vec<1>, 10000, 1>(queue) != philox4_32_ref;
     err += test<ex::philox4x32_vec<2>, 10000, 2>(queue) != philox4_32_ref;
     // In case of philox4x32_vec<3> engine generate 10002 values as 10000 % 3 != 0
@@ -40,11 +43,12 @@ main()
     err += test<ex::philox4x32_vec<4>, 10000, 4>(queue) != philox4_32_ref;
     err += test<ex::philox4x32_vec<8>, 10000, 8>(queue) != philox4_32_ref;
     err += test<ex::philox4x32_vec<16>, 10000, 16>(queue) != philox4_32_ref;
-
+#endif // TEST_LONG_RUN
     EXPECT_TRUE(!err, "Test FAILED");
 
     // Generate 10 000th element for philox4_64
     err += test<ex::philox4x64, 10000, 1>(queue) != philox4_64_ref;
+#if TEST_LONG_RUN
     err += test<ex::philox4x64_vec<1>, 10000, 1>(queue) != philox4_64_ref;
     err += test<ex::philox4x64_vec<2>, 10000, 2>(queue) != philox4_64_ref;
     // In case of philox4x64_vec<3> engine generate 10002 values as 10000 % 3 != 0
@@ -52,8 +56,10 @@ main()
     err += test<ex::philox4x64_vec<4>, 10000, 4>(queue) != philox4_64_ref;
     err += test<ex::philox4x64_vec<8>, 10000, 8>(queue) != philox4_64_ref;
     err += test<ex::philox4x64_vec<16>, 10000, 16>(queue) != philox4_64_ref;
-
+#endif // TEST_LONG_RUN
     EXPECT_TRUE(!err, "Test FAILED");
+
+#endif // TEST_UNNAMED_LAMBDAS
 
     return TestUtils::done(TEST_UNNAMED_LAMBDAS);
 }

--- a/test/xpu_api/random/unit_tests/philox_unit_test.pass.cpp
+++ b/test/xpu_api/random/unit_tests/philox_unit_test.pass.cpp
@@ -140,7 +140,7 @@ main()
     std::cout << "void discard_overflow_test() [Engine = philox4x64_w49]";
     err += discard_overflow_test<philox4x64_w49>();
 
-    return TestUtils::done(TEST_UNNAMED_LAMBDAS);
+    return TestUtils::done();
 }
 
 /*


### PR DESCRIPTION
These guards are necessary to filter out some testing, they were forgotten to be added in the initial PR.
Also, 2 unnecessary headers were noticed in the test, they were removed.