### PR TITLE
[doc] Fix or remove outdated links to the oneDPL specification

### DIFF
--- a/documentation/CHANGES.rst
+++ b/documentation/CHANGES.rst
@@ -186,7 +186,7 @@ Known Issues and Limitations
 - The ``using namespace oneapi;`` directive in a oneDPL program code may result in compilation errors
   with some compilers including GCC 7 and earlier. Instead of this directive, explicitly use
   ``oneapi::dpl`` namespace, or create a namespace alias.
-- The implementation does not yet provide ``namespace oneapi::std`` as defined in `the oneDPL Specification`_.
+- The implementation does not yet provide ``namespace oneapi::std`` as defined in the oneDPL Specification.
 - The use of the range-based API requires C++17 and the C++ standard libraries coming with GCC 8.1 (or higher)
   or Clang 7 (or higher).
 - ``std::tuple``, ``std::pair`` cannot be used with SYCL buffers to transfer data between host and device.
@@ -576,7 +576,6 @@ Known Issues and Limitations
 
 .. [#fnote1] The sorting algorithms in oneDPL use Radix sort for arithmetic data types compared with
    ``std::less`` or ``std::greater``, otherwise Merge sort.
-.. _`the oneDPL Specification`: https://spec.oneapi.com/versions/latest/elements/oneDPL/source/index.html
 .. _`Intel® oneAPI Threading Building Blocks (oneTBB) Release Notes`: https://www.intel.com/content/www/us/en/developer/articles/release-notes/intel-oneapi-threading-building-blocks-release-notes.html
 .. _`oneDPL Guide`: https://oneapi-src.github.io/oneDPL/index.html
 .. _`Tested Standard C++ API`: https://oneapi-src.github.io/oneDPL/api_for_dpcpp_kernels/tested_standard_cpp_api.html#tested-standard-c-api-reference

--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -2,10 +2,10 @@
 #######################################
 
 The |onedpl_long| (|onedpl_short|) is implemented in accordance with the `oneDPL
-Specification <https://spec.oneapi.io/versions/latest/elements/oneDPL/source/index.html>`_.
+Specification <https://uxlfoundation.github.io/oneAPI-spec/spec/elements/oneDPL/source/index.html>`_.
 
-To support heterogeneity, |onedpl_short| works with the DPC++ API. More information can be found in the
-`oneAPI Specification <https://spec.oneapi.io/versions/latest/elements/sycl/source/index.html>`_.
+To support heterogeneity, |onedpl_short| uses `SYCL <https://registry.khronos.org/SYCL/>`_.
+More information about SYCL can be found in the `SYCL Specification`_.
 
 Before You Begin
 ================
@@ -90,15 +90,13 @@ Useful Information
 
 .. _library-restrictions:
 
-
 Difference with Standard C++ Parallel Algorithms
 ************************************************
 
 * oneDPL execution policies only result in parallel execution if random access iterators are provided,
   the execution will remain serial for other iterator types.
 * Function objects passed in to algorithms executed with device policies must provide ``const``-qualified ``operator()``.
-  `The SYCL specification <https://registry.khronos.org/SYCL/>`_ states that writing to such an object during a SYCL
-  kernel is undefined behavior.
+  The `SYCL specification`_ states that writing to such an object during a SYCL kernel is undefined behavior.
 * For the following algorithms, ``par_unseq`` and ``unseq`` policies do not result in SIMD execution:
   ``includes``, ``inplace_merge``, ``merge``, ``set_difference``, ``set_intersection``,
   ``set_symmetric_difference``, ``set_union``, ``stable_partition``, ``unique``.
@@ -167,3 +165,5 @@ Known Limitations
   the dereferenced value type of the provided iterators should satisfy the ``DefaultConstructible`` requirements.
 * For ``remove``, ``remove_if``, ``unique`` the dereferenced value type of the provided
   iterators should be ``MoveConstructible``.
+
+.. _`SYCL Specification`: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html

--- a/documentation/library_guide/kernel_templates/esimd/radix_sort.rst
+++ b/documentation/library_guide/kernel_templates/esimd/radix_sort.rst
@@ -314,7 +314,7 @@ The initial configuration may be selected according to these high-level guidelin
    since ``param.workgroup_size`` currently supports only one value (`64`).
 
 
-.. [#fnote1] Andy Adinets and Duane Merrill (2022). Onesweep: A Faster Least Significant Digit Radix Sort for GPUs. Retrieved from https://arxiv.org/abs/2206.01784.
+.. [#fnote1] Andy Adinets and Duane Merrill (2022). Onesweep: A Faster Least Significant Digit Radix Sort for GPUs. https://arxiv.org/abs/2206.01784.
 .. [#fnote2] The X\ :sup:`e`-core term is described in the `oneAPI GPU Optimization Guide
    <https://www.intel.com/content/www/us/en/docs/oneapi/optimization-guide-gpu/2024-0/intel-xe-gpu-architecture.html#XE-CORE>`_.
    Check the number of cores in the device specification, such as `Intel® Data Center GPU Max specification

--- a/documentation/library_guide/kernel_templates/esimd/radix_sort_by_key.rst
+++ b/documentation/library_guide/kernel_templates/esimd/radix_sort_by_key.rst
@@ -355,7 +355,7 @@ The initial configuration may be selected according to these high-level guidelin
    since ``param.workgroup_size`` currently supports only one value (`64`).
 
 
-.. [#fnote1] Andy Adinets and Duane Merrill (2022). Onesweep: A Faster Least Significant Digit Radix Sort for GPUs. Retrieved from https://arxiv.org/abs/2206.01784.
+.. [#fnote1] Andy Adinets and Duane Merrill (2022). Onesweep: A Faster Least Significant Digit Radix Sort for GPUs. https://arxiv.org/abs/2206.01784.
 .. [#fnote2] The X\ :sup:`e`-core term is described in the `oneAPI GPU Optimization Guide
    <https://www.intel.com/content/www/us/en/docs/oneapi/optimization-guide-gpu/2024-0/intel-xe-gpu-architecture.html#XE-CORE>`_.
    Check the number of cores in the device specification, such as `Intel® Data Center GPU Max specification

--- a/documentation/library_guide/kernel_templates/kernel_configuration.rst
+++ b/documentation/library_guide/kernel_templates/kernel_configuration.rst
@@ -58,21 +58,19 @@ Member Types
 | ``kernel_name`` | ``KernelName`` | An optional parameter that is used to set a kernel name.                         |
 |                 |                |                                                                                  |
 |                 |                | .. note::                                                                        |
-|                 |                |                                                                                  |
-|                 |                |     The ``KernelName`` parameter might be required in case an implementation of  |
-|                 |                |     SYCL is not fully compliant with the SYCL 2020 Specification and             |
-|                 |                |     does not support optional kernel names.                                      |
+|                 |                |     The ``KernelName`` parameter might be required in case an implementation     |
+|                 |                |     of SYCL is not fully compliant with the `SYCL 2020 Specification`_           |
+|                 |                |     and does not support optional kernel names.                                  |
 |                 |                |                                                                                  |
 |                 |                | If omitted, SYCL kernel name(s) will be automatically generated.                 |
 |                 |                |                                                                                  |
 |                 |                | If provided, it must be a unique C++ typename that satisfies the requirements    |
-|                 |                | for SYCL kernel names (see `SYCL 2020 Specification                              |
-|                 |                | <https://registry.khronos.org/SYCL/specs/                                        |
-|                 |                | sycl-2020/html/sycl-2020.html#sec:naming.kernels>`_).                            |
+|                 |                | for SYCL kernel names in the `SYCL 2020 Specification`_.                         |
 |                 |                |                                                                                  |
 |                 |                | .. note::                                                                        |
-|                 |                |                                                                                  |
 |                 |                |    The provided name can be augmented by oneDPL when used with                   |
 |                 |                |    a template that creates multiple SYCL kernels.                                |
 |                 |                |                                                                                  |
 +-----------------+----------------+----------------------------------------------------------------------------------+
+
+.. _`SYCL 2020 Specification`: https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:naming.kernels

--- a/documentation/library_guide/kernel_templates/single_pass_scan.rst
+++ b/documentation/library_guide/kernel_templates/single_pass_scan.rst
@@ -81,7 +81,9 @@ Parameters
   - The function is intended to be asynchronous, but in some cases, the function will not return until the algorithm fully completes.
     Although intended in the future to be an asynchronous call, the algorithm is currently synchronous.
   - The SYCL device associated with the provided queue must support 64-bit atomic operations if the element type is 64-bits.
-  - There must be a known identity value for the provided combination of the element type and the binary operation. That is, ``sycl::has_known_identity_v`` must evaluate to true. Such operators are listed in the `SYCL 2020 specification <https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#table.identities>`_.
+  - There must be a known identity value for the provided combination of the element type and the binary operation. That is,
+    ``sycl::has_known_identity_v`` must evaluate to true. Such operators are listed in
+    the `SYCL 2020 specification <https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#table.identities>`_.
 
 Return Value
 ------------

--- a/documentation/release_notes.rst
+++ b/documentation/release_notes.rst
@@ -524,7 +524,7 @@ Existing Issues
 - The ``using namespace oneapi;`` directive in a oneDPL program code may result in compilation errors
   with some compilers including GCC 7 and earlier. Instead of this directive, explicitly use
   ``oneapi::dpl`` namespace, or create a namespace alias.
-- The implementation does not yet provide ``namespace oneapi::std`` as defined in `the oneDPL Specification`_.
+- The implementation does not yet provide ``namespace oneapi::std`` as defined in the oneDPL Specification.
 - The use of the range-based API requires C++17 and the C++ standard libraries coming with GCC 8.1 (or higher)
   or Clang 7 (or higher).
 - ``std::tuple``, ``std::pair`` cannot be used with SYCL buffers to transfer data between host and device.
@@ -578,7 +578,7 @@ Existing Issues
 - The ``using namespace oneapi;`` directive in a oneDPL program code may result in compilation errors
   with some compilers including GCC 7 and earlier. Instead of this directive, explicitly use
   ``oneapi::dpl`` namespace, or create a namespace alias.
-- The implementation does not yet provide ``namespace oneapi::std`` as defined in `the oneDPL Specification`_.
+- The implementation does not yet provide ``namespace oneapi::std`` as defined in the oneDPL Specification.
 - The use of the range-based API requires C++17 and the C++ standard libraries coming with GCC 8.1 (or higher)
   or Clang 7 (or higher).
 - ``std::tuple``, ``std::pair`` cannot be used with SYCL buffers to transfer data between host and device.
@@ -635,7 +635,7 @@ Existing Issues
 - The ``using namespace oneapi;`` directive in a oneDPL program code may result in compilation errors
   with some compilers including GCC 7 and earlier. Instead of this directive, explicitly use
   ``oneapi::dpl`` namespace, or create a namespace alias.
-- The implementation does not yet provide ``namespace oneapi::std`` as defined in `the oneDPL Specification`_.
+- The implementation does not yet provide ``namespace oneapi::std`` as defined in the oneDPL Specification.
 - The use of the range-based API requires C++17 and the C++ standard libraries coming with GCC 8.1 (or higher)
   or Clang 7 (or higher).
 - ``std::tuple``, ``std::pair`` cannot be used with SYCL buffers to transfer data between host and device.
@@ -689,7 +689,7 @@ Known Issues and Limitations
 - The ``using namespace oneapi;`` directive in a oneDPL program code may result in compilation errors
   with some compilers including GCC 7 and earlier. Instead of this directive, explicitly use
   ``oneapi::dpl`` namespace, or create a namespace alias.
-- The implementation does not yet provide ``namespace oneapi::std`` as defined in `the oneDPL Specification`_.
+- The implementation does not yet provide ``namespace oneapi::std`` as defined in the oneDPL Specification.
 - The use of the range-based API requires C++17 and the C++ standard libraries coming with GCC 8.1 (or higher)
   or Clang 7 (or higher).
 - ``std::tuple``, ``std::pair`` cannot be used with SYCL buffers to transfer data between host and device.
@@ -708,7 +708,7 @@ New in 2021.1 Gold
 
 Key Features
 -------------
-- This version implements `the oneDPL Specification`_ v1.0, including parallel algorithms,
+- This version implements the oneDPL Specification v1.0, including parallel algorithms,
   DPC++ execution policies, special iterators, and other utilities.
 - oneDPL algorithms can work with data in DPC++ buffers as well as in unified shared memory (USM).
 - For several algorithms, experimental API that accepts ranges (similar to C++20) is additionally provided.
@@ -731,7 +731,7 @@ Known Issues and Limitations
   ``oneapi::dpl`` namespace, or create a namespace alias.
 - The ``partial_sort_copy``, ``sort`` and ``stable_sort`` algorithms are prone to ``CL_BUILD_PROGRAM_FAILURE``
   when a program uses Radix sort [#fnote1]_, is built with -O0 option and executed on CPU devices.
-- The implementation does not yet provide ``namespace oneapi::std`` as defined in `the oneDPL Specification`_.
+- The implementation does not yet provide ``namespace oneapi::std`` as defined in the oneDPL Specification.
 - The use of the range-based API requires C++17 and the C++ standard libraries coming with GCC 8.1 (or higher)
   or Clang 7 (or higher).
 - ``std::tuple``, ``std::pair`` cannot be used with SYCL buffers to transfer data between host and device.
@@ -747,7 +747,6 @@ Known Issues and Limitations
 
 .. [#fnote1] The sorting algorithms in oneDPL use Radix sort for arithmetic data types and
    ``sycl::half`` (since oneDPL 2022.6) compared with ``std::less`` or ``std::greater``, otherwise Merge sort.
-.. _`the oneDPL Specification`: https://spec.oneapi.com/versions/latest/elements/oneDPL/source/index.html
 .. _`oneDPL Guide`: https://oneapi-src.github.io/oneDPL/index.html
 .. _`Intel® oneAPI Threading Building Blocks (oneTBB) Release Notes`: https://www.intel.com/content/www/us/en/developer/articles/release-notes/intel-oneapi-threading-building-blocks-release-notes.html
 .. _`restrictions and known limitations`: https://oneapi-src.github.io/oneDPL/introduction.html#restrictions.


### PR DESCRIPTION
The link to the specification in the introduction is updated. The links in change logs are removed, as the specification rule which the logs refer to has been removed since then.

Additionally, I looked at other links and made some modifications, particularly for the links to the SYCL specification, and a few other cosmetic improvements.