### PR TITLE
[doc] Use code directives for code and literal blocks for output

### DIFF
--- a/documentation/library_guide/dynamic_selection_api/auto_tune_policy.rst
+++ b/documentation/library_guide/dynamic_selection_api/auto_tune_policy.rst
@@ -127,7 +127,7 @@ The selection algorithm for ``auto_tune_policy`` uses runtime profiling
 to choose the best resource for the given function. A simplified, expository 
 implementation of the selection algorithm follows:
  
-.. code::
+.. code:: cpp
 
   template<typename Function, typename ...Args>
   selection_type auto_tune_policy::select(Function&& f, Args&&...args) {

--- a/documentation/library_guide/dynamic_selection_api/dynamic_load_policy.rst
+++ b/documentation/library_guide/dynamic_selection_api/dynamic_load_policy.rst
@@ -122,7 +122,7 @@ available resource.
 
 Simplified, expository implementation of the selection algorithm:
  
-.. code::
+.. code:: cpp
 
   template<typename... Args>
   selection_type dynamic_load_policy::select(Args&& ...) {

--- a/documentation/library_guide/dynamic_selection_api/fixed_resource_policy.rst
+++ b/documentation/library_guide/dynamic_selection_api/fixed_resource_policy.rst
@@ -138,7 +138,7 @@ resource is set during construction or deferred initialization.
 
 Simplified, expository implementation of the selection algorithm:
  
-.. code::
+.. code:: cpp
 
   template<typename... Args>
   selection_type fixed_resource_policy::select(Args&& ...) {

--- a/documentation/library_guide/dynamic_selection_api/functions.rst
+++ b/documentation/library_guide/dynamic_selection_api/functions.rst
@@ -42,9 +42,7 @@ An example that calls ``select`` using a ``round_robin_policy``:
     }
   }
   
-The output of this example:
-
-.. code::
+The output of this example is::
 
   selected queue is cpu
   selected queue is gpu
@@ -134,9 +132,7 @@ submitted to the selected queue.
     }
   }
 
-The output from this example:
-
-.. code::
+The output from this example is::
 
   (j == 0): submit to cpu
   (i == 0): async work on main thread
@@ -204,9 +200,7 @@ command groups can be submitted to the selected queue.
     }
   }
 
-The output from this example:
-
-.. code::
+The output from this example is::
 
   (j == 0): submit to cpu
   (i == 0): async work on main thread
@@ -269,9 +263,7 @@ the object returned by ``get_submission_group()`` to ``wait``:
     std::cout << "done waiting for all submissions\n";
   }
   
-The output from this example:
-
-.. code::
+The output from this example is::
 
   (j == 0): submit to cpu
   (i == 0): async work on main thread
@@ -345,9 +337,7 @@ submitted to the selected queue.
     }
   }
 
-The output from this example:
-
-.. code::
+The output from this example is::
 
   (j == 0): submit to cpu
   (i == 0): submission done
@@ -410,9 +400,7 @@ submitted to the selected queue.
   }
 
 
-The output from this example:
-
-.. code::
+The output from this example is::
 
   (j == 0): submit to cpu
   (i == 0): submission done
@@ -462,9 +450,7 @@ selects from. The following example demonstrates the use of the function
       std::cout << "queue is " << ((q.get_device().is_gpu()) ? "gpu\n" : "not-gpu\n");
   }
   
-The output from this example on a test machine is shown below. 
-
-.. code::
+The output from this example on a test machine is::
 
   Resources in explicitly set policy
   queue is cpu

--- a/documentation/library_guide/dynamic_selection_api/policies.rst
+++ b/documentation/library_guide/dynamic_selection_api/policies.rst
@@ -100,9 +100,7 @@ An example, demonstrating this difference, is shown below:
     print_type("p2 selection 4: ", p2s4);
   }
 
-The output of this example:
-
-.. code::
+The output of this example is::
 
   p1 selection 1: cpu
   p2 selection 1: cpu

