### PR TITLE
Optimize `merge` algorithm for data sizes equal or greater then 4M items with SLM cache usage

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -299,7 +299,7 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
         _PRINT_INFO_IN_DEBUG_MODE(__exec);
 
         // Empirical number of values to process per work-item
-        const _IdType __chunk = __exec.queue().get_device().is_cpu() ? 128 : 8;
+        const _IdType __chunk = __exec.queue().get_device().is_cpu() ? 128 : 4;
         assert(__chunk > 0);
 
         // Pessimistically only use half of the memory to take into account memory used by compiled kernel

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -631,24 +631,12 @@ __parallel_merge(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy
     {
         static_assert(__starting_size_limit_for_large_submitter < std::numeric_limits<std::uint32_t>::max());
 
-        if (__n <= std::numeric_limits<std::uint16_t>::max())
-        {
-            using _WiIndex = std::uint16_t;
-            using _MergeKernelName = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
-                __merge_kernel_name<_CustomName, _WiIndex>>;
-            return __parallel_merge_submitter<_WiIndex, _MergeKernelName>()(
-                std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
-                std::forward<_Range3>(__rng3), __comp);
-        }
-        else
-        {
-            using _WiIndex = std::uint32_t;
-            using _MergeKernelName = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
-                __merge_kernel_name<_CustomName, _WiIndex>>;
-            return __parallel_merge_submitter<_WiIndex, _MergeKernelName>()(
-                std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
-                std::forward<_Range3>(__rng3), __comp);
-        }
+        using _WiIndex = std::uint32_t;
+        using _MergeKernelName = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
+            __merge_kernel_name<_CustomName, _WiIndex>>;
+        return __parallel_merge_submitter<_WiIndex, _MergeKernelName>()(
+            std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
+            std::forward<_Range3>(__rng3), __comp);
     }
     else
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -327,7 +327,7 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
     };
 
     template <typename _Range, typename _DataType>
-    static void
+    inline static void
     load_data_into_slm(_Range&& __rng, _DataType* __slm,
                        std::size_t __sp_base_left_global_from, std::size_t __sp_base_left_global_to,
                        std::size_t __items_in_wg_count, std::size_t __local_id)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -299,13 +299,13 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
         _PRINT_INFO_IN_DEBUG_MODE(__exec);
 
         // Define SLM bank size
-        constexpr std::size_t __slm_bank_size = 32;     // TODO is it correct value? How to get it from hardware?
+        //constexpr std::size_t __slm_bank_size = 32;     // TODO is it correct value? How to get it from hardware?
 
         // Calculate how many data items we can read into one SLM bank
-        constexpr std::size_t __data_items_in_slm_bank = std::max((std::size_t)1, __slm_bank_size / sizeof(_RangeValueType));
+        //constexpr std::size_t __data_items_in_slm_bank = std::max((std::size_t)1, __slm_bank_size / sizeof(_RangeValueType));
 
         // Empirical number of values to process per work-item
-        const _IdType __chunk = __exec.queue().get_device().is_cpu() ? 128 : __data_items_in_slm_bank;
+        const _IdType __chunk = __exec.queue().get_device().is_cpu() ? 128 : 4;// __data_items_in_slm_bank;
         assert(__chunk > 0);
 
         // Get the size of local memory arena in bytes.
@@ -396,7 +396,7 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
                     _RangeValueType* __rng1_cache_slm = std::addressof(__loc_acc[0]);
                     _RangeValueType* __rng2_cache_slm = std::addressof(__loc_acc[0]) + __rng1_wg_data_size;
 
-                    const _IdType __chunk_of_data_reading = std::max(__data_items_in_slm_bank, oneapi::dpl::__internal::__dpl_ceiling_div(__rng1_wg_data_size + __rng2_wg_data_size, __wi_in_one_wg));
+                    const _IdType __chunk_of_data_reading = std::max(__chunk/*__data_items_in_slm_bank*/, (_IdType)oneapi::dpl::__internal::__dpl_ceiling_div(__rng1_wg_data_size + __rng2_wg_data_size, __wi_in_one_wg));
 
                     const _IdType __how_many_wi_reads_rng1 = oneapi::dpl::__internal::__dpl_ceiling_div(__rng1_wg_data_size, __chunk_of_data_reading);
                     const _IdType __how_many_wi_reads_rng2 = oneapi::dpl::__internal::__dpl_ceiling_div(__rng2_wg_data_size, __chunk_of_data_reading);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -302,6 +302,12 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
         const _IdType __chunk = __exec.queue().get_device().is_cpu() ? 128 : 4;
         assert(__chunk > 0);
 
+        // Define SLM bank size
+        constexpr std::size_t __slm_bank_size = 32;     // TODO is it correct value? How to get it from hardware?
+
+        // Calculate how many data items we can read into one SLM bank
+        constexpr std::size_t __data_items_in_slm_bank = std::max((std::size_t)1, __slm_bank_size / sizeof(_RangeValueType));
+
         // Pessimistically only use 2/3 of the memory to take into account memory used by compiled kernel
         const auto __slm_adjusted_work_group_size = oneapi::dpl::__internal::__slm_adjusted_work_group_size(__exec, sizeof(_RangeValueType));
         const auto __slm_adjusted_work_group_size_x_part = __slm_adjusted_work_group_size * 2 / 3;
@@ -388,7 +394,7 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
                     _RangeValueType* __rng1_cache_slm = std::addressof(__loc_acc[0]);
                     _RangeValueType* __rng2_cache_slm = std::addressof(__loc_acc[0]) + __rng1_wg_data_size;
 
-                    const std::size_t __chunk_of_data_reading = oneapi::dpl::__internal::__dpl_ceiling_div(__rng1_wg_data_size + __rng2_wg_data_size, __wi_in_one_wg);
+                    const std::size_t __chunk_of_data_reading = std::max(__data_items_in_slm_bank, oneapi::dpl::__internal::__dpl_ceiling_div(__rng1_wg_data_size + __rng2_wg_data_size, __wi_in_one_wg));
 
                     const std::size_t __how_many_wi_reads_rng1 = oneapi::dpl::__internal::__dpl_ceiling_div(__rng1_wg_data_size, __chunk_of_data_reading);
                     const std::size_t __how_many_wi_reads_rng2 = oneapi::dpl::__internal::__dpl_ceiling_div(__rng2_wg_data_size, __chunk_of_data_reading);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -383,6 +383,7 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
                 std::size_t __slm_idx = __slm_idx_begin;
                 std::size_t __rng_idx = __idx_global_begin + __slm_idx;
 
+                _ONEDPL_PRAGMA_UNROLL
                 for (; __slm_idx < __slm_idx_end && __rng_idx < __idx_global_end; ++__slm_idx, ++__rng_idx)
                         __slm[__slm_idx] = __rng[__rng_idx];
             }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -438,7 +438,7 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
             else if (__local_id < __wi_for_data_reading1 + __wi_for_data_reading2)
             {
                 // When we reading data from parallel-working work-items, we should reduce the local id of current work-item
-                // because we calculate readed data size based on this value.
+                // because we calculate reeded data size based on this value.
                 load_data_into_slm_impl(__rng2, __slm2, __idx_global_begin2, __idx_global_end2, __wi_for_data_reading2, __local_id - __wi_for_data_reading1);
             }
         }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -390,7 +390,11 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
                     _RangeValueType* __rng1_cache_slm = std::addressof(__loc_acc[0]);
                     _RangeValueType* __rng2_cache_slm = std::addressof(__loc_acc[0]) + __rng1_wg_data_size;
 
