### PR TITLE
Fix comparison of expected and actual values in tests

### DIFF
--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -113,6 +113,11 @@ is_equal_val(const T1& val1, const T2& val2)
         const auto eps = std::numeric_limits<T>::epsilon();
         return std::fabs(T(val1) - T(val2)) < eps;
     }
+
+    if constexpr (std::is_same_v<T1, T2>)
+    {
+        return val1 == val2;
+    }
     else
     {
         return T(val1) == T(val2);

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -177,7 +177,7 @@ expect_equal(Iterator1 expected_first, Iterator2 actual_first, Size n, const cha
     size_t error_count = 0;
     for (size_t k = 0; k < n && error_count < 10; ++k, ++expected_first, ++actual_first)
     {
-        if (!(*expected_first == *actual_first))
+        if (!is_equal_val(*expected_first, *actual_first))
         {
             ::std::stringstream outstr;
             outstr << "error at " << file << ":" << line << " - " << message << ", at index " << k;

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -125,20 +125,9 @@ template <typename T1, typename T2>
 void
 expect_equal_val(const T1& expected, const T2& actual, const char* file, std::int32_t line, const char* message)
 {
-    using T = std::common_type_t<T1, T2>;
-
-    bool __is_error = false;
-    if constexpr (std::is_floating_point_v<T>)
+    if (!is_equal_val(expected, actual))
     {
-        const auto eps = std::numeric_limits<T>::epsilon();
-        __is_error = std::fabs(T(expected) - T(actual)) >= eps;
-    }
-    else
-        __is_error = !(T(expected) == T(actual));
-
-    if (__is_error)
-    {
-        ::std::stringstream outstr;
+        std::stringstream outstr;
         outstr << "error at " << file << ":" << line << " - " << message << ", expected " << expected << " got "
                << actual;
         issue_error_message(outstr);

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -103,6 +103,25 @@ expect(bool expected, bool condition, const char* file, std::int32_t line, const
 // Do not change signature to const T&.
 // Function must be able to detect const differences between expected and actual.
 template <typename T1, typename T2>
+bool
+is_equal_val(const T1& val1, const T2& val2)
+{
+    using T = std::common_type_t<T1, T2>;
+
+    if constexpr (std::is_floating_point_v<T>)
+    {
+        const auto eps = std::numeric_limits<T>::epsilon();
+        return std::fabs(T(val1) - T(val2)) < eps;
+    }
+    else
+    {
+        return T(val1) == T(val2);
+    }
+}
+
+// Do not change signature to const T&.
+// Function must be able to detect const differences between expected and actual.
+template <typename T1, typename T2>
 void
 expect_equal_val(const T1& expected, const T2& actual, const char* file, std::int32_t line, const char* message)
 {

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -151,7 +151,7 @@ expect_equal(const R1& expected, const R2& actual, const char* file, std::int32_
     size_t error_count = 0;
     for (size_t k = 0; k < n && error_count < 10; ++k)
     {
-        if (!(expected[k] == actual[k]))
+        if (!is_equal_val(expected[k], actual[k]))
         {
             ::std::stringstream outstr;
             outstr << "error at " << file << ":" << line << " - " << message << ", at index " << k << " expected "

--- a/test/support/utils.h
+++ b/test/support/utils.h
@@ -193,7 +193,7 @@ check_data(const T1* device_iter, const T2* host_iter, int N)
 {
     for (int i = 0; i < N; ++i)
     {
-        if (*(host_iter + i) != *(device_iter + i))
+        if (!is_equal_val(*(host_iter + i), *(device_iter + i)))
             return false;
     }
     return true;

--- a/test/xpu_api/algorithms/alg.sorting/alg.binary.search/binary.search/partitioned_g1.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.binary.search/binary.search/partitioned_g1.pass.cpp
@@ -39,9 +39,9 @@ struct X
         return this->odd() && !x.odd();
     }
     bool
-    operator!=(const X& x) const
+    operator==(const X& x) const
     {
-        return this->val != x.val;
+        return this->val == x.val;
     }
 };
 

--- a/test/xpu_api/algorithms/alg.sorting/alg.binary.search/lower.bound/partitioned_g2.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.binary.search/lower.bound/partitioned_g2.pass.cpp
@@ -39,9 +39,9 @@ struct X
         return this->odd() && !x.odd();
     }
     bool
-    operator!=(const X& x) const
+    operator==(const X& x) const
     {
-        return this->val != x.val;
+        return this->val == x.val;
     }
 };
 
@@ -111,9 +111,9 @@ struct Y
         return val < int(y.val);
     }
     bool
-    operator!=(const Y& y) const
+    operator==(const Y& y) const
     {
-        return val != (y.val);
+        return val == y.val;
     }
 };
 

--- a/test/xpu_api/algorithms/alg.sorting/alg.binary.search/upper.bound/partitioned_g.pass.cpp
+++ b/test/xpu_api/algorithms/alg.sorting/alg.binary.search/upper.bound/partitioned_g.pass.cpp
@@ -39,9 +39,9 @@ struct X
         return this->odd() && !x.odd();
     }
     bool
-    operator!=(const X& x) const
+    operator==(const X& x) const
     {
-        return this->val != x.val;
+        return this->val == x.val;
     }
 };
 
@@ -109,9 +109,9 @@ struct Y
         return val < (int)y.val;
     }
     bool
-    operator!=(const Y& y) const
+    operator==(const Y& y) const
     {
-        return val != y.val;
+        return val == y.val;
     }
 };
 


### PR DESCRIPTION
Issue: https://github.com/oneapi-src/oneDPL/issues/1382

In this PR we fixing value comparisons in oneDPL tests: the goal is to compare `floating point` values through `std::numeric_limits<T>::epsilon()` precision usage.