### PR TITLE
Make kernel names unique in radix sort 

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -655,7 +655,7 @@ struct __parallel_radix_sort_iteration
         using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
         using _RadixCountKernel =
             __internal::__kernel_name_generator<__count_phase, _CustomName, _ExecutionPolicy, ::std::decay_t<_InRange>,
-                                                ::std::decay_t<_TmpBuf>>;
+                                                ::std::decay_t<_TmpBuf>, _Proj>;
         using _RadixLocalScanKernel = __internal::__kernel_name_generator<__local_scan_phase, _CustomName,
                                                                           _ExecutionPolicy, ::std::decay_t<_TmpBuf>>;
         using _RadixReorderPeerKernel =

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_radix_sort.h
@@ -660,10 +660,10 @@ struct __parallel_radix_sort_iteration
                                                                           _ExecutionPolicy, ::std::decay_t<_TmpBuf>>;
         using _RadixReorderPeerKernel =
             __internal::__kernel_name_generator<__reorder_peer_phase, _CustomName, _ExecutionPolicy,
-                                                ::std::decay_t<_InRange>, ::std::decay_t<_OutRange>>;
+                                                ::std::decay_t<_InRange>, ::std::decay_t<_OutRange>, _Proj>;
         using _RadixReorderKernel =
             __internal::__kernel_name_generator<__reorder_phase, _CustomName, _ExecutionPolicy,
-                                                ::std::decay_t<_InRange>, ::std::decay_t<_OutRange>>;
+                                                ::std::decay_t<_InRange>, ::std::decay_t<_OutRange>, _Proj>;
 
         ::std::size_t __max_sg_size = oneapi::dpl::__internal::__max_sub_group_size(__exec);
         ::std::size_t __reorder_sg_size = __max_sg_size;


### PR DESCRIPTION
Fixes #1922. You can find elaborate description of the issue there.

It appears that `_Proj`, a lambda declared in `__pattern_sort_by_key` template, will have different types for different `__patter_sort_by_key` instantiations:
https://github.com/oneapi-src/oneDPL/blob/28cb633583570457a2e21a752f6a517f5fc7134a/include/oneapi/dpl/pstl/hetero/algorithm_impl_hetero.h#L1274-L1275

Here is a simplified example of a lambda having different types in different function template instantiations: https://godbolt.org/z/ddrM6Tseq