### PR TITLE
Tune merge launch config

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -18,7 +18,7 @@
 
 #include <limits>    // std::numeric_limits
 #include <cassert>   // assert
-#include <cstdint>   // std::uint8_t, ...
+#include <cstdint>   // std::uint16_t, ...
 #include <utility>   // std::make_pair, std::forward
 #include <algorithm> // std::min, std::lower_bound
 
@@ -44,75 +44,65 @@ namespace __par_backend_hetero
 // 2 | 0   0  0  0 | 1
 //   |             ---->
 // 3 | 0   0  0  0   0 |
-template <typename _Rng1, typename _Rng2, typename _Index, typename _Index1, typename _Index2, typename _Compare>
+template <typename _Rng1, typename _Rng2, typename _Index, typename _Compare>
 auto
-__find_start_point(const _Rng1& __rng1, const _Rng2& __rng2, _Index __i_elem, _Index1 __n1, _Index2 __n2,
-                   _Compare __comp)
+__find_start_point(const _Rng1& __rng1, const _Rng2& __rng2, const _Index __i_elem, const _Index __n1,
+                   const _Index __n2, const _Compare& __comp)
 {
-    _Index1 __start1 = 0;
-    _Index2 __start2 = 0;
+    //searching for the first '1', a lower bound for a diagonal [0, 0,..., 0, 1, 1,.... 1, 1]
+    oneapi::dpl::counting_iterator<_Index> __diag_it(0);
+
     if (__i_elem < __n2) //a condition to specify upper or lower part of the merge matrix to be processed
     {
-        auto __q = __i_elem;                          //diagonal index
-        auto __n_diag = std::min<_Index2>(__q, __n1); //diagonal size
-
-        //searching for the first '1', a lower bound for a diagonal [0, 0,..., 0, 1, 1,.... 1, 1]
-        oneapi::dpl::counting_iterator<_Index> __diag_it(0);
+        const _Index __q = __i_elem;                         //diagonal index
+        const _Index __n_diag = std::min<_Index>(__q, __n1); //diagonal size
         auto __res =
             std::lower_bound(__diag_it, __diag_it + __n_diag, 1 /*value to find*/,
                              [&__rng2, &__rng1, __q, __comp](const auto& __i_diag, const auto& __value) mutable {
                                  auto __zero_or_one = __comp(__rng2[__q - __i_diag - 1], __rng1[__i_diag]);
                                  return __zero_or_one < __value;
                              });
-        __start1 = *__res;
-        __start2 = __q - *__res;
+        return std::make_pair(*__res, __q - *__res);
     }
     else
     {
-        auto __q = __i_elem - __n2;                          //diagonal index
-        auto __n_diag = std::min<_Index1>(__n1 - __q, __n2); //diagonal size
-
-        //searching for the first '1', a lower bound for a diagonal [0, 0,..., 0, 1, 1,.... 1, 1]
-        oneapi::dpl::counting_iterator<_Index> __diag_it(0);
+        const _Index __q = __i_elem - __n2;                         //diagonal index
+        const _Index __n_diag = std::min<_Index>(__n1 - __q, __n2); //diagonal size
         auto __res =
             std::lower_bound(__diag_it, __diag_it + __n_diag, 1 /*value to find*/,
                              [&__rng2, &__rng1, __n2, __q, __comp](const auto& __i_diag, const auto& __value) mutable {
                                  auto __zero_or_one = __comp(__rng2[__n2 - __i_diag - 1], __rng1[__q + __i_diag]);
                                  return __zero_or_one < __value;
                              });
-
-        __start1 = __q + *__res;
-        __start2 = __n2 - *__res;
+        return std::make_pair(__q + *__res, __n2 - *__res);
     }
-    return std::make_pair(__start1, __start2);
 }
 
 // Do serial merge of the data from rng1 (starting from start1) and rng2 (starting from start2) and writing
 // to rng3 (starting from start3) in 'chunk' steps, but do not exceed the total size of the sequences (n1 and n2)
