### PR TITLE
[oneDPL][tests] Remove unrequired `typename` keywords

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -564,8 +564,9 @@ struct __parallel_copy_if_static_single_group_submitter<_Size, _ElemsPerItem, _W
 
         // This type is used as a workaround for when an internal tuple is assigned to ::std::tuple, such as
         // with zip_iterator
-        using __tuple_type = typename ::oneapi::dpl::__internal::__get_tuple_type<
-            typename ::std::decay_t<decltype(__in_rng[0])>, typename ::std::decay_t<decltype(__out_rng[0])>>::__type;
+        using __tuple_type =
+            typename ::oneapi::dpl::__internal::__get_tuple_type<std::decay_t<decltype(__in_rng[0])>,
+                                                                 std::decay_t<decltype(__out_rng[0])>>::__type;
 
         constexpr ::std::uint32_t __elems_per_wg = _ElemsPerItem * _WGSize;
         using __result_and_scratch_storage_t = __result_and_scratch_storage<_Policy, _Size>;

--- a/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/exclusive_scan_by_segment.pass.cpp
@@ -90,10 +90,10 @@ DEFINE_TEST_2(test_exclusive_scan_by_segment, BinaryPredicate, BinaryOperation)
         if (n < 1)
             return;
 
-        using key_type = typename ::std::decay_t<decltype(host_keys[0])>;
+        using key_type = std::decay_t<decltype(host_keys[0])>;
         key_type current_key = key_type(999); //not one of the input keys
 
-        using value_type = typename ::std::decay_t<decltype(val_res[0])>;
+        using value_type = std::decay_t<decltype(val_res[0])>;
 
         ::std::vector<value_type> expected_val_res(n);
         exclusive_scan_by_segment_serial(host_keys, host_vals, ::std::begin(expected_val_res), n,

--- a/test/support/test_dynamic_load_utils.h
+++ b/test/support/test_dynamic_load_utils.h
@@ -26,7 +26,7 @@ template <typename Op, ::std::size_t CallNumber>
 struct unique_kernel_name;
 
 template <typename Policy, int idx>
-using new_kernel_name = unique_kernel_name<typename ::std::decay_t<Policy>, idx>;
+using new_kernel_name = unique_kernel_name<std::decay_t<Policy>, idx>;
 } // namespace TestUtils
 
 int

--- a/test/support/test_dynamic_selection_utils.h
+++ b/test/support/test_dynamic_selection_utils.h
@@ -23,7 +23,7 @@ template <typename Op, ::std::size_t CallNumber>
 struct unique_kernel_name;
 
 template <typename Policy, int idx>
-using new_kernel_name = unique_kernel_name<typename ::std::decay_t<Policy>, idx>;
+using new_kernel_name = unique_kernel_name<std::decay_t<Policy>, idx>;
 } // namespace TestUtils
 
 static inline void


### PR DESCRIPTION
Issue: https://github.com/oneapi-src/oneDPL/issues/1216

In this PR we remove some unrequired `typename` keywords from oneDPL code and tests.