### PR TITLE
Enabling reduce_then_scan for "Set" family of scan APIs

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1726,8 +1726,10 @@ __pattern_hetero_set_op(__hetero_tag<_BackendTag> __backend_tag, _ExecutionPolic
     auto __keep3 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _OutputIterator>();
     auto __buf3 = __keep3(__result, __result + __n1);
 
-    auto __result_size = __par_backend_hetero::__parallel_set_op(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(),
-                                         __buf2.all_view(), __buf3.all_view(), __comp, __is_op_difference).get();
+    auto __result_size = __par_backend_hetero::__parallel_set_op(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec),
+                                                                 __buf1.all_view(), __buf2.all_view(),
+                                                                 __buf3.all_view(), __comp, __is_op_difference)
+                             .get();
 
     return __result + __result_size;
 }

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1708,7 +1708,7 @@ __pattern_rotate_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Bid
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator1, typename _ForwardIterator2,
           typename _OutputIterator, typename _Compare, typename _IsOpDifference>
 _OutputIterator
-__pattern_hetero_set_op(__hetero_tag<_BackendTag> __backend_tag, _ExecutionPolicy&& __exec, _ForwardIterator1 __first1,
+__pattern_hetero_set_op(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIterator1 __first1,
                         _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
                         _OutputIterator __result, _Compare __comp, _IsOpDifference __is_op_difference)
 {

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1726,7 +1726,7 @@ __pattern_hetero_set_op(__hetero_tag<_BackendTag> __backend_tag, _ExecutionPolic
     auto __keep3 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _OutputIterator>();
     auto __buf3 = __keep3(__result, __result + __n1);
 
-    auto result_size = __parallel_set_op(__backend_tag, std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(),
+    auto __result_size = __par_backend_hetero::__parallel_set_op(_BackendTag{}, std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(),
                                          __buf2.all_view(), __buf3.all_view(), __comp, __is_op_difference).get();
 
     return __result + __result_size;

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -1708,34 +1708,13 @@ __pattern_rotate_copy(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _Bid
 template <typename _BackendTag, typename _ExecutionPolicy, typename _ForwardIterator1, typename _ForwardIterator2,
           typename _OutputIterator, typename _Compare, typename _IsOpDifference>
 _OutputIterator
-__pattern_hetero_set_op(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _ForwardIterator1 __first1,
+__pattern_hetero_set_op(__hetero_tag<_BackendTag> __backend_tag, _ExecutionPolicy&& __exec, _ForwardIterator1 __first1,
                         _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
-                        _OutputIterator __result, _Compare __comp, _IsOpDifference)
+                        _OutputIterator __result, _Compare __comp, _IsOpDifference __is_op_difference)
 {
     typedef typename ::std::iterator_traits<_ForwardIterator1>::difference_type _Size1;
-    typedef typename ::std::iterator_traits<_ForwardIterator2>::difference_type _Size2;
 
     const _Size1 __n1 = __last1 - __first1;
-    const _Size2 __n2 = __last2 - __first2;
-
-    //Algo is based on the recommended approach of set_intersection algo for GPU: binary search + scan (copying by mask).
-    using _ReduceOp = ::std::plus<_Size1>;
-    using _Assigner = unseq_backend::__scan_assigner;
-    using _NoAssign = unseq_backend::__scan_no_assign;
-    using _MaskAssigner = unseq_backend::__mask_assigner<2>;
-    using _InitType = unseq_backend::__no_init_value<_Size1>;
-    using _DataAcc = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;
-
-    _ReduceOp __reduce_op;
-    _Assigner __assign_op;
-    _DataAcc __get_data_op;
-    unseq_backend::__copy_by_mask<_ReduceOp, oneapi::dpl::__internal::__pstl_assign, /*inclusive*/ ::std::true_type, 2>
-        __copy_by_mask_op;
-    unseq_backend::__brick_set_op<_ExecutionPolicy, _Compare, _Size1, _Size2, _IsOpDifference> __create_mask_op{
-        __comp, __n1, __n2};
-
-    // temporary buffer to store boolean mask
-    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, int32_t> __mask_buf(__exec, __n1);
 
     auto __keep1 =
         oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::read, _ForwardIterator1>();
@@ -1747,25 +1726,8 @@ __pattern_hetero_set_op(__hetero_tag<_BackendTag>, _ExecutionPolicy&& __exec, _F
     auto __keep3 = oneapi::dpl::__ranges::__get_sycl_range<__par_backend_hetero::access_mode::write, _OutputIterator>();
     auto __buf3 = __keep3(__result, __result + __n1);
 
-    auto __result_size =
-        __par_backend_hetero::__parallel_transform_scan_base(
-            _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
-            oneapi::dpl::__ranges::make_zip_view(
-                __buf1.all_view(), __buf2.all_view(),
-                oneapi::dpl::__ranges::all_view<int32_t, __par_backend_hetero::access_mode::read_write>(
-                    __mask_buf.get_buffer())),
-            __buf3.all_view(), __reduce_op, _InitType{},
-            // local scan
-            unseq_backend::__scan</*inclusive*/ ::std::true_type, _ExecutionPolicy, _ReduceOp, _DataAcc, _Assigner,
-                                  _MaskAssigner, decltype(__create_mask_op), _InitType>{
-                __reduce_op, __get_data_op, __assign_op, _MaskAssigner{}, __create_mask_op},
-            // scan between groups
-            unseq_backend::__scan</*inclusive=*/::std::true_type, _ExecutionPolicy, _ReduceOp, _DataAcc, _NoAssign,
-                                  _Assigner, _DataAcc, _InitType>{__reduce_op, __get_data_op, _NoAssign{}, __assign_op,
-                                                                  __get_data_op},
-            // global scan
-            __copy_by_mask_op)
-            .get();
+    auto result_size = __parallel_set_op(__backend_tag, std::forward<_ExecutionPolicy>(__exec), __buf1.all_view(),
+                                         __buf2.all_view(), __buf3.all_view(), __comp, __is_op_difference).get();
 
     return __result + __result_size;
 }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -840,9 +840,7 @@ struct __gen_set_mask
 
         std::size_t __nb = __set_b.size();
 
-        auto __id_c = __id;
-        const auto __id_a = __id;
-        auto __val_a = __set_a[__id_a];
+        auto __val_a = __set_a[__id];
 
         auto __res = oneapi::dpl::__internal::__pstl_lower_bound(__set_b, std::size_t{0}, __nb, __val_a, __comp);
 
@@ -850,21 +848,20 @@ struct __gen_set_mask
             _IsOpDifference::value; //initialization in true in case of difference operation; false - intersection.
         if (__res == __nb || __comp(__val_a, __set_b[__res]))
         {
-            // there is no __val_a in __set_b, so __set_b in the difference {__a}/{__b};
+            // there is no __val_a in __set_b, so __set_b in the difference {__set_a}/{__set_b};
         }
         else
         {
             auto __val_b = __set_b[__res];
 
-            //Difference operation logic: if number of duplication in __a on left side from __id > total number of
-            //duplication in __b than a mask is 1
+            //Difference operation logic: if number of duplication in __set_a on left side from __id > total number of
+            //duplication in __set_b than a mask is 1
 
-            //Intersection operation logic: if number of duplication in __a on left side from __id <= total number of
-            //duplication in __b than a mask is 1
+            //Intersection operation logic: if number of duplication in __set_a on left side from __id <= total number of
+            //duplication in __set_b than a mask is 1
 
             const std::size_t __count_a_left =
-                __id_a - oneapi::dpl::__internal::__pstl_left_bound(__set_a, std::size_t{0}, __id_a, __val_a, __comp) +
-                1;
+                __id - oneapi::dpl::__internal::__pstl_left_bound(__set_a, std::size_t{0}, __id, __val_a, __comp) + 1;
 
             const std::size_t __count_b =
                 oneapi::dpl::__internal::__pstl_right_bound(__set_b, __res, __nb, __val_b, __comp) - __res + __res -
@@ -888,7 +885,7 @@ struct __extract_range_from_zip
     auto
     operator()(const _InRng& __in_rng) const
     {
-        return std::get<I>(__in_rng.tuple()); 
+        return std::get<I>(__in_rng.tuple());
     }
 };
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -825,6 +825,58 @@ struct __gen_unique_mask
     _BinaryPredicate __pred;
 };
 
+template <typename _IsOpDifference, typename _Compare>
+struct __gen_set_mask
+{
+    template <typename _InRng>
+    bool
+    operator()(const _InRng& __in_rng, std::size_t __id) const
+    {
+        using ::std::get;
+        auto __set_a = get<0>(__in_rng.tuple()); // first sequence
+        auto __set_b = get<1>(__in_rng.tuple()); // second sequence
+
+
+        std::size_t __nb = __set_b.size();
+
+        auto __id_c = __id;
+        const auto __id_a = __id;
+        auto __val_a = __set_a[__id_a];
+
+        auto __res = __internal::__pstl_lower_bound(__set_b, std::size_t{0}, __nb, __val_a, __comp);
+
+        bool bres = _IsOpDifference::value; //initialization in true in case of difference operation; false - intersection.
+        if (__res == __nb || __comp(__val_a, __set_b[__res]))
+        {
+            // there is no __val_a in __set_b, so __set_b in the difference {__a}/{__b};
+        }
+        else
+        {
+            auto __val_b = __b[__res];
+
+            //Difference operation logic: if number of duplication in __a on left side from __id > total number of
+            //duplication in __b than a mask is 1
+
+            //Intersection operation logic: if number of duplication in __a on left side from __id <= total number of
+            //duplication in __b than a mask is 1
+
+            const _Size1 __count_a_left =
+                __id_a - __internal::__pstl_left_bound(__set_a, 0, __id_a, __val_a, __comp) + 1;
+
+            const _Size2 __count_b = __internal::__pstl_right_bound(__set_b, __res, __nb, __val_b, __comp) - __res +
+                                     __res -
+                                     __internal::__pstl_left_bound(__set_b, 0, __res, __val_b, __comp);
+
+            if constexpr (_IsOpDifference::value)
+                bres = __count_a_left > __count_b; /*difference*/
+            else
+                bres = __count_a_left <= __count_b; /*intersection*/
+        }
+        return bres;
+    }
+    _Compare __comp;
+};
+
 template <typename _GenMask>
 struct __gen_count_mask
 {
@@ -1195,6 +1247,104 @@ __parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag __backend_tag, 
         return __parallel_scan_copy(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
                                     std::forward<_InRng>(__in_rng), std::forward<_OutRng>(__out_rng), __n,
                                     _CreateOp{__pred}, _CopyOp{_ReduceOp{}, __assign});
+    }
+}
+
+
+auto
+template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Compare,
+          typename _IsOpDifference>
+__parallel_set_reduce_then_scan(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
+                          _Range1&& __rng1, _Range2&& __rng2, _Range3&& __result, _Compare __comp, _IsOpDifference)
+{
+    // fill in reduce then scan impl
+    using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_set_mask<_IsOpDifference, _Compare>;
+    using _WriteOp = oneapi::dpl::__par_backend_hetero::__write_to_id_if<0, _Assign>;
+
+    using _GenReduceInput = oneapi::dpl::__par_backend_hetero::__gen_count_mask<_GenMask>;
+    using _ReduceOp = std::plus<_Size>;
+    using _GenScanInput = oneapi::dpl::__par_backend_hetero::__gen_expand_count_mask<_GenMask>;
+    using _ScanInputTransform = oneapi::dpl::__par_backend_hetero::__get_first_set_from_zeroth_ele;
+
+    
+    return __parallel_transform_reduce_then_scan(
+        __backend_tag, std::forward<_ExecutionPolicy>(__exec),
+        oneapi::dpl::__ranges::make_zip_view(std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2)),
+        std::forward<_Range3>(__result), _GenReduceInput{_GenMask{__comp}}}, _ReduceOp{}, _GenScanInput{},
+        _ScanInputTransform{}, _WriteOp{}, oneapi::dpl::unseq_backend::__no_init_value<_Size>{},
+        /*_Inclusive=*/std::true_type{}, /*__is_unique_pattern=*/std::false_type);
+}
+
+
+auto
+template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Compare,
+          typename _IsOpDifference>
+__parallel_set_scan(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
+                    _Range1&& __rng1, _Range2&& __rng2, _Range3&& __result, _Compare __comp,
+                    _IsOpDifference __is_op_difference)
+{
+    using _Size1 = oneapi::dpl::__internal::__difference_t<_Range1>;
+    using _Size2 = oneapi::dpl::__internal::__difference_t<_Range2>;
+
+    _Size1 __n1 = __rng1.size();
+    _Size2 __n2 = __rng2.size();
+
+    //Algo is based on the recommended approach of set_intersection algo for GPU: binary search + scan (copying by mask).
+    using _ReduceOp = ::std::plus<_Size1>;
+    using _Assigner = unseq_backend::__scan_assigner;
+    using _NoAssign = unseq_backend::__scan_no_assign;
+    using _MaskAssigner = unseq_backend::__mask_assigner<2>;
+    using _InitType = unseq_backend::__no_init_value<_Size1>;
+    using _DataAcc = unseq_backend::walk_n<_ExecutionPolicy, oneapi::dpl::__internal::__no_op>;
+
+    _ReduceOp __reduce_op;
+    _Assigner __assign_op;
+    _DataAcc __get_data_op;
+    unseq_backend::__copy_by_mask<_ReduceOp, oneapi::dpl::__internal::__pstl_assign, /*inclusive*/ ::std::true_type, 2>
+        __copy_by_mask_op;
+    unseq_backend::__brick_set_op<_ExecutionPolicy, _Compare, _Size1, _Size2, _IsOpDifference> __create_mask_op{
+        __comp, __n1, __n2};
+
+    // temporary buffer to store boolean mask
+    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, int32_t> __mask_buf(__exec, __n1);
+
+    return __par_backend_hetero::__parallel_transform_scan_base(
+            _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
+            oneapi::dpl::__ranges::make_zip_view(
+                __buf1.all_view(), __buf2.all_view(),
+                oneapi::dpl::__ranges::all_view<int32_t, __par_backend_hetero::access_mode::read_write>(
+                    __mask_buf.get_buffer())),
+            __buf3.all_view(), __reduce_op, _InitType{},
+            // local scan
+            unseq_backend::__scan</*inclusive*/ ::std::true_type, _ExecutionPolicy, _ReduceOp, _DataAcc, _Assigner,
+                                  _MaskAssigner, decltype(__create_mask_op), _InitType>{
+                __reduce_op, __get_data_op, __assign_op, _MaskAssigner{}, __create_mask_op},
+            // scan between groups
+            unseq_backend::__scan</*inclusive=*/::std::true_type, _ExecutionPolicy, _ReduceOp, _DataAcc, _NoAssign,
+                                  _Assigner, _DataAcc, _InitType>{__reduce_op, __get_data_op, _NoAssign{}, __assign_op,
+                                                                  __get_data_op},
+            // global scan
+            __copy_by_mask_op);
+}
+
+
+template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Compare,
+          typename _IsOpDifference>
+auto
+__parallel_set_op(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
+                          _Range1&& __rng1, _Range2&& __rng2, _Range3&& __result, _Compare __comp, _IsOpDifference __is_op_difference)
+    oneapi::dpl::__internal::__difference_t<_Range1> __n = __rng.size();
+    if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec))
+    {
+        return __parallel_set_reduce_then_scan(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
+                                                std::forward<_Range1>(__rng), std::forward<_Range2>(__rng2),
+                                                std::forward<_Range3>(__result), __compare, __is_op_difference);
+    }
+    else
+    {
+        return __parallel_set_scan(__backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng),
+                                   std::forward<_Range2>(__rng2), std::forward<_Range3>(__result), __compare,
+                                   __is_op_difference);
     }
 }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -798,14 +798,14 @@ struct __simple_write_to_id
     }
 };
 
