### PR TITLE
[oneDPL][ranges][tests] a fix for std::ranges::<algo> using with Windows C++ standard library.

### DIFF
--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -424,10 +424,9 @@ struct __stable_sort_fn
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
-        return oneapi::dpl::__internal::__ranges::__pattern_sort_ranges(__dispatch_tag,
-            std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __comp, __proj,
-            [](auto&&... __args) { return std::ranges::stable_sort(std::forward<decltype(__args)>(__args)...); }
-            );
+        return oneapi::dpl::__internal::__ranges::__pattern_sort_ranges(
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __comp, __proj,
+            [](auto&&... __args) { return std::ranges::stable_sort(std::forward<decltype(__args)>(__args)...); });
     }
 }; //__stable_sort_fn
 }  //__internal
@@ -446,10 +445,9 @@ struct __sort_fn
     operator()(_ExecutionPolicy&& __exec, _R&& __r, _Comp __comp = {}, _Proj __proj = {}) const
     {
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
-        return oneapi::dpl::__internal::__ranges::__pattern_sort_ranges(__dispatch_tag,
-            std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __comp, __proj,
-            [](auto&&... __args) { return std::ranges::sort(std::forward<decltype(__args)>(__args)...); }
-            );
+        return oneapi::dpl::__internal::__ranges::__pattern_sort_ranges(
+            __dispatch_tag, std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __comp, __proj,
+            [](auto&&... __args) { return std::ranges::sort(std::forward<decltype(__args)>(__args)...); });
     }
 }; //__sort_fn
 }  //__internal

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -426,7 +426,7 @@ struct __stable_sort_fn
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         return oneapi::dpl::__internal::__ranges::__pattern_sort_ranges(__dispatch_tag,
             std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __comp, __proj,
-            _ONEDPL_PREPARE_CALLABLE(std::ranges::stable_sort)
+            [](auto&&... __args) { return std::ranges::stable_sort(std::forward<decltype(__args)>(__args)...); }
             );
     }
 }; //__stable_sort_fn
@@ -448,7 +448,7 @@ struct __sort_fn
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         return oneapi::dpl::__internal::__ranges::__pattern_sort_ranges(__dispatch_tag,
             std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __comp, __proj,
-            _ONEDPL_PREPARE_CALLABLE(std::ranges::sort)
+            [](auto&&... __args) { return std::ranges::sort(std::forward<decltype(__args)>(__args)...); }
             );
     }
 }; //__sort_fn

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -426,11 +426,7 @@ struct __stable_sort_fn
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         return oneapi::dpl::__internal::__ranges::__pattern_sort_ranges(__dispatch_tag,
             std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __comp, __proj,
-#if _ONEDPL_STD_RANGES_ALGO_CPP_FUN
-            [](auto&&... __args) { return std::ranges::stable_sort(std::forward<decltype(__args)>(__args)...); }
-#else
-            std::ranges::stable_sort
-#endif
+            _ONEDPL_ALGO(std::ranges::stable_sort)
             );
     }
 }; //__stable_sort_fn
@@ -452,11 +448,7 @@ struct __sort_fn
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         return oneapi::dpl::__internal::__ranges::__pattern_sort_ranges(__dispatch_tag,
             std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __comp, __proj,
-#if _ONEDPL_STD_RANGES_ALGO_CPP_FUN
-            [](auto&&... __args) { return std::ranges::sort(std::forward<decltype(__args)>(__args)...); }
-#else
-            std::ranges::sort
-#endif
+            _ONEDPL_ALGO(std::ranges::sort)
             );
     }
 }; //__sort_fn

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -427,7 +427,7 @@ struct __stable_sort_fn
         return oneapi::dpl::__internal::__ranges::__pattern_sort_ranges(__dispatch_tag,
             std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __comp, __proj,
 #if _ONEDPL_STD_RANGES_ALGO_CPP_FUN
-            [](auto&&... __args) { std::ranges::stable_sort(std::forward<decltype(__args)>(__args)...); }
+            [](auto&&... __args) { return std::ranges::stable_sort(std::forward<decltype(__args)>(__args)...); }
 #else
             std::ranges::stable_sort
 #endif
@@ -453,7 +453,7 @@ struct __sort_fn
         return oneapi::dpl::__internal::__ranges::__pattern_sort_ranges(__dispatch_tag,
             std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __comp, __proj,
 #if _ONEDPL_STD_RANGES_ALGO_CPP_FUN
-            [](auto&&... __args) { std::ranges::sort(std::forward<decltype(__args)>(__args)...); }
+            [](auto&&... __args) { return std::ranges::sort(std::forward<decltype(__args)>(__args)...); }
 #else
             std::ranges::sort
 #endif

--- a/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
+++ b/include/oneapi/dpl/pstl/glue_algorithm_ranges_impl.h
@@ -426,7 +426,7 @@ struct __stable_sort_fn
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         return oneapi::dpl::__internal::__ranges::__pattern_sort_ranges(__dispatch_tag,
             std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __comp, __proj,
-            _ONEDPL_ALGO(std::ranges::stable_sort)
+            _ONEDPL_PREPARE_CALLABLE(std::ranges::stable_sort)
             );
     }
 }; //__stable_sort_fn
@@ -448,7 +448,7 @@ struct __sort_fn
         const auto __dispatch_tag = oneapi::dpl::__ranges::__select_backend(__exec);
         return oneapi::dpl::__internal::__ranges::__pattern_sort_ranges(__dispatch_tag,
             std::forward<_ExecutionPolicy>(__exec), std::forward<_R>(__r), __comp, __proj,
-            _ONEDPL_ALGO(std::ranges::sort)
+            _ONEDPL_PREPARE_CALLABLE(std::ranges::sort)
             );
     }
 }; //__sort_fn

