### PR TITLE
[test] Reduce test input sizes for debug builds with OpenMP in `transform_binary.pass`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,7 +180,7 @@ if (ONEDPL_BACKEND MATCHES "^(tbb|dpcpp|dpcpp_only)$")
 
     target_compile_definitions(oneDPL INTERFACE
         $<$<CONFIG:Debug>:TBB_USE_DEBUG=1>
-        $<$<CONFIG:Debug>:PSTL_USE_DEBUG>
+        $<$<CONFIG:Debug>:PSTL_USE_DEBUG=1>
         $<$<BOOL:${SET_BACKEND_DPCPP_ONLY}>:ONEDPL_USE_TBB_BACKEND=0>
         $<$<BOOL:${SET_BACKEND_TBB}>:ONEDPL_USE_DPCPP_BACKEND=0>
         )
@@ -340,7 +340,7 @@ elseif(ONEDPL_BACKEND MATCHES "^(omp)$")
             target_link_libraries(oneDPL INTERFACE OpenMP::OpenMP_CXX)
         endif()
         target_compile_definitions(oneDPL INTERFACE
-            $<$<CONFIG:Debug>:PSTL_USE_DEBUG>
+            $<$<CONFIG:Debug>:PSTL_USE_DEBUG=1>
             ONEDPL_USE_TBB_BACKEND=0
             ONEDPL_USE_DPCPP_BACKEND=0
             ONEDPL_USE_OPENMP_BACKEND=1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,7 @@ endif()
 ###############################################################################
 add_library(oneDPL INTERFACE)
 target_compile_features(oneDPL INTERFACE cxx_std_17)
+target_compile_definitions(oneDPL INTERFACE $<$<CONFIG:Debug>:PSTL_USE_DEBUG=1>)
 
 if (CMAKE_BUILD_TYPE)
     message(STATUS "Build type is ${CMAKE_BUILD_TYPE}")
@@ -180,7 +181,6 @@ if (ONEDPL_BACKEND MATCHES "^(tbb|dpcpp|dpcpp_only)$")
 
     target_compile_definitions(oneDPL INTERFACE
         $<$<CONFIG:Debug>:TBB_USE_DEBUG=1>
-        $<$<CONFIG:Debug>:PSTL_USE_DEBUG=1>
         $<$<BOOL:${SET_BACKEND_DPCPP_ONLY}>:ONEDPL_USE_TBB_BACKEND=0>
         $<$<BOOL:${SET_BACKEND_TBB}>:ONEDPL_USE_DPCPP_BACKEND=0>
         )
@@ -340,7 +340,6 @@ elseif(ONEDPL_BACKEND MATCHES "^(omp)$")
             target_link_libraries(oneDPL INTERFACE OpenMP::OpenMP_CXX)
         endif()
         target_compile_definitions(oneDPL INTERFACE
-            $<$<CONFIG:Debug>:PSTL_USE_DEBUG=1>
             ONEDPL_USE_TBB_BACKEND=0
             ONEDPL_USE_DPCPP_BACKEND=0
             ONEDPL_USE_OPENMP_BACKEND=1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,6 +340,7 @@ elseif(ONEDPL_BACKEND MATCHES "^(omp)$")
             target_link_libraries(oneDPL INTERFACE OpenMP::OpenMP_CXX)
         endif()
         target_compile_definitions(oneDPL INTERFACE
+            $<$<CONFIG:Debug>:PSTL_USE_DEBUG>
             ONEDPL_USE_TBB_BACKEND=0
             ONEDPL_USE_DPCPP_BACKEND=0
             ONEDPL_USE_OPENMP_BACKEND=1

--- a/test/parallel_api/algorithm/alg.modifying.operations/transform_binary.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/transform_binary.pass.cpp
@@ -98,7 +98,7 @@ template <::std::size_t CallNumber, typename In1, typename In2, typename Out, ty
 void
 test(Predicate pred, _IteratorAdapter adap = {})
 {
-    // Testing is restricted for debug build + OpenMp backend as without optimization the compiler generates
+    // Testing is restricted for debug build + OpenMP backend as without optimization the compiler generates
     // very slow code leading to test timeouts.
     size_t max_n =
 #if PSTL_USE_DEBUG && ONEDPL_USE_OPENMP_BACKEND

--- a/test/parallel_api/algorithm/alg.modifying.operations/transform_binary.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/transform_binary.pass.cpp
@@ -98,7 +98,15 @@ template <::std::size_t CallNumber, typename In1, typename In2, typename Out, ty
 void
 test(Predicate pred, _IteratorAdapter adap = {})
 {
-    for (size_t n = 0; n <= 100000; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
+    // Testing is restricted for debug build + OpenMp backend as without optimization the compiler generates
+    // very slow code leading to test timeouts.
+    size_t max_n =
+#if PSTL_USE_DEBUG && ONEDPL_USE_OPENMP_BACKEND
+        10000;
+#else
+        100000;
+#endif
+    for (size_t n = 0; n <= max_n; n = n <= 16 ? n + 1 : size_t(3.1415 * n))
     {
         Sequence<In1> in1(n, [](size_t k) { return k % 5 != 1 ? In1(3 * k + 7) : 0; });
         Sequence<In2> in2(n, [](size_t k) { return k % 7 != 2 ? In2(5 * k + 5) : 0; });


### PR DESCRIPTION
`transform_binary.pass` with the OpenMP backend in debug builds has been timing out. This is caused by testing of forward and bidirectional iterators. When no compiler optimization is present, a large number of re-computation of iterators occurs in this line: https://github.com/oneapi-src/oneDPL/blob/66ead74ff6db1eb7e047227086da836531499a74/include/oneapi/dpl/pstl/omp/parallel_for_each.h#L40 which has an expensive cost for iterators without random access. In release builds, there is no problem due to compiler optimization.

The test is updated to reduce test sizes in this timeout case. I have also updated our `CMakeLists.txt` to set the `PSTL_USE_DEBUG` macro for OpenMP builds as well.