### PR TITLE
Correct member name of `__access_mode_resolver` to address compilation issues

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_iterator.h
@@ -141,7 +141,7 @@ struct __access_mode_resolver
 template <typename _NoInitT>
 struct __access_mode_resolver<std::decay_t<decltype(sycl::read_only)>, _NoInitT>
 {
-    static constexpr access_mode __mode = access_mode::read;
+    static constexpr access_mode __value = access_mode::read;
 };
 
 template <typename _NoInitT>


### PR DESCRIPTION
Attempting to use a `sycl::read_only` access tag results in a compilation error with code such as the following:
```
#include <iostream>
#include <oneapi/dpl/algorithm>
#include <oneapi/dpl/execution>
#include <oneapi/dpl/iterator>
#include <sycl/sycl.hpp>

int main()
{
    sycl::buffer<int> buf1(1);
    {
        buf1.get_host_access()[0] = 2;
    }
    sycl::buffer<int> buf2(1);
    auto beg1 = oneapi::dpl::begin(buf1, sycl::read_only);
    auto end1 = oneapi::dpl::end(buf1, sycl::read_only);
    auto beg2 = oneapi::dpl::begin(buf2, sycl::write_only);
    oneapi::dpl::copy(oneapi::dpl::execution::dpcpp_default, beg1, end1, beg2);
    std::cout << buf2.get_host_access()[0] << std::endl;
}
```
The single member of the read only specialization of `__access_mode_resolver` just needs to be updated to `__value` to be consistent with its usage elsewhere.