--- a/test/parallel_api/ranges/std_ranges_adjacent_find.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_adjacent_find.pass.cpp
@@ -22,10 +22,12 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    test_range_algo<0>{big_sz}(dpl_ranges::adjacent_find, std::ranges::adjacent_find, binary_pred);
-    test_range_algo<1>{}(dpl_ranges::adjacent_find, std::ranges::adjacent_find, binary_pred, proj);
-    test_range_algo<2, P2>{}(dpl_ranges::adjacent_find, std::ranges::adjacent_find, binary_pred, &P2::x);
-    test_range_algo<3, P2>{}(dpl_ranges::adjacent_find, std::ranges::adjacent_find, binary_pred, &P2::proj);
+    auto adj_find_checker = _ONEDPL_ALGO(std::ranges::adjacent_find);
+
+    test_range_algo<0>{big_sz}(dpl_ranges::adjacent_find, adj_find_checker, binary_pred);
+    test_range_algo<1>{}(dpl_ranges::adjacent_find, adj_find_checker, binary_pred, proj);
+    test_range_algo<2, P2>{}(dpl_ranges::adjacent_find, adj_find_checker, binary_pred, &P2::x);
+    test_range_algo<3, P2>{}(dpl_ranges::adjacent_find, adj_find_checker, binary_pred, &P2::proj);
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_adjacent_find.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_adjacent_find.pass.cpp
@@ -22,7 +22,7 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    auto adj_find_checker = _ONEDPL_ALGO(std::ranges::adjacent_find);
+    auto adj_find_checker = _ONEDPL_PREPARE_CALLABLE(std::ranges::adjacent_find);
 
     test_range_algo<0>{big_sz}(dpl_ranges::adjacent_find, adj_find_checker, binary_pred);
     test_range_algo<1>{}(dpl_ranges::adjacent_find, adj_find_checker, binary_pred, proj);

--- a/test/parallel_api/ranges/std_ranges_adjacent_find.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_adjacent_find.pass.cpp
@@ -22,7 +22,7 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    auto adj_find_checker = _ONEDPL_PREPARE_CALLABLE(std::ranges::adjacent_find);
+    auto adj_find_checker = TEST_PREPARE_CALLABLE(std::ranges::adjacent_find);
 
     test_range_algo<0>{big_sz}(dpl_ranges::adjacent_find, adj_find_checker, binary_pred);
     test_range_algo<1>{}(dpl_ranges::adjacent_find, adj_find_checker, binary_pred, proj);

--- a/test/parallel_api/ranges/std_ranges_all_of.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_all_of.pass.cpp
@@ -22,7 +22,7 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    auto all_of_checker = _ONEDPL_ALGO(std::ranges::all_of);
+    auto all_of_checker = _ONEDPL_PREPARE_CALLABLE(std::ranges::all_of);
 
     test_range_algo<0>{big_sz}(dpl_ranges::all_of,  all_of_checker, pred1);
     test_range_algo<1>{}(dpl_ranges::all_of,  all_of_checker, pred1, proj);

--- a/test/parallel_api/ranges/std_ranges_all_of.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_all_of.pass.cpp
@@ -22,10 +22,12 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    test_range_algo<0>{big_sz}(dpl_ranges::all_of,  std::ranges::all_of, pred1);
-    test_range_algo<1>{}(dpl_ranges::all_of,  std::ranges::all_of, pred1, proj);
-    test_range_algo<2, P2>{}(dpl_ranges::all_of,  std::ranges::all_of, pred1, &P2::x);
-    test_range_algo<3, P2>{}(dpl_ranges::all_of,  std::ranges::all_of, pred1, &P2::proj);
+    auto all_of_checker = _ONEDPL_ALGO(std::ranges::all_of);
+
+    test_range_algo<0>{big_sz}(dpl_ranges::all_of,  all_of_checker, pred1);
+    test_range_algo<1>{}(dpl_ranges::all_of,  all_of_checker, pred1, proj);
+    test_range_algo<2, P2>{}(dpl_ranges::all_of,  all_of_checker, pred1, &P2::x);
+    test_range_algo<3, P2>{}(dpl_ranges::all_of,  all_of_checker, pred1, &P2::proj);
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_all_of.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_all_of.pass.cpp
@@ -22,7 +22,7 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    auto all_of_checker = _ONEDPL_PREPARE_CALLABLE(std::ranges::all_of);
+    auto all_of_checker = TEST_PREPARE_CALLABLE(std::ranges::all_of);
 
     test_range_algo<0>{big_sz}(dpl_ranges::all_of,  all_of_checker, pred1);
     test_range_algo<1>{}(dpl_ranges::all_of,  all_of_checker, pred1, proj);

--- a/test/parallel_api/ranges/std_ranges_any_of.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_any_of.pass.cpp
@@ -22,7 +22,7 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    auto any_of_checker = _ONEDPL_PREPARE_CALLABLE(std::ranges::any_of);
+    auto any_of_checker = TEST_PREPARE_CALLABLE(std::ranges::any_of);
 
     test_range_algo<0>{big_sz}(dpl_ranges::any_of,  any_of_checker, pred2);
     test_range_algo<1>{}(dpl_ranges::any_of,  any_of_checker, pred2, proj);

--- a/test/parallel_api/ranges/std_ranges_any_of.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_any_of.pass.cpp
@@ -22,10 +22,12 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    test_range_algo<0>{big_sz}(dpl_ranges::any_of,  std::ranges::any_of, pred2);
-    test_range_algo<1>{}(dpl_ranges::any_of,  std::ranges::any_of, pred2, proj);
-    test_range_algo<2, P2>{}(dpl_ranges::any_of,  std::ranges::any_of, pred2, &P2::x);
-    test_range_algo<3, P2>{}(dpl_ranges::any_of,  std::ranges::any_of, pred2, &P2::proj);
+    auto any_of_checker = _ONEDPL_ALGO(std::ranges::any_of);
+
+    test_range_algo<0>{big_sz}(dpl_ranges::any_of,  any_of_checker, pred2);
+    test_range_algo<1>{}(dpl_ranges::any_of,  any_of_checker, pred2, proj);
+    test_range_algo<2, P2>{}(dpl_ranges::any_of,  any_of_checker, pred2, &P2::x);
+    test_range_algo<3, P2>{}(dpl_ranges::any_of,  any_of_checker, pred2, &P2::proj);
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_any_of.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_any_of.pass.cpp
@@ -22,7 +22,7 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    auto any_of_checker = _ONEDPL_ALGO(std::ranges::any_of);
+    auto any_of_checker = _ONEDPL_PREPARE_CALLABLE(std::ranges::any_of);
 
     test_range_algo<0>{big_sz}(dpl_ranges::any_of,  any_of_checker, pred2);
     test_range_algo<1>{}(dpl_ranges::any_of,  any_of_checker, pred2, proj);

--- a/test/parallel_api/ranges/std_ranges_count.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_count.pass.cpp
@@ -22,7 +22,7 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    auto count_checker = _ONEDPL_PREPARE_CALLABLE(std::ranges::count);
+    auto count_checker = TEST_PREPARE_CALLABLE(std::ranges::count);
 
     test_range_algo<0>{big_sz}(dpl_ranges::count, count_checker, 4);
     test_range_algo<1>{}(dpl_ranges::count, count_checker, 4, proj);

