### PR TITLE
Move difference_t utility to utils_ranges header

### DIFF
--- a/include/oneapi/dpl/pstl/execution_defs.h
+++ b/include/oneapi/dpl/pstl/execution_defs.h
@@ -124,22 +124,6 @@ struct __ref_or_copy_impl
 template <typename _ExecPolicy, typename _T>
 using __ref_or_copy = typename __ref_or_copy_impl<::std::decay_t<_ExecPolicy>, _T>::type;
 
-// utilities for Range API
-template <typename _R>
-auto
-__check_size(int) -> decltype(::std::declval<_R&>().size());
-
-template <typename _R>
-auto
-__check_size(long) -> decltype(::std::declval<_R&>().get_count());
-
-template <typename _It>
-auto
-__check_size(...) -> typename ::std::iterator_traits<_It>::difference_type;
-
-template <typename _R>
-using __difference_t = ::std::make_signed_t<decltype(__check_size<_R>(0))>;
-
 //------------------------------------------------------------------------
 // backend tags
 //------------------------------------------------------------------------

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_defs.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_defs.h
@@ -18,6 +18,7 @@
 
 #include "../functional"
 #include "execution_defs.h"
+#include "utils_ranges.h"
 
 namespace oneapi
 {

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -22,8 +22,10 @@
 #    include <functional>
 #    include <type_traits>
 #    include <iterator>
-#    include <algorithm> //to use std::ranges::sort, std::ranges::stable_sort
+#    include <algorithm> // std::ranges::sort, std::ranges::stable_sort
 #endif
+
+#include "utils_ranges.h" // __difference_t
 
 #include "execution_defs.h"
 #include "oneapi/dpl/pstl/ranges_defs.h"

--- a/include/oneapi/dpl/pstl/glue_numeric_ranges_defs.h
+++ b/include/oneapi/dpl/pstl/glue_numeric_ranges_defs.h
@@ -17,6 +17,7 @@
 #define _ONEDPL_GLUE_NUMERIC_RANGES_DEFS_H
 
 #include "execution_defs.h"
+#include "utils_ranges.h"
 
 namespace oneapi
 {

--- a/include/oneapi/dpl/pstl/glue_numeric_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_numeric_ranges_impl.h
@@ -17,6 +17,7 @@
 #define _ONEDPL_GLUE_NUMERIC_RANGES_IMPL_H
 
 #include "execution_defs.h"
+#include "utils_ranges.h"
 #include "glue_numeric_defs.h"
 
 #if _ONEDPL_HETERO_BACKEND

--- a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h
@@ -20,6 +20,7 @@
 #include "../algorithm_fwd.h"
 
 #include "../parallel_backend.h"
+#include "../utils_ranges.h"
 #include "utils_hetero.h"
 
 #if _ONEDPL_BACKEND_SYCL

--- a/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/algorithm_ranges_impl_hetero.h
@@ -18,6 +18,7 @@
 
 #include "../algorithm_fwd.h"
 #include "../parallel_backend.h"
+#include "../utils_ranges.h"
 #include "utils_hetero.h"
 
 #if _ONEDPL_BACKEND_SYCL

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
@@ -25,6 +25,7 @@
 
 #include "sycl_defs.h"                   // __dpl_sycl::__local_accessor, __dpl_sycl::__group_barrier
 #include "../../utils.h"                 // __dpl_bit_floor, __dpl_bit_ceil
+#include "../../utils_ranges.h"          // __difference_t
 #include "parallel_backend_sycl_merge.h" // __find_start_point, __serial_merge
 
 namespace oneapi

--- a/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
+++ b/include/oneapi/dpl/pstl/hetero/numeric_ranges_impl_hetero.h
@@ -24,6 +24,8 @@
 #    include "dpcpp/unseq_backend_sycl.h"
 #endif
 
+#include "../utils_ranges.h"
+
 namespace oneapi
 {
 namespace dpl

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -93,18 +93,18 @@ using __range_size_t = typename __range_size<_R>::type;
 
 template <typename _R>
 auto
-__check_size(int) -> decltype(::std::declval<_R&>().size());
+__check_size(int) -> decltype(std::declval<_R&>().size());
 
 template <typename _R>
 auto
-__check_size(long) -> decltype(::std::declval<_R&>().get_count());
+__check_size(long) -> decltype(std::declval<_R&>().get_count());
 
 template <typename _It>
 auto
-__check_size(...) -> typename ::std::iterator_traits<_It>::difference_type;
+__check_size(...) -> typename std::iterator_traits<_It>::difference_type;
 
 template <typename _R>
-using __difference_t = ::std::make_signed_t<decltype(__check_size<_R>(0))>;
+using __difference_t = std::make_signed_t<decltype(__check_size<_R>(0))>;
 
 } //namespace __internal
 

--- a/include/oneapi/dpl/pstl/utils_ranges.h
+++ b/include/oneapi/dpl/pstl/utils_ranges.h
@@ -21,7 +21,6 @@
 
 #include "iterator_defs.h"
 #include "iterator_impl.h"
-#include "execution_defs.h" // __internal::__difference_t
 
 namespace oneapi
 {
@@ -91,6 +90,21 @@ template <typename _R>
 using __range_size_t = typename __range_size<_R>::type;
 
 #endif //_ONEDPL_CPP20_RANGES_PRESENT
+
+template <typename _R>
+auto
+__check_size(int) -> decltype(::std::declval<_R&>().size());
+
+template <typename _R>
+auto
+__check_size(long) -> decltype(::std::declval<_R&>().get_count());
+
+template <typename _It>
+auto
+__check_size(...) -> typename ::std::iterator_traits<_It>::difference_type;
+
+template <typename _R>
+using __difference_t = ::std::make_signed_t<decltype(__check_size<_R>(0))>;
 
 } //namespace __internal
 


### PR DESCRIPTION
Utilities for Range API should be in `utils_ranges.h` instead of `execution_defs.h`. 