-template <typename _Predicate>
+template <typename _Predicate, typename _RangeTransform = oneapi::dpl::__internal::__no_op>
 struct __gen_mask
 {
     template <typename _InRng>
     bool
-    operator()(const _InRng& __in_rng, std::size_t __id) const
+    operator()(_InRng&& __in_rng, std::size_t __id) const
     {
-        return __pred(__in_rng[__id]);
+        return __pred((_RangeTransform{}(std::forward<_InRng>(__in_rng)))[__id]);
     }
     _Predicate __pred;
 };
@@ -879,16 +879,14 @@ struct __gen_set_mask
     _Compare __comp;
 };
 
-struct __gen_set_cached_mask
+template <std::size_t I>
+struct __extract_range_from_zip
 {
     template <typename _InRng>
-    bool
-    operator()(const _InRng& __in_rng, std::size_t __id) const
+    auto
+    operator()(const _InRng& __in_rng) const
     {
-        // First we must extract invididual sequences from zip iterator because they may not have the same length,
-        // dereferencing is dangerous
-        auto __set_mask = std::get<2>(__in_rng.tuple()); // mask sequence
-        return __set_mask[__id];
+        return std::get<I>(__in_rng.tuple()); 
     }
 };
 
@@ -904,39 +902,19 @@ struct __gen_count_mask
     _GenMask __gen_mask;
 };
 
