### PR TITLE
Align with SYCL 2020: remove sycl::mode_tag_t

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -219,13 +219,11 @@ begin(sycl::buffer<T, /*dim=*/1, Allocator> buf, ModeTagT)
 }
 
 template <typename T, typename Allocator, typename ModeTagT>
-__internal::sycl_iterator<
-    __internal::__access_mode_resolver<ModeTagT, __dpl_sycl::__no_init>::__value, T, Allocator>
+__internal::sycl_iterator<__internal::__access_mode_resolver<ModeTagT, __dpl_sycl::__no_init>::__value, T, Allocator>
 begin(sycl::buffer<T, /*dim=*/1, Allocator> buf, ModeTagT, __dpl_sycl::__no_init)
 {
-    return __internal::sycl_iterator<
-        __internal::__access_mode_resolver<ModeTagT, __dpl_sycl::__no_init>::__value, T,
-        Allocator>{buf, 0};
+    return __internal::sycl_iterator<__internal::__access_mode_resolver<ModeTagT, __dpl_sycl::__no_init>::__value, T,
+                                     Allocator>{buf, 0};
 }
 
 template <typename T, typename Allocator>
@@ -245,13 +243,11 @@ end(sycl::buffer<T, /*dim=*/1, Allocator> buf, ModeTagT)
 }
 
 template <typename T, typename Allocator, typename ModeTagT>
-__internal::sycl_iterator<
-    __internal::__access_mode_resolver<ModeTagT, __dpl_sycl::__no_init>::__value, T, Allocator>
+__internal::sycl_iterator<__internal::__access_mode_resolver<ModeTagT, __dpl_sycl::__no_init>::__value, T, Allocator>
 end(sycl::buffer<T, /*dim=*/1, Allocator> buf, ModeTagT, __dpl_sycl::__no_init)
 {
-    return __internal::sycl_iterator<
-        __internal::__access_mode_resolver<ModeTagT, __dpl_sycl::__no_init>::__value, T,
-        Allocator>{buf, __dpl_sycl::__get_buffer_size(buf)};
+    return __internal::sycl_iterator<__internal::__access_mode_resolver<ModeTagT, __dpl_sycl::__no_init>::__value, T,
+                                     Allocator>{buf, __dpl_sycl::__get_buffer_size(buf)};
 }
 
 template <typename T, typename Allocator>

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -147,17 +147,16 @@ struct __access_mode_resolver<std::decay_t<decltype(sycl::read_only)>, _NoInitT>
 template <typename _NoInitT>
 struct __access_mode_resolver<std::decay_t<decltype(sycl::write_only)>, _NoInitT>
 {
-    static constexpr access_mode __value = std::is_same_v<_NoInitT, void> ? access_mode::write :
-                                                                            access_mode::discard_write;
+    static constexpr access_mode __value =
+        std::is_same_v<_NoInitT, void> ? access_mode::write : access_mode::discard_write;
 };
 
 template <typename _NoInitT>
 struct __access_mode_resolver<std::decay_t<decltype(sycl::read_write)>, _NoInitT>
 {
-    static constexpr access_mode __value = std::is_same_v<_NoInitT, void> ? access_mode::read_write :
-                                                                            access_mode::discard_read_write;
+    static constexpr access_mode __value =
+        std::is_same_v<_NoInitT, void> ? access_mode::read_write : access_mode::discard_read_write;
 };
-
 
 template <typename Iter, typename ValueType = std::decay_t<typename std::iterator_traits<Iter>::value_type>>
 using __default_alloc_vec_iter = typename std::vector<ValueType>::iterator;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -149,7 +149,7 @@ struct __access_mode_converter<access_mode::write>
 {
     static constexpr access_mode __value = access_mode::discard_write;
 };
- 
+
 // map access_mode tag to access_mode value
 template <typename T>
 struct __access_mode_resolver
