### PR TITLE
[tests] Multiple translation units

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -274,3 +274,11 @@ foreach (_file IN LISTS UNIT_TESTS)
     endif()
 
 endforeach()
+
+# add additional TUs if required
+if (TARGET multiple_translation_units.pass)
+    target_sources(
+        multiple_translation_units.pass PRIVATE
+        "${CMAKE_CURRENT_LIST_DIR}/general/multiple_translation_units/translation_unit1.cpp"
+        "${CMAKE_CURRENT_LIST_DIR}/general/multiple_translation_units/translation_unit2.cpp")
+endif()

--- a/test/general/multiple_translation_units/header_umbrella.h
+++ b/test/general/multiple_translation_units/header_umbrella.h
@@ -1,0 +1,38 @@
+#include "support/test_config.h"
+
+#include <oneapi/dpl/algorithm>
+#include <oneapi/dpl/array>
+
+#if TEST_DPCPP_BACKEND_PRESENT
+#   include <oneapi/dpl/async>
+#endif
+
+#include <oneapi/dpl/cmath>
+#include <oneapi/dpl/complex>
+#include <oneapi/dpl/cstddef>
+#include <oneapi/dpl/cstring>
+
+#if TEST_DPCPP_BACKEND_PRESENT && __has_include(<oneapi/dpl/dynamic_selection>)
+#   include <oneapi/dpl/dynamic_selection>
+#endif
+
+#include <oneapi/dpl/execution>
+#include <oneapi/dpl/functional>
+#include <oneapi/dpl/iterator>
+
+#if TEST_DPCPP_BACKEND_PRESENT && __has_include(<oneapi/dpl/experimental/kernel_templates>)
+#   include <oneapi/dpl/experimental/kernel_templates>
+#endif
+
+#include <oneapi/dpl/limits>
+#include <oneapi/dpl/memory>
+#include <oneapi/dpl/numeric>
+#include <oneapi/dpl/optional>
+// TODO: investigate issues:
+//     philox_engine.h:36:11: error: no template named 'element_type_t' in namespace 'oneapi::dpl::experimental::internal'; did you mean '::oneapi::dpl::internal::element_type_t'?
+// #include <oneapi/dpl/random>
+#include <oneapi/dpl/ranges>
+#include <oneapi/dpl/ratio>
+#include <oneapi/dpl/tuple>
+#include <oneapi/dpl/type_traits>
+#include <oneapi/dpl/utility>

--- a/test/general/multiple_translation_units/header_umbrella.h
+++ b/test/general/multiple_translation_units/header_umbrella.h
@@ -1,3 +1,18 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
 #include "support/test_config.h"
 
 #include <oneapi/dpl/algorithm>

--- a/test/general/multiple_translation_units/header_umbrella.h
+++ b/test/general/multiple_translation_units/header_umbrella.h
@@ -27,7 +27,7 @@
 #include <oneapi/dpl/cstddef>
 #include <oneapi/dpl/cstring>
 
-#if TEST_DPCPP_BACKEND_PRESENT && __has_include(<oneapi/dpl/dynamic_selection>)
+#if TEST_DPCPP_BACKEND_PRESENT
 #   include <oneapi/dpl/dynamic_selection>
 #endif
 
@@ -35,7 +35,7 @@
 #include <oneapi/dpl/functional>
 #include <oneapi/dpl/iterator>
 
-#if TEST_DPCPP_BACKEND_PRESENT && __has_include(<oneapi/dpl/experimental/kernel_templates>)
+#if TEST_DPCPP_BACKEND_PRESENT
 #   include <oneapi/dpl/experimental/kernel_templates>
 #endif
 

--- a/test/general/multiple_translation_units/multiple_translation_units.pass.cpp
+++ b/test/general/multiple_translation_units/multiple_translation_units.pass.cpp
@@ -1,3 +1,18 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
 #include "support/test_config.h"
 #include "support/utils.h"
 

--- a/test/general/multiple_translation_units/multiple_translation_units.pass.cpp
+++ b/test/general/multiple_translation_units/multiple_translation_units.pass.cpp
@@ -1,0 +1,8 @@
+#include "support/test_config.h"
+#include "support/utils.h"
+
+int
+main()
+{
+    return TestUtils::done();
+}

--- a/test/general/multiple_translation_units/translation_unit1.cpp
+++ b/test/general/multiple_translation_units/translation_unit1.cpp
@@ -1,1 +1,16 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
 #include "header_umbrella.h"

--- a/test/general/multiple_translation_units/translation_unit1.cpp
+++ b/test/general/multiple_translation_units/translation_unit1.cpp
@@ -1,0 +1,1 @@
+#include "header_umbrella.h"

--- a/test/general/multiple_translation_units/translation_unit2.cpp
+++ b/test/general/multiple_translation_units/translation_unit2.cpp
@@ -1,1 +1,16 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
 #include "header_umbrella.h"

--- a/test/general/multiple_translation_units/translation_unit2.cpp
+++ b/test/general/multiple_translation_units/translation_unit2.cpp
@@ -1,0 +1,1 @@
+#include "header_umbrella.h"


### PR DESCRIPTION
The newly added test checks for ODR violations.

There are two object files including all oneDPL public headers which are linked with another one which contains `main` and does nothing.

It addresses #1229.