-template <typename _GenMask>
+template <typename _GenMask, typename _RangeTransform = oneapi::dpl::__internal::__no_op>
 struct __gen_expand_count_mask
 {
     template <typename _InRng, typename _SizeType>
     auto
     operator()(_InRng&& __in_rng, _SizeType __id) const
     {
+        auto __transformed_input = _RangeTransform{}(__in_rng);
         // Explicitly creating this element type is necessary to avoid modifying the input data when _InRng is a
         //  zip_iterator which will return a tuple of references when dereferenced. With this explicit type, we copy
         //  the values of zipped input types rather than their references.
-        using _ElementType = oneapi::dpl::__internal::__value_t<_InRng>;
-        _ElementType ele = __in_rng[__id];
-        bool mask = __gen_mask(std::forward<_InRng>(__in_rng), __id);
-        return std::tuple(mask ? _SizeType{1} : _SizeType{0}, mask, ele);
-    }
-    _GenMask __gen_mask;
-};
-
-template <typename _GenMask>
-struct __gen_expand_set_mask
-{
-    template <typename _InRng, typename _SizeType>
-    auto
-    operator()(_InRng&& __in_rng, _SizeType __id) const
-    {
-        // First we must extract the first sequence from zip iterator because they may not have the same length,
-        // dereferencing is dangerous
-        auto __set_a = std::get<0>(__in_rng.tuple()); // first sequence
-        // Explicitly creating this element type is necessary to avoid modifying the input data when _InRng is a
-        //  zip_iterator which will return a tuple of references when dereferenced. With this explicit type, we copy
-        //  the values of zipped input types rather than their references.
-        using _ElementType = oneapi::dpl::__internal::__value_t<decltype(__set_a)>;
-        _ElementType ele = __set_a[__id];
+        using _ElementType = oneapi::dpl::__internal::__value_t<decltype(__transformed_input)>;
+        _ElementType ele = __transformed_input[__id];
         bool mask = __gen_mask(std::forward<_InRng>(__in_rng), __id);
         return std::tuple(mask ? _SizeType{1} : _SizeType{0}, mask, ele);
     }
@@ -1295,13 +1273,14 @@ __parallel_set_reduce_then_scan(oneapi::dpl::__internal::__device_backend_tag __
 {
     // fill in reduce then scan impl
     using _GenMaskReduce = oneapi::dpl::__par_backend_hetero::__gen_set_mask<_IsOpDifference, _Compare>;
-    using _GenMaskScan = oneapi::dpl::__par_backend_hetero::__gen_set_cached_mask;
+    using _GenMaskScan = oneapi::dpl::__par_backend_hetero::__gen_mask<oneapi::dpl::__internal::__no_op,
+                                            oneapi::dpl::__par_backend_hetero::__extract_range_from_zip<2>>;
     using _WriteOp = oneapi::dpl::__par_backend_hetero::__write_to_id_if<0, oneapi::dpl::__internal::__pstl_assign>;
     using _Size = oneapi::dpl::__internal::__difference_t<_Range3>;
 
     using _GenReduceInput = oneapi::dpl::__par_backend_hetero::__gen_count_mask<_GenMaskReduce>;
     using _ReduceOp = std::plus<_Size>;
-    using _GenScanInput = oneapi::dpl::__par_backend_hetero::__gen_expand_set_mask<_GenMaskScan>;
+    using _GenScanInput = oneapi::dpl::__par_backend_hetero::__gen_expand_count_mask<_GenMaskScan, oneapi::dpl::__par_backend_hetero::__extract_range_from_zip<0>>;
     using _ScanInputTransform = oneapi::dpl::__par_backend_hetero::__get_zeroth_element;
 
     oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, int32_t> __mask_buf(__exec, __rng1.size());

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -843,7 +843,7 @@ struct __gen_set_mask
         const auto __id_a = __id;
         auto __val_a = __set_a[__id_a];
 
-        auto __res = __internal::__pstl_lower_bound(__set_b, std::size_t{0}, __nb, __val_a, __comp);
+        auto __res = oneapi::dpl::__internal::__pstl_lower_bound(__set_b, std::size_t{0}, __nb, __val_a, __comp);
 
         bool bres = _IsOpDifference::value; //initialization in true in case of difference operation; false - intersection.
         if (__res == __nb || __comp(__val_a, __set_b[__res]))
@@ -852,7 +852,7 @@ struct __gen_set_mask
         }
         else
         {
-            auto __val_b = __b[__res];
+            auto __val_b = __set_b[__res];
 
             //Difference operation logic: if number of duplication in __a on left side from __id > total number of
             //duplication in __b than a mask is 1
@@ -860,12 +860,12 @@ struct __gen_set_mask
             //Intersection operation logic: if number of duplication in __a on left side from __id <= total number of
             //duplication in __b than a mask is 1
 
-            const _Size1 __count_a_left =
-                __id_a - __internal::__pstl_left_bound(__set_a, 0, __id_a, __val_a, __comp) + 1;
+            const std::size_t __count_a_left =
+                __id_a - oneapi::dpl::__internal::__pstl_left_bound(__set_a, std::size_t{0}, __id_a, __val_a, __comp) + 1;
 
-            const _Size2 __count_b = __internal::__pstl_right_bound(__set_b, __res, __nb, __val_b, __comp) - __res +
+            const std::size_t __count_b = oneapi::dpl::__internal::__pstl_right_bound(__set_b, __res, __nb, __val_b, __comp) - __res +
                                      __res -
-                                     __internal::__pstl_left_bound(__set_b, 0, __res, __val_b, __comp);
+                                     oneapi::dpl::__internal::__pstl_left_bound(__set_b, std::size_t{0}, __res, __val_b, __comp);
 
             if constexpr (_IsOpDifference::value)
                 bres = __count_a_left > __count_b; /*difference*/
@@ -916,7 +916,7 @@ struct __gen_expand_set_mask
     {
         // First we must extract the first sequence from zip iterator because they may not have the same length,
         // dereferencing is dangerous
-        auto __set_a = get<0>(__in_rng.tuple()); // first sequence
+        auto __set_a = std::get<0>(__in_rng.tuple()); // first sequence
         // Explicitly creating this element type is necessary to avoid modifying the input data when _InRng is a
         //  zip_iterator which will return a tuple of references when dereferenced. With this explicit type, we copy
         //  the values of zipped input types rather than their references.
@@ -1272,34 +1272,35 @@ __parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag __backend_tag, 
 }
 
 
-auto
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Compare,
           typename _IsOpDifference>
+auto
 __parallel_set_reduce_then_scan(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
                           _Range1&& __rng1, _Range2&& __rng2, _Range3&& __result, _Compare __comp, _IsOpDifference)
 {
     // fill in reduce then scan impl
     using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_set_mask<_IsOpDifference, _Compare>;
-    using _WriteOp = oneapi::dpl::__par_backend_hetero::__write_to_id_if<0, _Assign>;
+    using _WriteOp = oneapi::dpl::__par_backend_hetero::__write_to_id_if<0, oneapi::dpl::__internal::__pstl_assign>;
+    using _Size = oneapi::dpl::__internal::__difference_t<_Range3>;
 
     using _GenReduceInput = oneapi::dpl::__par_backend_hetero::__gen_count_mask<_GenMask>;
     using _ReduceOp = std::plus<_Size>;
-    using _GenScanInput = oneapi::dpl::__par_backend_hetero::__gen_set_count_mask<_GenMask>;
+    using _GenScanInput = oneapi::dpl::__par_backend_hetero::__gen_expand_set_mask<_GenMask>;
     using _ScanInputTransform = oneapi::dpl::__par_backend_hetero::__get_zeroth_element;
 
     
     return __parallel_transform_reduce_then_scan(
         __backend_tag, std::forward<_ExecutionPolicy>(__exec),
         oneapi::dpl::__ranges::make_zip_view(std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2)),
-        std::forward<_Range3>(__result), _GenReduceInput{_GenMask{__comp}}}, _ReduceOp{}, _GenScanInput{},
+        std::forward<_Range3>(__result), _GenReduceInput{_GenMask{__comp}}, _ReduceOp{}, _GenScanInput{_GenMask{__comp}},
         _ScanInputTransform{}, _WriteOp{}, oneapi::dpl::unseq_backend::__no_init_value<_Size>{},
-        /*_Inclusive=*/std::true_type{}, /*__is_unique_pattern=*/std::false_type);
+        /*_Inclusive=*/std::true_type{}, /*__is_unique_pattern=*/std::false_type{});
 }
 
 