--- a/test/parallel_api/ranges/std_ranges_count.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_count.pass.cpp
@@ -22,7 +22,7 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    auto count_checker = _ONEDPL_ALGO(std::ranges::count);
+    auto count_checker = _ONEDPL_PREPARE_CALLABLE(std::ranges::count);
 
     test_range_algo<0>{big_sz}(dpl_ranges::count, count_checker, 4);
     test_range_algo<1>{}(dpl_ranges::count, count_checker, 4, proj);

--- a/test/parallel_api/ranges/std_ranges_count.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_count.pass.cpp
@@ -22,10 +22,12 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    test_range_algo<0>{big_sz}(dpl_ranges::count, std::ranges::count, 4);
-    test_range_algo<1>{}(dpl_ranges::count, std::ranges::count, 4, proj);
-    test_range_algo<2, P2>{}(dpl_ranges::count, std::ranges::count, 4, &P2::x);
-    test_range_algo<3, P2>{}(dpl_ranges::count, std::ranges::count, 4, &P2::proj);
+    auto count_checker = _ONEDPL_ALGO(std::ranges::count);
+
+    test_range_algo<0>{big_sz}(dpl_ranges::count, count_checker, 4);
+    test_range_algo<1>{}(dpl_ranges::count, count_checker, 4, proj);
+    test_range_algo<2, P2>{}(dpl_ranges::count, count_checker, 4, &P2::x);
+    test_range_algo<3, P2>{}(dpl_ranges::count, count_checker, 4, &P2::proj);
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_count_if.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_count_if.pass.cpp
@@ -22,7 +22,7 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    auto count_if_checker = _ONEDPL_ALGO(std::ranges::count_if);
+    auto count_if_checker = _ONEDPL_PREPARE_CALLABLE(std::ranges::count_if);
 
     test_range_algo<0>{big_sz}(dpl_ranges::count_if, count_if_checker, pred);
     test_range_algo<1>{}(dpl_ranges::count_if, count_if_checker, pred, proj);

--- a/test/parallel_api/ranges/std_ranges_count_if.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_count_if.pass.cpp
@@ -22,7 +22,7 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    auto count_if_checker = _ONEDPL_PREPARE_CALLABLE(std::ranges::count_if);
+    auto count_if_checker = TEST_PREPARE_CALLABLE(std::ranges::count_if);
 
     test_range_algo<0>{big_sz}(dpl_ranges::count_if, count_if_checker, pred);
     test_range_algo<1>{}(dpl_ranges::count_if, count_if_checker, pred, proj);

--- a/test/parallel_api/ranges/std_ranges_count_if.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_count_if.pass.cpp
@@ -22,10 +22,12 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    test_range_algo<0>{big_sz}(dpl_ranges::count_if, std::ranges::count_if, pred);
-    test_range_algo<1>{}(dpl_ranges::count_if, std::ranges::count_if, pred, proj);
-    test_range_algo<2, P2>{}(dpl_ranges::count_if, std::ranges::count_if, pred, &P2::x);
-    test_range_algo<3, P2>{}(dpl_ranges::count_if, std::ranges::count_if, pred, &P2::proj);
+    auto count_if_checker = _ONEDPL_ALGO(std::ranges::count_if);
+
+    test_range_algo<0>{big_sz}(dpl_ranges::count_if, count_if_checker, pred);
+    test_range_algo<1>{}(dpl_ranges::count_if, count_if_checker, pred, proj);
+    test_range_algo<2, P2>{}(dpl_ranges::count_if, count_if_checker, pred, &P2::x);
+    test_range_algo<3, P2>{}(dpl_ranges::count_if, count_if_checker, pred, &P2::proj);
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_equal.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_equal.pass.cpp
@@ -22,7 +22,7 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    auto equal_checker = _ONEDPL_PREPARE_CALLABLE(std::ranges::equal);
+    auto equal_checker = TEST_PREPARE_CALLABLE(std::ranges::equal);
 
     test_range_algo<0, int, data_in_in>{big_sz}(dpl_ranges::equal, equal_checker, binary_pred);
     test_range_algo<1, int, data_in_in>{}(dpl_ranges::equal, equal_checker, binary_pred, proj, proj);

--- a/test/parallel_api/ranges/std_ranges_equal.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_equal.pass.cpp
@@ -22,10 +22,12 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    test_range_algo<0, int, data_in_in>{big_sz}(dpl_ranges::equal, std::ranges::equal, binary_pred);
-    test_range_algo<1, int, data_in_in>{}(dpl_ranges::equal, std::ranges::equal, binary_pred, proj, proj);
-    test_range_algo<2, P2, data_in_in>{}(dpl_ranges::equal, std::ranges::equal, binary_pred, &P2::x, &P2::x);
-    test_range_algo<3, P2, data_in_in>{}(dpl_ranges::equal, std::ranges::equal, binary_pred, &P2::proj, &P2::proj);
+    auto equal_checker = _ONEDPL_ALGO(std::ranges::equal);
+
+    test_range_algo<0, int, data_in_in>{big_sz}(dpl_ranges::equal, equal_checker, binary_pred);
+    test_range_algo<1, int, data_in_in>{}(dpl_ranges::equal, equal_checker, binary_pred, proj, proj);
+    test_range_algo<2, P2, data_in_in>{}(dpl_ranges::equal, equal_checker, binary_pred, &P2::x, &P2::x);
+    test_range_algo<3, P2, data_in_in>{}(dpl_ranges::equal, equal_checker, binary_pred, &P2::proj, &P2::proj);
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_equal.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_equal.pass.cpp
@@ -22,7 +22,7 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    auto equal_checker = _ONEDPL_ALGO(std::ranges::equal);
+    auto equal_checker = _ONEDPL_PREPARE_CALLABLE(std::ranges::equal);
 
     test_range_algo<0, int, data_in_in>{big_sz}(dpl_ranges::equal, equal_checker, binary_pred);
     test_range_algo<1, int, data_in_in>{}(dpl_ranges::equal, equal_checker, binary_pred, proj, proj);