--- a/documentation/library_guide/dynamic_selection_api/round_robin_policy.rst
+++ b/documentation/library_guide/dynamic_selection_api/round_robin_policy.rst
@@ -116,7 +116,7 @@ The selection algorithm for ``round_robin_policy`` rotates through
 the elements of the set of available resources. A simplified, expository 
 implementation of the selection algorithm follows:
  
-.. code::
+.. code:: cpp
 
   template<typename ...Args>
   selection_type round_robin_policy::select(Args&&...) {

--- a/documentation/library_guide/dynamic_selection_api_main.rst
+++ b/documentation/library_guide/dynamic_selection_api_main.rst
@@ -68,9 +68,7 @@ In the preceding example, the key points in the code include:
 #. The submit function returns an object that can be waited on. Calling ``wait`` on the ``done`` object blocks the main thread until the work submitted to the queue by your function is complete.
 #. The whole group of submissions made during the loop can be waited on. In this example, the call is redundant, since each submission was already waited for inside of the loop body.
  
-The output from this example is:
-
-.. code::
+The output from this example is::
 
   submit task to cpu
   submit task to gpu

--- a/documentation/library_guide/introduction.rst
+++ b/documentation/library_guide/introduction.rst
@@ -67,17 +67,13 @@ Follow the steps below to build your code with |onedpl_short|:
 #. To build with the |dpcpp_cpp|, see the |dpcpp_gsg|_ for details.
 #. Set the environment variables for |onedpl_short| and |onetbb_short|.
 
-Below is an example of a command line used to compile code that contains |onedpl_short| parallel algorithms
-on Linux* (depending on the code, parameters within [] could be unnecessary):
-
-.. code::
+Here is an example of a command line used to compile code that contains |onedpl_short| parallel algorithms
+on Linux* (depending on the code, parameters within [] could be unnecessary)::
 
   icpx [-fsycl] [-fiopenmp] program.cpp [-ltbb] -o program
 
 You may also use the |pstl_offload_option|_ of |dpcpp_cpp| powered by |onedpl_short|
-to build the standard C++ code for execution on a SYCL device:
-
-.. code::
+to build the standard C++ code for execution on a SYCL device::
 
   icpx -fsycl -fsycl-pstl-offload=gpu program.cpp -o program
 

--- a/documentation/library_guide/kernel_templates/esimd/radix_sort.rst
+++ b/documentation/library_guide/kernel_templates/esimd/radix_sort.rst
@@ -152,9 +152,7 @@ In-Place Example
       return 0;
    }
 
-**Output:**
-
-.. code:: none
+**Output**::
 
    5 3 3 3 2 1
 
@@ -203,9 +201,7 @@ Out-of-Place Example
       return 0;
    }
 
-**Output:**
-
-.. code:: none
+**Output**::
 
    3 2 1 5 3 3
    5 3 3 3 2 1

--- a/documentation/library_guide/kernel_templates/esimd/radix_sort_by_key.rst
+++ b/documentation/library_guide/kernel_templates/esimd/radix_sort_by_key.rst
@@ -172,9 +172,7 @@ In-Place Example
       return 0;
    }
 
-**Output:**
-
-.. code:: none
+**Output**::
 
    1 2 3 3 3 5
    s o r t e d
@@ -245,9 +243,7 @@ Out-of-Place Example
       return 0;
    }
 
-**Output:**
-
-.. code:: none
+**Output**::
 
    3 2 1 5 3 3
    r o s d t e

--- a/documentation/library_guide/kernel_templates/single_pass_scan.rst
+++ b/documentation/library_guide/kernel_templates/single_pass_scan.rst
@@ -133,9 +133,7 @@ inclusive_scan Example
       return 0;
    }
 
-**Output:**
-
-.. code:: none
+**Output**::
 
    1 3 4 7 8 10
 

