### PR TITLE
[oneDPL][ranges][test] + test_range_algo::test_view functionality

### DIFF
--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -169,7 +169,7 @@ struct test
         auto expected_res = checker(expected_view, args...);
 
         typename Container::type& A = cont_in();
-        auto r_in = tr_in(A);
+        decltype(auto) r_in = tr_in(A);
         auto res = algo(exec, r_in, args...);
 
         //check result

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -169,12 +169,13 @@ struct test
         auto expected_res = checker(expected_view, args...);
 
         typename Container::type& A = cont_in();
-        auto res = algo(exec, tr_in(A), args...);
+        auto r_in = tr_in(A);
+        auto res = algo(exec, r_in, args...);
 
         //check result
-        static_assert(std::is_same_v<decltype(res), decltype(checker(tr_in(A), args...))>, "Wrong return type");
+        static_assert(std::is_same_v<decltype(res), decltype(checker(r_in, args...))>, "Wrong return type");
 
-        auto bres = ret_in_val(expected_res, expected_view.begin()) == ret_in_val(res, tr_in(A).begin());
+        auto bres = ret_in_val(expected_res, expected_view.begin()) == ret_in_val(res, r_in.begin());
         EXPECT_TRUE(bres, (std::string("wrong return value from algo with ranges: ") + typeid(Algo).name() + 
                 typeid(decltype(tr_in(std::declval<Container&>()()))).name()).c_str());
 
@@ -515,6 +516,14 @@ template<int call_id = 0, typename T = int, TestDataMode mode = data_in>
 struct test_range_algo
 {
     const int max_n = 10;
+    void test_view(auto view, auto algo, auto& checker, auto... args)
+    {
+        test<T, host_subrange<T>, mode>{max_n}(host_policies(), algo, checker, view, std::identity{}, args...);
+#if TEST_DPCPP_BACKEND_PRESENT
+        test<T, usm_subrange<T>, mode>{max_n}(dpcpp_policy<call_id>(), algo, checker, view, std::identity{}, args...);
+#endif //TEST_DPCPP_BACKEND_PRESENT
+    }
+
     void operator()(auto algo, auto& checker, auto... args)
     {
 

--- a/test/parallel_api/ranges/std_ranges_test_views.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_test_views.pass.cpp
@@ -1,0 +1,45 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Copyright (C) Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// This file incorporates work covered by the following copyright and permission
+// notice:
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#include "std_ranges_test.h"
+
+std::int32_t
+main()
+{
+#if _ENABLE_STD_RANGES_TESTING
+    using namespace test_std_ranges;
+    namespace dpl_ranges = oneapi::dpl::ranges;
+
+    const int n = 1<<25; //32M
+
+    //transform view
+    test_range_algo<0>{n}.test_view(std::views::transform([](const auto a) { return a*2; }), 
+        dpl_ranges::find_if, std::ranges::find_if, pred, proj);
+
+    //reverse view
+    test_range_algo<1>{n}.test_view(std::views::reverse, dpl_ranges::sort, std::ranges::sort, std::less{});
+
+    //take view
+    test_range_algo<2>{n}.test_view(std::views::take(n/2), dpl_ranges::count_if, std::ranges::count_if, pred, proj);
+
+    //drop view
+    test_range_algo<3>{n}.test_view(std::views::drop(n/2), dpl_ranges::count_if, std::ranges::count_if, pred, proj);
+
+    //NOTICE: std::ranges::views::all, std::ranges::subrange, std::span are tested implicitly within the 'test_range_algo' test engine.
+#endif //_ENABLE_STD_RANGES_TESTING
+
+    return TestUtils::done(_ENABLE_STD_RANGES_TESTING);
+}
+


### PR DESCRIPTION
The PR introduces the checks for following standard view adapters:

- transform_view
- reverse_view
- take_view
- drop_view

NOTICE: std::ranges::views::all, std::ranges::subrange, std::span are tested implicitly within the 'test_range_algo' test engine.
single_view - is a trivial view and it doesn't  make sense for testing in the parallel code.