### PR TITLE
Get rid of duplication in sort patterns

### DIFF
--- a/include/oneapi/dpl/pstl/algorithm_fwd.h
+++ b/include/oneapi/dpl/pstl/algorithm_fwd.h
@@ -738,29 +738,17 @@ __pattern_partition_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomA
                          _RandomAccessIterator2, _RandomAccessIterator3, _UnaryPredicate);
 
 //------------------------------------------------------------------------
-// sort
-//------------------------------------------------------------------------
-
-template <class _Tag, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
-void
-__pattern_sort(_Tag, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _Compare) noexcept;
-
-template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
-void
-__pattern_sort(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _Compare);
-
-//------------------------------------------------------------------------
 // stable_sort
 //------------------------------------------------------------------------
 
-template <class _Tag, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
+template <class _Tag, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _LeafSort>
 void
-__pattern_stable_sort(_Tag, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _Compare) noexcept;
+__pattern_stable_sort(_Tag, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator, _Compare, _LeafSort) noexcept;
 
-template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
+template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _LeafSort>
 void
 __pattern_stable_sort(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator, _RandomAccessIterator,
-                      _Compare);
+                      _Compare, _LeafSort);
 
 //------------------------------------------------------------------------
 // sort_by_key

--- a/include/oneapi/dpl/pstl/algorithm_fwd.h
+++ b/include/oneapi/dpl/pstl/algorithm_fwd.h
@@ -751,36 +751,20 @@ __pattern_stable_sort(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAcce
                       _Compare, _LeafSort);
 
 //------------------------------------------------------------------------
-// sort_by_key
-//------------------------------------------------------------------------
-
-template <typename _Tag, typename _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2,
-          typename _Compare>
-void
-__pattern_sort_by_key(_Tag, _ExecutionPolicy&&, _RandomAccessIterator1, _RandomAccessIterator1, _RandomAccessIterator2,
-                      _Compare) noexcept;
-
-template <typename _IsVector, typename _ExecutionPolicy, typename _RandomAccessIterator1,
-          typename _RandomAccessIterator2, typename _Compare>
-void
-__pattern_sort_by_key(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator1, _RandomAccessIterator1,
-                      _RandomAccessIterator2, _Compare);
-
-//------------------------------------------------------------------------
 // stable_sort_by_key
 //------------------------------------------------------------------------
 
 template <typename _Tag, typename _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2,
-          typename _Compare>
+          typename _Compare, typename _LeafSort>
 void
 __pattern_stable_sort_by_key(_Tag, _ExecutionPolicy&&, _RandomAccessIterator1, _RandomAccessIterator1,
-                             _RandomAccessIterator2, _Compare) noexcept;
+                             _RandomAccessIterator2, _Compare, _LeafSort) noexcept;
 
 template <typename _IsVector, typename _ExecutionPolicy, typename _RandomAccessIterator1,
-          typename _RandomAccessIterator2, typename _Compare>
+          typename _RandomAccessIterator2, typename _Compare, typename _LeafSort>
 void
 __pattern_stable_sort_by_key(__parallel_tag<_IsVector>, _ExecutionPolicy&&, _RandomAccessIterator1,
-                             _RandomAccessIterator1, _RandomAccessIterator2, _Compare);
+                             _RandomAccessIterator1, _RandomAccessIterator2, _Compare, _LeafSort);
 
 //------------------------------------------------------------------------
 // partial_sort

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -2390,62 +2390,31 @@ __pattern_partition_copy(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _
 }
 
 //------------------------------------------------------------------------
-// sort
-//------------------------------------------------------------------------
-
-template <class _Tag, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
-void
-__pattern_sort(_Tag, _ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __last,
-               _Compare __comp) noexcept
-{
-    static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
-
-    ::std::sort(__first, __last, __comp);
-}
-
-template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
-void
-__pattern_sort(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
-               _RandomAccessIterator __last, _Compare __comp)
-{
-    using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
-
-    __internal::__except_handler([&]() {
-        __par_backend::__parallel_stable_sort(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __comp,
-            [](_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp) {
-                ::std::sort(__first, __last, __comp);
-            },
-            __last - __first);
-    });
-}
-
-//------------------------------------------------------------------------
 // stable_sort
 //------------------------------------------------------------------------
 
