### PR TITLE
Fix inclusion order of numeric header

### DIFF
--- a/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
@@ -20,7 +20,10 @@
 #define _ONEDPL_INCLUSIVE_SCAN_BY_SEGMENT_IMPL_H
 
 #include "by_segment_extension_defs.h"
-#include "../numeric" // inclusive_scan, transform_inclusive_scan
+
+#include "../pstl/glue_numeric_defs.h"
+#include "../pstl/glue_numeric_impl.h"
+
 #include "../pstl/parallel_backend.h"
 #include "function.h"
 #include "../pstl/utils.h"

--- a/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
+++ b/include/oneapi/dpl/internal/inclusive_scan_by_segment_impl.h
@@ -20,7 +20,7 @@
 #define _ONEDPL_INCLUSIVE_SCAN_BY_SEGMENT_IMPL_H
 
 #include "by_segment_extension_defs.h"
-#include "../pstl/glue_numeric_impl.h"
+#include "../numeric" // inclusive_scan, transform_inclusive_scan
 #include "../pstl/parallel_backend.h"
 #include "function.h"
 #include "../pstl/utils.h"

--- a/include/oneapi/dpl/pstl/glue_numeric_impl.h
+++ b/include/oneapi/dpl/pstl/glue_numeric_impl.h
@@ -33,6 +33,35 @@ namespace oneapi
 namespace dpl
 {
 
+// [reduce]
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Tp, class _BinaryOperation>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _Tp>
+reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Tp __init,
+       _BinaryOperation __binary_op)
+{
+    return transform_reduce(::std::forward<_ExecutionPolicy>(__exec), __first, __last, __init, __binary_op,
+                            oneapi::dpl::__internal::__no_op());
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _Tp>
+reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Tp __init)
+{
+    return transform_reduce(::std::forward<_ExecutionPolicy>(__exec), __first, __last, __init, ::std::plus<_Tp>(),
+                            oneapi::dpl::__internal::__no_op());
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy,
+                                                      typename ::std::iterator_traits<_ForwardIterator>::value_type>
+reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last)
+{
+    typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType;
+    return transform_reduce(::std::forward<_ExecutionPolicy>(__exec), __first, __last, _ValueType{},
+                            ::std::plus<_ValueType>(), oneapi::dpl::__internal::__no_op());
+}
+
 // [transform.reduce]
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp>
@@ -71,35 +100,6 @@ transform_reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIt
 
     return oneapi::dpl::__internal::__pattern_transform_reduce(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
                                                                __first, __last, __init, __binary_op, __unary_op);
-}
-
-// [reduce]
-
-template <class _ExecutionPolicy, class _ForwardIterator, class _Tp, class _BinaryOperation>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _Tp>
-reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Tp __init,
-       _BinaryOperation __binary_op)
-{
-    return transform_reduce(::std::forward<_ExecutionPolicy>(__exec), __first, __last, __init, __binary_op,
-                            oneapi::dpl::__internal::__no_op());
-}
-
-template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _Tp>
-reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Tp __init)
-{
-    return transform_reduce(::std::forward<_ExecutionPolicy>(__exec), __first, __last, __init, ::std::plus<_Tp>(),
-                            oneapi::dpl::__internal::__no_op());
-}
-
-template <class _ExecutionPolicy, class _ForwardIterator>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy,
-                                                      typename ::std::iterator_traits<_ForwardIterator>::value_type>
-reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last)
-{
-    typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType;
-    return transform_reduce(::std::forward<_ExecutionPolicy>(__exec), __first, __last, _ValueType{},
-                            ::std::plus<_ValueType>(), oneapi::dpl::__internal::__no_op());
 }
 
 // [exclusive.scan]

--- a/include/oneapi/dpl/pstl/glue_numeric_impl.h
+++ b/include/oneapi/dpl/pstl/glue_numeric_impl.h
@@ -33,35 +33,6 @@ namespace oneapi
 namespace dpl
 {
 
-// [reduce]
-
-template <class _ExecutionPolicy, class _ForwardIterator, class _Tp, class _BinaryOperation>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _Tp>
-reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Tp __init,
-       _BinaryOperation __binary_op)
-{
-    return transform_reduce(::std::forward<_ExecutionPolicy>(__exec), __first, __last, __init, __binary_op,
-                            oneapi::dpl::__internal::__no_op());
-}
-
-template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _Tp>
-reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Tp __init)
-{
-    return transform_reduce(::std::forward<_ExecutionPolicy>(__exec), __first, __last, __init, ::std::plus<_Tp>(),
-                            oneapi::dpl::__internal::__no_op());
-}
-
-template <class _ExecutionPolicy, class _ForwardIterator>
-oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy,
-                                                      typename ::std::iterator_traits<_ForwardIterator>::value_type>
-reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last)
-{
-    typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType;
-    return transform_reduce(::std::forward<_ExecutionPolicy>(__exec), __first, __last, _ValueType{},
-                            ::std::plus<_ValueType>(), oneapi::dpl::__internal::__no_op());
-}
-
 // [transform.reduce]
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp>
@@ -100,6 +71,35 @@ transform_reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIt
 
     return oneapi::dpl::__internal::__pattern_transform_reduce(__dispatch_tag, ::std::forward<_ExecutionPolicy>(__exec),
                                                                __first, __last, __init, __binary_op, __unary_op);
+}
+
+// [reduce]
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Tp, class _BinaryOperation>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _Tp>
+reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Tp __init,
+       _BinaryOperation __binary_op)
+{
+    return transform_reduce(::std::forward<_ExecutionPolicy>(__exec), __first, __last, __init, __binary_op,
+                            oneapi::dpl::__internal::__no_op());
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy, _Tp>
+reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Tp __init)
+{
+    return transform_reduce(::std::forward<_ExecutionPolicy>(__exec), __first, __last, __init, ::std::plus<_Tp>(),
+                            oneapi::dpl::__internal::__no_op());
+}
+
+template <class _ExecutionPolicy, class _ForwardIterator>
+oneapi::dpl::__internal::__enable_if_execution_policy<_ExecutionPolicy,
+                                                      typename ::std::iterator_traits<_ForwardIterator>::value_type>
+reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last)
+{
+    typedef typename ::std::iterator_traits<_ForwardIterator>::value_type _ValueType;
+    return transform_reduce(::std::forward<_ExecutionPolicy>(__exec), __first, __last, _ValueType{},
+                            ::std::plus<_ValueType>(), oneapi::dpl::__internal::__no_op());
 }
 
 // [exclusive.scan]


### PR DESCRIPTION
The PR's aim is to fix #1886.

#1886 reproduces when oneDPL headers are included in the following order:
```
#include <oneapi/dpl/execution>
#include <oneapi/dpl/algorithm>
#include <oneapi/dpl/numeric>
```


The reason appears to be that  `glue_numeric_impl.h` is included before `glue_numeric_defs.h` in `inclusive_scan_by_segment_impl.h`, what means that `reduce` uses `transform_reduce`, which is defined later.

Unfortunately, I was not able to reproduce the issue with a simple reproducer (outside of the distributed-ranges context), to come up with a new test.
