### PR TITLE
Improve the tables of content

### DIFF
--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -3,6 +3,7 @@ oneAPI DPC++ Library (oneDPL)
 
 .. toctree::
    :maxdepth: 2
+   :titlesonly:
 
    release_notes.rst
    library_guide/overview.rst

--- a/documentation/library_guide/api_for_sycl_kernels_main.rst
+++ b/documentation/library_guide/api_for_sycl_kernels_main.rst
@@ -10,12 +10,12 @@ API for the SYCL* Kernels
 * :doc:`Utility Function Object Classes <api_for_sycl_kernels/utility_function_object_classes>`. Various
   utilities in addition to C++ standard functionality.
 
-.. toctree::
-   :maxdepth: 2
-   :titlesonly:
-   :glob:
-   :hidden:
+..
+    .. toctree::
+       :maxdepth: 2
+       :titlesonly:
+       :hidden:
 
-   api_for_sycl_kernels/random
-   api_for_sycl_kernels/tested_standard_cpp_api
-   api_for_sycl_kernels/utility_function_object_classes
+       api_for_sycl_kernels/random
+       api_for_sycl_kernels/tested_standard_cpp_api
+       api_for_sycl_kernels/utility_function_object_classes

--- a/documentation/library_guide/api_for_sycl_kernels_main.rst
+++ b/documentation/library_guide/api_for_sycl_kernels_main.rst
@@ -1,5 +1,5 @@
-API for the SYCL* Kernels
-#########################
+API for SYCL* Kernels
+#####################
 
 |onedpl_long| (|onedpl_short|) includes the following APIs for SYCL* kernels:
 

--- a/documentation/library_guide/api_for_sycl_kernels_main.rst
+++ b/documentation/library_guide/api_for_sycl_kernels_main.rst
@@ -10,12 +10,11 @@ API for the SYCL* Kernels
 * :doc:`Utility Function Object Classes <api_for_sycl_kernels/utility_function_object_classes>`. Various
   utilities in addition to C++ standard functionality.
 
-..
-    .. toctree::
-       :maxdepth: 2
-       :titlesonly:
-       :hidden:
+.. toctree::
+   :maxdepth: 2
+   :titlesonly:
+   :hidden:
 
-       api_for_sycl_kernels/random
-       api_for_sycl_kernels/tested_standard_cpp_api
-       api_for_sycl_kernels/utility_function_object_classes
+   api_for_sycl_kernels/tested_standard_cpp_api
+   api_for_sycl_kernels/random
+   api_for_sycl_kernels/utility_function_object_classes

--- a/documentation/library_guide/conf.py
+++ b/documentation/library_guide/conf.py
@@ -118,6 +118,5 @@ html_theme_options = {
     'use_issues_button': True,
     'use_edit_page_button': True,
     'repository_branch': 'main',
-    'show_navbar_depth': 2,
     'extra_footer': '<p align="right"><a data-cookie-notice="true" href="https://www.intel.com/content/www/us/en/privacy/intel-cookie-notice.html">Cookies</a></p>'
 }

--- a/documentation/library_guide/dynamic_selection_api/policies.rst
+++ b/documentation/library_guide/dynamic_selection_api/policies.rst
@@ -125,7 +125,6 @@ More detailed information about the API is provided in the following sections:
 .. toctree::
    :maxdepth: 2
    :titlesonly:
-   :glob:
 
    fixed_resource_policy
    round_robin_policy

--- a/documentation/library_guide/dynamic_selection_api_main.rst
+++ b/documentation/library_guide/dynamic_selection_api_main.rst
@@ -86,7 +86,6 @@ More detailed information about the API is provided in the following sections:
 .. toctree::
    :maxdepth: 2
    :titlesonly:
-   :glob:
 
    dynamic_selection_api/functions
    dynamic_selection_api/policies

--- a/documentation/library_guide/index.rst
+++ b/documentation/library_guide/index.rst
@@ -19,6 +19,7 @@ For general information, refer to the `oneDPL GitHub* repository
 .. toctree::
    :maxdepth: 2
    :titlesonly:
+   :includehidden:
    :caption: Library Core Guide
 
    introduction
@@ -31,6 +32,7 @@ For general information, refer to the `oneDPL GitHub* repository
 .. toctree::
    :maxdepth: 2
    :titlesonly:
+   :includehidden:
    :caption: Technology Preview Guide
 
    parallel_api/async_api

--- a/documentation/library_guide/index.rst
+++ b/documentation/library_guide/index.rst
@@ -10,6 +10,7 @@ For general information, refer to the `oneDPL GitHub* repository
 
 .. toctree::
    :maxdepth: 2
+   :titlesonly:
    :caption: Get Started
 
    introduction/release_notes.rst
@@ -17,6 +18,7 @@ For general information, refer to the `oneDPL GitHub* repository
 
 .. toctree::
    :maxdepth: 2
+   :titlesonly:
    :caption: Library Guide
 
    introduction