-template <class _Tag, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
+template <class _Tag, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _LeafSort>
 void
 __pattern_stable_sort(_Tag, _ExecutionPolicy&&, _RandomAccessIterator __first, _RandomAccessIterator __last,
-                      _Compare __comp) noexcept
+                      _Compare __comp, _LeafSort __leaf_sort) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
 
-    ::std::stable_sort(__first, __last, __comp);
+    __leaf_sort(__first, __last, __comp);
 }
 
-template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
+template <class _IsVector, class _ExecutionPolicy, class _RandomAccessIterator, class _Compare, class _LeafSort>
 void
 __pattern_stable_sort(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator __first,
-                      _RandomAccessIterator __last, _Compare __comp)
+                      _RandomAccessIterator __last, _Compare __comp, _LeafSort __leaf_sort)
 {
     using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
 
     __internal::__except_handler([&]() {
         __par_backend::__parallel_stable_sort(
             __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __comp,
-            [](_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp) {
-                ::std::stable_sort(__first, __last, __comp);
+            [__leaf_sort](_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp) {
+                __leaf_sort(__first, __last, __comp);
             },
             __last - __first);
     });

--- a/include/oneapi/dpl/pstl/algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_impl.h
@@ -2421,54 +2421,15 @@ __pattern_stable_sort(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _Ran
 }
 
 //------------------------------------------------------------------------
-// sort_by_key
-//------------------------------------------------------------------------
-
-template <class _Tag, typename _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2,
-          typename _Compare>
-void
-__pattern_sort_by_key(_Tag, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __keys_first,
-                      _RandomAccessIterator1 __keys_last, _RandomAccessIterator2 __values_first,
-                      _Compare __comp) noexcept
-{
-    static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
-
-    auto __beg = oneapi::dpl::make_zip_iterator(__keys_first, __values_first);
-    auto __end = __beg + (__keys_last - __keys_first);
-    auto __cmp_f = [__comp](const auto& __a, const auto& __b) { return __comp(std::get<0>(__a), std::get<0>(__b)); };
-
-    std::sort(__beg, __end, __cmp_f);
-}
-
-template <typename _IsVector, typename _ExecutionPolicy, typename _RandomAccessIterator1,
-          typename _RandomAccessIterator2, typename _Compare>
-void
-__pattern_sort_by_key(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __keys_first,
-                      _RandomAccessIterator1 __keys_last, _RandomAccessIterator2 __values_first, _Compare __comp)
-{
-    auto __beg = oneapi::dpl::make_zip_iterator(__keys_first, __values_first);
-    auto __end = __beg + (__keys_last - __keys_first);
-    auto __cmp_f = [__comp](const auto& __a, const auto& __b) { return __comp(std::get<0>(__a), std::get<0>(__b)); };
-
-    using __backend_tag = typename __parallel_tag<_IsVector>::__backend_tag;
-
-    __internal::__except_handler([&]() {
-        __par_backend::__parallel_stable_sort(
-            __backend_tag{}, ::std::forward<_ExecutionPolicy>(__exec), __beg, __end, __cmp_f,
-            [](auto __first, auto __last, auto __cmp) { std::sort(__first, __last, __cmp); }, __end - __beg);
-    });
-}
-
-//------------------------------------------------------------------------
 // stable_sort_by_key
 //------------------------------------------------------------------------
 
 template <typename _Tag, typename _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2,
-          typename _Compare>
+          typename _Compare, typename _LeafSort>
 void
 __pattern_stable_sort_by_key(_Tag, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __keys_first,
                              _RandomAccessIterator1 __keys_last, _RandomAccessIterator2 __values_first,
-                             _Compare __comp) noexcept
+                             _Compare __comp, _LeafSort __leaf_sort) noexcept
 {
     static_assert(__is_serial_tag_v<_Tag> || __is_parallel_forward_tag_v<_Tag>);
 
@@ -2476,14 +2437,15 @@ __pattern_stable_sort_by_key(_Tag, _ExecutionPolicy&& __exec, _RandomAccessItera
     auto __end = __beg + (__keys_last - __keys_first);
     auto __cmp_f = [__comp](const auto& __a, const auto& __b) { return __comp(std::get<0>(__a), std::get<0>(__b)); };
 
-    std::stable_sort(__beg, __end, __cmp_f);
+    __leaf_sort(__beg, __end, __cmp_f);
 }
 
 template <typename _IsVector, typename _ExecutionPolicy, typename _RandomAccessIterator1,
-          typename _RandomAccessIterator2, typename _Compare>
+          typename _RandomAccessIterator2, typename _Compare, typename _LeafSort>
 void
 __pattern_stable_sort_by_key(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exec, _RandomAccessIterator1 __keys_first,
-                             _RandomAccessIterator1 __keys_last, _RandomAccessIterator2 __values_first, _Compare __comp)
+                             _RandomAccessIterator1 __keys_last, _RandomAccessIterator2 __values_first, _Compare __comp,
+                             _LeafSort __leaf_sort)
 {
     auto __beg = oneapi::dpl::make_zip_iterator(__keys_first, __values_first);
     auto __end = __beg + (__keys_last - __keys_first);
@@ -2494,7 +2456,8 @@ __pattern_stable_sort_by_key(__parallel_tag<_IsVector>, _ExecutionPolicy&& __exe
     __internal::__except_handler([&]() {
         __par_backend::__parallel_stable_sort(
             __backend_tag{}, std::forward<_ExecutionPolicy>(__exec), __beg, __end, __cmp_f,
-            [](auto __first, auto __last, auto __cmp) { std::stable_sort(__first, __last, __cmp); }, __end - __beg);
+            [__leaf_sort](auto __first, auto __last, auto __cmp) { __leaf_sort(__first, __last, __cmp); },
+            __end - __beg);
     });
 }
 

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -27,6 +27,8 @@
 #include "algorithm_fwd.h"
 #include "execution_impl.h"
 
+#include "utils.h" // __internal::__leaf_std_ranges_stable_sort
+
 namespace oneapi
 {
 namespace dpl
@@ -331,7 +333,7 @@ __pattern_is_sorted(__serial_tag</*IsVector*/std::false_type>, _ExecutionPolicy&
 }
 
 //---------------------------------------------------------------------------------------------------------------------
-// pattern_sort
+// pattern_stable_sort_ranges
 //---------------------------------------------------------------------------------------------------------------------
 
 template <typename _Tag, typename _ExecutionPolicy, typename _R, typename _Proj, typename _Comp>

--- a/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/algorithm_ranges_impl.h
@@ -336,7 +336,7 @@ __pattern_is_sorted(__serial_tag</*IsVector*/std::false_type>, _ExecutionPolicy&
 
 template <typename _Tag, typename _ExecutionPolicy, typename _R, typename _Proj, typename _Comp>
 auto
-__pattern_sort_ranges(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, _Comp __comp, _Proj __proj)
+__pattern_stable_sort_ranges(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, _Comp __comp, _Proj __proj)
 {
     static_assert(__is_parallel_tag_v<_Tag> || typename _Tag::__is_vector{});
 
@@ -345,14 +345,15 @@ __pattern_sort_ranges(_Tag __tag, _ExecutionPolicy&& __exec, _R&& __r, _Comp __c
     // Call stable_sort pattern since __pattern_sort_ranges is shared between sort and stable_sort
     // TODO: add a separate pattern for ranges::sort for better performance
     oneapi::dpl::__internal::__pattern_stable_sort(__tag, std::forward<_ExecutionPolicy>(__exec),
-        std::ranges::begin(__r), std::ranges::begin(__r) + std::ranges::size(__r), __comp_2);
+        std::ranges::begin(__r), std::ranges::begin(__r) + std::ranges::size(__r), __comp_2,
+        oneapi::dpl::__internal::__leaf_std_ranges_stable_sort{});
 
     return std::ranges::borrowed_iterator_t<_R>(std::ranges::begin(__r) + std::ranges::size(__r));
 }
 
 template <typename _ExecutionPolicy, typename _R, typename _Proj, typename _Comp>
 auto
-__pattern_sort_ranges(__serial_tag</*IsVector*/std::false_type>, _ExecutionPolicy&& __exec, _R&& __r, _Comp __comp, _Proj __proj)
+__pattern_stable_sort_ranges(__serial_tag</*IsVector*/std::false_type>, _ExecutionPolicy&& __exec, _R&& __r, _Comp __comp, _Proj __proj)
 {
     return std::ranges::stable_sort(std::forward<_R>(__r), __comp, __proj);
 }

--- a/include/oneapi/dpl/pstl/glue_algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_impl.h
@@ -706,8 +706,9 @@ sort_by_key(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __keys_first, _Ran
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __keys_first, __values_first);
 
-    oneapi::dpl::__internal::__pattern_sort_by_key(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
-                                                   __keys_first, __keys_last, __values_first, __comp);
+    oneapi::dpl::__internal::__pattern_stable_sort_by_key(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
+                                                   __keys_first, __keys_last, __values_first, __comp,
+                                                   oneapi::dpl::__internal::__leaf_std_sort{});
 }
 
 template <typename _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2>
@@ -730,7 +731,8 @@ stable_sort_by_key(_ExecutionPolicy&& __exec, _RandomAccessIterator1 __keys_firs
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __keys_first, __values_first);
 
     oneapi::dpl::__internal::__pattern_stable_sort_by_key(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
-                                                          __keys_first, __keys_last, __values_first, __comp);
+                                                          __keys_first, __keys_last, __values_first, __comp,
+                                                          oneapi::dpl::__internal::__leaf_std_stable_sort{});
 }
 
 template <typename _ExecutionPolicy, typename _RandomAccessIterator1, typename _RandomAccessIterator2>

