### PR TITLE
[test] Limit the number of launched threads in `shift_left_right.pass` with the OMP backend to avoid timeouts

### DIFF
--- a/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
@@ -36,6 +36,10 @@
 #include "support/sycl_alloc_utils.h"
 #endif
 
+#if ONEDPL_USE_OPENMP_BACKEND
+#include <omp.h> // omp_get_max_threads, omp_set_num_threads
+#endif
+
 template<typename Name>
 struct USM;
 
@@ -214,6 +218,13 @@ test_shift_by_type(Size m, Size n)
 int
 main()
 {
+#if ONEDPL_USE_OPENMP_BACKEND
+    // Due to small problem sizes in this test, runtime explodes on CPUs with large core counts due to
+    // very small grain sizes per thread.
+    const int max_threads = omp_get_max_threads();
+    const int threads_to_use = std::min(max_threads, int(32));
+    omp_set_num_threads(threads_to_use);
+#endif
     using ValueType = ::std::int32_t;
 
     const ::std::size_t N = 100000;

--- a/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
+++ b/test/parallel_api/algorithm/alg.modifying.operations/shift_left_right.pass.cpp
@@ -220,7 +220,7 @@ main()
 {
 #if ONEDPL_USE_OPENMP_BACKEND
     // Due to small problem sizes in this test, runtime explodes on CPUs with large core counts due to
-    // very small grain sizes per thread.
+    // small grain sizes per thread and cross-socket traffic.
     const int max_threads = omp_get_max_threads();
     const int threads_to_use = std::min(max_threads, int(32));
     omp_set_num_threads(threads_to_use);


### PR DESCRIPTION
We have recently seen timeouts in CI in `shift_left_right.pass` when running on CPUs with large core counts using the OMP backend. This has occurred mostly with debug builds but also in a small number of release builds. Due to the small problem sizes in our tests, the grain size per thread is too small when a large number of threads are launched resulting in significant performance loss due to excessive parallelism and cross-socket traffic.

To resolve this issue, we cap the number of threads to `32` in `shift_left_right.pass` which enables the tests to pass in a reasonable time while also launching enough threads to assess the correctness of the parallel implementation.