### PR TITLE
[oneDPL][ranges] + fix for std::ranges::sort using (windows); 

### DIFF
--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -423,7 +423,13 @@ struct __stable_sort_fn
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         return oneapi::dpl::__internal::__ranges::__pattern_sort_ranges(__dispatch_tag,
-            std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __comp, __proj, std::ranges::stable_sort);
+            std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __comp, __proj,
+#if _ONEDPL_STD_RANGES_FUN_OBJ_WINDOWS_BROKEN
+            [](auto&&... __args) { std::ranges::stable_sort(std::forward<decltype(__args)>(__args)...); }
+#else
+            std::ranges::stable_sort
+#endif
+            );
     }
 }; //__stable_sort_fn
 }  //__internal
@@ -443,7 +449,13 @@ struct __sort_fn
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         return oneapi::dpl::__internal::__ranges::__pattern_sort_ranges(__dispatch_tag,
-            std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __comp, __proj, std::ranges::sort);
+            std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __comp, __proj,
+#if _ONEDPL_STD_RANGES_FUN_OBJ_WINDOWS_BROKEN
+            [](auto&&... __args) { std::ranges::sort(std::forward<decltype(__args)>(__args)...); }
+#else
+            std::ranges::sort
+#endif
+            );
     }
 }; //__sort_fn
 }  //__internal

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -326,4 +326,11 @@
 #    define _ONEDPL_STD_BIT_FLOOR_BROKEN 0
 #endif
 
+// The implementation of std::ranges algorithms in MS C++ standard library does not meet the C++ standard requirements.
+#if defined(_MSC_VER) && (_MSC_VER < 1939)
+#    define _ONEDPL_STD_RANGES_FUN_OBJ_WINDOWS_BROKEN 1
+#else
+#    define _ONEDPL_STD_RANGES_FUN_OBJ_WINDOWS_BROKEN 0
+#endif
+
 #endif // _ONEDPL_CONFIG_H


### PR DESCRIPTION
1. Microsoft standard libraries older than _MSC_VER == 1939 have std::ranges::<algo> definition as function instead of a global function object. It leads to a error in oneDPL implementation. The PR fixes this issue via a workaround. https://godbolt.org/z/sTfcsj897
2.  Added _ONEDPL_STD_RANGES_WINDOWS_NON_GLOBAL_FUN_OBJ  macro