### PR TITLE
Fixed coverity issue in Philox RNG engine

### DIFF
--- a/include/oneapi/dpl/internal/random_impl/philox_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/philox_engine.h
@@ -258,8 +258,11 @@ class philox_engine
                 __carry = 1;
             }
 
-            //          select high chunk             shift for addition with the next counter chunk
-            __ctr_inc = (__ctr_inc & (~in_mask)) >> (std::numeric_limits<unsigned long long>::digits - word_size);
+            // select high chunk and shift for addition with the next counter chunk
+            // __z should be added only once for 64-bit word_size
+            __ctr_inc = (word_size == std::numeric_limits<unsigned long long>::digits)
+                            ? 0
+                            : (__ctr_inc & (~in_mask)) >> word_size;
         }
     }
 

--- a/include/oneapi/dpl/internal/random_impl/philox_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/philox_engine.h
@@ -259,9 +259,8 @@ class philox_engine
             }
 
             // select high chunk and shift for addition with the next counter chunk
-            // __z should be added only once for 64-bit word_size
             __ctr_inc = (word_size == std::numeric_limits<unsigned long long>::digits)
-                            ? 0
+                            ? 0 // should be added only once for 64-bit word_size
                             : (__ctr_inc & (~in_mask)) >> word_size;
         }
     }

--- a/test/xpu_api/random/unit_tests/philox_unit_test.pass.cpp
+++ b/test/xpu_api/random/unit_tests/philox_unit_test.pass.cpp
@@ -162,7 +162,7 @@ main()
     std::cout << "void counter_management_test() [Engine = philox4x64_w25]";
     err += counter_management_test<philox4x64_w25>();
     std::cout << "void counter_management_test() [Engine = philox4x64_w49]";
-    err += counter_management_test<philox4x64_w49>(); 
+    err += counter_management_test<philox4x64_w49>();
 
     return TestUtils::done();
 }
@@ -367,10 +367,11 @@ discard_overflow_test()
     using T = typename Engine::result_type;
     using scalar_type = typename Engine::scalar_type;
 