--- a/test/parallel_api/ranges/std_ranges_find.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_find.pass.cpp
@@ -22,11 +22,13 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    test_range_algo<0>{big_sz}(dpl_ranges::find, std::ranges::find, 4);  //found case
-    test_range_algo<1>{}(dpl_ranges::find, std::ranges::find, -1); //not found case
-    test_range_algo<2>{}(dpl_ranges::find, std::ranges::find, 4, proj);
-    test_range_algo<3, P2>{}(dpl_ranges::find, std::ranges::find, 4, &P2::x);
-    test_range_algo<4, P2>{}(dpl_ranges::find, std::ranges::find, 4, &P2::proj);
+    auto find_checker = _ONEDPL_ALGO(std::ranges::find);
+
+    test_range_algo<0>{big_sz}(dpl_ranges::find, find_checker, 4);  //found case
+    test_range_algo<1>{}(dpl_ranges::find, find_checker, -1); //not found case
+    test_range_algo<2>{}(dpl_ranges::find, find_checker, 4, proj);
+    test_range_algo<3, P2>{}(dpl_ranges::find, find_checker, 4, &P2::x);
+    test_range_algo<4, P2>{}(dpl_ranges::find, find_checker, 4, &P2::proj);
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_find.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_find.pass.cpp
@@ -22,7 +22,7 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    auto find_checker = _ONEDPL_ALGO(std::ranges::find);
+    auto find_checker = _ONEDPL_PREPARE_CALLABLE(std::ranges::find);
 
     test_range_algo<0>{big_sz}(dpl_ranges::find, find_checker, 4);  //found case
     test_range_algo<1>{}(dpl_ranges::find, find_checker, -1); //not found case

--- a/test/parallel_api/ranges/std_ranges_find.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_find.pass.cpp
@@ -22,7 +22,7 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    auto find_checker = _ONEDPL_PREPARE_CALLABLE(std::ranges::find);
+    auto find_checker = TEST_PREPARE_CALLABLE(std::ranges::find);
 
     test_range_algo<0>{big_sz}(dpl_ranges::find, find_checker, 4);  //found case
     test_range_algo<1>{}(dpl_ranges::find, find_checker, -1); //not found case

--- a/test/parallel_api/ranges/std_ranges_find_if.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_find_if.pass.cpp
@@ -22,10 +22,12 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    test_range_algo<0>{big_sz}(dpl_ranges::find_if, std::ranges::find_if, pred);
-    test_range_algo<1>{}(dpl_ranges::find_if, std::ranges::find_if, pred, proj);
-    test_range_algo<2, P2>{}(dpl_ranges::find_if, std::ranges::find_if, pred, &P2::x);
-    test_range_algo<3, P2>{}(dpl_ranges::find_if, std::ranges::find_if, pred, &P2::proj);
+    auto find_if_checker = _ONEDPL_ALGO(std::ranges::find_if);
+
+    test_range_algo<0>{big_sz}(dpl_ranges::find_if, find_if_checker, pred);
+    test_range_algo<1>{}(dpl_ranges::find_if, find_if_checker, pred, proj);
+    test_range_algo<2, P2>{}(dpl_ranges::find_if, find_if_checker, pred, &P2::x);
+    test_range_algo<3, P2>{}(dpl_ranges::find_if, find_if_checker, pred, &P2::proj);
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_find_if.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_find_if.pass.cpp
@@ -22,7 +22,7 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    auto find_if_checker = _ONEDPL_PREPARE_CALLABLE(std::ranges::find_if);
+    auto find_if_checker = TEST_PREPARE_CALLABLE(std::ranges::find_if);
 
     test_range_algo<0>{big_sz}(dpl_ranges::find_if, find_if_checker, pred);
     test_range_algo<1>{}(dpl_ranges::find_if, find_if_checker, pred, proj);

--- a/test/parallel_api/ranges/std_ranges_find_if.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_find_if.pass.cpp
@@ -22,7 +22,7 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    auto find_if_checker = _ONEDPL_ALGO(std::ranges::find_if);
+    auto find_if_checker = _ONEDPL_PREPARE_CALLABLE(std::ranges::find_if);
 
     test_range_algo<0>{big_sz}(dpl_ranges::find_if, find_if_checker, pred);
     test_range_algo<1>{}(dpl_ranges::find_if, find_if_checker, pred, proj);

--- a/test/parallel_api/ranges/std_ranges_find_if_not.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_find_if_not.pass.cpp
@@ -22,7 +22,7 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    auto find_if_not_checker = _ONEDPL_ALGO(std::ranges::find_if_not);
+    auto find_if_not_checker = _ONEDPL_PREPARE_CALLABLE(std::ranges::find_if_not);
 
     test_range_algo<0>{big_sz}(dpl_ranges::find_if_not, find_if_not_checker, pred1);
     test_range_algo<1>{}(dpl_ranges::find_if_not, find_if_not_checker, pred, proj);

--- a/test/parallel_api/ranges/std_ranges_find_if_not.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_find_if_not.pass.cpp
@@ -22,10 +22,12 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    test_range_algo<0>{big_sz}(dpl_ranges::find_if_not, std::ranges::find_if_not, pred1);
-    test_range_algo<1>{}(dpl_ranges::find_if_not, std::ranges::find_if_not, pred, proj);
-    test_range_algo<2, P2>{}(dpl_ranges::find_if_not, std::ranges::find_if_not, pred, &P2::x);
-    test_range_algo<3, P2>{}(dpl_ranges::find_if_not, std::ranges::find_if_not, pred, &P2::proj);
+    auto find_if_not_checker = _ONEDPL_ALGO(std::ranges::find_if_not);
+
+    test_range_algo<0>{big_sz}(dpl_ranges::find_if_not, find_if_not_checker, pred1);
+    test_range_algo<1>{}(dpl_ranges::find_if_not, find_if_not_checker, pred, proj);
+    test_range_algo<2, P2>{}(dpl_ranges::find_if_not, find_if_not_checker, pred, &P2::x);
+    test_range_algo<3, P2>{}(dpl_ranges::find_if_not, find_if_not_checker, pred, &P2::proj);
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_find_if_not.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_find_if_not.pass.cpp
@@ -22,7 +22,7 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    auto find_if_not_checker = _ONEDPL_PREPARE_CALLABLE(std::ranges::find_if_not);
+    auto find_if_not_checker = TEST_PREPARE_CALLABLE(std::ranges::find_if_not);
 
     test_range_algo<0>{big_sz}(dpl_ranges::find_if_not, find_if_not_checker, pred1);
     test_range_algo<1>{}(dpl_ranges::find_if_not, find_if_not_checker, pred, proj);

--- a/test/parallel_api/ranges/std_ranges_is_sorted.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_is_sorted.pass.cpp
@@ -22,7 +22,7 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    auto is_sorted_checker = _ONEDPL_ALGO(std::ranges::is_sorted);
+    auto is_sorted_checker = _ONEDPL_PREPARE_CALLABLE(std::ranges::is_sorted);
 
     test_range_algo<0>{big_sz}(dpl_ranges::is_sorted, is_sorted_checker, std::ranges::less{});
 

