### PR TITLE
Avoid extra loops on sorted data in the `__subgroup_bubble_sorter::sort`

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
@@ -40,16 +40,20 @@ struct __subgroup_bubble_sorter
     void
     sort(const _StorageAcc& __storage_acc, _Compare __comp, std::uint32_t __start, std::uint32_t __end) const
     {
-        for (std::uint32_t i = __start; i < __end; ++i)
+        bool __changed = true;
+
+        for (std::uint32_t i = __start; i < __end && __changed; ++i)
         {
+            __changed = false;
+
             for (std::uint32_t j = __start + 1; j < __start + __end - i; ++j)
             {
                 auto& __first_item = __storage_acc[j - 1];
                 auto& __second_item = __storage_acc[j];
                 if (__comp(__second_item, __first_item))
                 {
-                    using std::swap;
-                    swap(__first_item, __second_item);
+                    std::swap(__first_item, __second_item);
+                    __changed = true;
                 }
             }
         }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
@@ -54,7 +54,10 @@ struct __subgroup_bubble_sorter
                 auto& __first_item = __storage_acc[__start];
                 auto& __second_item = __storage_acc[__start + 1];
                 if (__comp(__second_item, __first_item))
-                    std::swap(__first_item, __second_item);
+                {
+                    using std::swap;
+                    swap(__first_item, __second_item);
+                }
             }
             break;
         default:
@@ -67,7 +70,8 @@ struct __subgroup_bubble_sorter
                     auto& __second_item = __storage_acc[__start + __i];
                     if (__comp(__second_item, __first_item))
                     {
-                        std::swap(__first_item, __second_item);
+                        using std::swap;
+                        swap(__first_item, __second_item);
                         __new_n = __i;
                     }
                 }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
@@ -44,10 +44,10 @@ struct __subgroup_bubble_sorter
 
         switch (__n)
         {
-        case 0:
-        case 1:
+        case 0:             // The case when __end == __start       no source data means no sorting required
+        case 1:             // The case when __end == __start + 1   one source data item means no sorting required
             break;
-        case 2:
+        case 2:             // The case when __end == __start + 2   two source data items required only one comparison (and swap) without any loops and etc.
             {
                 auto& __first_item = __storage_acc[__start];
                 auto& __second_item = __storage_acc[__start + 1];
@@ -58,7 +58,7 @@ struct __subgroup_bubble_sorter
                 }
             }
             break;
-        default:
+        default:            // The case when __end > __start + 2    three or more source data items require full bubble sort
             do
             {
                 std::uint32_t __new_n = 0;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
@@ -40,22 +40,39 @@ struct __subgroup_bubble_sorter
     void
     sort(const _StorageAcc& __storage_acc, _Compare __comp, std::uint32_t __start, std::uint32_t __end) const
     {
-        bool __changed = true;
+        using _IndexType = std::make_signed_t<decltype(__end)>;
 
-        for (std::uint32_t i = __start; i < __end && __changed; ++i)
+        _IndexType __n = __end - __start;
+
+        switch (__n)
         {
-            __changed = false;
-
-            for (std::uint32_t j = __start + 1; j < __start + __end - i; ++j)
+        case 0:
+        case 1:
+            break;
+        case 2:
             {
-                auto& __first_item = __storage_acc[j - 1];
-                auto& __second_item = __storage_acc[j];
+                auto& __first_item = __storage_acc[__start];
+                auto& __second_item = __storage_acc[__start + 1];
                 if (__comp(__second_item, __first_item))
-                {
                     std::swap(__first_item, __second_item);
-                    __changed = true;
-                }
             }
+            break;
+        default:
+            do
+            {
+                _IndexType __new_n = 0;
+                for (_IndexType __i = 1; __i < __n; ++__i)
+                {
+                    auto& __first_item = __storage_acc[__start + __i - 1];
+                    auto& __second_item = __storage_acc[__start + __i];
+                    if (__comp(__second_item, __first_item))
+                    {
+                        std::swap(__first_item, __second_item);
+                        __new_n = __i;
+                    }
+                }
+                __n = __new_n;
+            } while (__n > 1);
         }
     }
 };

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
@@ -40,9 +40,7 @@ struct __subgroup_bubble_sorter
     void
     sort(const _StorageAcc& __storage_acc, _Compare __comp, std::uint32_t __start, std::uint32_t __end) const
     {
-        using _IndexType = std::make_signed_t<decltype(__end)>;
-
-        _IndexType __n = __end - __start;
+        std::uint32_t __n = __end - __start;
 
         switch (__n)
         {
@@ -63,8 +61,8 @@ struct __subgroup_bubble_sorter
         default:
             do
             {
-                _IndexType __new_n = 0;
-                for (_IndexType __i = 1; __i < __n; ++__i)
+                std::uint32_t __new_n = 0;
+                for (std::uint32_t __i = 1; __i < __n; ++__i)
                 {
                     auto& __first_item = __storage_acc[__start + __i - 1];
                     auto& __second_item = __storage_acc[__start + __i];


### PR DESCRIPTION
In this PR we avoid extra loops on sorted data in the `__subgroup_bubble_sorter::sort`,
which calls in sort algorithms on the device for every work item.

This is beneficial when the data is already sorted, which according to https://en.wikipedia.org/wiki/Sorting_algorithm is a common real-world case.