--- a/include/oneapi/dpl/pstl/glue_algorithm_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_impl.h
@@ -664,8 +664,8 @@ sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIter
 {
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
-    oneapi::dpl::__internal::__pattern_sort(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
-                                            __comp);
+    oneapi::dpl::__internal::__pattern_stable_sort(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last,
+                                            __comp, oneapi::dpl::__internal::__leaf_std_sort{});
 }
 
 template <class _ExecutionPolicy, class _RandomAccessIterator>
@@ -685,7 +685,7 @@ stable_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAcc
     const auto __dispatch_tag = oneapi::dpl::__internal::__select_backend(__exec, __first);
 
     oneapi::dpl::__internal::__pattern_stable_sort(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec), __first,
-                                                   __last, __comp);
+                                                   __last, __comp, oneapi::dpl::__internal::__leaf_std_stable_sort{});
 }
 
 template <class _ExecutionPolicy, class _RandomAccessIterator>

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -421,7 +421,7 @@ struct __stable_sort_fn
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
-        return oneapi::dpl::__internal::__ranges::__pattern_sort_ranges(__dispatch_tag,
+        return oneapi::dpl::__internal::__ranges::__pattern_stable_sort_ranges(__dispatch_tag,
             std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __comp, __proj);
     }
 }; //__stable_sort_fn
