### PR TITLE
[oneDPL][ranges] A macro _ONEDPL_STD_RANGES_FUN_OBJ_WINDOWS_BROKEN renamed

### DIFF
--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -426,7 +426,7 @@ struct __stable_sort_fn
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         return oneapi::dpl::__internal::__ranges::__pattern_sort_ranges(__dispatch_tag,
             std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __comp, __proj,
-#if _ONEDPL_STD_RANGES_FUN_OBJ_WINDOWS_BROKEN
+#if _ONEDPL_STD_RANGES_ALGO_CPP_FUN
             [](auto&&... __args) { std::ranges::stable_sort(std::forward<decltype(__args)>(__args)...); }
 #else
             std::ranges::stable_sort
@@ -452,7 +452,7 @@ struct __sort_fn
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         return oneapi::dpl::__internal::__ranges::__pattern_sort_ranges(__dispatch_tag,
             std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __comp, __proj,
-#if _ONEDPL_STD_RANGES_FUN_OBJ_WINDOWS_BROKEN
+#if _ONEDPL_STD_RANGES_ALGO_CPP_FUN
             [](auto&&... __args) { std::ranges::sort(std::forward<decltype(__args)>(__args)...); }
 #else
             std::ranges::sort

--- a/include/oneapi/dpl/pstl/onedpl_config.h
+++ b/include/oneapi/dpl/pstl/onedpl_config.h
@@ -326,11 +326,11 @@
 #    define _ONEDPL_STD_BIT_FLOOR_BROKEN 0
 #endif
 
-// The implementation of std::ranges algorithms in MS C++ standard library does not meet the C++ standard requirements.
+// The implementation of std::ranges algorithms in MS C++ standard library is done via C++ functions.
 #if defined(_MSC_VER) && (_MSC_VER < 1939)
-#    define _ONEDPL_STD_RANGES_FUN_OBJ_WINDOWS_BROKEN 1
+#    define _ONEDPL_STD_RANGES_ALGO_CPP_FUN 1
 #else
-#    define _ONEDPL_STD_RANGES_FUN_OBJ_WINDOWS_BROKEN 0
+#    define _ONEDPL_STD_RANGES_ALGO_CPP_FUN 0
 #endif
 
 #endif // _ONEDPL_CONFIG_H


### PR DESCRIPTION
[oneDPL][ranges] A macro `_ONEDPL_STD_RANGES_FUN_OBJ_WINDOWS_BROKEN `renamed to `_ONEDPL_STD_RANGES_ALGO_CPP_FUN`