-auto
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Compare,
           typename _IsOpDifference>
+auto
 __parallel_set_scan(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
                     _Range1&& __rng1, _Range2&& __rng2, _Range3&& __result, _Compare __comp,
                     _IsOpDifference __is_op_difference)
@@ -1330,12 +1331,12 @@ __parallel_set_scan(oneapi::dpl::__internal::__device_backend_tag __backend_tag,
     oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, int32_t> __mask_buf(__exec, __n1);
 
     return __par_backend_hetero::__parallel_transform_scan_base(
-            _BackendTag{}, ::std::forward<_ExecutionPolicy>(__exec),
+            __backend_tag, ::std::forward<_ExecutionPolicy>(__exec),
             oneapi::dpl::__ranges::make_zip_view(
-                __buf1.all_view(), __buf2.all_view(),
+                std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
                 oneapi::dpl::__ranges::all_view<int32_t, __par_backend_hetero::access_mode::read_write>(
                     __mask_buf.get_buffer())),
-            __buf3.all_view(), __reduce_op, _InitType{},
+            std::forward<_Range3>(__result), __reduce_op, _InitType{},
             // local scan
             unseq_backend::__scan</*inclusive*/ ::std::true_type, _ExecutionPolicy, _ReduceOp, _DataAcc, _Assigner,
                                   _MaskAssigner, decltype(__create_mask_op), _InitType>{
@@ -1354,17 +1355,17 @@ template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typenam
 auto
 __parallel_set_op(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
                           _Range1&& __rng1, _Range2&& __rng2, _Range3&& __result, _Compare __comp, _IsOpDifference __is_op_difference)
-    oneapi::dpl::__internal::__difference_t<_Range1> __n = __rng.size();
+{
     if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec))
     {
         return __parallel_set_reduce_then_scan(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
-                                                std::forward<_Range1>(__rng), std::forward<_Range2>(__rng2),
-                                                std::forward<_Range3>(__result), __compare, __is_op_difference);
+                                                std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
+                                                std::forward<_Range3>(__result), __comp, __is_op_difference);
     }
     else
     {
-        return __parallel_set_scan(__backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng),
-                                   std::forward<_Range2>(__rng2), std::forward<_Range3>(__result), __compare,
+        return __parallel_set_scan(__backend_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng1),
+                                   std::forward<_Range2>(__rng2), std::forward<_Range3>(__result), __comp,
                                    __is_op_difference);
     }
 }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -836,6 +836,7 @@ struct __gen_set_mask
         // dereferencing is dangerous
         auto __set_a = std::get<0>(__in_rng.tuple()); // first sequence
         auto __set_b = std::get<1>(__in_rng.tuple()); // second sequence