@@ -1044,7 +1044,7 @@ sort(_ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp, _Proj __proj)
 {
     const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec, __rng);
 
-    oneapi::dpl::__internal::__ranges::__pattern_sort(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
+    oneapi::dpl::__internal::__ranges::__pattern_stable_sort(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
                                                       views::all(::std::forward<_Range>(__rng)), __comp, __proj);
 }
 

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1241,23 +1241,10 @@ __stable_sort_with_projection(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __ex
         .__deferrable_wait();
 }
 
-template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _Compare>
-void
-__pattern_sort(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last,
-               _Compare __comp)
-{
-    __stable_sort_with_projection(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __comp,
-                                  oneapi::dpl::identity{});
-}
-
-//------------------------------------------------------------------------
-// stable_sort
-//------------------------------------------------------------------------
-
-template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _Compare>
+template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator, typename _Compare, typename _LeafSort>
 void
 __pattern_stable_sort(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Iterator __first, _Iterator __last,
-                      _Compare __comp)
+                      _Compare __comp, _LeafSort)
 {
     __stable_sort_with_projection(__tag, ::std::forward<_ExecutionPolicy>(__exec), __first, __last, __comp,
                                   oneapi::dpl::identity{});

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1254,10 +1254,11 @@ __pattern_stable_sort(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec
 // sort_by_key
 //------------------------------------------------------------------------
 
-template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2, typename _Compare>
+template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2, typename _Compare,
+          typename _LeafSort>
 void
 __pattern_stable_sort_by_key(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Iterator1 __keys_first,
-                             _Iterator1 __keys_last, _Iterator2 __values_first, _Compare __comp)
+                             _Iterator1 __keys_last, _Iterator2 __values_first, _Compare __comp, _LeafSort)
 {
     static_assert(std::is_move_constructible_v<typename std::iterator_traits<_Iterator1>::value_type> &&
                       std::is_move_constructible_v<typename std::iterator_traits<_Iterator2>::value_type>,
@@ -1267,19 +1268,6 @@ __pattern_stable_sort_by_key(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&&
     auto __end = __beg + (__keys_last - __keys_first);
     __stable_sort_with_projection(__tag, std::forward<_ExecutionPolicy>(__exec), __beg, __end, __comp,
                                   [](const auto& __a) { return std::get<0>(__a); });
-}
-
-//------------------------------------------------------------------------
-// stable_sort_by_key
-//------------------------------------------------------------------------
-
-template <typename _BackendTag, typename _ExecutionPolicy, typename _Iterator1, typename _Iterator2, typename _Compare>
-void
-__pattern_sort_by_key(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _Iterator1 __keys_first,
-                      _Iterator1 __keys_last, _Iterator2 __values_first, _Compare __comp)
-{
-    __pattern_stable_sort_by_key(__tag, std::forward<_ExecutionPolicy>(__exec), __keys_first, __keys_last,
-                                 __values_first, __comp);
 }
 
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -749,7 +749,7 @@ __pattern_merge(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _R1&
 
 template <typename _BackendTag, typename _ExecutionPolicy, typename _Range, typename _Compare, typename _Proj>
 void
-__pattern_sort(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp, _Proj __proj)
+__pattern_stable_sort(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&& __rng, _Compare __comp, _Proj __proj)
 {
     if (__rng.size() >= 2)
         __par_backend_hetero::__parallel_stable_sort(_BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
@@ -760,9 +760,9 @@ __pattern_sort(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Range&& __
 #if _ONEDPL_CPP20_RANGES_PRESENT
 template <typename _BackendTag, typename _ExecutionPolicy, typename _R, typename _Comp, typename _Proj>
 auto
-__pattern_sort_ranges(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _R&& __r, _Comp __comp, _Proj __proj)
+__pattern_stable_sort_ranges(__hetero_tag<_BackendTag> __tag, _ExecutionPolicy&& __exec, _R&& __r, _Comp __comp, _Proj __proj)
 {
-    oneapi::dpl::__internal::__ranges::__pattern_sort(__tag, std::forward<_ExecutionPolicy>(__exec),
+    oneapi::dpl::__internal::__ranges::__pattern_stable_sort(__tag, std::forward<_ExecutionPolicy>(__exec),
         oneapi::dpl::__ranges::views::all(__r), __comp, __proj);
 
     return std::ranges::borrowed_iterator_t<_R>(std::ranges::begin(__r) + std::ranges::size(__r));

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -784,6 +784,38 @@ union __lazy_ctor_storage
     }
 };
 
+struct __leaf_std_sort
+{
+    template <typename _It, typename _Compare>
+    void operator()(_It __first, _It __last, _Compare __comp) const
+    {
+        std::sort(__first, __last, __comp);
+    }
+};
+
+struct __leaf_std_stable_sort
+{
+    template <typename _It, typename _Compare>
+    void operator()(_It __first, _It __last, _Compare __comp) const
+    {
+        std::stable_sort(__first, __last, __comp);
+    }
+};
+
+// Add separate patterns for std::ranges::sort due to std::indirectly_swappable requirement,
+// which implies the use of std::ranges::iter_swap, which can be customized externally
+#if _ONEDPL_CPP20_RANGES_PRESENT
+struct __leaf_std_ranges_stable_sort
+{
+    template <typename _It, typename _Compare>
+    void operator()(_It __first, _It __last, _Compare __comp) const
+    {
+        std::ranges::stable_sort(__first, __last, __comp);
+    }
+};
+#endif // _ONEDPL_CPP20_RANGES_PRESENT
+
+
 } // namespace __internal
 } // namespace dpl
 } // namespace oneapi

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -816,7 +816,6 @@ struct __leaf_std_ranges_stable_sort
 };
 #endif // _ONEDPL_CPP20_RANGES_PRESENT
 
-
 } // namespace __internal
 } // namespace dpl
 } // namespace oneapi

--- a/include/oneapi/dpl/pstl/utils.h
+++ b/include/oneapi/dpl/pstl/utils.h
@@ -23,6 +23,7 @@
 #include <utility>
 #include <climits>
 #include <iterator>
+#include <algorithm>
 #include <functional>
 #include <type_traits>
 


### PR DESCRIPTION
Parameterize sort patterns with a leaf sorting algorithm to get rid of duplication for unstable/stable and classic/ranged sort.
It also fixed an issue already addressed in #1815 in a less verbose way. 