### PR TITLE
Fix implementations of `lower_bound_impl`, `upper_bound_impl` and `binary_search_impl` functions

### DIFF
--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -90,10 +90,9 @@ lower_bound_impl(_Tag tag, Policy&& policy, InputIterator1 start, InputIterator1
 
     return oneapi::dpl::__internal::__pattern_walk2(
         tag, std::forward<Policy>(policy), value_start, value_end, result,
-        oneapi::dpl::__internal::__transform_functor{
-            [=](typename std::iterator_traits<InputIterator2>::reference val) {
-                return std::lower_bound(start, end, val, comp) - start;
-            }});
+        oneapi::dpl::__internal::__transform_functor{[=](typename std::iterator_traits<InputIterator2>::reference val) {
+            return std::lower_bound(start, end, val, comp) - start;
+        }});
 }
 
 template <class _Tag, typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
@@ -106,10 +105,9 @@ upper_bound_impl(_Tag tag, Policy&& policy, InputIterator1 start, InputIterator1
 
     return oneapi::dpl::__internal::__pattern_walk2(
         tag, std::forward<Policy>(policy), value_start, value_end, result,
-        oneapi::dpl::__internal::__transform_functor{
-            [=](typename std::iterator_traits<InputIterator2>::reference val) {
-                return std::upper_bound(start, end, val, comp) - start;
-            }});
+        oneapi::dpl::__internal::__transform_functor{[=](typename std::iterator_traits<InputIterator2>::reference val) {
+            return std::upper_bound(start, end, val, comp) - start;
+        }});
 }
 
 template <class _Tag, typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -115,15 +115,16 @@ upper_bound_impl(_Tag tag, Policy&& policy, InputIterator1 start, InputIterator1
 template <class _Tag, typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename StrictWeakOrdering>
 OutputIterator
-binary_search_impl(_Tag, Policy&& policy, InputIterator1 start, InputIterator1 end, InputIterator2 value_start,
+binary_search_impl(_Tag tag, Policy&& policy, InputIterator1 start, InputIterator1 end, InputIterator2 value_start,
                    InputIterator2 value_end, OutputIterator result, StrictWeakOrdering comp)
 {
     static_assert(__internal::__is_host_dispatch_tag_v<_Tag>);
 
-    return oneapi::dpl::transform(policy, value_start, value_end, result,
-                                  [=](typename ::std::iterator_traits<InputIterator2>::reference val) {
-                                      return ::std::binary_search(start, end, val, comp);
-                                  });
+    return oneapi::dpl::__internal::__pattern_walk2(
+        tag, std::forward<Policy>(policy), value_start, value_end, result,
+        oneapi::dpl::__internal::__transform_functor{[=](typename std::iterator_traits<InputIterator2>::reference val) {
+            return std::binary_search(start, end, val, comp);
+        }});
 }
 
 #if _ONEDPL_BACKEND_SYCL

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -99,15 +99,17 @@ lower_bound_impl(_Tag tag, Policy&& policy, InputIterator1 start, InputIterator1
 template <class _Tag, typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename StrictWeakOrdering>
 OutputIterator
-upper_bound_impl(_Tag, Policy&& policy, InputIterator1 start, InputIterator1 end, InputIterator2 value_start,
+upper_bound_impl(_Tag tag, Policy&& policy, InputIterator1 start, InputIterator1 end, InputIterator2 value_start,
                  InputIterator2 value_end, OutputIterator result, StrictWeakOrdering comp)
 {
     static_assert(__internal::__is_host_dispatch_tag_v<_Tag>);
 
-    return oneapi::dpl::transform(policy, value_start, value_end, result,
-                                  [=](typename ::std::iterator_traits<InputIterator2>::reference val) {
-                                      return ::std::upper_bound(start, end, val, comp) - start;
-                                  });
+    return oneapi::dpl::__internal::__pattern_walk2(
+        tag, std::forward<Policy>(policy), value_start, value_end, result,
+        oneapi::dpl::__internal::__transform_functor{
+            [=](typename std::iterator_traits<InputIterator2>::reference val) {
+                return std::upper_bound(start, end, val, comp) - start;
+            }});
 }
 
 template <class _Tag, typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -83,15 +83,17 @@ struct custom_brick
 template <class _Tag, typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
           typename StrictWeakOrdering>
 OutputIterator
-lower_bound_impl(_Tag, Policy&& policy, InputIterator1 start, InputIterator1 end, InputIterator2 value_start,
+lower_bound_impl(_Tag tag, Policy&& policy, InputIterator1 start, InputIterator1 end, InputIterator2 value_start,
                  InputIterator2 value_end, OutputIterator result, StrictWeakOrdering comp)
 {
     static_assert(__internal::__is_host_dispatch_tag_v<_Tag>);
 
-    return oneapi::dpl::transform(policy, value_start, value_end, result,
-                                  [=](typename ::std::iterator_traits<InputIterator2>::reference val) {
-                                      return ::std::lower_bound(start, end, val, comp) - start;
-                                  });
+    return oneapi::dpl::__internal::__pattern_walk2(
+        tag, std::forward<Policy>(policy), value_start, value_end, result,
+        oneapi::dpl::__internal::__transform_functor{
+            [=](typename std::iterator_traits<InputIterator2>::reference val) {
+                return std::lower_bound(start, end, val, comp) - start;
+            }});
 }
 
 template <class _Tag, typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -88,11 +88,12 @@ lower_bound_impl(_Tag tag, Policy&& policy, InputIterator1 start, InputIterator1
 {
     static_assert(__internal::__is_host_dispatch_tag_v<_Tag>);
 
+    using _ValueType = typename std::iterator_traits<InputIterator2>::value_type;
+
     return oneapi::dpl::__internal::__pattern_walk2(
         tag, std::forward<Policy>(policy), value_start, value_end, result,
-        oneapi::dpl::__internal::__transform_functor{[=](typename std::iterator_traits<InputIterator2>::reference val) {
-            return std::lower_bound(start, end, val, comp) - start;
-        }});
+        oneapi::dpl::__internal::__transform_functor{
+            [=](const _ValueType& val) { return std::lower_bound(start, end, val, comp) - start; }});
 }
 
 template <class _Tag, typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
@@ -103,11 +104,12 @@ upper_bound_impl(_Tag tag, Policy&& policy, InputIterator1 start, InputIterator1
 {
     static_assert(__internal::__is_host_dispatch_tag_v<_Tag>);
 
+    using _ValueType = typename std::iterator_traits<InputIterator2>::value_type;
+
     return oneapi::dpl::__internal::__pattern_walk2(
         tag, std::forward<Policy>(policy), value_start, value_end, result,
-        oneapi::dpl::__internal::__transform_functor{[=](typename std::iterator_traits<InputIterator2>::reference val) {
-            return std::upper_bound(start, end, val, comp) - start;
-        }});
+        oneapi::dpl::__internal::__transform_functor{
+            [=](const _ValueType& val) { return std::upper_bound(start, end, val, comp) - start; }});
 }
 
 template <class _Tag, typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
@@ -118,11 +120,12 @@ binary_search_impl(_Tag tag, Policy&& policy, InputIterator1 start, InputIterato
 {
     static_assert(__internal::__is_host_dispatch_tag_v<_Tag>);
 
+    using _ValueType = typename std::iterator_traits<InputIterator2>::value_type;
+
     return oneapi::dpl::__internal::__pattern_walk2(
         tag, std::forward<Policy>(policy), value_start, value_end, result,
-        oneapi::dpl::__internal::__transform_functor{[=](typename std::iterator_traits<InputIterator2>::reference val) {
-            return std::binary_search(start, end, val, comp);
-        }});
+        oneapi::dpl::__internal::__transform_functor{
+            [=](const _ValueType& val) { return std::binary_search(start, end, val, comp); }});
 }
 
 #if _ONEDPL_BACKEND_SYCL

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -92,8 +92,9 @@ lower_bound_impl(_Tag tag, Policy&& policy, InputIterator1 start, InputIterator1
 
     return oneapi::dpl::__internal::__pattern_walk2(
         tag, std::forward<Policy>(policy), value_start, value_end, result,
-        oneapi::dpl::__internal::__transform_functor{
-            [=](const _ValueType& val) { return std::lower_bound(start, end, val, comp) - start; }});
+        oneapi::dpl::__internal::__transform_functor{[start, end, comp](const _ValueType& val) {
+            return std::lower_bound(start, end, val, comp) - start;
+        }});
 }
 
 template <class _Tag, typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
@@ -108,8 +109,9 @@ upper_bound_impl(_Tag tag, Policy&& policy, InputIterator1 start, InputIterator1
 
     return oneapi::dpl::__internal::__pattern_walk2(
         tag, std::forward<Policy>(policy), value_start, value_end, result,
-        oneapi::dpl::__internal::__transform_functor{
-            [=](const _ValueType& val) { return std::upper_bound(start, end, val, comp) - start; }});
+        oneapi::dpl::__internal::__transform_functor{[start, end, comp](const _ValueType& val) {
+            return std::upper_bound(start, end, val, comp) - start;
+        }});
 }
 
 template <class _Tag, typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
@@ -124,8 +126,9 @@ binary_search_impl(_Tag tag, Policy&& policy, InputIterator1 start, InputIterato
 
     return oneapi::dpl::__internal::__pattern_walk2(
         tag, std::forward<Policy>(policy), value_start, value_end, result,
-        oneapi::dpl::__internal::__transform_functor{
-            [=](const _ValueType& val) { return std::binary_search(start, end, val, comp); }});
+        oneapi::dpl::__internal::__transform_functor{[start, end, comp](const _ValueType& val) {
+            return std::binary_search(start, end, val, comp);
+        }});
 }
 
 #if _ONEDPL_BACKEND_SYCL

--- a/include/oneapi/dpl/internal/binary_search_impl.h
+++ b/include/oneapi/dpl/internal/binary_search_impl.h
@@ -92,9 +92,8 @@ lower_bound_impl(_Tag tag, Policy&& policy, InputIterator1 start, InputIterator1
 
     return oneapi::dpl::__internal::__pattern_walk2(
         tag, std::forward<Policy>(policy), value_start, value_end, result,
-        oneapi::dpl::__internal::__transform_functor{[start, end, comp](const _ValueType& val) {
-            return std::lower_bound(start, end, val, comp) - start;
-        }});
+        oneapi::dpl::__internal::__transform_functor{
+            [start, end, comp](const _ValueType& val) { return std::lower_bound(start, end, val, comp) - start; }});
 }
 
 template <class _Tag, typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
@@ -109,9 +108,8 @@ upper_bound_impl(_Tag tag, Policy&& policy, InputIterator1 start, InputIterator1
 
     return oneapi::dpl::__internal::__pattern_walk2(
         tag, std::forward<Policy>(policy), value_start, value_end, result,
-        oneapi::dpl::__internal::__transform_functor{[start, end, comp](const _ValueType& val) {
-            return std::upper_bound(start, end, val, comp) - start;
-        }});
+        oneapi::dpl::__internal::__transform_functor{
+            [start, end, comp](const _ValueType& val) { return std::upper_bound(start, end, val, comp) - start; }});
 }
 
 template <class _Tag, typename Policy, typename InputIterator1, typename InputIterator2, typename OutputIterator,
@@ -126,9 +124,8 @@ binary_search_impl(_Tag tag, Policy&& policy, InputIterator1 start, InputIterato
 
     return oneapi::dpl::__internal::__pattern_walk2(
         tag, std::forward<Policy>(policy), value_start, value_end, result,
-        oneapi::dpl::__internal::__transform_functor{[start, end, comp](const _ValueType& val) {
-            return std::binary_search(start, end, val, comp);
-        }});
+        oneapi::dpl::__internal::__transform_functor{
+            [start, end, comp](const _ValueType& val) { return std::binary_search(start, end, val, comp); }});
 }
 
 #if _ONEDPL_BACKEND_SYCL


### PR DESCRIPTION
Issue: https://github.com/oneapi-src/oneDPL/issues/1436

In this PR we fix implementations of the `lower_bound_impl`, `upper_bound_impl` and `binary_search_impl`:
- the way they were implemented before doesn't match Tag Dispatching design because they has called public `oneDPL` algorithms instead of internal pattern calls.