@@ -218,16 +218,19 @@ __internal::sycl_iterator<access_mode::read_write, T, Allocator> end(sycl::buffe
 // begin
 template <typename T, typename Allocator, typename ModeTagT>
 __internal::sycl_iterator<__internal::__access_mode_resolver<ModeTagT>::__value, T, Allocator>
-    begin(sycl::buffer<T, /*dim=*/1, Allocator> buf, ModeTagT)
+begin(sycl::buffer<T, /*dim=*/1, Allocator> buf, ModeTagT)
 {
     return __internal::sycl_iterator<__internal::__access_mode_resolver<ModeTagT>::__value, T, Allocator>{buf, 0};
 }
 
 template <typename T, typename Allocator, typename ModeTagT>
-__internal::sycl_iterator<__internal::__access_mode_converter<__internal::__access_mode_resolver<ModeTagT>::__value>::__value, T, Allocator>
-    begin(sycl::buffer<T, /*dim=*/1, Allocator> buf, ModeTagT, __dpl_sycl::__no_init)
+__internal::sycl_iterator<
+    __internal::__access_mode_converter<__internal::__access_mode_resolver<ModeTagT>::__value>::__value, T, Allocator>
+begin(sycl::buffer<T, /*dim=*/1, Allocator> buf, ModeTagT, __dpl_sycl::__no_init)
 {
-    return __internal::sycl_iterator<__internal::__access_mode_converter<__internal::__access_mode_resolver<ModeTagT>::__value>::__value, T, Allocator>{buf, 0};
+    return __internal::sycl_iterator<
+        __internal::__access_mode_converter<__internal::__access_mode_resolver<ModeTagT>::__value>::__value, T,
+        Allocator>{buf, 0};
 }
 
 template <typename T, typename Allocator>
@@ -239,17 +242,21 @@ __internal::sycl_iterator<access_mode::discard_read_write, T, Allocator>
 
 // end
 template <typename T, typename Allocator, typename ModeTagT>
-__internal::sycl_iterator<__internal::__access_mode_resolver<ModeTagT>::__value, T, Allocator> end(sycl::buffer<T, /*dim=*/1, Allocator> buf, ModeTagT)
+__internal::sycl_iterator<__internal::__access_mode_resolver<ModeTagT>::__value, T, Allocator>
+end(sycl::buffer<T, /*dim=*/1, Allocator> buf, ModeTagT)
 {
-    return __internal::sycl_iterator<__internal::__access_mode_resolver<ModeTagT>::__value, T, Allocator>{buf, __dpl_sycl::__get_buffer_size(buf)};
+    return __internal::sycl_iterator<__internal::__access_mode_resolver<ModeTagT>::__value, T, Allocator>{
+        buf, __dpl_sycl::__get_buffer_size(buf)};
 }
 
 template <typename T, typename Allocator, typename ModeTagT>
-__internal::sycl_iterator<__internal::__access_mode_converter<__internal::__access_mode_resolver<ModeTagT>::__value>::__value, T, Allocator>
-    end(sycl::buffer<T, /*dim=*/1, Allocator> buf, ModeTagT, __dpl_sycl::__no_init)
+__internal::sycl_iterator<
+    __internal::__access_mode_converter<__internal::__access_mode_resolver<ModeTagT>::__value>::__value, T, Allocator>
+end(sycl::buffer<T, /*dim=*/1, Allocator> buf, ModeTagT, __dpl_sycl::__no_init)
 {
-    return __internal::sycl_iterator<__internal::__access_mode_converter<__internal::__access_mode_resolver<ModeTagT>::__value>::__value, T, Allocator>{
-        buf, __dpl_sycl::__get_buffer_size(buf)};
+    return __internal::sycl_iterator<
+        __internal::__access_mode_converter<__internal::__access_mode_resolver<ModeTagT>::__value>::__value, T,
+        Allocator>{buf, __dpl_sycl::__get_buffer_size(buf)};
 }
 
 template <typename T, typename Allocator>


### PR DESCRIPTION
`sycl::mode_tag_t` is not a part of SYCL 2020. It was a part of the provisional specification, but it is absent in the newer revisions. 
There is a more radical approach: remove seemingly unused `access_mode` from `sycl_iterator` class entirely, but I am not sure about design / ABI implications.

Note, that the host_task tags (such as `read_write_host_task`) were not added, because they are not currently supported, and there is no sense to do so. The oneDPL specification suggest that the `begin` and `end` functions should be  provided during code submission to a device, which is not applicable within a host task context:

> The begin and end functions can take SYCL 2020 deduction tags and sycl::no_init as arguments to explicitly mention which access mode should be applied to the buffer accessor when submitting a SYCL kernel to a device.
