### PR TITLE
Fix includes in scan_2 test

### DIFF
--- a/test/parallel_api/numeric/numeric.ops/scan_2.pass.cpp
+++ b/test/parallel_api/numeric/numeric.ops/scan_2.pass.cpp
@@ -19,7 +19,7 @@
 #include "support/test_config.h"
 
 #include "oneapi/dpl/execution"
-#include "oneapi/dpl/algorithm"
+#include "oneapi/dpl/numeric"
 #include "oneapi/dpl/iterator"
 
 #include "support/utils.h"


### PR DESCRIPTION
scan algorithms are defined in `numeric` header instead of `algorithm`. 