### PR TITLE
[RNG] Fixed warnings in Philox tests build and test failures under Windows

### DIFF
--- a/include/oneapi/dpl/internal/random_impl/philox_engine.h
+++ b/include/oneapi/dpl/internal/random_impl/philox_engine.h
@@ -261,7 +261,7 @@ class philox_engine
             // select high chunk and shift for addition with the next counter chunk
             __ctr_inc = (word_size == std::numeric_limits<unsigned long long>::digits)
                             ? 0 // should be added only once for 64-bit word_size
-                            : (__ctr_inc & (~in_mask)) >> word_size;
+                            : __ctr_inc >> word_size;
         }
     }
 

--- a/test/xpu_api/random/unit_tests/philox_unit_test.pass.cpp
+++ b/test/xpu_api/random/unit_tests/philox_unit_test.pass.cpp
@@ -496,7 +496,7 @@ discard_overflow_test()
         std::array<T, Engine::word_count> counter2 = {0};
         for (int i = Engine::word_count - overflown_position - 1; i < Engine::word_count - 1; ++i)
         {
-            counter2[i] = std::numeric_limits<unsigned long long>::max();
+            counter2[i] = std::numeric_limits<T>::max();
         }
 
         engine2.set_counter(counter2);


### PR DESCRIPTION
**Fixed failed unit test details:**
```
void counter_management_test() [Engine = philox2x32_w18] failed
void counter_management_test() [Engine = philox2x32_w30] failed
void counter_management_test() [Engine = philox4x32_w18] failed
void counter_management_test() [Engine = philox4x32_w30] failed
```
- The problem appeared only under Windows, because `in_mask` is of type `scalar_type`, which is for failed cases`uint_fast32_t`  -  the bitsize of this type is implementation-defined and differs on Windows(4 bytes) and Linux(8 bytes). On Windows the higher bits of the increment were removed by  `(~in_mask)`, that is why some unit tests failed.
- Lower bits of the shifted counter are removed by shift operation anyway, so the masking operation is not necessary there.

**Fixed warning in test details:**
```
 warning: implicit conversion from 'unsigned long long' to 'unsigned int' changes value from 18446744073709551615 to 4294967295 [-Wconstant-conversion]

  499 |             counter2[i] = std::numeric_limits<unsigned long long>::max();
```