+        auto __set_mask = std::get<2>(__in_rng.tuple()); // mask sequence
 
         std::size_t __nb = __set_b.size();
 
@@ -872,9 +873,23 @@ struct __gen_set_mask
             else
                 bres = __count_a_left <= __count_b; /*intersection*/
         }
+        __set_mask[__id] = bres;
         return bres;
     }
     _Compare __comp;
+};
+
+struct __gen_set_cached_mask
+{
+    template <typename _InRng>
+    bool
+    operator()(const _InRng& __in_rng, std::size_t __id) const
+    {
+        // First we must extract invididual sequences from zip iterator because they may not have the same length,
+        // dereferencing is dangerous
+        auto __set_mask = std::get<2>(__in_rng.tuple()); // mask sequence
+        return __set_mask[__id];
+    }
 };
 
 template <typename _GenMask>
@@ -1279,21 +1294,26 @@ __parallel_set_reduce_then_scan(oneapi::dpl::__internal::__device_backend_tag __
                           _Range1&& __rng1, _Range2&& __rng2, _Range3&& __result, _Compare __comp, _IsOpDifference)
 {
     // fill in reduce then scan impl
-    using _GenMask = oneapi::dpl::__par_backend_hetero::__gen_set_mask<_IsOpDifference, _Compare>;
+    using _GenMaskReduce = oneapi::dpl::__par_backend_hetero::__gen_set_mask<_IsOpDifference, _Compare>;
+    using _GenMaskScan = oneapi::dpl::__par_backend_hetero::__gen_set_cached_mask;
     using _WriteOp = oneapi::dpl::__par_backend_hetero::__write_to_id_if<0, oneapi::dpl::__internal::__pstl_assign>;
     using _Size = oneapi::dpl::__internal::__difference_t<_Range3>;
 
-    using _GenReduceInput = oneapi::dpl::__par_backend_hetero::__gen_count_mask<_GenMask>;
+    using _GenReduceInput = oneapi::dpl::__par_backend_hetero::__gen_count_mask<_GenMaskReduce>;
     using _ReduceOp = std::plus<_Size>;
-    using _GenScanInput = oneapi::dpl::__par_backend_hetero::__gen_expand_set_mask<_GenMask>;
+    using _GenScanInput = oneapi::dpl::__par_backend_hetero::__gen_expand_set_mask<_GenMaskScan>;
     using _ScanInputTransform = oneapi::dpl::__par_backend_hetero::__get_zeroth_element;
 
-    
+    oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, int32_t> __mask_buf(__exec, __rng1.size());
+
     return __parallel_transform_reduce_then_scan(
         __backend_tag, std::forward<_ExecutionPolicy>(__exec),
-        oneapi::dpl::__ranges::make_zip_view(std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2)),
-        std::forward<_Range3>(__result), _GenReduceInput{_GenMask{__comp}}, _ReduceOp{}, _GenScanInput{_GenMask{__comp}},
-        _ScanInputTransform{}, _WriteOp{}, oneapi::dpl::unseq_backend::__no_init_value<_Size>{},
+        oneapi::dpl::__ranges::make_zip_view(std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
+        oneapi::dpl::__ranges::all_view<int32_t, __par_backend_hetero::access_mode::read_write>(
+                    __mask_buf.get_buffer())),
+        std::forward<_Range3>(__result), _GenReduceInput{_GenMaskReduce{__comp}}, _ReduceOp{},
+        _GenScanInput{_GenMaskScan{}}, _ScanInputTransform{}, _WriteOp{},
+        oneapi::dpl::unseq_backend::__no_init_value<_Size>{},
         /*_Inclusive=*/std::true_type{}, /*__is_unique_pattern=*/std::false_type{});
 }
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -832,10 +832,10 @@ struct __gen_set_mask
     bool
     operator()(const _InRng& __in_rng, std::size_t __id) const
     {
-        using ::std::get;
-        auto __set_a = get<0>(__in_rng.tuple()); // first sequence
-        auto __set_b = get<1>(__in_rng.tuple()); // second sequence
-
+        // First we must extract invididual sequences from zip iterator because they may not have the same length,
+        // dereferencing is dangerous
+        auto __set_a = std::get<0>(__in_rng.tuple()); // first sequence
+        auto __set_b = std::get<1>(__in_rng.tuple()); // second sequence
 
         std::size_t __nb = __set_b.size();
 
@@ -901,6 +901,27 @@ struct __gen_expand_count_mask
         //  the values of zipped input types rather than their references.
         using _ElementType = oneapi::dpl::__internal::__value_t<_InRng>;
         _ElementType ele = __in_rng[__id];
+        bool mask = __gen_mask(std::forward<_InRng>(__in_rng), __id);
+        return std::tuple(mask ? _SizeType{1} : _SizeType{0}, mask, ele);
+    }
+    _GenMask __gen_mask;
+};
+
+template <typename _GenMask>
+struct __gen_expand_set_mask
+{
+    template <typename _InRng, typename _SizeType>
+    auto
+    operator()(_InRng&& __in_rng, _SizeType __id) const
+    {
+        // First we must extract the first sequence from zip iterator because they may not have the same length,
+        // dereferencing is dangerous
+        auto __set_a = get<0>(__in_rng.tuple()); // first sequence
+        // Explicitly creating this element type is necessary to avoid modifying the input data when _InRng is a
+        //  zip_iterator which will return a tuple of references when dereferenced. With this explicit type, we copy
+        //  the values of zipped input types rather than their references.
+        using _ElementType = oneapi::dpl::__internal::__value_t<decltype(__set_a)>;
+        _ElementType ele = __set_a[__id];
         bool mask = __gen_mask(std::forward<_InRng>(__in_rng), __id);
         return std::tuple(mask ? _SizeType{1} : _SizeType{0}, mask, ele);
     }
@@ -1263,8 +1284,8 @@ __parallel_set_reduce_then_scan(oneapi::dpl::__internal::__device_backend_tag __
 
     using _GenReduceInput = oneapi::dpl::__par_backend_hetero::__gen_count_mask<_GenMask>;
     using _ReduceOp = std::plus<_Size>;
-    using _GenScanInput = oneapi::dpl::__par_backend_hetero::__gen_expand_count_mask<_GenMask>;
-    using _ScanInputTransform = oneapi::dpl::__par_backend_hetero::__get_first_set_from_zeroth_ele;
+    using _GenScanInput = oneapi::dpl::__par_backend_hetero::__gen_set_count_mask<_GenMask>;
+    using _ScanInputTransform = oneapi::dpl::__par_backend_hetero::__get_zeroth_element;
 
     
     return __parallel_transform_reduce_then_scan(

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -834,8 +834,8 @@ struct __gen_set_mask
     {
         // First we must extract invididual sequences from zip iterator because they may not have the same length,
         // dereferencing is dangerous
-        auto __set_a = std::get<0>(__in_rng.tuple()); // first sequence
-        auto __set_b = std::get<1>(__in_rng.tuple()); // second sequence
+        auto __set_a = std::get<0>(__in_rng.tuple());    // first sequence
+        auto __set_b = std::get<1>(__in_rng.tuple());    // second sequence
         auto __set_mask = std::get<2>(__in_rng.tuple()); // mask sequence
 
         std::size_t __nb = __set_b.size();
@@ -846,7 +846,8 @@ struct __gen_set_mask
 
         auto __res = oneapi::dpl::__internal::__pstl_lower_bound(__set_b, std::size_t{0}, __nb, __val_a, __comp);
 
-        bool bres = _IsOpDifference::value; //initialization in true in case of difference operation; false - intersection.
+        bool bres =
+            _IsOpDifference::value; //initialization in true in case of difference operation; false - intersection.
         if (__res == __nb || __comp(__val_a, __set_b[__res]))
         {
             // there is no __val_a in __set_b, so __set_b in the difference {__a}/{__b};
@@ -862,11 +863,12 @@ struct __gen_set_mask
             //duplication in __b than a mask is 1
 
             const std::size_t __count_a_left =
-                __id_a - oneapi::dpl::__internal::__pstl_left_bound(__set_a, std::size_t{0}, __id_a, __val_a, __comp) + 1;
+                __id_a - oneapi::dpl::__internal::__pstl_left_bound(__set_a, std::size_t{0}, __id_a, __val_a, __comp) +
+                1;
 
-            const std::size_t __count_b = oneapi::dpl::__internal::__pstl_right_bound(__set_b, __res, __nb, __val_b, __comp) - __res +
-                                     __res -
-                                     oneapi::dpl::__internal::__pstl_left_bound(__set_b, std::size_t{0}, __res, __val_b, __comp);
+            const std::size_t __count_b =
+                oneapi::dpl::__internal::__pstl_right_bound(__set_b, __res, __nb, __val_b, __comp) - __res + __res -
+                oneapi::dpl::__internal::__pstl_left_bound(__set_b, std::size_t{0}, __res, __val_b, __comp);
 
             if constexpr (_IsOpDifference::value)
                 bres = __count_a_left > __count_b; /*difference*/
@@ -1264,38 +1266,40 @@ __parallel_copy_if(oneapi::dpl::__internal::__device_backend_tag __backend_tag, 
     }
 }
 
-
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Compare,
           typename _IsOpDifference>
 auto
 __parallel_set_reduce_then_scan(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
-                          _Range1&& __rng1, _Range2&& __rng2, _Range3&& __result, _Compare __comp, _IsOpDifference)
+                                _Range1&& __rng1, _Range2&& __rng2, _Range3&& __result, _Compare __comp,
+                                _IsOpDifference)
 {
     // fill in reduce then scan impl
     using _GenMaskReduce = oneapi::dpl::__par_backend_hetero::__gen_set_mask<_IsOpDifference, _Compare>;
-    using _GenMaskScan = oneapi::dpl::__par_backend_hetero::__gen_mask<oneapi::dpl::__internal::__no_op,
-                                            oneapi::dpl::__par_backend_hetero::__extract_range_from_zip<2>>;
+    using _GenMaskScan =
+        oneapi::dpl::__par_backend_hetero::__gen_mask<oneapi::dpl::__internal::__no_op,
+                                                      oneapi::dpl::__par_backend_hetero::__extract_range_from_zip<2>>;
     using _WriteOp = oneapi::dpl::__par_backend_hetero::__write_to_id_if<0, oneapi::dpl::__internal::__pstl_assign>;
     using _Size = oneapi::dpl::__internal::__difference_t<_Range3>;
 
     using _GenReduceInput = oneapi::dpl::__par_backend_hetero::__gen_count_mask<_GenMaskReduce>;
     using _ReduceOp = std::plus<_Size>;
-    using _GenScanInput = oneapi::dpl::__par_backend_hetero::__gen_expand_count_mask<_GenMaskScan, oneapi::dpl::__par_backend_hetero::__extract_range_from_zip<0>>;
+    using _GenScanInput = oneapi::dpl::__par_backend_hetero::__gen_expand_count_mask<
+        _GenMaskScan, oneapi::dpl::__par_backend_hetero::__extract_range_from_zip<0>>;
     using _ScanInputTransform = oneapi::dpl::__par_backend_hetero::__get_zeroth_element;
 
     oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, int32_t> __mask_buf(__exec, __rng1.size());
 
     return __parallel_transform_reduce_then_scan(
         __backend_tag, std::forward<_ExecutionPolicy>(__exec),
-        oneapi::dpl::__ranges::make_zip_view(std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
-        oneapi::dpl::__ranges::all_view<int32_t, __par_backend_hetero::access_mode::read_write>(
-                    __mask_buf.get_buffer())),
+        oneapi::dpl::__ranges::make_zip_view(
+            std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
+            oneapi::dpl::__ranges::all_view<int32_t, __par_backend_hetero::access_mode::read_write>(
+                __mask_buf.get_buffer())),
         std::forward<_Range3>(__result), _GenReduceInput{_GenMaskReduce{__comp}}, _ReduceOp{},
         _GenScanInput{_GenMaskScan{}}, _ScanInputTransform{}, _WriteOp{},
         oneapi::dpl::unseq_backend::__no_init_value<_Size>{},
         /*_Inclusive=*/std::true_type{}, /*__is_unique_pattern=*/std::false_type{});
 }
-
 
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Compare,
           typename _IsOpDifference>
@@ -1330,36 +1334,36 @@ __parallel_set_scan(oneapi::dpl::__internal::__device_backend_tag __backend_tag,
     oneapi::dpl::__par_backend_hetero::__buffer<_ExecutionPolicy, int32_t> __mask_buf(__exec, __n1);
 
     return __par_backend_hetero::__parallel_transform_scan_base(
-            __backend_tag, ::std::forward<_ExecutionPolicy>(__exec),
-            oneapi::dpl::__ranges::make_zip_view(
-                std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
-                oneapi::dpl::__ranges::all_view<int32_t, __par_backend_hetero::access_mode::read_write>(
-                    __mask_buf.get_buffer())),
-            std::forward<_Range3>(__result), __reduce_op, _InitType{},
-            // local scan
-            unseq_backend::__scan</*inclusive*/ ::std::true_type, _ExecutionPolicy, _ReduceOp, _DataAcc, _Assigner,
-                                  _MaskAssigner, decltype(__create_mask_op), _InitType>{
-                __reduce_op, __get_data_op, __assign_op, _MaskAssigner{}, __create_mask_op},
-            // scan between groups
-            unseq_backend::__scan</*inclusive=*/::std::true_type, _ExecutionPolicy, _ReduceOp, _DataAcc, _NoAssign,
-                                  _Assigner, _DataAcc, _InitType>{__reduce_op, __get_data_op, _NoAssign{}, __assign_op,
-                                                                  __get_data_op},
-            // global scan
-            __copy_by_mask_op);
+        __backend_tag, ::std::forward<_ExecutionPolicy>(__exec),
+        oneapi::dpl::__ranges::make_zip_view(
+            std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
+            oneapi::dpl::__ranges::all_view<int32_t, __par_backend_hetero::access_mode::read_write>(
+                __mask_buf.get_buffer())),
+        std::forward<_Range3>(__result), __reduce_op, _InitType{},
+        // local scan
+        unseq_backend::__scan</*inclusive*/ ::std::true_type, _ExecutionPolicy, _ReduceOp, _DataAcc, _Assigner,
+                              _MaskAssigner, decltype(__create_mask_op), _InitType>{
+            __reduce_op, __get_data_op, __assign_op, _MaskAssigner{}, __create_mask_op},
+        // scan between groups
+        unseq_backend::__scan</*inclusive=*/::std::true_type, _ExecutionPolicy, _ReduceOp, _DataAcc, _NoAssign,
+                              _Assigner, _DataAcc, _InitType>{__reduce_op, __get_data_op, _NoAssign{}, __assign_op,
+                                                              __get_data_op},
+        // global scan
+        __copy_by_mask_op);
 }
-
 
 template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Compare,
           typename _IsOpDifference>
 auto
 __parallel_set_op(oneapi::dpl::__internal::__device_backend_tag __backend_tag, _ExecutionPolicy&& __exec,
-                          _Range1&& __rng1, _Range2&& __rng2, _Range3&& __result, _Compare __comp, _IsOpDifference __is_op_difference)
+                  _Range1&& __rng1, _Range2&& __rng2, _Range3&& __result, _Compare __comp,
+                  _IsOpDifference __is_op_difference)
 {
     if (oneapi::dpl::__par_backend_hetero::__is_gpu_with_sg_32(__exec))
     {
         return __parallel_set_reduce_then_scan(__backend_tag, std::forward<_ExecutionPolicy>(__exec),
-                                                std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
-                                                std::forward<_Range3>(__result), __comp, __is_op_difference);
+                                               std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
+                                               std::forward<_Range3>(__result), __comp, __is_op_difference);
     }
     else
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -236,7 +236,7 @@ namespace oneapi::dpl::__par_backend_hetero
 template <typename _UnaryOp>
 struct __gen_transform_input;
 
-template <typename _Predicate>
+template <typename _Predicate, typename _RangeTransform>
 struct __gen_mask;
 
 template <typename _BinaryPredicate>
@@ -245,7 +245,7 @@ struct __gen_unique_mask;
 template <typename _GenMask>
 struct __gen_count_mask;
 
-template <typename _GenMask>
+template <typename _GenMask, typename _RangeTransform>
 struct __gen_expand_count_mask;
 
 template <int32_t __offset, typename _Assign>
@@ -266,8 +266,8 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backen
 {
 };
 
-template <typename _Predicate>
-struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__gen_mask, _Predicate)>
+template <typename _Predicate, typename _RangeTransform>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__gen_mask, _Predicate, _RangeTransform)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_Predicate>
 {
 };