--- a/test/parallel_api/ranges/std_ranges_is_sorted.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_is_sorted.pass.cpp
@@ -22,15 +22,17 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    test_range_algo<0>{big_sz}(dpl_ranges::is_sorted, std::ranges::is_sorted, std::ranges::less{});
+    auto is_sorted_checker = _ONEDPL_ALGO(std::ranges::is_sorted);
 
-    test_range_algo<1>{}(dpl_ranges::is_sorted, std::ranges::is_sorted, std::ranges::less{}, proj);
-    test_range_algo<2, P2>{}(dpl_ranges::is_sorted, std::ranges::is_sorted, std::ranges::less{}, &P2::x);
-    test_range_algo<3, P2>{}(dpl_ranges::is_sorted, std::ranges::is_sorted, std::ranges::less{}, &P2::proj);
+    test_range_algo<0>{big_sz}(dpl_ranges::is_sorted, is_sorted_checker, std::ranges::less{});
 
-    test_range_algo<4>{}(dpl_ranges::is_sorted, std::ranges::is_sorted, std::ranges::greater{}, proj);
-    test_range_algo<5, P2>{}(dpl_ranges::is_sorted, std::ranges::is_sorted, std::ranges::greater{}, &P2::x);
-    test_range_algo<6, P2>{}(dpl_ranges::is_sorted, std::ranges::is_sorted, std::ranges::greater{}, &P2::proj);
+    test_range_algo<1>{}(dpl_ranges::is_sorted, is_sorted_checker, std::ranges::less{}, proj);
+    test_range_algo<2, P2>{}(dpl_ranges::is_sorted, is_sorted_checker, std::ranges::less{}, &P2::x);
+    test_range_algo<3, P2>{}(dpl_ranges::is_sorted, is_sorted_checker, std::ranges::less{}, &P2::proj);
+
+    test_range_algo<4>{}(dpl_ranges::is_sorted, is_sorted_checker, std::ranges::greater{}, proj);
+    test_range_algo<5, P2>{}(dpl_ranges::is_sorted, is_sorted_checker, std::ranges::greater{}, &P2::x);
+    test_range_algo<6, P2>{}(dpl_ranges::is_sorted, is_sorted_checker, std::ranges::greater{}, &P2::proj);
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_is_sorted.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_is_sorted.pass.cpp
@@ -22,7 +22,7 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    auto is_sorted_checker = _ONEDPL_PREPARE_CALLABLE(std::ranges::is_sorted);
+    auto is_sorted_checker = TEST_PREPARE_CALLABLE(std::ranges::is_sorted);
 
     test_range_algo<0>{big_sz}(dpl_ranges::is_sorted, is_sorted_checker, std::ranges::less{});
 

--- a/test/parallel_api/ranges/std_ranges_max_element.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_max_element.pass.cpp
@@ -22,7 +22,7 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    auto max_element_checker = _ONEDPL_PREPARE_CALLABLE(std::ranges::max_element);
+    auto max_element_checker = TEST_PREPARE_CALLABLE(std::ranges::max_element);
 
     test_range_algo<0>{big_sz}(dpl_ranges::max_element, max_element_checker, std::ranges::less{});
     test_range_algo<1>{}(dpl_ranges::max_element, max_element_checker, std::ranges::less{}, proj);

--- a/test/parallel_api/ranges/std_ranges_max_element.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_max_element.pass.cpp
@@ -22,14 +22,16 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    test_range_algo<0>{big_sz}(dpl_ranges::max_element, std::ranges::max_element, std::ranges::less{});
-    test_range_algo<1>{}(dpl_ranges::max_element, std::ranges::max_element, std::ranges::less{}, proj);
-    test_range_algo<2, P2>{}(dpl_ranges::max_element, std::ranges::max_element, std::ranges::less{}, &P2::x);
-    test_range_algo<3, P2>{}(dpl_ranges::max_element, std::ranges::max_element, std::ranges::less{}, &P2::proj);
+    auto max_element_checker = _ONEDPL_ALGO(std::ranges::max_element);
 
-    test_range_algo<4>{}(dpl_ranges::max_element, std::ranges::max_element, std::ranges::greater{}, proj);
-    test_range_algo<5, P2>{}(dpl_ranges::max_element, std::ranges::max_element, std::ranges::greater{}, &P2::x);
-    test_range_algo<6, P2>{}(dpl_ranges::max_element, std::ranges::max_element, std::ranges::greater{}, &P2::proj);    
+    test_range_algo<0>{big_sz}(dpl_ranges::max_element, max_element_checker, std::ranges::less{});
+    test_range_algo<1>{}(dpl_ranges::max_element, max_element_checker, std::ranges::less{}, proj);
+    test_range_algo<2, P2>{}(dpl_ranges::max_element, max_element_checker, std::ranges::less{}, &P2::x);
+    test_range_algo<3, P2>{}(dpl_ranges::max_element, max_element_checker, std::ranges::less{}, &P2::proj);
+
+    test_range_algo<4>{}(dpl_ranges::max_element, max_element_checker, std::ranges::greater{}, proj);
+    test_range_algo<5, P2>{}(dpl_ranges::max_element, max_element_checker, std::ranges::greater{}, &P2::x);
+    test_range_algo<6, P2>{}(dpl_ranges::max_element, max_element_checker, std::ranges::greater{}, &P2::proj);    
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_max_element.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_max_element.pass.cpp
@@ -22,7 +22,7 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    auto max_element_checker = _ONEDPL_ALGO(std::ranges::max_element);
+    auto max_element_checker = _ONEDPL_PREPARE_CALLABLE(std::ranges::max_element);
 
     test_range_algo<0>{big_sz}(dpl_ranges::max_element, max_element_checker, std::ranges::less{});
     test_range_algo<1>{}(dpl_ranges::max_element, max_element_checker, std::ranges::less{}, proj);

--- a/test/parallel_api/ranges/std_ranges_min_element.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_min_element.pass.cpp
@@ -22,7 +22,7 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    auto min_element_checker = _ONEDPL_PREPARE_CALLABLE(std::ranges::min_element);
+    auto min_element_checker = TEST_PREPARE_CALLABLE(std::ranges::min_element);
 
     test_range_algo<0>{big_sz}(dpl_ranges::min_element, min_element_checker, std::ranges::less{});
 