-    // Iterate throug the counter's position being overflown 
-    for(int overflown_position = 0; overflown_position < Engine::word_count - 1; ++overflown_position) {
+    // Iterate throug the counter's position being overflown
+    for (int overflown_position = 0; overflown_position < Engine::word_count - 1; ++overflown_position)
+    {
         Engine engine1;
-        std::array<T, Engine::word_count> counter = { 0 };
+        std::array<T, Engine::word_count> counter = {0};
 
         // Overflow of a counter's element. Correspondance is the following:
         // 0 1 2 3 overflow position
@@ -384,20 +385,20 @@ discard_overflow_test()
         Engine engine2;
 
         // To reduce the execution time pre-set counter to almost-overflown state
-        std::array<T, Engine::word_count> counter2 = { 0 };
-        for(int i = Engine::word_count-overflown_position-1; i < Engine::word_count-1; ++i) {
+        std::array<T, Engine::word_count> counter2 = {0};
+        for (int i = Engine::word_count - overflown_position - 1; i < Engine::word_count - 1; ++i)
+        {
             counter2[i] = std::numeric_limits<unsigned long long>::max();
         }
 
         engine2.set_counter(counter2);
-
 
         for (int i = 0; i < Engine::word_count; i++)
         {
             engine2();
         }
 
-        int num_iteratoions = sizeof(unsigned long long)/Engine::word_size;
+        int num_iteratoions = sizeof(unsigned long long) / Engine::word_size;
         for (int i = 0; i < Engine::word_count; i++)
         {
             engine2.discard(engine2.max());
@@ -415,7 +416,7 @@ discard_overflow_test()
         }
     }
 
-    if(!ret_sts)
+    if (!ret_sts)
         std::cout << " passed" << std::endl;
 
     return ret_sts;
@@ -429,12 +430,13 @@ counter_management_test()
     Engine testedEngine;
     Engine referenceEngine;
 
-    // set the counter which value is 2-chunk bitsize 
+    // set the counter which value is 2-chunk bitsize
     unsigned long long increment = ((unsigned long long)testedEngine.max() << Engine::word_size) | testedEngine.max();
     unsigned long long counter_increment = increment / 4;
 
-    std::array<T, Engine::word_count> expected_counter = { 0 };
-    for(int i = Engine::word_count -1 ; i >= 0 ; i--) {
+    std::array<T, Engine::word_count> expected_counter = {0};
+    for (int i = Engine::word_count - 1; i >= 0; i--)
+    {
         expected_counter[i] = counter_increment;
         counter_increment >>= Engine::word_size;
     }
@@ -448,7 +450,6 @@ counter_management_test()
     if (testedEngine() == referenceEngine())
     {
         std::cout << " passed" << std::endl;
-        
     }
     else
     {

--- a/test/xpu_api/random/unit_tests/philox_unit_test.pass.cpp
+++ b/test/xpu_api/random/unit_tests/philox_unit_test.pass.cpp
@@ -367,13 +367,13 @@ discard_overflow_test()
     using T = typename Engine::result_type;
     using scalar_type = typename Engine::scalar_type;
 
-    // Iterate throug the counter's position being overflown
+    // Iterate through the counter's position being overflown
     for (int overflown_position = 0; overflown_position < Engine::word_count - 1; ++overflown_position)
     {
         Engine engine1;
         std::array<T, Engine::word_count> counter = {0};
 
-        // Overflow of a counter's element. Correspondance is the following:
+        // Overflow of a counter's element. Correspondence is the following:
         // 0 1 2 3 overflow position
         // 1 2 3 0 set-up counter position in engine
         // 2 1 0 3 raw_counter_position

--- a/test/xpu_api/random/unit_tests/philox_unit_test.pass.cpp
+++ b/test/xpu_api/random/unit_tests/philox_unit_test.pass.cpp
@@ -43,24 +43,38 @@ template <typename Engine>
 int
 counter_management_test();
 
+// Philox with word_count = 2
+using philox2x32 = ex::philox_engine<std::uint_fast32_t, 32, 2, 10, 0xD256D193, 0x0>;
+using philox2x64 = ex::philox_engine<std::uint_fast64_t, 64, 2, 10, 0xD2B74407B1CE6E93, 0x0>;
+using philox2x32_w5 = ex::philox_engine<std::uint_fast32_t, 5, 2, 10, 0xD256D193, 0x0>;
+using philox2x32_w15 = ex::philox_engine<std::uint_fast32_t, 15, 2, 10, 0xD256D193, 0x0>;
+using philox2x32_w18 = ex::philox_engine<std::uint_fast32_t, 18, 2, 10, 0xD256D193, 0x0>;
+using philox2x32_w30 = ex::philox_engine<std::uint_fast32_t, 30, 2, 10, 0xD256D193, 0x0>;
+using philox2x64_w5 = ex::philox_engine<std::uint_fast64_t, 5, 2, 10, 0xD2B74407B1CE6E93, 0x0>;
+using philox2x64_w15 = ex::philox_engine<std::uint_fast64_t, 15, 2, 10, 0xD2B74407B1CE6E93, 0x0>;
+using philox2x64_w18 = ex::philox_engine<std::uint_fast64_t, 18, 2, 10, 0xD2B74407B1CE6E93, 0x0>;
+using philox2x64_w25 = ex::philox_engine<std::uint_fast64_t, 25, 2, 10, 0xD2B74407B1CE6E93, 0x0>;
+using philox2x64_w49 = ex::philox_engine<std::uint_fast64_t, 49, 2, 10, 0xD2B74407B1CE6E93, 0x0>;
+
+// Philox with word_count = 4
 using philox4x32_w5 = ex::philox_engine<std::uint_fast32_t, 5, 4, 10, 0xCD9E8D57, 0x9E3779B9, 0xD2511F53, 0xBB67AE85>;
 using philox4x32_w15 = ex::philox_engine<std::uint_fast32_t, 15, 4, 10, 0xCD9E8D57, 0x9E3779B9, 0xD2511F53, 0xBB67AE85>;
 using philox4x32_w18 = ex::philox_engine<std::uint_fast32_t, 18, 4, 10, 0xCD9E8D57, 0x9E3779B9, 0xD2511F53, 0xBB67AE85>;
 using philox4x32_w30 = ex::philox_engine<std::uint_fast32_t, 30, 4, 10, 0xCD9E8D57, 0x9E3779B9, 0xD2511F53, 0xBB67AE85>;
 using philox4x64_w5 =
-    oneapi::dpl::experimental::philox_engine<std::uint_fast64_t, 5, 4, 10, 0xCA5A826395121157, 0x9E3779B97F4A7C15,
+    ex::philox_engine<std::uint_fast64_t, 5, 4, 10, 0xCA5A826395121157, 0x9E3779B97F4A7C15,
                                              0xD2E7470EE14C6C93, 0xBB67AE8584CAA73B>;
 using philox4x64_w15 =
-    oneapi::dpl::experimental::philox_engine<std::uint_fast64_t, 15, 4, 10, 0xCA5A826395121157, 0x9E3779B97F4A7C15,
+    ex::philox_engine<std::uint_fast64_t, 15, 4, 10, 0xCA5A826395121157, 0x9E3779B97F4A7C15,
                                              0xD2E7470EE14C6C93, 0xBB67AE8584CAA73B>;
 using philox4x64_w18 =
-    oneapi::dpl::experimental::philox_engine<std::uint_fast64_t, 18, 4, 10, 0xCA5A826395121157, 0x9E3779B97F4A7C15,
+    ex::philox_engine<std::uint_fast64_t, 18, 4, 10, 0xCA5A826395121157, 0x9E3779B97F4A7C15,
                                              0xD2E7470EE14C6C93, 0xBB67AE8584CAA73B>;
 using philox4x64_w25 =
-    oneapi::dpl::experimental::philox_engine<std::uint_fast64_t, 25, 4, 10, 0xCA5A826395121157, 0x9E3779B97F4A7C15,
+    ex::philox_engine<std::uint_fast64_t, 25, 4, 10, 0xCA5A826395121157, 0x9E3779B97F4A7C15,
                                              0xD2E7470EE14C6C93, 0xBB67AE8584CAA73B>;
 using philox4x64_w49 =
-    oneapi::dpl::experimental::philox_engine<std::uint_fast64_t, 49, 4, 10, 0xCA5A826395121157, 0x9E3779B97F4A7C15,
+    ex::philox_engine<std::uint_fast64_t, 49, 4, 10, 0xCA5A826395121157, 0x9E3779B97F4A7C15,
                                              0xD2E7470EE14C6C93, 0xBB67AE8584CAA73B>;
 
 int
@@ -69,11 +83,20 @@ main()
     int err = 0;
 
     /* Test of the Philox engine with pre-defined standard parameters */
+
+    std::cout << "void seed_test() [Engine = philox2x32]";
+    err += seed_test<philox2x32>();
+    std::cout << "void seed_test() [Engine = philox2x64]";
+    err += seed_test<philox2x64>();
     std::cout << "void seed_test() [Engine = philox4x32]";
     err += seed_test<ex::philox4x32>();
     std::cout << "void seed_test() [Engine = philox4x64]";
     err += seed_test<ex::philox4x64>();
 
+    std::cout << "void discard_test() [Engine = philox2x32]";
+    err += discard_test<philox2x32>();
+    std::cout << "void discard_test() [Engine = philox2x64]";
+    err += discard_test<philox2x64>();
     std::cout << "void discard_test() [Engine = philox4x32]";
     err += discard_test<ex::philox4x32>();
     std::cout << "void discard_test() [Engine = philox4x64]";
@@ -84,16 +107,28 @@ main()
     std::cout << "void set_counter_conformance_test() [Engine = philox4x64]";
     err += set_counter_conformance_test<ex::philox4x64>();
 
+    std::cout << "void skip_test() [Engine = philox2x32]";
+    err += skip_test<philox2x32>();
+    std::cout << "void skip_test() [Engine = philox2x64]";
+    err += skip_test<philox2x64>();
     std::cout << "void skip_test() [Engine = philox4x32]";
     err += skip_test<ex::philox4x32>();
     std::cout << "void skip_test() [Engine = philox4x64]";
     err += skip_test<ex::philox4x64>();
-
+    
+    std::cout << "void counter_overflow_test() [Engine = philox2x32]";
+    err += counter_overflow_test<philox2x32>();
+    std::cout << "void counter_overflow_test() [Engine = philox2x64]";
+    err += counter_overflow_test<philox2x64>();
     std::cout << "void counter_overflow_test() [Engine = philox4x32]";
     err += counter_overflow_test<ex::philox4x32>();
     std::cout << "void counter_overflow_test() [Engine = philox4x64]";
     err += counter_overflow_test<ex::philox4x64>();
 
+    std::cout << "void discard_overflow_test() [Engine = philox2x32]";
+    err += discard_overflow_test<philox2x32>();
+    std::cout << "void discard_overflow_test() [Engine = philox2x64]";
+    err += discard_overflow_test<philox2x64>();
     std::cout << "void discard_overflow_test() [Engine = philox4x32]";
     err += discard_overflow_test<ex::philox4x32>();
     std::cout << "void discard_overflow_test() [Engine = philox4x64]";
@@ -102,6 +137,29 @@ main()
     EXPECT_TRUE(!err, "Test FAILED");
 
     /* Test of the Philox engine with non-standard parameters */
+
+    // `counter_overflow_test` philox2x*
+    std::cout << "void counter_overflow_test() [Engine = philox2x32_w5]";
+    err += counter_overflow_test<philox2x32_w5>();
+    std::cout << "void counter_overflow_test() [Engine = philox2x32_w15]";
+    err += counter_overflow_test<philox2x32_w15>();
+    std::cout << "void counter_overflow_test() [Engine = philox2x32_w18]";
+    err += counter_overflow_test<philox2x32_w18>();
+    std::cout << "void counter_overflow_test() [Engine = philox2x32_w30]";
+    err += counter_overflow_test<philox2x32_w30>();
+
+    std::cout << "void counter_overflow_test() [Engine = philox2x64_w5]";
+    err += counter_overflow_test<philox2x64_w5>();
+    std::cout << "void counter_overflow_test() [Engine = philox2x64_w15]";
+    err += counter_overflow_test<philox2x64_w15>();
+    std::cout << "void counter_overflow_test() [Engine = philox2x64_w18]";
+    err += counter_overflow_test<philox2x64_w18>();
+    std::cout << "void counter_overflow_test() [Engine = philox2x64_w25]";
+    err += counter_overflow_test<philox2x64_w25>();
+    std::cout << "void counter_overflow_test() [Engine = philox2x64_w49]";
+    err += counter_overflow_test<philox2x64_w49>();
+
+    // `counter_overflow_test` philox4x*
     std::cout << "void counter_overflow_test() [Engine = philox4x32_w5]";
     err += counter_overflow_test<philox4x32_w5>();
     std::cout << "void counter_overflow_test() [Engine = philox4x32_w15]";
@@ -122,6 +180,30 @@ main()
     std::cout << "void counter_overflow_test() [Engine = philox4x64_w49]";
     err += counter_overflow_test<philox4x64_w49>();
 
+    EXPECT_TRUE(!err, "Test FAILED");
+
+    // `discard_overflow_test` philox2x*
+    std::cout << "void discard_overflow_test() [Engine = philox2x32_w5]";
+    err += discard_overflow_test<philox2x32_w5>();
+    std::cout << "void discard_overflow_test() [Engine = philox2x32_w15]";
+    err += discard_overflow_test<philox2x32_w15>();
+    std::cout << "void discard_overflow_test() [Engine = philox2x32_w18]";
+    err += discard_overflow_test<philox2x32_w18>();
+    std::cout << "void discard_overflow_test() [Engine = philox2x32_w30]";
+    err += discard_overflow_test<philox2x32_w30>();
+
+    std::cout << "void discard_overflow_test() [Engine = philox2x64_w5]";
+    err += discard_overflow_test<philox2x64_w5>();
+    std::cout << "void discard_overflow_test() [Engine = philox2x64_w15]";
+    err += discard_overflow_test<philox2x64_w15>();
+    std::cout << "void discard_overflow_test() [Engine = philox2x64_w18]";
+    err += discard_overflow_test<philox2x64_w18>();
+    std::cout << "void discard_overflow_test() [Engine = philox2x64_w25]";
+    err += discard_overflow_test<philox2x64_w25>();
+    std::cout << "void discard_overflow_test() [Engine = philox2x64_w49]";
+    err += discard_overflow_test<philox2x64_w49>();
+
+    // `discard_overflow_test` philox4x*
     std::cout << "void discard_overflow_test() [Engine = philox4x32_w5]";
     err += discard_overflow_test<philox4x32_w5>();
     std::cout << "void discard_overflow_test() [Engine = philox4x32_w15]";
@@ -131,8 +213,6 @@ main()
     std::cout << "void discard_overflow_test() [Engine = philox4x32_w30]";
     err += discard_overflow_test<philox4x32_w30>();
 
-    std::cout << "void discard_overflow_test() [Engine = philox4x64]";
-    err += discard_overflow_test<ex::philox4x64>();
     std::cout << "void discard_overflow_test() [Engine = philox4x64_w5]";
     err += discard_overflow_test<philox4x64_w5>();
     std::cout << "void discard_overflow_test() [Engine = philox4x64_w15]";
@@ -144,6 +224,30 @@ main()
     std::cout << "void discard_overflow_test() [Engine = philox4x64_w49]";
     err += discard_overflow_test<philox4x64_w49>();
 
+    EXPECT_TRUE(!err, "Test FAILED");
+
+    // `counter_management_test` philox2x*
+    std::cout << "void counter_management_test() [Engine = philox2x32_w5]";
+    err += counter_management_test<philox2x32_w5>();
+    std::cout << "void counter_management_test() [Engine = philox2x32_w15]";
+    err += counter_management_test<philox2x32_w15>();
+    std::cout << "void counter_management_test() [Engine = philox2x32_w18]";
+    err += counter_management_test<philox2x32_w18>();
+    std::cout << "void counter_management_test() [Engine = philox2x32_w30]";
+    err += counter_management_test<philox2x32_w30>();
+
+    std::cout << "void counter_management_test() [Engine = philox2x64_w5]";
+    err += counter_management_test<philox2x64_w5>();
+    std::cout << "void counter_management_test() [Engine = philox2x64_w15]";
+    err += counter_management_test<philox2x64_w15>();
+    std::cout << "void counter_management_test() [Engine = philox2x64_w18]";
+    err += counter_management_test<philox2x64_w18>();
+    std::cout << "void counter_management_test() [Engine = philox2x64_w25]";
+    err += counter_management_test<philox2x64_w25>();
+    std::cout << "void counter_management_test() [Engine = philox2x64_w49]";
+    err += counter_management_test<philox2x64_w49>();
+    
+    // `counter_management_test` philox4x*
     std::cout << "void counter_management_test() [Engine = philox4x32_w5]";
     err += counter_management_test<philox4x32_w5>();
     std::cout << "void counter_management_test() [Engine = philox4x32_w15]";
@@ -163,6 +267,8 @@ main()
     err += counter_management_test<philox4x64_w25>();
     std::cout << "void counter_management_test() [Engine = philox4x64_w49]";
     err += counter_management_test<philox4x64_w49>();
+
+    EXPECT_TRUE(!err, "Test FAILED");
 
     return TestUtils::done();
 }
@@ -305,7 +411,9 @@ skip_test()
     for (T i = 1; i <= Engine::word_count + 1; i++)
     {
         Engine engine1;
-        std::array<T, Engine::word_count> counter = {0, 0, 0, i / Engine::word_count};
+        std::array<T, Engine::word_count> counter = {0};
+        counter[Engine::word_count-1] = i / Engine::word_count;
+
         engine1.set_counter(counter);
         for (T j = 0; j < i % Engine::word_count; j++)
         {
@@ -373,10 +481,10 @@ discard_overflow_test()
         Engine engine1;
         std::array<T, Engine::word_count> counter = {0};
 
-        // Overflow of a counter's element. The correspondence is the following:
-        // 0 1 2 3 overflow position
-        // 1 2 3 0 set-up counter position in engine
-        // 2 1 0 3 raw_counter_position
+        // Overflow of a counter's element. The correspondence for Engine::word_count = 4 is the following:
+        //      0 1 2 possible overflow position
+        //      1 2 3 counter position in engine to be set up to 1
+        //      2 1 0 raw_counter_position (representation of the counter outside engine)
         int raw_counter_position = (Engine::word_count - overflown_position - 2) % Engine::word_count;
         counter[raw_counter_position] = 1;
 
@@ -421,6 +529,11 @@ discard_overflow_test()
     return ret_sts;
 }
 
+/*
+ * The testing is based on comparing the work of two different methods of the engine:
+ *      `set_counter` - referenceEngine
+ *      `increase_counter_internal(unsigned long long __z)` called by `discard()` - testedEngine
+*/
 template <typename Engine>
 int
 counter_management_test()
@@ -431,7 +544,7 @@ counter_management_test()
 
     // set the counter which value is 2-chunk bitsize
     unsigned long long increment = ((unsigned long long)testedEngine.max() << Engine::word_size) | testedEngine.max();
-    unsigned long long counter_increment = increment / 4;
+    unsigned long long counter_increment = increment / Engine::word_count;
 
     std::array<T, Engine::word_count> expected_counter = {0};
     for (int i = Engine::word_count - 1; i >= 0; i--)
@@ -439,10 +552,11 @@ counter_management_test()
         expected_counter[i] = counter_increment;
         counter_increment >>= Engine::word_size;
     }
+
     referenceEngine.set_counter(expected_counter);
-    referenceEngine();
-    referenceEngine();
-    referenceEngine();
+    for (int i = 0; i < Engine::word_count - 1; ++i){
+        referenceEngine();
+    }
 
     testedEngine.discard(increment);
 

--- a/test/xpu_api/random/unit_tests/philox_unit_test.pass.cpp
+++ b/test/xpu_api/random/unit_tests/philox_unit_test.pass.cpp
@@ -373,7 +373,7 @@ discard_overflow_test()
         Engine engine1;
         std::array<T, Engine::word_count> counter = {0};
 
-        // Overflow of a counter's element. Correspondence is the following:
+        // Overflow of a counter's element. The correspondence is the following:
         // 0 1 2 3 overflow position
         // 1 2 3 0 set-up counter position in engine
         // 2 1 0 3 raw_counter_position
@@ -398,7 +398,6 @@ discard_overflow_test()
             engine2();
         }
 
-        int num_iteratoions = sizeof(unsigned long long) / Engine::word_size;
         for (int i = 0; i < Engine::word_count; i++)
         {
             engine2.discard(engine2.max());


### PR DESCRIPTION
**What introduces this PR:**
1. Fix for the incorrect counter incrementing in case `w` is not the recommended value (`w!=32` and `w!=64`)
2. `discard_overflow_test` was extended: previously only the first chunk of the counter was overflowing, now introduced the high-level loop, which iterates through the other positions of the counter(2nd and 3rd) and also checks for the overflow.
3. Introduced a new unit test - `counter_management_test`. 
   - The testing is based on comparing the work of two different methods of the engine - simple `set_counter` and more complicated `increase_counter_internal(unsigned long long __z)` which is called by `discard`
   - The test discards the engine by the increment which takes at least 2 chunks of the counter type(`2*w`) - this way `increase_counter_internal` will take `__z` that should be placed properly in the 1st chunk and propagated to the 2nd one. The right calculations are checked by `referenceEngine` which is based on simpler `set_counter` function. 