### PR TITLE
Remove `TestUtils::invoke_test_if` and some extra macros from tests

### DIFF
--- a/test/support/test_complex.h
+++ b/test/support/test_complex.h
@@ -111,7 +111,10 @@ run_test()
         __fnc();                                                                                      \
     }
 #define IF_DOUBLE_SUPPORT_L(...)                                                                      \
-    TestUtils::invoke_test_if(HasDoubleSupportInRuntime(), __VA_ARGS__);
+    if constexpr (HasDoubleSupportInRuntime{})                                                        \
+    {                                                                                                 \
+        __VA_ARGS__;                                                                                  \
+    }
 
 // We should use this macros to avoid compile-time error in code with long double type in Kernel.
 #define IF_LONG_DOUBLE_SUPPORT(...)                                                                   \

--- a/test/support/test_complex.h
+++ b/test/support/test_complex.h
@@ -137,19 +137,6 @@ namespace TestUtils
     // This lead to an error on devices where the double type is not supported.
     static constexpr float infinity_val = INFINITY;
 
-    template <typename _FncTest>
-    void
-    invoke_test_if(::std::true_type, _FncTest __fncTest)
-    {
-        __fncTest();
-    }
-
-    template <typename _FncTest>
-    void
-    invoke_test_if(::std::false_type, _FncTest)
-    {
-    }
-
     // Run test in Kernel as single task
     template <typename TFncDoubleHasSupportInRuntime, typename TFncDoubleHasntSupportInRuntime>
     void

--- a/test/support/test_complex.h
+++ b/test/support/test_complex.h
@@ -105,7 +105,11 @@ run_test()
 //         // ...
 //     }
 #define IF_DOUBLE_SUPPORT(...)                                                                        \
-    TestUtils::invoke_test_if(HasDoubleSupportInRuntime(), []() { __VA_ARGS__; });
+    if constexpr (HasDoubleSupportInRuntime{})                                                        \
+    {                                                                                                 \
+        auto __fnc = []() { __VA_ARGS__; };                                                           \
+        __fnc();                                                                                      \
+    }
 #define IF_DOUBLE_SUPPORT_L(...)                                                                      \
     TestUtils::invoke_test_if(HasDoubleSupportInRuntime(), __VA_ARGS__);
 

--- a/test/support/test_complex.h
+++ b/test/support/test_complex.h
@@ -124,7 +124,10 @@ run_test()
         __fnc();                                                                                      \
     }
 #define IF_LONG_DOUBLE_SUPPORT_L(...)                                                                 \
-    TestUtils::invoke_test_if(HasLongDoubleSupportInCompiletime(), __VA_ARGS__);
+    if constexpr (HasLongDoubleSupportInCompiletime{})                                                \
+    {                                                                                                 \
+        __VA_ARGS__;                                                                                  \
+    }
 
 namespace TestUtils
 {

--- a/test/support/test_complex.h
+++ b/test/support/test_complex.h
@@ -118,7 +118,11 @@ run_test()
 
 // We should use this macros to avoid compile-time error in code with long double type in Kernel.
 #define IF_LONG_DOUBLE_SUPPORT(...)                                                                   \
-    TestUtils::invoke_test_if(HasLongDoubleSupportInCompiletime(), []() { __VA_ARGS__; });
+    if constexpr (HasLongDoubleSupportInCompiletime{})                                                \
+    {                                                                                                 \
+        auto __fnc = []() { __VA_ARGS__; };                                                           \
+        __fnc();                                                                                      \
+    }
 #define IF_LONG_DOUBLE_SUPPORT_L(...)                                                                 \
     TestUtils::invoke_test_if(HasLongDoubleSupportInCompiletime(), __VA_ARGS__);
 

--- a/test/support/test_complex.h
+++ b/test/support/test_complex.h
@@ -52,17 +52,17 @@ int main(int, char**)                                                           
     static_assert(!is_fast_math_switched_on(),                                                        \
                   "Tests of std::complex are not compatible with -ffast-math compiler option.");      \
                                                                                                       \
-    run_test<::std::true_type, ::std::true_type>();                                                   \
+    run_test<std::true_type, std::true_type>();                                                       \
                                                                                                       \
     /* Sometimes we may start test on device, which don't support type double. */                     \
     /* In this case generates run-time error.                                  */                     \
     /* This two types allow us to avoid this situation.                        */                     \
-    using HasDoubleTypeSupportInRuntime = ::std::true_type;                                           \
-    using HasntDoubleTypeSupportInRuntime = ::std::false_type;                                        \
+    using HasDoubleTypeSupportInRuntime = std::true_type;                                             \
+    using HasntDoubleTypeSupportInRuntime = std::false_type;                                          \
                                                                                                       \
     /* long double type generate compile-time error in Kernel code             */                     \
     /* and we never can use this type inside Kernel                            */                     \
-    using HasntLongDoubleSupportInCompiletime = ::std::false_type;                                    \
+    using HasntLongDoubleSupportInCompiletime = std::false_type;                                      \
                                                                                                       \
     TestUtils::run_test_in_kernel(                                                                    \
         /* lambda for the case when we have support of double type on device */                       \
@@ -82,7 +82,7 @@ run_test()
 // Example:
 //     template <class T>
 //     void
-//     test(T x, ::std::enable_if_t<std::is_integral_v<T>>* = 0)
+//     test(T x, std::enable_if_t<std::is_integral_v<T>>* = 0)
 //     {
 //         static_assert((std::is_same_v<decltype(dpl::conj(x)), dpl::complex<double>>));
 //


### PR DESCRIPTION
In this PR we remove `TestUtils::invoke_test_if` from tests :
- starting from C++17  we can use `if constexpr` instead.