--- a/test/parallel_api/ranges/std_ranges_min_element.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_min_element.pass.cpp
@@ -22,7 +22,7 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    auto min_element_checker = _ONEDPL_ALGO(std::ranges::min_element);
+    auto min_element_checker = _ONEDPL_PREPARE_CALLABLE(std::ranges::min_element);
 
     test_range_algo<0>{big_sz}(dpl_ranges::min_element, min_element_checker, std::ranges::less{});
 

--- a/test/parallel_api/ranges/std_ranges_min_element.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_min_element.pass.cpp
@@ -22,15 +22,17 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    test_range_algo<0>{big_sz}(dpl_ranges::min_element, std::ranges::min_element, std::ranges::less{});
+    auto min_element_checker = _ONEDPL_ALGO(std::ranges::min_element);
 
-    test_range_algo<1>{}(dpl_ranges::min_element, std::ranges::min_element, std::ranges::less{}, proj);
-    test_range_algo<2, P2>{}(dpl_ranges::min_element, std::ranges::min_element, std::ranges::less{}, &P2::x);
-    test_range_algo<3, P2>{}(dpl_ranges::min_element, std::ranges::min_element, std::ranges::less{}, &P2::proj);
+    test_range_algo<0>{big_sz}(dpl_ranges::min_element, min_element_checker, std::ranges::less{});
 
-    test_range_algo<4>{}(dpl_ranges::min_element, std::ranges::min_element, std::ranges::greater{}, proj);
-    test_range_algo<5, P2>{}(dpl_ranges::min_element, std::ranges::min_element, std::ranges::greater{}, &P2::x);
-    test_range_algo<6, P2>{}(dpl_ranges::min_element, std::ranges::min_element, std::ranges::greater{}, &P2::proj);
+    test_range_algo<1>{}(dpl_ranges::min_element, min_element_checker, std::ranges::less{}, proj);
+    test_range_algo<2, P2>{}(dpl_ranges::min_element, min_element_checker, std::ranges::less{}, &P2::x);
+    test_range_algo<3, P2>{}(dpl_ranges::min_element, min_element_checker, std::ranges::less{}, &P2::proj);
+
+    test_range_algo<4>{}(dpl_ranges::min_element, min_element_checker, std::ranges::greater{}, proj);
+    test_range_algo<5, P2>{}(dpl_ranges::min_element, min_element_checker, std::ranges::greater{}, &P2::x);
+    test_range_algo<6, P2>{}(dpl_ranges::min_element, min_element_checker, std::ranges::greater{}, &P2::proj);
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_none_of.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_none_of.pass.cpp
@@ -22,7 +22,7 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    auto none_of_checker = _ONEDPL_PREPARE_CALLABLE(std::ranges::none_of);
+    auto none_of_checker = TEST_PREPARE_CALLABLE(std::ranges::none_of);
 
     test_range_algo<0>{big_sz}(dpl_ranges::none_of, none_of_checker, pred3);
     test_range_algo<1>{}(dpl_ranges::none_of, none_of_checker, pred2, proj);

--- a/test/parallel_api/ranges/std_ranges_none_of.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_none_of.pass.cpp
@@ -22,10 +22,12 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    test_range_algo<0>{big_sz}(dpl_ranges::none_of, std::ranges::none_of, pred3);
-    test_range_algo<1>{}(dpl_ranges::none_of, std::ranges::none_of, pred2, proj);
-    test_range_algo<2, P2>{}(dpl_ranges::none_of, std::ranges::none_of, pred3, &P2::x);
-    test_range_algo<3, P2>{}(dpl_ranges::none_of, std::ranges::none_of, pred3, &P2::proj);
+    auto none_of_checker = _ONEDPL_ALGO(std::ranges::none_of);
+
+    test_range_algo<0>{big_sz}(dpl_ranges::none_of, none_of_checker, pred3);
+    test_range_algo<1>{}(dpl_ranges::none_of, none_of_checker, pred2, proj);
+    test_range_algo<2, P2>{}(dpl_ranges::none_of, none_of_checker, pred3, &P2::x);
+    test_range_algo<3, P2>{}(dpl_ranges::none_of, none_of_checker, pred3, &P2::proj);
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_none_of.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_none_of.pass.cpp
@@ -22,7 +22,7 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    auto none_of_checker = _ONEDPL_ALGO(std::ranges::none_of);
+    auto none_of_checker = _ONEDPL_PREPARE_CALLABLE(std::ranges::none_of);
 
     test_range_algo<0>{big_sz}(dpl_ranges::none_of, none_of_checker, pred3);
     test_range_algo<1>{}(dpl_ranges::none_of, none_of_checker, pred2, proj);

--- a/test/parallel_api/ranges/std_ranges_search.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_search.pass.cpp
@@ -22,7 +22,7 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    auto search_checker = _ONEDPL_ALGO(std::ranges::search);
+    auto search_checker = _ONEDPL_PREPARE_CALLABLE(std::ranges::search);
 
     test_range_algo<0, int, data_in_in>{big_sz}(dpl_ranges::search,  search_checker, binary_pred);
     test_range_algo<1, int, data_in_in>{}(dpl_ranges::search,  search_checker, binary_pred, proj, proj);

--- a/test/parallel_api/ranges/std_ranges_search.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_search.pass.cpp
@@ -22,10 +22,12 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    test_range_algo<0, int, data_in_in>{big_sz}(dpl_ranges::search,  std::ranges::search, binary_pred);
-    test_range_algo<1, int, data_in_in>{}(dpl_ranges::search,  std::ranges::search, binary_pred, proj, proj);
-    test_range_algo<2, P2, data_in_in>{}(dpl_ranges::search,  std::ranges::search, binary_pred, &P2::x, &P2::x);
-    test_range_algo<3, P2, data_in_in>{}(dpl_ranges::search,  std::ranges::search, binary_pred, &P2::proj, &P2::proj);
+    auto search_checker = _ONEDPL_ALGO(std::ranges::search);
+
+    test_range_algo<0, int, data_in_in>{big_sz}(dpl_ranges::search,  search_checker, binary_pred);
+    test_range_algo<1, int, data_in_in>{}(dpl_ranges::search,  search_checker, binary_pred, proj, proj);
+    test_range_algo<2, P2, data_in_in>{}(dpl_ranges::search,  search_checker, binary_pred, &P2::x, &P2::x);
+    test_range_algo<3, P2, data_in_in>{}(dpl_ranges::search,  search_checker, binary_pred, &P2::proj, &P2::proj);
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_search.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_search.pass.cpp
@@ -22,7 +22,7 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    auto search_checker = _ONEDPL_PREPARE_CALLABLE(std::ranges::search);
+    auto search_checker = TEST_PREPARE_CALLABLE(std::ranges::search);
 
     test_range_algo<0, int, data_in_in>{big_sz}(dpl_ranges::search,  search_checker, binary_pred);
     test_range_algo<1, int, data_in_in>{}(dpl_ranges::search,  search_checker, binary_pred, proj, proj);