--- a/documentation/library_guide/index.rst
+++ b/documentation/library_guide/index.rst
@@ -20,7 +20,7 @@ For general information, refer to the `oneDPL GitHub* repository
    :maxdepth: 2
    :titlesonly:
    :includehidden:
-   :caption: Library Core Guide
+   :caption: Core Functionality
 
    introduction
    parallel_api_main
@@ -33,7 +33,7 @@ For general information, refer to the `oneDPL GitHub* repository
    :maxdepth: 1
    :titlesonly:
    :includehidden:
-   :caption: Technology Preview Guide
+   :caption: Technology Preview
 
    parallel_api/async_api
    dynamic_selection_api_main

--- a/documentation/library_guide/index.rst
+++ b/documentation/library_guide/index.rst
@@ -36,7 +36,6 @@ For general information, refer to the `oneDPL GitHub* repository
    :caption: Technology Preview Guide
 
    parallel_api/async_api
-   parallel_api/range_based_api
    dynamic_selection_api_main
    kernel_templates_main
 

--- a/documentation/library_guide/index.rst
+++ b/documentation/library_guide/index.rst
@@ -19,7 +19,7 @@ For general information, refer to the `oneDPL GitHub* repository
 .. toctree::
    :maxdepth: 2
    :titlesonly:
-   :caption: Library Guide
+   :caption: Library Core Guide
 
    introduction
    parallel_api_main
@@ -31,7 +31,10 @@ For general information, refer to the `oneDPL GitHub* repository
 .. toctree::
    :maxdepth: 2
    :titlesonly:
-   :caption: Experimental APIs
+   :caption: Technology Preview Guide
+
+   parallel_api/async_api
+   parallel_api/range_based_api
    dynamic_selection_api_main
    kernel_templates_main
 

--- a/documentation/library_guide/index.rst
+++ b/documentation/library_guide/index.rst
@@ -24,11 +24,16 @@ For general information, refer to the `oneDPL GitHub* repository
    introduction
    parallel_api_main
    api_for_sycl_kernels_main
-   dynamic_selection_api_main
-   kernel_templates_main
    macros
    cmake_support
    oneDPL_2022.0_changes
+
+.. toctree::
+   :maxdepth: 2
+   :titlesonly:
+   :caption: Experimental APIs
+   dynamic_selection_api_main
+   kernel_templates_main
 
 .. toctree::
    :hidden:

--- a/documentation/library_guide/index.rst
+++ b/documentation/library_guide/index.rst
@@ -30,7 +30,7 @@ For general information, refer to the `oneDPL GitHub* repository
    oneDPL_2022.0_changes
 
 .. toctree::
-   :maxdepth: 2
+   :maxdepth: 1
    :titlesonly:
    :includehidden:
    :caption: Technology Preview Guide

--- a/documentation/library_guide/kernel_templates/esimd_main.rst
+++ b/documentation/library_guide/kernel_templates/esimd_main.rst
@@ -9,14 +9,14 @@ These templates are available in the ``oneapi::dpl::experimental::kt::gpu::esimd
 * :doc:`radix_sort <esimd/radix_sort>`
 * :doc:`radix_sort_by_key <esimd/radix_sort_by_key>`
 
-.. toctree::
-   :maxdepth: 2
-   :titlesonly:
-   :glob:
-   :hidden:
+..
+    .. toctree::
+       :maxdepth: 2
+       :titlesonly:
+       :hidden:
 
-   esimd/radix_sort
-   esimd/radix_sort_by_key
+       esimd/radix_sort
+       esimd/radix_sort_by_key
 
 -------------------
 System Requirements

--- a/documentation/library_guide/kernel_templates/esimd_main.rst
+++ b/documentation/library_guide/kernel_templates/esimd_main.rst
@@ -9,14 +9,13 @@ These templates are available in the ``oneapi::dpl::experimental::kt::gpu::esimd
 * :doc:`radix_sort <esimd/radix_sort>`
 * :doc:`radix_sort_by_key <esimd/radix_sort_by_key>`
 
-..
-    .. toctree::
-       :maxdepth: 2
-       :titlesonly:
-       :hidden:
+.. toctree::
+   :maxdepth: 2
+   :titlesonly:
+   :hidden:
 
-       esimd/radix_sort
-       esimd/radix_sort_by_key
+   esimd/radix_sort
+   esimd/radix_sort_by_key
 
 -------------------
 System Requirements

--- a/documentation/library_guide/kernel_templates_main.rst
+++ b/documentation/library_guide/kernel_templates_main.rst
@@ -17,12 +17,12 @@ The primary API namespace is ``oneapi::dpl::experimental::kt``, and nested names
 * :doc:`ESIMD-based kernel templates <kernel_templates/esimd_main>`. Algorithms implemented with the Explicit SIMD SYCL extension.
 * :doc:`Inclusive scan algorithm <kernel_templates/single_pass_scan>`. Inclusive scan kernel template algorithm using a single-pass approach.
 
-.. toctree::
-   :maxdepth: 2
-   :titlesonly:
-   :glob:
-   :hidden:
+..
+    .. toctree::
+       :maxdepth: 2
+       :titlesonly:
+       :hidden:
 
-   kernel_templates/kernel_configuration
-   kernel_templates/esimd_main
-   kernel_templates/single_pass_scan
+       kernel_templates/kernel_configuration
+       kernel_templates/esimd_main
+       kernel_templates/single_pass_scan

--- a/documentation/library_guide/kernel_templates_main.rst
+++ b/documentation/library_guide/kernel_templates_main.rst
@@ -17,12 +17,11 @@ The primary API namespace is ``oneapi::dpl::experimental::kt``, and nested names
 * :doc:`ESIMD-based kernel templates <kernel_templates/esimd_main>`. Algorithms implemented with the Explicit SIMD SYCL extension.
 * :doc:`Inclusive scan algorithm <kernel_templates/single_pass_scan>`. Inclusive scan kernel template algorithm using a single-pass approach.
 
-..
-    .. toctree::
-       :maxdepth: 2
-       :titlesonly:
-       :hidden:
+.. toctree::
+   :maxdepth: 2
+   :titlesonly:
+   :hidden:
 
-       kernel_templates/kernel_configuration
-       kernel_templates/esimd_main
-       kernel_templates/single_pass_scan
+   kernel_templates/kernel_configuration
+   kernel_templates/esimd_main
+   kernel_templates/single_pass_scan

--- a/documentation/library_guide/parallel_api/async_api.rst
+++ b/documentation/library_guide/parallel_api/async_api.rst
@@ -1,5 +1,5 @@
-Asynchronous API Algorithms
-###########################
+Asynchronous Algorithms
+#######################
 
 The functions defined in the STL ``<algorithm>`` or ``<numeric>`` headers are traditionally blocking. |onedpl_long| (|onedpl_short|)
 extends the functionality of the C++17 parallel algorithms by providing asynchronous algorithms with non-blocking behavior.

--- a/documentation/library_guide/parallel_api_main.rst
+++ b/documentation/library_guide/parallel_api_main.rst
@@ -35,3 +35,4 @@ that may be passed to algorithms such as reduce or transform.
    parallel_api/additional_algorithms
    parallel_api/pass_data_algorithms
    parallel_api/iterators
+   parallel_api/range_based_api

--- a/documentation/library_guide/parallel_api_main.rst
+++ b/documentation/library_guide/parallel_api_main.rst
@@ -31,7 +31,7 @@ that may be passed to algorithms such as reduce or transform.
    :hidden:
 
    parallel_api/execution_policies
-   parallel_api/iterators
    parallel_api/parallel_range_algorithms
    parallel_api/additional_algorithms
    parallel_api/pass_data_algorithms
+   parallel_api/iterators

--- a/documentation/library_guide/parallel_api_main.rst
+++ b/documentation/library_guide/parallel_api_main.rst
@@ -25,16 +25,16 @@ that may be passed to algorithms such as reduce or transform.
 
 |onedpl_short| also includes an experimental implementation of asynchronous algorithms.
 
-.. toctree::
-   :maxdepth: 2
-   :titlesonly:
-   :glob:
-   :hidden:
+..
+    .. toctree::
+       :maxdepth: 2
+       :titlesonly:
+       :hidden:
 
-   parallel_api/execution_policies
-   parallel_api/iterators
-   parallel_api/parallel_range_algorithms
-   parallel_api/additional_algorithms
-   parallel_api/pass_data_algorithms
-   parallel_api/async_api
-   parallel_api/range_based_api
+       parallel_api/execution_policies
+       parallel_api/iterators
+       parallel_api/parallel_range_algorithms
+       parallel_api/additional_algorithms
+       parallel_api/pass_data_algorithms
+       parallel_api/async_api
+       parallel_api/range_based_api

--- a/documentation/library_guide/parallel_api_main.rst
+++ b/documentation/library_guide/parallel_api_main.rst
@@ -25,16 +25,13 @@ that may be passed to algorithms such as reduce or transform.
 
 |onedpl_short| also includes an experimental implementation of asynchronous algorithms.
 
-..
-    .. toctree::
-       :maxdepth: 2
-       :titlesonly:
-       :hidden:
+.. toctree::
+   :maxdepth: 2
+   :titlesonly:
+   :hidden:
 
-       parallel_api/execution_policies
-       parallel_api/iterators
-       parallel_api/parallel_range_algorithms
-       parallel_api/additional_algorithms
-       parallel_api/pass_data_algorithms
-       parallel_api/async_api
-       parallel_api/range_based_api
+   parallel_api/execution_policies
+   parallel_api/iterators
+   parallel_api/parallel_range_algorithms
+   parallel_api/additional_algorithms
+   parallel_api/pass_data_algorithms


### PR DESCRIPTION
The patch restructures the table of content to better organized documentation topics. It also does related minor changes such as page reordering and title modifications.