### PR TITLE
Fix __lifetime_keeper_base destructor

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -421,7 +421,7 @@ struct __get_sycl_range
     }
 
   private:
-    //We have to keep sycl buffer(s) instance here by sync reasons;
+    // We have to keep sycl buffer(s) instance here by sync reasons;
     std::vector<std::unique_ptr<oneapi::dpl::__internal::__lifetime_keeper_base>> m_buffers;
 
     template <sycl::access::mode _LocalAccMode>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/utils_ranges_sycl.h
@@ -422,7 +422,7 @@ struct __get_sycl_range
 
   private:
     //We have to keep sycl buffer(s) instance here by sync reasons;
-    ::std::vector<::std::unique_ptr<oneapi::dpl::__internal::__lifetime_keeper_base>> m_buffers;
+    std::vector<std::unique_ptr<oneapi::dpl::__internal::__lifetime_keeper_base>> m_buffers;
 
     template <sycl::access::mode _LocalAccMode>
     static constexpr bool __is_copy_direct_v =
@@ -709,7 +709,7 @@ struct __get_sycl_range
         // We have to extend sycl buffer lifetime by sync reasons in case of host iterators. SYCL runtime has sync
         // in buffer destruction and a sycl view instance keeps just placeholder accessor, not a buffer.
         using BufferType = oneapi::dpl::__internal::__lifetime_keeper<decltype(__buf)>;
-        m_buffers.push_back(::std::make_unique<BufferType>(__buf));
+        m_buffers.push_back(std::make_unique<BufferType>(__buf));
 
         using _T = val_t<_Iter>;
         return __range_holder<oneapi::dpl::__ranges::all_view<_T, _LocalAccMode>>{

--- a/include/oneapi/dpl/pstl/parallel_backend_tbb.h
+++ b/include/oneapi/dpl/pstl/parallel_backend_tbb.h
@@ -1105,7 +1105,7 @@ class __stable_sort_func
     _Compare _M_comp;
     _LeafSort _M_leaf_sort;
     bool _M_root;
-    _SizeType _M_nsort; //zero or number of elements to be sorted for partial_sort alforithm
+    _SizeType _M_nsort; //zero or number of elements to be sorted for partial_sort algorithm
 
   public:
     __stable_sort_func(_RandomAccessIterator1 __xs, _RandomAccessIterator1 __xe, _RandomAccessIterator2 __zs,

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -482,7 +482,7 @@ class __future;
 // empty base class for type erasure
 struct __lifetime_keeper_base
 {
-    virtual ~__lifetime_keeper_base() {}
+    virtual ~__lifetime_keeper_base() = default;
 };
 
 // derived class to keep temporaries (e.g. buffer) alive


### PR DESCRIPTION
This PR based on issue https://github.com/oneapi-src/oneDPL/issues/1469

In this PR we rewrite the destructor of `struct __lifetime_keeper_base` :
 - instead of empty body we rewrote it as `= default;`

Why it's better: https://isocpp.org/blog/2015/04/quick-q-how-is-default-different-from-for-default-constructor-and-destructo