--- a/test/parallel_api/ranges/std_ranges_search_n.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_search_n.pass.cpp
@@ -22,7 +22,7 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    auto search_n_checker = _ONEDPL_PREPARE_CALLABLE(std::ranges::search_n);
+    auto search_n_checker = TEST_PREPARE_CALLABLE(std::ranges::search_n);
 
     test_range_algo<0>{big_sz}(dpl_ranges::search_n, search_n_checker, 1, 5, binary_pred);
     test_range_algo<1>{}(dpl_ranges::search_n, search_n_checker, 3, 5, binary_pred, proj);

--- a/test/parallel_api/ranges/std_ranges_search_n.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_search_n.pass.cpp
@@ -22,7 +22,7 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    auto search_n_checker = _ONEDPL_ALGO(std::ranges::search_n);
+    auto search_n_checker = _ONEDPL_PREPARE_CALLABLE(std::ranges::search_n);
 
     test_range_algo<0>{big_sz}(dpl_ranges::search_n, search_n_checker, 1, 5, binary_pred);
     test_range_algo<1>{}(dpl_ranges::search_n, search_n_checker, 3, 5, binary_pred, proj);

--- a/test/parallel_api/ranges/std_ranges_search_n.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_search_n.pass.cpp
@@ -22,10 +22,12 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    test_range_algo<0>{big_sz}(dpl_ranges::search_n, std::ranges::search_n, 1, 5, binary_pred);
-    test_range_algo<1>{}(dpl_ranges::search_n, std::ranges::search_n, 3, 5, binary_pred, proj);
-    test_range_algo<2, P2>{}(dpl_ranges::search_n, std::ranges::search_n, 1, 2, binary_pred, &P2::x);
-    test_range_algo<3, P2>{}(dpl_ranges::search_n, std::ranges::search_n, 3, 5, binary_pred, &P2::proj);
+    auto search_n_checker = _ONEDPL_ALGO(std::ranges::search_n);
+
+    test_range_algo<0>{big_sz}(dpl_ranges::search_n, search_n_checker, 1, 5, binary_pred);
+    test_range_algo<1>{}(dpl_ranges::search_n, search_n_checker, 3, 5, binary_pred, proj);
+    test_range_algo<2, P2>{}(dpl_ranges::search_n, search_n_checker, 1, 2, binary_pred, &P2::x);
+    test_range_algo<3, P2>{}(dpl_ranges::search_n, search_n_checker, 3, 5, binary_pred, &P2::proj);
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_sort.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_sort.pass.cpp
@@ -21,18 +21,24 @@ main()
 #if _ENABLE_STD_RANGES_TESTING
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
+    auto sort_checker = 
+#if _ONEDPL_STD_RANGES_ALGO_CPP_FUN
+            [](auto&&... __args) { return std::ranges::sort(std::forward<decltype(__args)>(__args)...); };
+#else
+            std::ranges::sort;
+#endif
 
-    test_range_algo<0>{big_sz}(dpl_ranges::sort, std::ranges::sort);
-    test_range_algo<1>{}(dpl_ranges::sort, std::ranges::sort, std::ranges::less{});
+    test_range_algo<0>{big_sz}(dpl_ranges::sort, sort_checker);
+    test_range_algo<1>{}(dpl_ranges::sort, sort_checker, std::ranges::less{});
 
-    test_range_algo<2>{}(dpl_ranges::sort, std::ranges::sort, std::ranges::less{}, proj);
-    test_range_algo<3>{}(dpl_ranges::sort, std::ranges::sort, std::ranges::greater{}, proj);
+    test_range_algo<2>{}(dpl_ranges::sort, sort_checker, std::ranges::less{}, proj);
+    test_range_algo<3>{}(dpl_ranges::sort, sort_checker, std::ranges::greater{}, proj);
 
-    test_range_algo<4, P2>{}(dpl_ranges::sort, std::ranges::sort, std::ranges::less{}, &P2::x);
-    test_range_algo<5, P2>{}(dpl_ranges::sort, std::ranges::sort, std::ranges::greater{}, &P2::x);
+    test_range_algo<4, P2>{}(dpl_ranges::sort, sort_checker, std::ranges::less{}, &P2::x);
+    test_range_algo<5, P2>{}(dpl_ranges::sort, sort_checker, std::ranges::greater{}, &P2::x);
 
-    test_range_algo<6, P2>{}(dpl_ranges::sort, std::ranges::sort, std::ranges::less{}, &P2::proj);
-    test_range_algo<7, P2>{}(dpl_ranges::sort, std::ranges::sort, std::ranges::greater{}, &P2::proj);
+    test_range_algo<6, P2>{}(dpl_ranges::sort, sort_checker, std::ranges::less{}, &P2::proj);
+    test_range_algo<7, P2>{}(dpl_ranges::sort, sort_checker, std::ranges::greater{}, &P2::proj);
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_sort.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_sort.pass.cpp
@@ -22,7 +22,7 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    auto sort_checker = _ONEDPL_PREPARE_CALLABLE(std::ranges::sort);
+    auto sort_checker = TEST_PREPARE_CALLABLE(std::ranges::sort);
 
     test_range_algo<0>{big_sz}(dpl_ranges::sort, sort_checker);
     test_range_algo<1>{}(dpl_ranges::sort, sort_checker, std::ranges::less{});

--- a/test/parallel_api/ranges/std_ranges_sort.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_sort.pass.cpp
@@ -21,12 +21,8 @@ main()
 #if _ENABLE_STD_RANGES_TESTING
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
-    auto sort_checker = 
-#if _ONEDPL_STD_RANGES_ALGO_CPP_FUN
-            [](auto&&... __args) { return std::ranges::sort(std::forward<decltype(__args)>(__args)...); };
-#else
-            std::ranges::sort;
-#endif
+
+    auto sort_checker = _ONEDPL_ALGO(std::ranges::sort);
 
     test_range_algo<0>{big_sz}(dpl_ranges::sort, sort_checker);
     test_range_algo<1>{}(dpl_ranges::sort, sort_checker, std::ranges::less{});