@@ -284,9 +284,9 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backen
 {
 };
 
-template <typename _GenMask>
+template <typename _GenMask, typename _RangeTransform>
 struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__gen_expand_count_mask,
-                                                       _GenMask)>
+                                                       _GenMask, _RangeTransform)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_GenMask>
 {
 };

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -267,7 +267,8 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backen
 };
 
 template <typename _Predicate, typename _RangeTransform>
-struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__gen_mask, _Predicate, _RangeTransform)>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::__par_backend_hetero::__gen_mask, _Predicate,
+                                                       _RangeTransform)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_Predicate>
 {
 };


### PR DESCRIPTION
Enabling reduce then scan algorithm to be used for set family APIs:
`set_intersection`
`set_union`
`set_difference`
`set_symmetric_difference`

Adds high-level helpers required to convert set family to use reduce_then_scan on GPU with size 32 subgroups.

Also makes set consistent with the other scan algorithms to select algorithm in the `__parallel_*` level of function call.

This provides significant performance improvements, especially at small sizes of `n`.  At larger sizes of `n`, this is an improvement over the existing algorithm, but not by a lot.  

There is still significant room for improvement here, this algorithm is very inefficient.  

Three future things to try (from easiest to hardest) to improve the set family within the reduce then scan alg:
1) We could explore our alternative `__pstl_lower_bound`, `__shars_lower_bound` to see if it provides benefit.
2) We could propagate a "hint" minimum search index between blocks (this provides a lower bound and better "blocks" the second set, in addition to the blocking we do inherently on the first set) 
3) We could propagate a similar "hint minimum search index subgroup from one iteration to the next.   (This prevents redundant computation for consecutive iterations for a subgroup.  Since the sets are ordered, subsequent searches will never go backward as long as the element we are searching's index in the first set is greater than the previous iteration's search).

Right now, we are wasting lots of memory accesses and comparisons on sections of the second set which should be able to ruled out from knowledge we have access to at the time we are making the search (in the "Reduce" predicate).  We also lose the "blocking" cache advantage of reduce_then_scan, because the second set always searches from the start of the list.
