### PR TITLE
[test] Use macro workaround to avoid calling vectorized MSVC algorithms from within a SYCL kernel

### DIFF
--- a/test/xpu_api/containers/sequences/array/array.comparison/greater_g.pass.cpp
+++ b/test/xpu_api/containers/sequences/array/array.comparison/greater_g.pass.cpp
@@ -13,6 +13,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+// In Windows, as a temporary workaround, disable vector algorithm calls to avoid calls within sycl kernels
+#if defined(_MSC_VER)
+#    define _USE_STD_VECTOR_ALGORITHMS 0
+#endif
+
 #include "support/test_config.h"
 
 #include <oneapi/dpl/array>

--- a/test/xpu_api/containers/sequences/array/array.comparison/greater_or_equal_g.pass.cpp
+++ b/test/xpu_api/containers/sequences/array/array.comparison/greater_or_equal_g.pass.cpp
@@ -13,6 +13,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+// In Windows, as a temporary workaround, disable vector algorithm calls to avoid calls within sycl kernels
+#if defined(_MSC_VER)
+#    define _USE_STD_VECTOR_ALGORITHMS 0
+#endif
+
 #include "support/test_config.h"
 
 #include <oneapi/dpl/array>

--- a/test/xpu_api/containers/sequences/array/array.comparison/less_g.pass.cpp
+++ b/test/xpu_api/containers/sequences/array/array.comparison/less_g.pass.cpp
@@ -13,6 +13,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+// In Windows, as a temporary workaround, disable vector algorithm calls to avoid calls within sycl kernels
+#if defined(_MSC_VER)
+#    define _USE_STD_VECTOR_ALGORITHMS 0
+#endif
+
 #include "support/test_config.h"
 
 #include <oneapi/dpl/array>

--- a/test/xpu_api/containers/sequences/array/array.comparison/less_or_equal_g.pass.cpp
+++ b/test/xpu_api/containers/sequences/array/array.comparison/less_or_equal_g.pass.cpp
@@ -13,6 +13,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+// In Windows, as a temporary workaround, disable vector algorithm calls to avoid calls within sycl kernels
+#if defined(_MSC_VER)
+#    define _USE_STD_VECTOR_ALGORITHMS 0
+#endif
+
 #include "support/test_config.h"
 
 #include <oneapi/dpl/array>


### PR DESCRIPTION
With newer MSVC versions, we see compilation errors such as:
```
error: SYCL kernel cannot call an undefined function without SYCL_EXTERNAL attribute
  334 |         return __std_mismatch_4(_First1, _First2, _Count);
      |                ^
```
which occurs when vectorized MSVC algorithms are attempted to be called from within a SYCL kernel. This is showing up with array comparisons within kernels.

To resolve this issue, we can set `_USE_STD_VECTOR_ALGORITHMS=0` which has already been applied to similar tests.