### PR TITLE
Add missing device copyable specialization for `single_match_pred`

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_traits.h
@@ -332,6 +332,9 @@ template <typename _ExecutionPolicy, typename _Pred>
 struct single_match_pred_by_idx;
 
 template <typename _ExecutionPolicy, typename _Pred>
+struct single_match_pred;
+
+template <typename _ExecutionPolicy, typename _Pred>
 struct multiple_match_pred;
 
 template <typename _ExecutionPolicy, typename _Pred, typename _Tp, typename _Size>
@@ -400,6 +403,13 @@ struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::unseq_backen
 
 template <typename _ExecutionPolicy, typename _Pred>
 struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::unseq_backend::single_match_pred_by_idx,
+                                                       _ExecutionPolicy, _Pred)>
+    : oneapi::dpl::__internal::__are_all_device_copyable<_Pred>
+{
+};
+
+template <typename _ExecutionPolicy, typename _Pred>
+struct sycl::is_device_copyable<_ONEDPL_SPECIALIZE_FOR(oneapi::dpl::unseq_backend::single_match_pred,
                                                        _ExecutionPolicy, _Pred)>
     : oneapi::dpl::__internal::__are_all_device_copyable<_Pred>
 {


### PR DESCRIPTION
`zip_iterator_find.pass` which has been recently added fails to compile on Windows. This is caused by a missing device copyable specialization for `oneapi::dpl::unseq_backend::single_match_pred`. As a result, `find_if` does not compile if a `std::tuple` member is in the user-provided predicate.

Adding the specialization resolved the compile error and the test now passes.