### PR TITLE
Code cleanup (ranges)

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -485,8 +485,8 @@ __pattern_is_sorted(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, 
 
     return oneapi::dpl::__internal::__ranges::__pattern_adjacent_find(__tag,
         std::forward<_ExecutionPolicy>(__exec), oneapi::dpl::__ranges::views::all_read(__r),
-        oneapi::dpl::__internal::__reorder_pred(__pred_2), oneapi::dpl::__internal::__or_semantic()) 
-        == std::ranges::size(__r);
+        oneapi::dpl::__internal::__reorder_pred(__pred_2),
+        oneapi::dpl::__internal::__or_semantic()) == std::ranges::size(__r);
 }
 
 #endif //_ONEDPL_CPP20_RANGES_PRESENT
@@ -758,7 +758,7 @@ __pattern_sort(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&& __
 }
 
 #if _ONEDPL_CPP20_RANGES_PRESENT
-template <typename _BackendTag, typename _ExecutionPolicy, typename _R, typename _Proj, typename _Comp>
+template <typename _BackendTag, typename _ExecutionPolicy, typename _R, typename _Comp, typename _Proj>
 auto
 __pattern_sort_ranges(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _R&& __r, _Comp __comp, _Proj __proj)
 {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -19,10 +19,6 @@
 #include <iterator>
 #include <type_traits>
 
-#if _ONEDPL_CPP20_SPAN_PRESENT
-#include <span>
-#endif
-
 #include "../../utils_ranges.h"
 #include "../../iterator_impl.h"
 #include "../../glue_numeric_defs.h"

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -302,7 +302,6 @@
     (_ONEDPL___cplusplus >= 202002L && (_MSC_VER >= 1921 || _GLIBCXX_RELEASE >= 10))
 
 #if _ONEDPL_STD_FEATURE_MACROS_PRESENT
-#    define _ONEDPL_CPP20_SPAN_PRESENT (__cpp_lib_span >= 202002L)
 #    define _ONEDPL_CPP20_CONCEPTS_PRESENT (__cpp_concepts >= 201907L && __cpp_lib_concepts >= 202002L)
 // Clang 15 and older do not support range adaptors, see https://bugs.llvm.org/show_bug.cgi?id=44833
 #    define _ONEDPL_CPP20_RANGES_PRESENT ((__cpp_lib_ranges >= 201911L) && !(__clang__ && __clang_major__ < 16))
@@ -310,7 +309,6 @@
         (_ONEDPL___cplusplus >= 202302L && __cpp_lib_tuple_like >= 202207L)
 #    define _ONEDPL_CPP23_RANGES_ZIP_PRESENT (_ONEDPL___cplusplus >= 202302L && __cpp_lib_ranges_zip >= 202110L)
 #else
-#    define _ONEDPL_CPP20_SPAN_PRESENT 0
 #    define _ONEDPL_CPP20_CONCEPTS_PRESENT 0
 #    define _ONEDPL_CPP20_RANGES_PRESENT 0
 #    define _ONEDPL_CPP23_TUPLE_LIKE_COMMON_REFERENCE_PRESENT 0


### PR DESCRIPTION
Remove non-used `_ONEDPL_CPP20_SPAN_PRESENT`, and do some stylistic changes. 