### PR TITLE
Remove system requirements section for ESIMD-based KT

### DIFF
--- a/documentation/library_guide/kernel_templates/esimd/radix_sort.rst
+++ b/documentation/library_guide/kernel_templates/esimd/radix_sort.rst
@@ -9,6 +9,10 @@ The ``radix_sort`` function sorts data using the radix sort algorithm.
 The sorting is stable, preserving the relative order of elements with equal keys.
 Both in-place and out-of-place overloads are provided. Out-of-place overloads do not alter the input sequence.
 
+.. note::
+   the ``radix_sort`` is currently available only for Intel® Data Center GPU Max Series,
+   and requires Intel® oneAPI DPC++/C++ Compiler 2023.2 and newer.
+
 The functions implement a Onesweep* [#fnote1]_ algorithm variant.
 
 A synopsis of the ``radix_sort`` function is provided below:

--- a/documentation/library_guide/kernel_templates/esimd/radix_sort.rst
+++ b/documentation/library_guide/kernel_templates/esimd/radix_sort.rst
@@ -11,7 +11,7 @@ Both in-place and out-of-place overloads are provided. Out-of-place overloads do
 
 .. note::
    the ``radix_sort`` is currently available only for Intel® Data Center GPU Max Series,
-   and requires Intel® oneAPI DPC++/C++ Compiler 2023.2 and newer.
+   and requires Intel® oneAPI DPC++/C++ Compiler 2023.2 or newer.
 
 The functions implement a Onesweep* [#fnote1]_ algorithm variant.
 

--- a/documentation/library_guide/kernel_templates/esimd/radix_sort.rst
+++ b/documentation/library_guide/kernel_templates/esimd/radix_sort.rst
@@ -9,10 +9,6 @@ The ``radix_sort`` function sorts data using the radix sort algorithm.
 The sorting is stable, preserving the relative order of elements with equal keys.
 Both in-place and out-of-place overloads are provided. Out-of-place overloads do not alter the input sequence.
 
-.. note::
-   the ``radix_sort`` is currently available only for Intel® Data Center GPU Max Series,
-   and requires Intel® oneAPI DPC++/C++ Compiler 2023.2 or newer.
-
 The functions implement a Onesweep* [#fnote1]_ algorithm variant.
 
 A synopsis of the ``radix_sort`` function is provided below:
@@ -51,6 +47,9 @@ A synopsis of the ``radix_sort`` function is provided below:
                KernelParam param); // (4)
    }
 
+.. note::
+   The ``radix_sort`` is currently available only for Intel® Data Center GPU Max Series,
+   and requires Intel® oneAPI DPC++/C++ Compiler 2023.2 or newer.
 
 Template Parameters
 --------------------

--- a/documentation/library_guide/kernel_templates/esimd/radix_sort_by_key.rst
+++ b/documentation/library_guide/kernel_templates/esimd/radix_sort_by_key.rst
@@ -11,7 +11,7 @@ Both in-place and out-of-place overloads are provided. Out-of-place overloads do
 
 .. note::
    the ``radix_sort_by_key`` is currently available only for Intel® Data Center GPU Max Series,
-   and requires Intel® oneAPI DPC++/C++ Compiler 2023.2 and newer.
+   and requires Intel® oneAPI DPC++/C++ Compiler 2023.2 or newer.
 
 The functions implement a Onesweep* [#fnote1]_ algorithm variant.
 

--- a/documentation/library_guide/kernel_templates/esimd/radix_sort_by_key.rst
+++ b/documentation/library_guide/kernel_templates/esimd/radix_sort_by_key.rst
@@ -9,6 +9,10 @@ The ``radix_sort_by_key`` function sorts keys using the radix sort algorithm, ap
 The sorting is stable, preserving the relative order of elements with equal keys.
 Both in-place and out-of-place overloads are provided. Out-of-place overloads do not alter the input sequences.
 
+.. note::
+   the ``radix_sort_by_key`` is currently available only for Intel® Data Center GPU Max Series,
+   and requires Intel® oneAPI DPC++/C++ Compiler 2023.2 and newer.
+
 The functions implement a Onesweep* [#fnote1]_ algorithm variant.
 
 A synopsis of the ``radix_sort_by_key`` function is provided below:

--- a/documentation/library_guide/kernel_templates/esimd/radix_sort_by_key.rst
+++ b/documentation/library_guide/kernel_templates/esimd/radix_sort_by_key.rst
@@ -9,8 +9,6 @@ The ``radix_sort_by_key`` function sorts keys using the radix sort algorithm, ap
 The sorting is stable, preserving the relative order of elements with equal keys.
 Both in-place and out-of-place overloads are provided. Out-of-place overloads do not alter the input sequences.
 
-
-
 The functions implement a Onesweep* [#fnote1]_ algorithm variant.
 
 A synopsis of the ``radix_sort_by_key`` function is provided below:

--- a/documentation/library_guide/kernel_templates/esimd/radix_sort_by_key.rst
+++ b/documentation/library_guide/kernel_templates/esimd/radix_sort_by_key.rst
@@ -9,9 +9,7 @@ The ``radix_sort_by_key`` function sorts keys using the radix sort algorithm, ap
 The sorting is stable, preserving the relative order of elements with equal keys.
 Both in-place and out-of-place overloads are provided. Out-of-place overloads do not alter the input sequences.
 
-.. note::
-   the ``radix_sort_by_key`` is currently available only for Intel® Data Center GPU Max Series,
-   and requires Intel® oneAPI DPC++/C++ Compiler 2023.2 or newer.
+
 
 The functions implement a Onesweep* [#fnote1]_ algorithm variant.
 
@@ -57,6 +55,9 @@ A synopsis of the ``radix_sort_by_key`` function is provided below:
                       KernelParam param); // (4)
    }
 
+.. note::
+   The ``radix_sort_by_key`` is currently available only for Intel® Data Center GPU Max Series,
+   and requires Intel® oneAPI DPC++/C++ Compiler 2023.2 or newer.
 
 Template Parameters
 --------------------

--- a/documentation/library_guide/kernel_templates/esimd_main.rst
+++ b/documentation/library_guide/kernel_templates/esimd_main.rst
@@ -17,14 +17,3 @@ These templates are available in the ``oneapi::dpl::experimental::kt::gpu::esimd
    esimd/radix_sort
    esimd/radix_sort_by_key
 
--------------------
-System Requirements
--------------------
-
-- Hardware: Intel® Data Center GPU Max Series.
-- Compiler: Intel® oneAPI DPC++/C++ Compiler 2023.2 and newer.
-- Operating Systems:
-
-  - Red Hat Enterprise Linux* 9.2,
-  - SUSE Linux Enterprise Server* 15 SP5,
-  - Ubuntu* 22.04.


### PR DESCRIPTION
The information is partially outdated. Additionally the set of the supported systems matches what the compiler/driver stack supports, that is why I suggest omitting it.