### PR TITLE
[Test] Fix for ranges testing in multi translational units

### DIFF
--- a/test/general/multiple_translation_units/header_umbrella.h
+++ b/test/general/multiple_translation_units/header_umbrella.h
@@ -48,7 +48,10 @@
 #   include <oneapi/dpl/random>
 #endif
 
-#include <oneapi/dpl/ranges>
+#if _ENABLE_RANGES_TESTING
+#   include <oneapi/dpl/ranges>
+#endif
+
 #include <oneapi/dpl/ratio>
 #include <oneapi/dpl/tuple>
 #include <oneapi/dpl/type_traits>


### PR DESCRIPTION
Bugfix for multi translational units test.
Ranges header can only be included in combination with certain STL versions, we need to guard the ranges header include.