-                    const std::size_t __chunk_of_data_reading = oneapi::dpl::__internal::__dpl_ceiling_div(__rng_wg_data_size, __wi_in_one_wg);
+                    constexpr std::size_t __slm_bank_size = 32;
+
+                    const std::size_t __chunk_of_data_reading = std::max(
+                        oneapi::dpl::__internal::__dpl_ceiling_div(__rng_wg_data_size, __wi_in_one_wg),
+                        oneapi::dpl::__internal::__dpl_ceiling_div(__slm_bank_size, 2 * sizeof(_RangeValueType)));
                     const std::size_t __idx_begin = __local_id * __chunk_of_data_reading;
                     if (__idx_begin < __rng_wg_data_size)
                     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -302,7 +302,7 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
             using _Range1ValueType = typename std::iterator_traits<decltype(__rng1.begin())>::value_type;
             using _Range2ValueType = typename std::iterator_traits<decltype(__rng2.begin())>::value_type;
 
-            if constexpr (false && std::is_same_v<_Range1ValueType, _Range2ValueType>)
+            if constexpr (std::is_same_v<_Range1ValueType, _Range2ValueType>)
                 return std::tuple<__dpl_sycl::__local_accessor<_Range1ValueType>>(
                     __dpl_sycl::__local_accessor<_Range1ValueType>(2 * __slm_cached_data_size, __cgh));
             else

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -345,14 +345,14 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
            |  rng[2]           |   +   |       |       |       |     |                        | slm[1]     |                                        | SLM bank: write into one SLM bank from one work-item
            |  rng[3]           |   +   |       |       |       |     |                        | slm[2]     |                                       /
            |  rng[4]           |       |   +   |       |       |     |                        | slm[3]     |
-           |  rng[5]           |       |   +   |       |       |     |                        | slm[3]     |
-           |  rng[6]           |       |   +   |       |       |     |                        | slm[3]     |
-           |  rng[7]           |       |       |   +   |       |     |                        | slm[3]     |
-           |  rng[8]           |       |       |   +   |       |     |                        | slm[3]     |
-           |  rng[9]           |       |       |   +   |       |     |                        | slm[3]     |
-           |  rng[10]          |       |       |       |   +   |     |                        | slm[3]     |
-           |  rng[11]          |       |       |       |   +   |     |                        | slm[3]     |
-           |  rng[12]          |       |       |       |   +   |     |                        | slm[3]     |
+           |  rng[5]           |       |   +   |       |       |     |                        | slm[4]     |
+           |  rng[6]           |       |   +   |       |       |     |                        | slm[5]     |
+           |  rng[7]           |       |       |   +   |       |     |                        | slm[6]     |
+           |  rng[8]           |       |       |   +   |       |     |                        | slm[7]     |
+           |  rng[9]           |       |       |   +   |       |     |                        | slm[8]     |
+           |  rng[10]          |       |       |       |   +   |     |                        | slm[9]     |
+           |  rng[11]          |       |       |       |   +   |     |                        | slm[10]    |
+           |  rng[12]          |       |       |       |   +   |     |                        | slm[11]    |
            |  .....            |       |       |       |       | +++ |                        | ...        |  
            |  rng[M + 1]       |       |       |       |       |     |           +            | slm[M]     |  
            |  rng[M + 2]       |       |       |       |       |     |           +            | slm[M + 1] |  

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -575,9 +575,8 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
                                            __wi_in_one_wg, __local_id);
                     }
 