--- a/documentation/library_guide/parallel_api/iterators.rst
+++ b/documentation/library_guide/parallel_api/iterators.rst
@@ -6,7 +6,9 @@ header.  All iterators are implemented in the ``oneapi::dpl`` namespace.
 
 * ``counting_iterator``: a random-access iterator-like type whose dereferenced value is an integer
   counter. Instances of a ``counting_iterator`` provide read-only dereference operations. The counter of an
-  ``counting_iterator`` instance changes according to the arithmetic of the random-access iterator type::
+  ``counting_iterator`` instance changes according to the arithmetic of the random-access iterator type:
+
+  .. code:: cpp
 
     dpl::counting_iterator<int> count_a(0);
     dpl::counting_iterator<int> count_b = count_a + 10;
@@ -25,7 +27,9 @@ header.  All iterators are implemented in the ``oneapi::dpl`` namespace.
 
   The ``zip_iterator`` is useful in defining by key algorithms where input iterators
   representing keys and values are processed as key-value pairs. The example below demonstrates a stable sort
-  by key, where only the keys are compared but both keys and values are swapped::
+  by key, where only the keys are compared but both keys and values are swapped:
+
+  .. code:: cpp
 
     auto zipped_begin = dpl::make_zip_iterator(keys_begin, vals_begin);
     dpl::stable_sort(dpl::execution::dpcpp_default, zipped_begin, zipped_begin + n,
@@ -33,7 +37,9 @@ header.  All iterators are implemented in the ``oneapi::dpl`` namespace.
 
   The dereferenced object of ``zip_iterator`` supports the *structured binding* feature (`C++17 and above
   <https://en.cppreference.com/w/cpp/language/structured_binding>`_) for easier access to
-  wrapped iterators values::
+  wrapped iterators values:
+
+  .. code:: cpp
 
     auto zipped_begin = dpl::make_zip_iterator(sequence1.begin(), sequence2.begin(), sequence3.begin());
     auto found = dpl::find(dpl::execution::dpcpp_default, zipped_begin, zipped_begin + n,
@@ -54,7 +60,9 @@ header.  All iterators are implemented in the ``oneapi::dpl`` namespace.
   The ``discard_iterator`` is useful in the implementation of stencil algorithms where the stencil is not part of the
   desired output. An example of this would be a ``copy_if`` algorithm that receives an input iterator range,
   a stencil iterator range, and copies the elements of the input whose corresponding stencil value is 1. Use
-  ``discard_iterator`` so you do not declare a temporary allocation to store the copy of the stencil::
+  ``discard_iterator`` so you do not declare a temporary allocation to store the copy of the stencil:
+
+  .. code:: cpp
 
     auto zipped_first = dpl::make_zip_iterator(first, stencil);
     dpl::copy_if(dpl::execution::dpcpp_default,
@@ -83,7 +91,9 @@ header.  All iterators are implemented in the ``oneapi::dpl`` namespace.
 
   To simplify the construction of the iterator, ``oneapi::dpl::make_transform_iterator`` is provided. The
   function receives the base iterator and transform operation instance as arguments, and constructs the
-  ``transform_iterator`` instance::
+  ``transform_iterator`` instance:
+
+  .. code:: cpp
 
     dpl::counting_iterator<int> first(0);
     dpl::counting_iterator<int> last(10);
@@ -101,7 +111,9 @@ header.  All iterators are implemented in the ``oneapi::dpl`` namespace.
   in cases where algorithms are executed with device policies.
 
   The ``make_permutation_iterator`` is provided to simplify construction of iterator instances. The function
-  receives the source iterator and the iterator or function object representing the index map::
+  receives the source iterator and the iterator or function object representing the index map:
+
+  .. code:: cpp
 
     struct multiply_index_by_two {
         template <typename Index>


### PR DESCRIPTION
Instead of `.. code:: none` directive (or the one with no language), it is better to use so-called literal blocks (https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#rst-literal-blocks) for output, command lines etc.

And vice versa, for code samples it is better to use the directive, not a literal block.