--- a/test/parallel_api/ranges/std_ranges_sort.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_sort.pass.cpp
@@ -22,7 +22,7 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    auto sort_checker = _ONEDPL_ALGO(std::ranges::sort);
+    auto sort_checker = _ONEDPL_PREPARE_CALLABLE(std::ranges::sort);
 
     test_range_algo<0>{big_sz}(dpl_ranges::sort, sort_checker);
     test_range_algo<1>{}(dpl_ranges::sort, sort_checker, std::ranges::less{});

--- a/test/parallel_api/ranges/std_ranges_stable_sort.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_stable_sort.pass.cpp
@@ -22,17 +22,24 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    test_range_algo<0>{big_sz}(dpl_ranges::stable_sort, std::ranges::stable_sort);
-    test_range_algo<1>{}(dpl_ranges::stable_sort, std::ranges::stable_sort, std::ranges::less{});
+    auto sort_stable_checker = 
+#if _ONEDPL_STD_RANGES_ALGO_CPP_FUN
+            [](auto&&... __args) { return std::ranges::stable_sort(std::forward<decltype(__args)>(__args)...); };
+#else
+            std::ranges::stable_sort;
+#endif
 
-    test_range_algo<2>{}(dpl_ranges::stable_sort, std::ranges::stable_sort, std::ranges::less{}, proj);
-    test_range_algo<3>{}(dpl_ranges::stable_sort, std::ranges::stable_sort, std::ranges::greater{}, proj);
+    test_range_algo<0>{big_sz}(dpl_ranges::stable_sort, sort_stable_checker);
+    test_range_algo<1>{}(dpl_ranges::stable_sort, sort_stable_checker, std::ranges::less{});
 
-    test_range_algo<4, P2>{}(dpl_ranges::stable_sort, std::ranges::stable_sort, std::ranges::less{}, &P2::x);
-    test_range_algo<5, P2>{}(dpl_ranges::stable_sort, std::ranges::stable_sort, std::ranges::greater{}, &P2::x);
+    test_range_algo<2>{}(dpl_ranges::stable_sort, sort_stable_checker, std::ranges::less{}, proj);
+    test_range_algo<3>{}(dpl_ranges::stable_sort, sort_stable_checker, std::ranges::greater{}, proj);
 
-    test_range_algo<6, P2>{}(dpl_ranges::stable_sort, std::ranges::stable_sort, std::ranges::less{}, &P2::proj);
-    test_range_algo<7, P2>{}(dpl_ranges::stable_sort, std::ranges::stable_sort, std::ranges::greater{}, &P2::proj);
+    test_range_algo<4, P2>{}(dpl_ranges::stable_sort, sort_stable_checker, std::ranges::less{}, &P2::x);
+    test_range_algo<5, P2>{}(dpl_ranges::stable_sort, sort_stable_checker, std::ranges::greater{}, &P2::x);
+
+    test_range_algo<6, P2>{}(dpl_ranges::stable_sort, sort_stable_checker, std::ranges::less{}, &P2::proj);
+    test_range_algo<7, P2>{}(dpl_ranges::stable_sort, sort_stable_checker, std::ranges::greater{}, &P2::proj);
 #endif //_ENABLE_STD_RANGES_TESTING
 
     return TestUtils::done(_ENABLE_STD_RANGES_TESTING);

--- a/test/parallel_api/ranges/std_ranges_stable_sort.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_stable_sort.pass.cpp
@@ -22,7 +22,7 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    auto sort_stable_checker = _ONEDPL_PREPARE_CALLABLE(std::ranges::stable_sort);
+    auto sort_stable_checker = TEST_PREPARE_CALLABLE(std::ranges::stable_sort);
 
     test_range_algo<0>{big_sz}(dpl_ranges::stable_sort, sort_stable_checker);
     test_range_algo<1>{}(dpl_ranges::stable_sort, sort_stable_checker, std::ranges::less{});

--- a/test/parallel_api/ranges/std_ranges_stable_sort.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_stable_sort.pass.cpp
@@ -22,7 +22,7 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    auto sort_stable_checker = _ONEDPL_ALGO(std::ranges::stable_sort);
+    auto sort_stable_checker = _ONEDPL_PREPARE_CALLABLE(std::ranges::stable_sort);
 
     test_range_algo<0>{big_sz}(dpl_ranges::stable_sort, sort_stable_checker);
     test_range_algo<1>{}(dpl_ranges::stable_sort, sort_stable_checker, std::ranges::less{});

--- a/test/parallel_api/ranges/std_ranges_stable_sort.pass.cpp
+++ b/test/parallel_api/ranges/std_ranges_stable_sort.pass.cpp
@@ -22,12 +22,7 @@ main()
     using namespace test_std_ranges;
     namespace dpl_ranges = oneapi::dpl::ranges;
 
-    auto sort_stable_checker = 
-#if _ONEDPL_STD_RANGES_ALGO_CPP_FUN
-            [](auto&&... __args) { return std::ranges::stable_sort(std::forward<decltype(__args)>(__args)...); };
-#else
-            std::ranges::stable_sort;
-#endif
+    auto sort_stable_checker = _ONEDPL_ALGO(std::ranges::stable_sort);
 
     test_range_algo<0>{big_sz}(dpl_ranges::stable_sort, sort_stable_checker);
     test_range_algo<1>{}(dpl_ranges::stable_sort, sort_stable_checker, std::ranges::less{});

--- a/test/parallel_api/ranges/std_ranges_test.h
+++ b/test/parallel_api/ranges/std_ranges_test.h
@@ -17,7 +17,7 @@
 #include <oneapi/dpl/algorithm>
 
 #include "support/test_config.h"
-
+#include "support/test_macros.h"
 #include "support/utils.h"
 
 #if _ENABLE_STD_RANGES_TESTING

--- a/test/support/test_macros.h
+++ b/test/support/test_macros.h
@@ -377,4 +377,7 @@ inline void DoNotOptimize(Tp const& value) {
 #define TEST_NO_UNIQUE_ADDRESS
 #endif
 
+#define TEST_PREPARE_CALLABLE(std_algo_name) \
+    [](auto&&... __args) { return std_algo_name(std::forward<decltype(__args)>(__args)...); }
+
 #endif // _SUPPORT_TEST_MACROS_H


### PR DESCRIPTION
[oneDPL][ranges][tests] a fix for std::ranges::sort using with Windows C++ standard library.
This PR is a sequel for https://github.com/oneapi-src/oneDPL/pull/1885.