-                    // Wait until all the data is loaded (if we have more then one item in work-group
-                    if (__wi_in_one_wg > 1)
-                        __dpl_sycl::__group_barrier(__nd_item);
+                    // Wait until all the data is loaded
+                    __dpl_sycl::__group_barrier(__nd_item);
 
                     // Current diagonal inside of the merge matrix?
                     if (__have_data)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -631,7 +631,7 @@ __parallel_merge(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy
 {
     using _CustomName = oneapi::dpl::__internal::__policy_kernel_name<_ExecutionPolicy>;
 
-    constexpr std::size_t __starting_size_limit_for_large_submitter = 4 * 1'048'576; // 4 Mb
+    constexpr std::size_t __starting_size_limit_for_large_submitter = 16 * 1'048'576; // 4 Mb
 
     const std::size_t __n = __rng1.size() + __rng2.size();
     if (__n < __starting_size_limit_for_large_submitter)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -382,8 +382,8 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
 
                     // Split points on left anr right base diagonals
                     //  - in GLOBAL coordinates
-                    const _split_point_t<std::size_t>& __sp_base_left_global  = __base_diagonals_sp_global_ptr[__group_linear_id];
-                    const _split_point_t<std::size_t>& __sp_base_right_global = __base_diagonals_sp_global_ptr[__group_linear_id + 1]; 
+                    const auto& __sp_base_left_global  = __base_diagonals_sp_global_ptr[__group_linear_id];
+                    const auto& __sp_base_right_global = __base_diagonals_sp_global_ptr[__group_linear_id + 1]; 
 
                     assert(__sp_base_right_global.first >= __sp_base_left_global.first);
                     assert(__sp_base_right_global.second >= __sp_base_left_global.second);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -385,7 +385,7 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
 
                 _ONEDPL_PRAGMA_UNROLL
                 for (; __slm_idx < __slm_idx_end && __rng_idx < __idx_global_end; ++__slm_idx, ++__rng_idx)
-                        __slm[__slm_idx] = __rng[__rng_idx];
+                    __slm[__slm_idx] = __rng[__rng_idx];
             }
             else
             {
@@ -400,8 +400,6 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
     static std::size_t
     __calc_wi_amount_for_data_reading(const std::size_t __wi_in_one_wg, const std::size_t __reading_data)
     {
-        //const std::size_t __required_reading_data_per_wi = __slm_bank_size / sizeof(_RangeValueType);
-
         std::size_t __wi_for_data_reading = 0;
         if (__reading_data > 0)
         {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -631,11 +631,24 @@ __parallel_merge(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy
     {
         static_assert(__starting_size_limit_for_large_submitter < std::numeric_limits<std::uint32_t>::max());
 
-        using _MergeKernelName = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
-            __merge_kernel_name<_CustomName>>;
-        return __parallel_merge_submitter<std::uint32_t, _MergeKernelName>()(
-            std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
-            std::forward<_Range3>(__rng3), __comp);
+        if (__n <= std::numeric_limits<std::uint16_t>::max())
+        {
+            using _WiIndex = std::uint16_t;
+            using _MergeKernelName = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
+                __merge_kernel_name<_CustomName, _WiIndex>>;
+            return __parallel_merge_submitter<_WiIndex, _MergeKernelName>()(
+                std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
+                std::forward<_Range3>(__rng3), __comp);
+        }
+        else
+        {
+            using _WiIndex = std::uint32_t;
+            using _MergeKernelName = oneapi::dpl::__par_backend_hetero::__internal::__kernel_name_provider<
+                __merge_kernel_name<_CustomName, _WiIndex>>;
+            return __parallel_merge_submitter<_WiIndex, _MergeKernelName>()(
+                std::forward<_ExecutionPolicy>(__exec), std::forward<_Range1>(__rng1), std::forward<_Range2>(__rng2),
+                std::forward<_Range3>(__rng3), __comp);
+        }
     }
     else
     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -446,7 +446,7 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
                         }
                     }
 
-                    const std::size_t __first_wi_local_id_for_read_rng2 = __wi_in_one_wg - __how_many_wi_reads_rng2 - 1;
+                    const std::size_t __first_wi_local_id_for_read_rng2 = __wi_in_one_wg - __how_many_wi_reads_rng2;
                     if (__local_id >= __first_wi_local_id_for_read_rng2)
                     {
                         const _IdType __idx_begin = (__local_id - __first_wi_local_id_for_read_rng2) * __chunk_of_data_reading;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -464,7 +464,7 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
         _PRINT_INFO_IN_DEBUG_MODE(__exec);
 
         // Empirical number of values to process per work-item
-        const _IdType __chunk = __exec.queue().get_device().is_cpu() ? 128 : 4;
+        const _IdType __chunk = __exec.queue().get_device().is_cpu() ? 128 : 8;
         assert(__chunk > 0);
 
         // Pessimistically only use half of the memory to take into account memory used by compiled kernel

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -194,19 +194,19 @@ __serial_merge(const _Rng1& __rng1, const _Rng2& __rng2, _Rng3& __rng3, _Index _
     {
         //copying a residual of the second seq
         const _Index __n = std::min<_Index>(__n2 - __start2, __chunk);
-        for (std::uint8_t __i = 0; __i < __n; ++__i)
+        for (_Index __i = 0; __i < __n; ++__i)
             __rng3[__start3 + __i] = __rng2[__start2 + __i];
     }
     else if (__start2 >= __n2)
     {
         //copying a residual of the first seq
         const _Index __n = std::min<_Index>(__n1 - __start1, __chunk);
-        for (std::uint8_t __i = 0; __i < __n; ++__i)
+        for (_Index __i = 0; __i < __n; ++__i)
             __rng3[__start3 + __i] = __rng1[__start1 + __i];
     }
     else
     {
-        for (std::uint8_t __i = 0; __i < __chunk && __start1 < __n1 && __start2 < __n2; ++__i)
+        for (_Index __i = 0; __i < __chunk && __start1 < __n1 && __start2 < __n2; ++__i)
         {
             const auto& __val1 = __rng1[__start1];
             const auto& __val2 = __rng2[__start2];

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -284,8 +284,8 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
     auto
     operator()(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _Range3&& __rng3, _Compare __comp) const
     {
-        using _Range1ValueType = typename std::iterator_traits<decltype(__rng1.begin())>::value_type;
-        using _Range2ValueType = typename std::iterator_traits<decltype(__rng2.begin())>::value_type;
+        using _Range1ValueType = oneapi::dpl::__internal::__value_t<_Range1>;
+        using _Range2ValueType = oneapi::dpl::__internal::__value_t<_Range2>;
         static_assert(std::is_same_v<_Range1ValueType, _Range2ValueType>, "In this implementation we can merge only data of the same type");
 
         using _RangeValueType = _Range1ValueType;
@@ -482,8 +482,8 @@ __parallel_merge(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy
 
     constexpr std::size_t __starting_size_limit_for_large_submitter = 1 * 1'048'576; // 1 Mb
 
-    using _Range1ValueType = typename std::iterator_traits<decltype(__rng1.begin())>::value_type;
-    using _Range2ValueType = typename std::iterator_traits<decltype(__rng2.begin())>::value_type;
+    using _Range1ValueType = oneapi::dpl::__internal::__value_t<_Range1>;
+    using _Range2ValueType = oneapi::dpl::__internal::__value_t<_Range2>;
 
     constexpr bool __same_merge_types = std::is_same_v<_Range1ValueType, _Range2ValueType>;
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -357,8 +357,6 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
             }
             else
             {
-                assert(__loading_data_per_wi == 1);
-
                 const std::size_t __rng_idx = __sp_base_left_global_from + __local_id;
                 if (__rng_idx < __sp_base_left_global_to)
                 {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -380,26 +380,17 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
                 const auto __slm_idx_begin = __local_id * __loading_data_per_wi;
                 const auto __slm_idx_end = __slm_idx_begin + __loading_data_per_wi;
 
-                for (std::size_t __slm_idx = __slm_idx_begin; __slm_idx < __slm_idx_end; ++__slm_idx)
-                {
-                    const std::size_t __rng_idx = __idx_global_begin + __slm_idx;
-                    if (__rng_idx < __idx_global_end)
-                    {
-                        assert(__slm_idx < __wg_data_size_rng);
-                        assert(__rng_idx < __rng.size());
+                std::size_t __slm_idx = __slm_idx_begin;
+                std::size_t __rng_idx = __idx_global_begin + __slm_idx;
+
+                for (; __slm_idx < __slm_idx_end && __rng_idx < __idx_global_end; ++__slm_idx, ++__rng_idx)
                         __slm[__slm_idx] = __rng[__rng_idx];
-                    }
-                }
             }
             else
             {
                 const std::size_t __rng_idx = __idx_global_begin + __local_id;
                 if (__rng_idx < __idx_global_end)
-                {
-                    assert(__local_id < __wg_data_size_rng);
-                    assert(__rng_idx < __rng.size());
                     __slm[__local_id] = __rng[__rng_idx];
-                }
             }
         }
     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -56,9 +56,10 @@ _split_point_t<_Index>
 __find_start_point(const _Rng1& __rng1, const _Rng2& __rng2, const _Index __i_elem, const _Index __n1,
                    const _Index __n2, _Compare __comp)
 {
-    const _Index __rng1_from = 0;
+    constexpr _Index __rng1_from = 0;
+    constexpr _Index __rng2_from = 0;
+
     const _Index __rng1_to = __n1;
-    const _Index __rng2_from = 0;
     const _Index __rng2_to = __n2;
 
     assert(__rng1_from <= __rng1_to);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -327,7 +327,7 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
     };
 
     template <typename _Range, typename _DataType>
-    inline static void
+    static void
     load_data_into_slm_impl(_Range&& __rng, _DataType* __slm,
                        std::size_t __idx_global_begin, std::size_t __idx_global_end,
                        std::size_t __wi_in_one_wg, std::size_t __local_id)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -634,7 +634,7 @@ __parallel_merge(oneapi::dpl::__internal::__device_backend_tag, _ExecutionPolicy
     constexpr std::size_t __starting_size_limit_for_large_submitter = 16 * 1'048'576; // 4 Mb
 
     const std::size_t __n = __rng1.size() + __rng2.size();
-    if (__n < __starting_size_limit_for_large_submitter)
+    if (false)  //if (__n < __starting_size_limit_for_large_submitter)
     {
         static_assert(__starting_size_limit_for_large_submitter < std::numeric_limits<std::uint32_t>::max());
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -391,13 +391,14 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
 
                     // Calculate __i_elem in LOCAL coordinates because __rng1_cache_slm and __rng1_cache_slm is work-group SLM cached copy of source data
                     const _IdType __i_elem = __local_id * __chunk;
+                    const _IdType __i_elem_next = (__local_id + 1) * __chunk;
 
                     // Cooperative data load from __rng1 to __rng1_cache_slm, from __rng2 to __rng1_cache_slm
                     _ONEDPL_PRAGMA_UNROLL
-                    for (_IdType __idx = __i_elem; __idx < __i_elem + __chunk && __sp_base_left_global.first + __idx < __sp_base_right_global.first; ++__idx)
+                    for (_IdType __idx = __i_elem; __idx < __i_elem_next && __idx < __rng1_wg_data_size; ++__idx)
                         __rng1_cache_slm[__idx] = __rng1[__sp_base_left_global.first + __idx];
                     _ONEDPL_PRAGMA_UNROLL
-                    for (_IdType __idx = __i_elem; __idx < __i_elem + __chunk && __sp_base_left_global.second + __idx < __sp_base_right_global.second; ++__idx)
+                    for (_IdType __idx = __i_elem; __idx < __i_elem_next && __idx < __rng2_wg_data_size; ++__idx)
                         __rng2_cache_slm[__idx] = __rng2[__sp_base_left_global.second + __idx];
 
                     // Wait until all the data is loaded

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -290,9 +290,9 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
 
         using _RangeValueType = _Range1ValueType;
 
-        const _IdType __n1 = __rng1.size();
-        const _IdType __n2 = __rng2.size();
-        const _IdType __n = __n1 + __n2;
+        const std::size_t __n1 = __rng1.size();
+        const std::size_t __n2 = __rng2.size();
+        const std::size_t __n = __n1 + __n2;
 
         assert(__n1 > 0 || __n2 > 0);
 
@@ -305,7 +305,7 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
         //constexpr std::size_t __data_items_in_slm_bank = std::max((std::size_t)1, __slm_bank_size / sizeof(_RangeValueType));
 
         // Empirical number of values to process per work-item
-        const _IdType __chunk = __exec.queue().get_device().is_cpu() ? 128 : 4;// __data_items_in_slm_bank;
+        const std::size_t __chunk = __exec.queue().get_device().is_cpu() ? 128 : 4; // __data_items_in_slm_bank;
         assert(__chunk > 0);
 
         // Get the size of local memory arena in bytes.
@@ -390,26 +390,26 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
                     assert(__sp_base_right_global.first >= __sp_base_left_global.first);
                     assert(__sp_base_right_global.second >= __sp_base_left_global.second);
 
-                    const _IdType __rng1_wg_data_size = __sp_base_right_global.first - __sp_base_left_global.first;
-                    const _IdType __rng2_wg_data_size = __sp_base_right_global.second - __sp_base_left_global.second;
+                    const std::size_t __rng1_wg_data_size = __sp_base_right_global.first - __sp_base_left_global.first;
+                    const std::size_t __rng2_wg_data_size = __sp_base_right_global.second - __sp_base_left_global.second;
 
                     _RangeValueType* __rng1_cache_slm = std::addressof(__loc_acc[0]);
                     _RangeValueType* __rng2_cache_slm = std::addressof(__loc_acc[0]) + __rng1_wg_data_size;
 
-                    const _IdType __chunk_of_data_reading = std::max(__chunk/*__data_items_in_slm_bank*/, (_IdType)oneapi::dpl::__internal::__dpl_ceiling_div(__rng1_wg_data_size + __rng2_wg_data_size, __wi_in_one_wg));
+                    const std::size_t __chunk_of_data_reading = std::max(__chunk/*__data_items_in_slm_bank*/, (_IdType)oneapi::dpl::__internal::__dpl_ceiling_div(__rng1_wg_data_size + __rng2_wg_data_size, __wi_in_one_wg));
 
-                    const _IdType __how_many_wi_reads_rng1 = oneapi::dpl::__internal::__dpl_ceiling_div(__rng1_wg_data_size, __chunk_of_data_reading);
-                    const _IdType __how_many_wi_reads_rng2 = oneapi::dpl::__internal::__dpl_ceiling_div(__rng2_wg_data_size, __chunk_of_data_reading);
+                    const std::size_t __how_many_wi_reads_rng1 = oneapi::dpl::__internal::__dpl_ceiling_div(__rng1_wg_data_size, __chunk_of_data_reading);
+                    const std::size_t __how_many_wi_reads_rng2 = oneapi::dpl::__internal::__dpl_ceiling_div(__rng2_wg_data_size, __chunk_of_data_reading);
                     
                     // Calculate the amount of WI for read data from rng1
                     if (__local_id < __how_many_wi_reads_rng1)
                     {
-                        const _IdType __idx_begin = __local_id * __chunk_of_data_reading;
+                        const std::size_t __idx_begin = __local_id * __chunk_of_data_reading;
 
                         // Cooperative data load from __rng1 to __rng1_cache_slm
                         if (__idx_begin < __rng1_wg_data_size)
                         {
-                            const _IdType __idx_end = std::min(__idx_begin + __chunk_of_data_reading, __rng1_wg_data_size);
+                            const std::size_t __idx_end = std::min(__idx_begin + __chunk_of_data_reading, __rng1_wg_data_size);
                     
                             _ONEDPL_PRAGMA_UNROLL
                             for (_IdType __idx = __idx_begin; __idx < __idx_end; ++__idx)
@@ -420,12 +420,12 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
                     const std::size_t __first_wi_local_id_for_read_rng2 = __wi_in_one_wg - __how_many_wi_reads_rng2;
                     if (__local_id >= __first_wi_local_id_for_read_rng2)
                     {
-                        const _IdType __idx_begin = (__local_id - __first_wi_local_id_for_read_rng2) * __chunk_of_data_reading;
+                        const std::size_t __idx_begin = (__local_id - __first_wi_local_id_for_read_rng2) * __chunk_of_data_reading;
 
                         // Cooperative data load from __rng2 to __rng2_cache_slm
                         if (__idx_begin < __rng2_wg_data_size)
                         {
-                            const _IdType __idx_end = std::min(__idx_begin + __chunk_of_data_reading, __rng2_wg_data_size);
+                            const std::size_t __idx_end = std::min(__idx_begin + __chunk_of_data_reading, __rng2_wg_data_size);
                     
                             _ONEDPL_PRAGMA_UNROLL
                             for (_IdType __idx = __idx_begin; __idx < __idx_end; ++__idx)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -412,10 +412,10 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
         return __wi_for_data_reading;
     }
 
-    template <typename _Range, typename _DataType>
+    template <typename _Range, typename _DataType1, typename _DataType2>
     static void
-    load_data_into_slm(_Range&& __rng1, _DataType* __slm1, const std::size_t __idx_global_begin1, const std::size_t __idx_global_end1,
-                       _Range&& __rng2, _DataType* __slm2, const std::size_t __idx_global_begin2, const std::size_t __idx_global_end2,
+    load_data_into_slm(_Range&& __rng1, _DataType1* __slm1, const std::size_t __idx_global_begin1, const std::size_t __idx_global_end1,
+                       _Range&& __rng2, _DataType2* __slm2, const std::size_t __idx_global_begin2, const std::size_t __idx_global_end2,
                        const std::size_t __wi_in_one_wg, const std::size_t __local_id)
     {
         // TODO what size of SLM bank we have now?

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -418,7 +418,7 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
                        const std::size_t __wi_in_one_wg, const std::size_t __local_id)
     {
         // TODO what size of SLM bank we have now?
-        constexpr std::size_t __slm_bank_size = 1024;
+        constexpr std::size_t __slm_bank_size = 64;     // = 1024;
 
 #if 0
         auto __n1 = __rng1.size();

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -351,7 +351,7 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
                     //  - in GLOBAL coordinates
                     _split_point_t<_IdType> __sp(__linear_id == 0 ? __zero_split_point<std::size_t> : _split_point_t<std::size_t>{__n1, __n2});
                     if (0 < __linear_id && __linear_id < __wg_count)
-                        __sp = __find_start_point(__rng1, __rng2, (_IdType)(__linear_id * __wi_in_one_wg * __chunk), __n1, __n2, __comp);
+                        __sp = __find_start_point(__rng1, __rng2, __linear_id * __wi_in_one_wg * __chunk, __n1, __n2, __comp);
 
                     __base_diagonals_sp_global_ptr[__linear_id] = __sp;
                 });
@@ -396,7 +396,7 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
                     _RangeValueType* __rng1_cache_slm = std::addressof(__loc_acc[0]);
                     _RangeValueType* __rng2_cache_slm = std::addressof(__loc_acc[0]) + __rng1_wg_data_size;
 
-                    const std::size_t __chunk_of_data_reading = std::max(__chunk/*__data_items_in_slm_bank*/, (_IdType)oneapi::dpl::__internal::__dpl_ceiling_div(__rng1_wg_data_size + __rng2_wg_data_size, __wi_in_one_wg));
+                    const std::size_t __chunk_of_data_reading = std::max(__chunk/*__data_items_in_slm_bank*/, oneapi::dpl::__internal::__dpl_ceiling_div(__rng1_wg_data_size + __rng2_wg_data_size, __wi_in_one_wg));
 
                     const std::size_t __how_many_wi_reads_rng1 = oneapi::dpl::__internal::__dpl_ceiling_div(__rng1_wg_data_size, __chunk_of_data_reading);
                     const std::size_t __how_many_wi_reads_rng2 = oneapi::dpl::__internal::__dpl_ceiling_div(__rng2_wg_data_size, __chunk_of_data_reading);
@@ -443,7 +443,7 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
                         //  - bottom-right split point describes the size of current area between two base diagonals.
                         const _split_point_t<_IdType> __sp_local = __find_start_point(
                             __rng1_cache_slm, __rng2_cache_slm,                         // SLM cached copy of merging data
-                            (_IdType)(__local_id * __chunk),                            // __i_elem in LOCAL coordinates because __rng1_cache_slm and __rng1_cache_slm is work-group SLM cached copy of source data
+                            __local_id * __chunk,                                       // __i_elem in LOCAL coordinates because __rng1_cache_slm and __rng1_cache_slm is work-group SLM cached copy of source data
                             __rng1_wg_data_size, __rng2_wg_data_size,                   // size of rng1 and rng2
                             __comp);
 
@@ -451,9 +451,9 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
                         //  - we should have here __sp_global in GLOBAL coordinates
                         __serial_merge(__rng1_cache_slm, __rng2_cache_slm,              // SLM cached copy of merging data
                                        __rng3,                                          // Destination range
-                                       __sp_local.first,                                // __start1 in LOCAL coordinates because __rng1_cache_slm is work-group SLM cached copy of source data
-                                       __sp_local.second,                               // __start2 in LOCAL coordinates because __rng1_cache_slm is work-group SLM cached copy of source data
-                                       (_IdType)(__global_linear_id * __chunk),         // __start3 in GLOBAL coordinates because __rng3 is not cached at all
+                                       (std::size_t)__sp_local.first,                   // __start1 in LOCAL coordinates because __rng1_cache_slm is work-group SLM cached copy of source data
+                                       (std::size_t)__sp_local.second,                  // __start2 in LOCAL coordinates because __rng1_cache_slm is work-group SLM cached copy of source data
+                                       __global_linear_id * __chunk,                    // __start3 in GLOBAL coordinates because __rng3 is not cached at all
                                        __chunk,
                                        __rng1_wg_data_size, __rng2_wg_data_size,        // size of rng1 and rng2
                                        __comp);

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -468,7 +468,6 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
 
                     // Split points on left anr right base diagonals
                     //  - in GLOBAL coordinates
-                    assert(__group_linear_id + 1 < __wg_count + 1);
                     const _split_point_t<std::size_t>& __sp_base_left_global  = __base_diagonals_sp_global_ptr[__group_linear_id];
                     const _split_point_t<std::size_t>& __sp_base_right_global = __base_diagonals_sp_global_ptr[__group_linear_id + 1]; 
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -302,11 +302,11 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
         const _IdType __chunk = __exec.queue().get_device().is_cpu() ? 128 : 4;
         assert(__chunk > 0);
 
-        // Pessimistically only use half of the memory to take into account memory used by compiled kernel
+        // Pessimistically only use 2/3 of the memory to take into account memory used by compiled kernel
         const std::size_t __max_slm_size_adj = 
             std::max((std::size_t)__chunk,
                      std::min((std::size_t)__n, oneapi::dpl::__internal::__slm_adjusted_work_group_size(
-                                                                 __exec, 2 * sizeof(_RangeValueType))));
+                                                                 __exec, sizeof(_RangeValueType)))) * 2 / 3;
 
         // The amount of data must be a multiple of the chunk size.
         const std::size_t __max_source_data_items_fit_into_slm = __max_slm_size_adj - __max_slm_size_adj % __chunk;

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -26,8 +26,6 @@
 #include "sycl_defs.h"
 #include "parallel_backend_sycl_utils.h"
 
-//#define DUMP_DATA_LOADING 1
-
 namespace oneapi
 {
 namespace dpl
@@ -282,20 +280,6 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
                                         __internal::__optional_kernel_name<_DiagonalsKernelName...>,
                                         __internal::__optional_kernel_name<_MergeKernelName...>>
 {
-#if DUMP_DATA_LOADING
-    template <typename _Range, typename _Index, typename _Data>
-    static void
-    __load_item_into_slm(_Range&& __rng, _Index __idx_from, _Data* __slm, _Index __idx_to, std::size_t __range_index,
-                         bool __b_check, std::size_t __group_linear_id, std::size_t __local_id)
-    {
-        // BP
-        //  condition: __b_check
-        //  action: __range_index = {__range_index}, __rng[{__idx_from}] -> __slm[{__idx_to}], __group_linear_id = {__group_linear_id}, __local_id = {__local_id}
-        //  action: {__range_index}, {__idx_from}, {__idx_to}, {__group_linear_id}, {__local_id}
-        __slm[__idx_to] = __rng[__idx_from];
-    }
-#endif
-
     template <typename _ExecutionPolicy, typename _Range1, typename _Range2, typename _Range3, typename _Compare>
     auto
     operator()(_ExecutionPolicy&& __exec, _Range1&& __rng1, _Range2&& __rng2, _Range3&& __rng3, _Compare __comp) const
@@ -309,18 +293,6 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
         const _IdType __n1 = __rng1.size();
         const _IdType __n2 = __rng2.size();
         const _IdType __n = __n1 + __n2;
-
-#if DUMP_DATA_LOADING
-        //const bool __b_check = __n1 == 16144 && __n2 == 8072;
-        //const bool __b_check = __n1 == 50716 && __n2 == 25358;      // __wi_in_one_wg = 51 __wg_count = 12
-        const bool __b_check = false;
-
-        if (__b_check)
-        {
-            int i = 0;
-            i = i;
-        }
-#endif
 
         assert(__n1 > 0 || __n2 > 0);
 
@@ -447,11 +419,7 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
                     
                             _ONEDPL_PRAGMA_UNROLL
                             for (_IdType __idx = __idx_begin; __idx < __idx_end; ++__idx)
-#if !DUMP_DATA_LOADING
                                 __rng1_cache_slm[__idx] = __rng1[__sp_base_left_global.first + __idx];
-#else
-                                __load_item_into_slm(__rng1, __sp_base_left_global.first + __idx, __rng1_cache_slm, __idx, 1, __b_check, __group_linear_id, __local_id);
-#endif
                         }
                     }
 
@@ -467,43 +435,12 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
                     
                             _ONEDPL_PRAGMA_UNROLL
                             for (_IdType __idx = __idx_begin; __idx < __idx_end; ++__idx)
-#if !DUMP_DATA_LOADING
                                 __rng2_cache_slm[__idx] = __rng2[__sp_base_left_global.second + __idx];
-#else
-                                __load_item_into_slm(__rng2, __sp_base_left_global.second + __idx, __rng2_cache_slm, __idx, 2, __b_check, __group_linear_id, __local_id);
-#endif
                         }
                     }
 
                     // Wait until all the data is loaded
                     __dpl_sycl::__group_barrier(__nd_item);
-
-#if DUMP_DATA_LOADING
-                    if (__local_id == 0)
-                    {
-                        for (auto i = __sp_base_left_global.first; i < __sp_base_right_global.first; ++i)
-                        {
-                            auto _idx_slm = i - __sp_base_left_global.first;
-                            if (__rng1_cache_slm[_idx_slm] != __rng1[i])
-                            {
-                                auto __group_linear_id_tmp = __group_linear_id;
-                                __group_linear_id_tmp = __group_linear_id_tmp;
-                                assert(false);
-                            }
-                        }
-
-                        for (auto i = __sp_base_left_global.second; i < __sp_base_right_global.second; ++i)
-                        {
-                            auto _idx_slm = i - __sp_base_left_global.second;
-                            if (__rng2_cache_slm[_idx_slm] != __rng2[i])
-                            {
-                                auto __group_linear_id_tmp = __group_linear_id;
-                                __group_linear_id_tmp = __group_linear_id_tmp;
-                                assert(false);
-                            }
-                        }
-                    }
-#endif
 
                     // Current diagonal inside of the merge matrix?
                     if (__global_linear_id * __chunk < __n)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -310,7 +310,7 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
 
         // Pessimistically only use 2/3 of the memory to take into account memory used by compiled kernel
         const auto __slm_adjusted_work_group_size = oneapi::dpl::__internal::__slm_adjusted_work_group_size(__exec, sizeof(_RangeValueType));
-        const auto __slm_adjusted_work_group_size_x_part = __slm_adjusted_work_group_size * 2 / 3;
+        const auto __slm_adjusted_work_group_size_x_part = __slm_adjusted_work_group_size * 4 / 5;
         const std::size_t __max_slm_size_adj = __slm_adjusted_work_group_size_x_part;
 
         // The amount of data must be a multiple of the chunk size.

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -584,8 +584,9 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
                                        __rng2, __rng2_cache_slm, __sp_base_left_global.second, __sp_base_right_global.second,
                                        __wi_in_one_wg, __local_id);
 
-                    // Wait until all the data is loaded
-                    __dpl_sycl::__group_barrier(__nd_item);
+                    // Wait until all the data is loaded (if we have more then one item in work-group
+                    if (__wi_in_one_wg > 1)
+                        __dpl_sycl::__group_barrier(__nd_item);
 
                     // Current diagonal inside of the merge matrix?
                     if (__global_linear_id * __chunk < __n)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -394,11 +394,14 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
                     const _IdType __i_elem_next = (__local_id + 1) * __chunk;
 
                     // Cooperative data load from __rng1 to __rng1_cache_slm, from __rng2 to __rng1_cache_slm
+                    _IdType __idx_end = std::min(__i_elem_next, __rng1_wg_data_size);
                     _ONEDPL_PRAGMA_UNROLL
-                    for (_IdType __idx = __i_elem; __idx < __i_elem_next && __idx < __rng1_wg_data_size; ++__idx)
+                    for (_IdType __idx = __i_elem; __idx < __idx_end; ++__idx)
                         __rng1_cache_slm[__idx] = __rng1[__sp_base_left_global.first + __idx];
+
+                    __idx_end = std::min(__i_elem_next, __rng2_wg_data_size);
                     _ONEDPL_PRAGMA_UNROLL
-                    for (_IdType __idx = __i_elem; __idx < __i_elem_next && __idx < __rng2_wg_data_size; ++__idx)
+                    for (_IdType __idx = __i_elem; __idx < __idx_end; ++__idx)
                         __rng2_cache_slm[__idx] = __rng2[__sp_base_left_global.second + __idx];
 
                     // Wait until all the data is loaded

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -26,8 +26,6 @@
 #include "sycl_defs.h"
 #include "parallel_backend_sycl_utils.h"
 
-#define USE_DEBUG_CODE_IN_MERGE_SUBMITTER_LARGE 0
-
 namespace oneapi
 {
 namespace dpl
@@ -276,33 +274,6 @@ struct __parallel_merge_submitter<_IdType, __internal::__optional_kernel_name<_M
 template <typename _IdType, typename _CustomName, typename _DiagonalsKernelName, typename _MergeKernelName>
 struct __parallel_merge_submitter_large;
 
-#if USE_DEBUG_CODE_IN_MERGE_SUBMITTER_LARGE
-// TODO remove debug code
-template <typename _RngTo, typename _RngFrom, typename _IdType>
-void
-load_data(std::size_t __n1, std::size_t __n2, std::size_t __wg_id, std::size_t __rng_no, std::size_t __local_idx, _RngTo& __rng_to, std::size_t __idx_to, const _RngFrom& __rng_from, std::size_t __idx_from,
-          _IdType                       __wg_data_size_rng, 
-          _IdType                       __items_in_wg_count,
-          const std::size_t             __loading_data_per_wi,
-          const _split_point_t<_IdType> __sp_base_left_global,  
-          const _split_point_t<_IdType> __sp_base_right_global)
-{
-    __rng_to[__idx_to] = __rng_from[__idx_from];
-}
-
-// TODO remove debug code
-template <typename _IdType>
-void
-dump_split_point(_IdType __idx, const _split_point_t<_IdType> __sp)
-{
-    auto first = __sp.first;
-    auto second = __sp.second;
-
-    first = first;
-    second = second;
-}
-#endif
-
 template <typename _IdType, typename _CustomName, typename... _DiagonalsKernelName, typename... _MergeKernelName>
 struct __parallel_merge_submitter_large<_IdType, _CustomName,
                                         __internal::__optional_kernel_name<_DiagonalsKernelName...>,
@@ -499,16 +470,6 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
 
                     // Merge matrix base diagonal's GLOBAL index
                     const std::size_t __wg_id = __nd_item.get_group_linear_id();
-
-#if USE_DEBUG_CODE_IN_MERGE_SUBMITTER_LARGE
-                    // TODO remove debug code: dump split points
-                    {
-                        if (__wg_id == 0 && __local_idx == 0)
-                            for (std::size_t i = 0; i < __wg_count + 1; ++i)
-                                dump_split_point(i, __base_diagonals_sp_global_ptr[i]);
-                        __dpl_sycl::__group_barrier(__nd_item);
-                    }
-#endif
 
                     // Split points on left anr right base diagonals
                     //  - in GLOBAL coordinates

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -427,15 +427,8 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
                     // Save top-left split point for first/last base diagonals of merge matrix
                     //  - in GLOBAL coordinates
                     _split_point_t<_IdType> __sp(__linear_id == 0 ? __zero_split_point<std::size_t> : _split_point_t<std::size_t>{__n1, __n2});
-
                     if (0 < __linear_id && __linear_id < __wg_count)
-                    {
-                        const _IdType __i_elem = __linear_id * __items_in_wg_count * __chunk;
-
-                        // Save bottom-right split point for current base diagonal of merge matrix
-                        //  - in GLOBAL coordinates
-                        __sp = __find_start_point(__rng1, __rng2, __i_elem, __n1, __n2, __comp);
-                    }
+                        __sp = __find_start_point(__rng1, __rng2, (_IdType)(__linear_id * __items_in_wg_count * __chunk), __n1, __n2, __comp);
 
                     __base_diagonals_sp_global_ptr[__linear_id] = __sp;
                 });

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -493,9 +493,6 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
                     // Current diagonal inside of the merge matrix?
                     if (__global_linear_id * __chunk < __n)
                     {
-                        // We are between two base diagonals and need to find the start points in the merge matrix area,
-                        // limited by split points of the left and right base diagonals.
-
                         // Find split point in LOCAL coordinates
                         //  - bottom-right split point describes the size of current area between two base diagonals.
                         const _split_point_t<_IdType> __sp_local = __find_start_point(

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -409,7 +409,7 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
             auto __base_diagonals_sp_global_ptr = __base_diagonals_sp_storage_t::__get_usm_or_buffer_accessor_ptr(__base_diagonals_sp_global_acc);
 
             const std::size_t __slm_cached_data_size = __items_in_wg_count * __chunk;
-            auto local_accessors = __merge_slm_helper::create_local_accessors(__cgh, __rng1, __rng2, __slm_cached_data_size);
+            auto loc_acc_pack = __merge_slm_helper::create_local_accessors(__cgh, __rng1, __rng2, __slm_cached_data_size);
 
             // Run nd_range parallel_for to process all the data
             __cgh.parallel_for<_MergeKernelName...>(
@@ -437,11 +437,10 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
                     const _IdType __wg_data_size_rng1 = __sp_base_right_global.first - __sp_base_left_global.first;
                     const _IdType __wg_data_size_rng2 = __sp_base_right_global.second - __sp_base_left_global.second;
                    
-
-                    auto [__local_accessor_rng1, offset_to_slm1] = __merge_slm_helper::template get_local_accessor<0>(local_accessors);
-                    auto [__local_accessor_rng2, offset_to_slm2] = __merge_slm_helper::template get_local_accessor<1>(local_accessors, (std::size_t)(__sp_base_right_global.first -__sp_base_left_global.first));
-                    auto __rngs_data_in_slm1 = std::addressof(__local_accessor_rng1[0]) + offset_to_slm1;
-                    auto __rngs_data_in_slm2 = std::addressof(__local_accessor_rng2[0]) + offset_to_slm2;
+                    auto [__loc_acc_rng1, offset_to_slm1] = __merge_slm_helper::template get_local_accessor<0>(loc_acc_pack);
+                    auto [__loc_acc_rng2, offset_to_slm2] = __merge_slm_helper::template get_local_accessor<1>(loc_acc_pack, __wg_data_size_rng1);
+                    auto __rngs_data_in_slm1 = std::addressof(__loc_acc_rng1[0]) + offset_to_slm1;
+                    auto __rngs_data_in_slm2 = std::addressof(__loc_acc_rng2[0]) + offset_to_slm2;
 
                     // Full amount of work-items may be great then the amount of diagonals in the merge matrix
                     // so we should skip the redundant work-items

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -412,10 +412,10 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
         return __wi_for_data_reading;
     }
 
-    template <typename _Range, typename _DataType1, typename _DataType2>
+    template <typename _Range1, typename _Range2, typename _DataType1, typename _DataType2>
     static void
-    load_data_into_slm(_Range&& __rng1, _DataType1* __slm1, const std::size_t __idx_global_begin1, const std::size_t __idx_global_end1,
-                       _Range&& __rng2, _DataType2* __slm2, const std::size_t __idx_global_begin2, const std::size_t __idx_global_end2,
+    load_data_into_slm(_Range1&& __rng1, _DataType1* __slm1, const std::size_t __idx_global_begin1, const std::size_t __idx_global_end1,
+                       _Range2&& __rng2, _DataType2* __slm2, const std::size_t __idx_global_begin2, const std::size_t __idx_global_end2,
                        const std::size_t __wi_in_one_wg, const std::size_t __local_id)
     {
         // TODO what size of SLM bank we have now?

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -302,7 +302,7 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
             using _Range1ValueType = typename std::iterator_traits<decltype(__rng1.begin())>::value_type;
             using _Range2ValueType = typename std::iterator_traits<decltype(__rng2.begin())>::value_type;
 
-            if constexpr (std::is_same_v<_Range1ValueType, _Range2ValueType>)
+            if constexpr (false && std::is_same_v<_Range1ValueType, _Range2ValueType>)
                 return std::tuple<__dpl_sycl::__local_accessor<_Range1ValueType>>(
                     __dpl_sycl::__local_accessor<_Range1ValueType>(2 * __slm_cached_data_size, __cgh));
             else

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -394,20 +394,20 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
                     _RangeValueType* __rng1_cache_slm = std::addressof(__loc_acc[0]);
                     _RangeValueType* __rng2_cache_slm = std::addressof(__loc_acc[0]) + __rng1_wg_data_size;
 
-                    const std::size_t __chunk_of_data_reading = std::max(__data_items_in_slm_bank, oneapi::dpl::__internal::__dpl_ceiling_div(__rng1_wg_data_size + __rng2_wg_data_size, __wi_in_one_wg));
+                    const _IdType __chunk_of_data_reading = std::max(__data_items_in_slm_bank, oneapi::dpl::__internal::__dpl_ceiling_div(__rng1_wg_data_size + __rng2_wg_data_size, __wi_in_one_wg));
 
-                    const std::size_t __how_many_wi_reads_rng1 = oneapi::dpl::__internal::__dpl_ceiling_div(__rng1_wg_data_size, __chunk_of_data_reading);
-                    const std::size_t __how_many_wi_reads_rng2 = oneapi::dpl::__internal::__dpl_ceiling_div(__rng2_wg_data_size, __chunk_of_data_reading);
+                    const _IdType __how_many_wi_reads_rng1 = oneapi::dpl::__internal::__dpl_ceiling_div(__rng1_wg_data_size, __chunk_of_data_reading);
+                    const _IdType __how_many_wi_reads_rng2 = oneapi::dpl::__internal::__dpl_ceiling_div(__rng2_wg_data_size, __chunk_of_data_reading);
                     
                     // Calculate the amount of WI for read data from rng1
                     if (__local_id < __how_many_wi_reads_rng1)
                     {
-                        const std::size_t __idx_begin = __local_id * __chunk_of_data_reading;
+                        const _IdType __idx_begin = __local_id * __chunk_of_data_reading;
 
                         // Cooperative data load from __rng1 to __rng1_cache_slm
                         if (__idx_begin < __rng1_wg_data_size)
                         {
-                            const std::size_t __idx_end = std::min(__idx_begin + __chunk_of_data_reading, (std::size_t)__rng1_wg_data_size);
+                            const _IdType __idx_end = std::min(__idx_begin + __chunk_of_data_reading, __rng1_wg_data_size);
                     
                             _ONEDPL_PRAGMA_UNROLL
                             for (_IdType __idx = __idx_begin; __idx < __idx_end; ++__idx)
@@ -418,12 +418,12 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
                     const std::size_t __first_wi_local_id_for_read_rng2 = __wi_in_one_wg - __how_many_wi_reads_rng2 - 1;
                     if (__local_id >= __first_wi_local_id_for_read_rng2)
                     {
-                        const std::size_t __idx_begin = (__local_id - __first_wi_local_id_for_read_rng2) * __chunk_of_data_reading;
+                        const _IdType __idx_begin = (__local_id - __first_wi_local_id_for_read_rng2) * __chunk_of_data_reading;
 
                         // Cooperative data load from __rng2 to __rng2_cache_slm
                         if (__idx_begin < __rng2_wg_data_size)
                         {
-                            const std::size_t __idx_end = std::min(__idx_begin + __chunk_of_data_reading, (std::size_t)__rng2_wg_data_size);
+                            const _IdType __idx_end = std::min(__idx_begin + __chunk_of_data_reading, __rng2_wg_data_size);
                     
                             _ONEDPL_PRAGMA_UNROLL
                             for (_IdType __idx = __idx_begin; __idx < __idx_end; ++__idx)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -311,10 +311,9 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
         // Pessimistically only use 2/3 of the memory to take into account memory used by compiled kernel
         const auto __slm_adjusted_work_group_size = oneapi::dpl::__internal::__slm_adjusted_work_group_size(__exec, sizeof(_RangeValueType));
         const auto __slm_adjusted_work_group_size_x_part = __slm_adjusted_work_group_size * 4 / 5;
-        const std::size_t __max_slm_size_adj = __slm_adjusted_work_group_size_x_part;
 
         // The amount of data must be a multiple of the chunk size.
-        const std::size_t __max_source_data_items_fit_into_slm = __max_slm_size_adj - __max_slm_size_adj % __chunk;
+        const std::size_t __max_source_data_items_fit_into_slm = __slm_adjusted_work_group_size_x_part - __slm_adjusted_work_group_size_x_part % __chunk;
         assert(__max_source_data_items_fit_into_slm > 0);
         assert(__max_source_data_items_fit_into_slm % __chunk == 0);
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge.h
@@ -420,28 +420,12 @@ struct __parallel_merge_submitter_large<_IdType, _CustomName,
         // TODO what size of SLM bank we have now?
         constexpr std::size_t __slm_bank_size = 64;     // = 1024;
 
-#if 0
-        auto __n1 = __rng1.size();
-        auto __n2 = __rng2.size();
-
-        if (__n1 == 521 && __n2 == 260)
-        {
-            __n1 = __n1;
-            __n2 = __n2;
-        }
-#endif
-
         using _Range1ValueType = typename std::iterator_traits<decltype(__rng1.begin())>::value_type;
         using _Range2ValueType = typename std::iterator_traits<decltype(__rng2.begin())>::value_type;
 
         // Calculate how many work-items should read the part of __rng1 and __rng2 into SLM cache
         const std::size_t __wi_for_data_reading1 = __calc_wi_amount_for_data_reading<__slm_bank_size, _Range1ValueType>(__wi_in_one_wg, __idx_global_end1 - __idx_global_begin1);
         const std::size_t __wi_for_data_reading2 = __calc_wi_amount_for_data_reading<__slm_bank_size, _Range2ValueType>(__wi_in_one_wg, __idx_global_end2 - __idx_global_begin2);
-
-#if 0
-        const std::size_t __wi_for_data_reading1_128 = __calc_wi_amount_for_data_reading<128, _Range1ValueType>(__wi_in_one_wg, __idx_global_end1 - __idx_global_begin1);
-        const std::size_t __wi_for_data_reading2_128 = __calc_wi_amount_for_data_reading<128, _Range2ValueType>(__wi_in_one_wg, __idx_global_end2 - __idx_global_begin2);
-#endif
 
         // Now arrange the reading by work-items
         if (__wi_in_one_wg >= __wi_for_data_reading1 + __wi_for_data_reading2)

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl_merge_sort.h
@@ -63,7 +63,7 @@ struct __group_merge_path_sorter
     template <typename _StorageAcc, typename _Compare>
     bool
     sort(const sycl::nd_item<1>& __item, const _StorageAcc& __storage_acc, _Compare __comp, std::uint32_t __start,
-         std::uint32_t __end, std::uint32_t __sorted, std::uint16_t __data_per_workitem,
+         std::uint32_t __end, std::uint32_t __sorted, std::uint32_t __data_per_workitem,
          std::uint32_t __workgroup_size) const
     {
         const std::uint32_t __sorted_final = __data_per_workitem * __workgroup_size;
@@ -259,12 +259,12 @@ struct __merge_sort_global_submitter<_IndexT, __internal::__optional_kernel_name
 
                 __cgh.parallel_for<_GlobalSortName...>(
                     sycl::range</*dim=*/1>(__steps), [=](sycl::item</*dim=*/1> __item_id) {
-                        const _IndexT __i_elem = __item_id.get_linear_id() * __chunk;
-                        const _IndexT __i_elem_local = __i_elem % (__n_sorted * 2);
+                        const std::uint32_t __i_elem = __item_id.get_linear_id() * __chunk;
+                        const std::uint32_t __i_elem_local = __i_elem % (__n_sorted * 2);
 
-                        const _IndexT __offset = std::min<_IndexT>(__i_elem - __i_elem_local, __n);
-                        const _IndexT __n1 = std::min<_IndexT>(__offset + __n_sorted, __n) - __offset;
-                        const _IndexT __n2 = std::min<_IndexT>(__offset + __n1 + __n_sorted, __n) - (__offset + __n1);
+                        const std::uint32_t __offset = std::min<_IndexT>(__i_elem - __i_elem_local, __n);
+                        const std::uint32_t __n1 = std::min<_IndexT>(__offset + __n_sorted, __n) - __offset;
+                        const std::uint32_t __n2 = std::min<_IndexT>(__offset + __n1 + __n_sorted, __n) - (__offset + __n1);
 
                         if (__data_in_temp)
                         {


### PR DESCRIPTION
One more approach for https://github.com/oneapi-src/oneDPL/pull/1933

Unfortunately this approach doesn't gave us performance profit in comparison with https://github.com/oneapi-src/oneDPL/pull/1933