-template <typename _Rng1, typename _Rng2, typename _Rng3, typename _Index1, typename _Index2, typename _Index3,
-          typename _Size1, typename _Size2, typename _Compare>
+template <typename _Rng1, typename _Rng2, typename _Rng3, typename _Index, typename _Compare>
 void
-__serial_merge(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, _Index1 __start1, _Index2 __start2,
-               _Index3 __start3, std::uint8_t __chunk, _Size1 __n1, _Size2 __n2, _Compare __comp)
+__serial_merge(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, _Index __start1, _Index __start2,
+               const _Index __start3, const std::uint16_t __chunk, const _Index __n1, const _Index __n2,
+               const _Compare& __comp)
 {
     if (__start1 >= __n1)
     {
         //copying a residual of the second seq
-        const auto __n = std::min<_Index2>(__n2 - __start2, __chunk);
-        for (std::uint8_t __i = 0; __i < __n; ++__i)
+        const _Index __n = std::min<_Index>(__n2 - __start2, __chunk);
+        for (std::uint16_t __i = 0; __i < __n; ++__i)
             __rng3[__start3 + __i] = __rng2[__start2 + __i];
     }
     else if (__start2 >= __n2)
     {
         //copying a residual of the first seq
-        const auto __n = std::min<_Index1>(__n1 - __start1, __chunk);
-        for (std::uint8_t __i = 0; __i < __n; ++__i)
+        const _Index __n = std::min<_Index>(__n1 - __start1, __chunk);
+        for (std::uint16_t __i = 0; __i < __n; ++__i)
             __rng3[__start3 + __i] = __rng1[__start1 + __i];
     }
     else
     {
-        std::uint8_t __n = __chunk;
-        for (std::uint8_t __i = 0; __i < __n && __start1 < __n1 && __start2 < __n2; ++__i)
+        for (std::uint16_t __i = 0; __i < __chunk && __start1 < __n1 && __start2 < __n2; ++__i)
         {
             const auto& __val1 = __rng1[__start1];
             const auto& __val2 = __rng2[__start2];
@@ -122,7 +112,7 @@ __serial_merge(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, _Index1 
                 if (++__start2 == __n2)
                 {
                     //copying a residual of the first seq
-                    for (++__i; __i < __n && __start1 < __n1; ++__i, ++__start1)
+                    for (++__i; __i < __chunk && __start1 < __n1; ++__i, ++__start1)
                         __rng3[__start3 + __i] = __rng1[__start1];
                 }
             }
@@ -132,7 +122,7 @@ __serial_merge(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, _Index1 
                 if (++__start1 == __n1)
                 {
                     //copying a residual of the second seq
-                    for (++__i; __i < __n && __start2 < __n2; ++__i, ++__start2)
+                    for (++__i; __i < __chunk && __start2 < __n2; ++__i, ++__start2)
                         __rng3[__start3 + __i] = __rng2[__start2];
                 }
             }
@@ -149,20 +139,28 @@ struct __parallel_merge_submitter<_IdType, __internal::__optional_kernel_name<_N
 {
     template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Compare>
     auto
-    operator()(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _Range3&& __rng3, _Compare __comp) const
+    operator()(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _Range3&& __rng3,
+               const _Compare& __comp) const
     {
-        using _Size = oneapi::dpl::__internal::__difference_t<_Range3>;
-
-        auto __n1 = __rng1.size();
-        auto __n2 = __rng2.size();
+        const _IdType __n1 = __rng1.size();
+        const _IdType __n2 = __rng2.size();
+        const _IdType __n = __n1 + __n2;
 
         assert(__n1 > 0 || __n2 > 0);
 
         _PRINT_INFO_IN_DEBUG_MODE(__exec);
 
-        const std::uint8_t __chunk = __exec.queue().get_device().is_cpu() ? 128 : 4;
-        const _Size __n = __n1 + __n2;
-        const _Size __steps = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __chunk);
+        // Empirical number of values to process per work-item
+        std::uint16_t __chunk = 128;
+        if (__exec.queue().get_device().is_gpu())
+        {
+            if (__n > 16'777'216)
+                __chunk = 256;
+            else
+                __chunk = 4;
+        }
+
+        const _IdType __steps = oneapi::dpl::__internal::__dpl_ceiling_div(__n, __chunk);
 
         auto __event = __exec.queue().submit([&](sycl::handler& __cgh) {
             oneapi::dpl::__ranges::__require_access(__cgh, __rng1, __rng2, __rng3);
@@ -190,19 +188,19 @@ __parallel_merge(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy
     const auto __n = __rng1.size() + __rng2.size();
     if (__n <= std::numeric_limits<std::uint32_t>::max())
     {
-        using _wi_index_type = std::uint32_t;
+        using _WiIndex = std::uint32_t;
         using _MergeKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
-            __merge_kernel_name<_CustomName, _wi_index_type>>;
-        return __parallel_merge_submitter<_wi_index_type, _MergeKernel>()(
+            __merge_kernel_name<_CustomName, _WiIndex>>;
+        return __parallel_merge_submitter<_WiIndex, _MergeKernel>()(
             std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
             std::forward<_Range3>(__rng3), __comp);
     }
     else
     {
-        using _wi_index_type = std::uint64_t;
+        using _WiIndex = std::uint64_t;
         using _MergeKernel = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
-            __merge_kernel_name<_CustomName, _wi_index_type>>;
-        return __parallel_merge_submitter<_wi_index_type, _MergeKernel>()(
+            __merge_kernel_name<_CustomName, _WiIndex>>;
+        return __parallel_merge_submitter<_WiIndex, _MergeKernel>()(
             std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
             std::forward<_Range3>(__rng3), __comp);
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -58,8 +58,8 @@ __find_start_point(const _Rng1& __rng1, const _Rng2& __rng2, const _Index __i_el
         const _Index __n_diag = std::min<_Index>(__q, __n1); //diagonal size
         auto __res =
             std::lower_bound(__diag_it, __diag_it + __n_diag, 1 /*value to find*/,
-                             [&__rng2, &__rng1, __q, __comp](const auto& __i_diag, const auto& __value) mutable {
-                                 auto __zero_or_one = __comp(__rng2[__q - __i_diag - 1], __rng1[__i_diag]);
+                             [&__rng2, &__rng1, __q, &__comp](const auto& __i_diag, const auto& __value) mutable {
+                                 const auto __zero_or_one = __comp(__rng2[__q - __i_diag - 1], __rng1[__i_diag]);
                                  return __zero_or_one < __value;
                              });
         return std::make_pair(*__res, __q - *__res);
@@ -70,8 +70,8 @@ __find_start_point(const _Rng1& __rng1, const _Rng2& __rng2, const _Index __i_el
         const _Index __n_diag = std::min<_Index>(__n1 - __q, __n2); //diagonal size
         auto __res =
             std::lower_bound(__diag_it, __diag_it + __n_diag, 1 /*value to find*/,
-                             [&__rng2, &__rng1, __n2, __q, __comp](const auto& __i_diag, const auto& __value) mutable {
-                                 auto __zero_or_one = __comp(__rng2[__n2 - __i_diag - 1], __rng1[__q + __i_diag]);
+                             [&__rng2, &__rng1, __n2, __q, &__comp](const auto& __i_diag, const auto& __value) mutable {
+                                 const auto __zero_or_one = __comp(__rng2[__n2 - __i_diag - 1], __rng1[__q + __i_diag]);
                                  return __zero_or_one < __value;
                              });
         return std::make_pair(__q + *__res, __n2 - *__res);
@@ -154,8 +154,10 @@ struct __parallel_merge_submitter<_IdType, __internal::__optional_kernel_name<_N
         std::uint16_t __chunk = 128;
         if (__exec.queue().get_device().is_gpu())
         {
-            if (__n > 16'777'216)
+            if (__n >= 16'777'216)
                 __chunk = 256;
+            else if (__n > 4'194'304)
+                __chunk = 8;
             else
                 __chunk = 4;
         }


### PR DESCRIPTION
This is a first patch towards improving the throughput of the merge algorithm especially for large input arrays. It includes minor improvements and code cleanups. Increasing the chunk size for large inputs increases the GPU memory throughput. The speedup for large arrays increases to about 1.8x for 2^28 elements on PVC.