### PR TITLE
Defining developer roles, responsibilities, and privileges and leadership process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,10 @@ your change directly to the repository:
 - Submit a
   [pull request](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request) into the
   main branch. You may add a description of your contribution into [CREDITS.txt](https://github.com/oneapi-src/oneDPL/blob/main/CREDITS.txt).
+- Contributors that would like to open branches directly in the oneDPL repo instead of working via fork may request
+  write access to the repository by contacting project maintainers on
+  [UXL Foundation Slack](https://slack-invite.uxlfoundation.org/) using the
+  [#onedpl](https://uxlfoundation.slack.com/channels/onedpl) channel.
 
 # Coding Conventions
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -24,7 +24,7 @@ The oneDPL project defines three primary roles, each with their own responsibili
 | Co-own on technical direction of component or<br> aspect of the library                                                                     |            ✗            |            ✓           |            ✓            |
 | Co-own the project as a whole,<br> including determining strategy and policy for the project                                                |            ✗            |            ✗           |            ✓            |
 
-|                                                                                                                         _Privileges_        |                         |                         |                         |
+|                                                                                                                         _Privileges_        |       Contributor       |       Code Owner        |       Maintainer        |
 | :------------------------------------------------------------------------------------------------------------------------------------------ | :---------------------: | :---------------------: | :---------------------: |
 | Permission granted                                                                                                                          |   [Write][permissions]   |   [Write][permissions]  | [Maintain][permissions] |
 | Can Approve PRs     |            ✗             |             ✓           |            ✓            |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -18,16 +18,18 @@ The oneDPL project defines three primary roles:
 | _Responsibilities_                                                                                                                          |                         |                         |                         |
 | Follow the Code of Conduct                                                                                                                  |            ✓            |            ✓           |            ✓            |
 | Follow Contribution Guidelines                                                                                                              |            ✓            |            ✓           |            ✓            |
-| Enforce Contribution Guidelines                                                                                                             |            ✗            |            ✓           |            ✓            |
+| Ensure Contribution Guidelines are followed                                                                                                 |            ✗            |            ✓           |            ✓            |
+| Cleanup Stale PRs and Branches impacting a component                                                                                        |            ✗            |            ✓           |            ✓            |
 | Co-own component or aspect of the library,<br>  including contributing: bug fixes, implementing features,<br> and performance optimizations |            ✗            |            ✓           |            ✓            |
-| Co-own on technical direction of component or<br> aspect of the library                                                                     |            ✗            |            ✗           |            ✓            |
+| Co-own on technical direction of component or<br> aspect of the library                                                                     |            ✗            |            ✓           |            ✓            |
 | Co-own the project as a whole,<br> including determining strategy and policy for the project                                                |            ✗            |            ✗           |            ✓            |
 | _Privileges_                                                                                                                                |                         |                         |                         |
-| Permission granted                                                                                                                          |   [Read][permissions]   |   [Write][permissions]  | [Maintain][permissions] |
+| Permission granted                                                                                                                          |   [Write][permissions]   |   [Write][permissions]  | [Maintain][permissions] |
+| Can Approve PRs     |            ✗             |             ✓           |            ✓            |
 | Eligible to become                                                                                                                          |       Code Owner        |       Maintainer        |            ✗            |
 | Can recommend Contributors<br> to become Code Owner                                                                                         |            ✗            |            ✓           |            ✓            |
 | Can participate in promotions of<br> Code Owners and  Maintainers                                                                           |            ✗            |            ✗           |            ✓            |
-| Can suggest Milestones during planning                                                                                                      |            ✓            |            ✓           |            ✓            |
+| Can suggest PRs/issues for<br> Milestones during planning                                                                                   |            ✓            |            ✓           |            ✓            |
 | Can choose Milestones for specific component                                                                                                |            ✗            |            ✓           |            ✓            |
 | Choose project's Milestones during planning                                                                                                 |            ✗            |            ✗           |            ✓            |
 | Can propose new RFC or<br> participate in review of existing RFC                                                                            |            ✓            |            ✓           |            ✓            |
@@ -45,7 +47,7 @@ A Contributor can invest their time and resources in several different ways to i
 * Answering questions from community members in Discussions on Issues
 * Providing feedback on RFC pull requests and Discussions
 * Reviewing and/or testing pull requests
-* Contribute code, including bug fixes, new examples of oneDPL use, and new feature implementations
+* Contribute code, including bug fixes, tests, new examples of oneDPL use, and new feature implementations
 * Contribute design proposals as RFCs
 
 Responsibilities:
@@ -76,8 +78,11 @@ Requirements:
 * Can propose new RFC or participate in review of existing RFCs
 
 Responsibilities in addition to those of Contributors:
-* Enforce the Contribution Guidelines
-* Co-own a component or aspect of the repository, including contributing bug fixes, implementing features, and performance optimizations
+* Ensure the Contribution Guidelines are followed in contributions impacting the Code Owner's component
+* Cleanup stale PRs and branches that have work impacting their component
+* Participate in the discussion of RFCs that impact their component
+* Co-own a component or aspect of the repository, including ensuring bugs are addressed, features are well tested,
+  requested features from RFCs are implemented, and the performance of component APIs is optimized.
 
 Privileges:
 * Eligible to become a Maintainer
@@ -96,7 +101,10 @@ affiliation.
 ## <a name="maintainer"></a>Maintainer
 
 A Maintainer is one of the most established contributors who are responsible for the project technical direction and
-participate in making decisions about strategy and priorities of the project.
+participate in making decisions about strategy and priorities of the project. The responsibilities they have increase
+in scope from that of Code Owners to encompass the entire project. Maintainers may make public presentations and
+statements in public forums (e.g., UXL DevSummit, UXL working group meetings, etc.) about the status and direction of
+the oneDPL project.
 
 Requirements:
   * Experience as a Code Owner.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,16 +6,16 @@ in oneDPL. The document also defines the process for maintainers to [Leave A Rol
 
 # Roles and Responsibilities
 
-The oneDPL project defines three primary roles:
+The oneDPL project defines three primary roles, each with their own responsibilities and privileges:
 * [Contributor](#contributor)
 * [Code Owner](#codeowner)
 * [Maintainer](#maintainer)
 
 [permissions]: https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization#permissions-for-each-role
 
-|                                                                                                                                             |       Contributor       |       Code Owner        |       Maintainer        |
+|                                                                                                                         _Responsibilities_  |       Contributor       |       Code Owner        |       Maintainer        |
 | :------------------------------------------------------------------------------------------------------------------------------------------ | :---------------------: | :---------------------: | :---------------------: |
-| _Responsibilities_                                                                                                                          |                         |                         |                         |
+|                                                                                                                                             |                         |                         |                         |
 | Follow the Code of Conduct                                                                                                                  |            ✓            |            ✓           |            ✓            |
 | Follow Contribution Guidelines                                                                                                              |            ✓            |            ✓           |            ✓            |
 | Ensure Contribution Guidelines are followed                                                                                                 |            ✗            |            ✓           |            ✓            |
@@ -23,7 +23,9 @@ The oneDPL project defines three primary roles:
 | Co-own component or aspect of the library,<br>  including contributing: bug fixes, implementing features,<br> and performance optimizations |            ✗            |            ✓           |            ✓            |
 | Co-own on technical direction of component or<br> aspect of the library                                                                     |            ✗            |            ✓           |            ✓            |
 | Co-own the project as a whole,<br> including determining strategy and policy for the project                                                |            ✗            |            ✗           |            ✓            |
-| _Privileges_                                                                                                                                |                         |                         |                         |
+
+|                                                                                                                         _Privileges_        |                         |                         |                         |
+| :------------------------------------------------------------------------------------------------------------------------------------------ | :---------------------: | :---------------------: | :---------------------: |
 | Permission granted                                                                                                                          |   [Write][permissions]   |   [Write][permissions]  | [Maintain][permissions] |
 | Can Approve PRs     |            ✗             |             ✓           |            ✓            |
 | Eligible to become                                                                                                                          |       Code Owner        |       Maintainer        |            ✗            |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -58,7 +58,7 @@ Privileges:
 * Code contributions recognized in the oneDPL [credits](CREDITS.txt)
 * Eligible to become a Code Owner
 * Read permissions granted to the repository
-* Can suggest Milestones during planning
+* Can suggest PRs and issues to be included in Milestones during planning
 
 ## <a name="codeowner"></a>Code Owner
 
@@ -88,8 +88,7 @@ Privileges:
 * Eligible to become a Maintainer
 * Write permissions granted to the repository
 * Can recommend Contributors to become Code Owners
-* Can suggest Milestones during planning
-* Can choose Milestones for a specific component
+* Can choose PRs and issues to be included in Milestones for a specific component
 * Can propose new RFC or participate in review of existing RFCs
 
 The process of becoming a Code Owner is:

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -146,7 +146,7 @@ approve the PR.
 | C++ standard policies and CPU backends | Dan Hoeflinger | @danhoeflinger | Intel |
 | SYCL device policies and SYCL backends | Mikhail Dvorskiy<br>Adam Fidel | @MikeDvorskiy<br>@adamfidel |  Intel |
 | Tested Standard C++ APIs & Utility Function Object Classes | Sergey Kopienko | @SergeyKopeinko | Intel |
-| C++17 standard algorithms | Mikhail Dvorskiy<br>Adam Fidel<br>SergeyKopienko<br>Julian Miller<br>Dmitriy Sobolev | @MikeDvorskiy<br>@adamfidel<br>@SergeyKopienko<br>@julianmi<br>@dmitriy-sobolev | Intel<br>Intel<br>Intel<br>Independent<br>Intel<br>Intel |
+| C++17 standard algorithms | Mikhail Dvorskiy<br>Adam Fidel<br>SergeyKopienko<br>Julian Miller<br>Dmitriy Sobolev | @MikeDvorskiy<br>@adamfidel<br>@SergeyKopienko<br>@julianmi<br>@dmitriy-sobolev | Intel<br>Intel<br>Intel<br>Independent<br>Intel |
 | Range-Based Algorithms | Mikhail Dvorskiy | @MikeDvorskiy | Intel |
 | Asynchronous API Algorithms | Pablo Reble | @reble | Intel |
 | Additional Algorithms | Dan Hoeflinger<br>Matt Michel | @danhoeflinger<br>@mmichel11 | Intel<br>Intel |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -52,7 +52,7 @@ Responsibilities:
 * Follow the [Code of Conduct](CODE_OF_CONDUCT.md)
 * Submit issues, feature requests, and code in accordance with the [Contribution Guidelines](CONTRIBUTING.md)
 
-Priviledges:
+Privileges:
 * Code contributions recognized in the oneDPL [credits](CREDITS.txt)
 * Eligible to become a Code Owner
 * Read permissions granted to the repository
@@ -61,7 +61,7 @@ Priviledges:
 ## Code Owner
 
 A Code Owner is an established contributor that is recognized by active code owners and maintaininers as capable of
-taking on additional activities and the responsibilities and priviledges that come with them. A Code Owner is
+taking on additional activities and the responsibilities and privileges that come with them. A Code Owner is
 responsible for a specific oneDPL component or functional area of the project. Code Owners are collectively responsible,
 with other Code Owners, for developing and maintaining their component or functional areas, including reviewing all
 changes to the corresponding areas of responsibility and indicating whether those changes are ready to be merged. Code
@@ -79,7 +79,7 @@ Responsibilities in addition to those of Contributors:
 * Enforce the Contribution Guidelines
 * Co-own a component or aspect of the repository, including contributing bug fixes, implementing features, and performance optimizations
 
-Priviledges:
+Privileges:
 * Eligible to become a Maintainer
 * Write permissions granted to the repository
 * Can recommend Contributors to become Code Owners
@@ -103,7 +103,7 @@ Requirements:
   * Track record of major project contributions to a specific project component.
   * Demonstrated deep knowledge of a specific project component.
   * Demonstrated broad knowledge of the project across multiple areas.
-  * Commits to using priviledges responsibly for the good of the project.
+  * Commits to using privileges responsibly for the good of the project.
   * Is able to exercise judgment for the good of the project, independent of
     their employer, friends, or team.
 
@@ -111,7 +111,7 @@ Responsibilities in additionto those of Code Owners:
 * Co-own the technical direction of a component or aspect of the library
 * Co-own the project as a whole, including determining strategy and policy for the project
 
-Priviledges:
+Privileges:
 * Maintain permissions granted to the repository
 * Can participate in promotions of Code Owners and Maintainers
 * Choose project's Milestones during planning

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -23,7 +23,7 @@ The oneDPL project defines three primary roles, each with their own responsibili
 | Co-own component or aspect of the library,<br>  including contributing: bug fixes, implementing features,<br> and performance optimizations |            ✗            |            ✓           |            ✓            |
 | Co-own on technical direction of component or<br> aspect of the library                                                                     |            ✗            |            ✓           |            ✓            |
 | Co-own the project as a whole,<br> including determining strategy and policy for the project                                                |            ✗            |            ✗           |            ✓            |
-
+|                     |                         |                        |                         |
 |                                                                                                                         _Privileges_        |       Contributor       |       Code Owner        |       Maintainer        |
 | :------------------------------------------------------------------------------------------------------------------------------------------ | :---------------------: | :---------------------: | :---------------------: |
 | Permission granted                                                                                                                          |   [Write][permissions]   |   [Write][permissions]  | [Maintain][permissions] |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -24,7 +24,7 @@ The oneDPL project defines three primary roles, each with their own responsibili
 | Co-own on technical direction of component or<br> aspect of the library                                                                     |            ✗            |            ✓           |            ✓            |
 | Co-own the project as a whole,<br> including determining strategy and policy for the project                                                |            ✗            |            ✗           |            ✓            |
 |                     |                         |                        |                         |
-|                                                                                                                         **Privileges**      |     **Contributor**     |     **Code Owner**      |     **Maintainer**      |
+|                                                                                                                         **_Privileges_**    |     **Contributor**     |     **Code Owner**      |     **Maintainer**      |
 |                                                                                                                         Permission granted  |   [Write][permissions]   |   [Write][permissions]  | [Maintain][permissions] |
 | Can Approve PRs     |            ✗             |             ✓           |            ✓            |
 | Eligible to become                                                                                                                          |       Code Owner        |       Maintainer        |            ✗            |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,6 +1,129 @@
 # Introduction
 
-This document provides a list of the maintainers for each area of development in the oneDPL project.
+This document defines the roles available in the oneDPL project and provides a list of the
+[current maintainers](Current Maintainers) for each area of development in oneDPL. The document also defines the
+process for maintainers to [Leave the Role](leave the role) in the project.
+
+# Roles and Responsibilities
+
+The oneDPL project defines three primary roles:
+* [Contributor](#contributor)
+* [Code Owner](#codeowner)
+* [Maintainer](#maintainer)
+
+[permissions]: https://docs.github.com/en/organizations/managing-user-access-to-your-organizations-repositories/managing-repository-roles/repository-roles-for-an-organization#permissions-for-each-role
+
+|                                                                                                                                             |       Contributor       |       Code Owner        |       Maintainer        |
+| :------------------------------------------------------------------------------------------------------------------------------------------ | :---------------------: | :---------------------: | :---------------------: |
+| _Responsibilities_                                                                                                                          |                         |                         |                         |
+| Follow the Code of Conduct                                                                                                                  |            ✓            |            ✓           |            ✓            |
+| Follow Contribution Guidelines                                                                                                              |            ✓            |            ✓           |            ✓            |
+| Enforce Contribution Guidelines                                                                                                             |            ✗            |            ✓           |            ✓            |
+| Co-own component or aspect of the library,<br>  including contributing: bug fixes, implementing features,<br> and performance optimizations |            ✗            |            ✓           |            ✓            |
+| Co-own on technical direction of component or<br> aspect of the library                                                                     |            ✗            |            ✗           |            ✓            |
+| Co-own the project as a whole,<br> including determining strategy and policy for the project                                                |            ✗            |            ✗           |            ✓            |
+| _Privileges_                                                                                                                                |                         |                         |                         |
+| Permission granted                                                                                                                          |   [Read][permissions]   |   [Write][permissions]  | [Maintain][permissions] |
+| Eligible to become                                                                                                                          |       Code Owner        |       Maintainer        |            ✗            |
+| Can recommend Contributors<br> to become Code Owner                                                                                         |            ✗            |            ✓           |            ✓            |
+| Can participate in promotions of<br> Code Owners and  Maintainers                                                                           |            ✗            |            ✗           |            ✓            |
+| Can suggest Milestones during planning                                                                                                      |            ✓            |            ✓           |            ✓            |
+| Can choose Milestones for specific component                                                                                                |            ✗            |            ✓           |            ✓            |
+| Choose project's Milestones during planning                                                                                                 |            ✗            |            ✗           |            ✓            |
+| Can propose new RFC or<br> participate in review of existing RFC                                                                            |            ✓            |            ✓           |            ✓            |
+| Can request rework of RFCs<br> in represented area of responsibility                                                                        |            ✗            |            ✓           |            ✓            |
+| Can request rework of RFCs<br> in any part of the project                                                                                   |            ✗            |            ✗           |            ✓            |
+| Can manage release process of the project                                                                                                   |            ✗            |            ✗           |            ✓            |
+| Can represent the project in public as a Maintainer                                                                                         |            ✗            |            ✗           |            ✓            |
+
+These roles are merit based. Refer to the corresponding section for specific
+requirements and the nomination process.
+
+## Contributor
+
+A Contributor can invest their time and resources in several different ways to improve oneDPL
+* Answering questions from community members in Discussions on Issues
+* Providing feedback on RFC pull requests and Discussions
+* Reviewing and/or testing pull requests
+* Contribute code, including bug fixes, new examples of oneDPL use, and new feature implementations
+* Contribute design proposals as RFCs
+
+Responsibilities:
+* Follow the [Code of Conduct](CODE_OF_CONDUCT.md)
+* Submit issues, feature requests, and code in accordance with the [Contribution Guidelines](CONTRIBUTING.md)
+
+Priviledges:
+* Code contributions recognized in the oneDPL [credits](CREDITS.txt)
+* Eligible to become a Code Owner
+* Read permissions granted to the repository
+* Can suggest Milestones during planning
+
+## Code Owner
+
+A Code Owner is an established contributor that is recognized by active code owners and maintaininers as capable of
+taking on additional activities and the responsibilities and priviledges that come with them. A Code Owner is
+responsible for a specific oneDPL component or functional area of the project. Code Owners are collectively responsible,
+with other Code Owners, for developing and maintaining their component or functional areas, including reviewing all
+changes to the corresponding areas of responsibility and indicating whether those changes are ready to be merged. Code
+Owners have a track record of code contribution and reviews in the project.
+
+Requirements:
+* Track record of accepted code contributions to a specific project component.
+* Track record of contributions to the code review process.
+* Demonstrated in-depth knowledge of the architecture of a specific project
+  component.
+* Commits to being responsible for that specific area.
+* Can propose new RFC or participate in review of existing RFCs
+
+Responsibilities in addition to those of Contributors:
+* Enforce the Contribution Guidelines
+* Co-own a component or aspect of the repository, including contributing bug fixes, implementing features, and performance optimizations
+
+Priviledges:
+* Eligible to become a Maintainer
+* Write permissions granted to the repository
+* Can recommend Contributors to become Code Owners
+* Can suggest Milestones during planning
+* Can chose Milestones for a specific component
+* Can propose new RFC or participate in review of existing RFCs
+
+The process of becoming a Code Owner is:
+1. A Contributor is nominated by opening a PR modifying the MAINTAINERS.md file including name, Github username, and
+affiliation.
+2. At least two specific component Maintainers approve the PR.
+3. MAINTAINERS.md file is updated to represent corresponding areas of responsibility.
+
+## Maintainer
+
+A Maintainer is one of the most established contributors who are responsible for the project technical direction and
+participate in making decisions about strategy and priorities of the project.
+
+Requirements:
+  * Experience as a Code Owner.
+  * Track record of major project contributions to a specific project component.
+  * Demonstrated deep knowledge of a specific project component.
+  * Demonstrated broad knowledge of the project across multiple areas.
+  * Commits to using priviledges responsibly for the good of the project.
+  * Is able to exercise judgment for the good of the project, independent of
+    their employer, friends, or team.
+
+Responsibilities in additionto those of Code Owners:
+* Co-own the technical direction of a component or aspect of the library
+* Co-own the project as a whole, including determining strategy and policy for the project
+
+Priviledges:
+* Maintain permissions granted to the repository
+* Can participate in promotions of Code Owners and Maintainers
+* Choose project's Milestones during planning
+* Can request rework of RFCs in any part of the project
+* Can manage release process of the project
+* Can represent the project in public as a Maintainer
+
+## Code Owners
+
+There are currently no Code Owners identified for oneDPL.
+
+## Current Maintainers
 
 | Feature               | Maintainer          | Github ID |
 | --------------------- | ------------------- | -------- |
@@ -15,3 +138,9 @@ This document provides a list of the maintainers for each area of development in
 | Random Number Generators | Pavel Dyakov | @paveldyakov |
 | Dynamic Selection API | Anuya Welling | @AnuyaWelling2801 |
 | Kernel Templates API | Sergey Kopienko<br>Dmitriy Sobolev | @SergeyKopienko<br>@dmitriy-sobolev |
+
+## Leaving the Role of Code Owner or Maintainer
+
+Active code owners and maintainers of the oneDPL project may leave their current role by submitting a PR removing their
+name from the list of current maintainers or code owners and tagging two or more active maintainers to review and
+approve the PR.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -25,8 +25,7 @@ The oneDPL project defines three primary roles, each with their own responsibili
 | Co-own the project as a whole,<br> including determining strategy and policy for the project                                                |            ✗            |            ✗           |            ✓            |
 |                     |                         |                        |                         |
 |                                                                                                                         _Privileges_        |       Contributor       |       Code Owner        |       Maintainer        |
-| :------------------------------------------------------------------------------------------------------------------------------------------ | :---------------------: | :---------------------: | :---------------------: |
-| Permission granted                                                                                                                          |   [Write][permissions]   |   [Write][permissions]  | [Maintain][permissions] |
+|                                                                                                                         Permission granted  |   [Write][permissions]   |   [Write][permissions]  | [Maintain][permissions] |
 | Can Approve PRs     |            ✗             |             ✓           |            ✓            |
 | Eligible to become                                                                                                                          |       Code Owner        |       Maintainer        |            ✗            |
 | Can recommend Contributors<br> to become Code Owner                                                                                         |            ✗            |            ✓           |            ✓            |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -39,7 +39,7 @@ The oneDPL project defines three primary roles:
 These roles are merit based. Refer to the corresponding section for specific
 requirements and the nomination process.
 
-## Contributor
+## <a name="contributor"></a>Contributor
 
 A Contributor can invest their time and resources in several different ways to improve oneDPL
 * Answering questions from community members in Discussions on Issues
@@ -58,7 +58,7 @@ Privileges:
 * Read permissions granted to the repository
 * Can suggest Milestones during planning
 
-## Code Owner
+## <a name="codeowner"></a>Code Owner
 
 A Code Owner is an established contributor that is recognized by active code owners and maintaininers as capable of
 taking on additional activities and the responsibilities and privileges that come with them. A Code Owner is
@@ -93,7 +93,7 @@ affiliation.
 2. At least two specific component Maintainers approve the PR.
 3. MAINTAINERS.md file is updated to represent corresponding areas of responsibility.
 
-## Maintainer
+## <a name="maintainer"></a>Maintainer
 
 A Maintainer is one of the most established contributors who are responsible for the project technical direction and
 participate in making decisions about strategy and priorities of the project.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -123,17 +123,17 @@ The process of becoming a Maintainer is:
 1. A Code Owner is nominated by a current Maintainer by opening a PR modifying the MAINTAINERS.md file to move the code owner into the Current Maintainers section.
 2. A majority of the Current Maintainers must approve the PR.
 
-## Leave A Role
+## <a name="leavearole"></a>Leave A Role
 
 Active code owners and maintainers of the oneDPL project may leave their current role by submitting a PR removing their
 name from the list of current maintainers or code owners and tagging two or more active maintainers to review and
 approve the PR.
 
-## Current Code Owners
+## <a name="currentcodeowners"></a>Current Code Owners
 
 There are currently no Code Owners identified for oneDPL.
 
-## Current Maintainers
+## <a name="currentmaintainers"></a>Current Maintainers
 
 | Feature               | Maintainer          | Github ID |
 | --------------------- | ------------------- | -------- |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -92,9 +92,9 @@ Privileges:
 * Can propose new RFC or participate in review of existing RFCs
 
 The process of becoming a Code Owner is:
-1. A Contributor is nominated by opening a PR modifying the MAINTAINERS.md file including name, Github username, and
-affiliation.
-2. At least two specific component Maintainers approve the PR.
+1. A Contributor is nominated by opening a PR modifying the MAINTAINERS.md file including project component along with
+contributor name, Github username, and affiliation.
+2. At least two specific component Code Owners or Maintainers approve the PR.
 3. MAINTAINERS.md file is updated to represent corresponding areas of responsibility.
 
 ## <a name="maintainer"></a>Maintainer
@@ -138,20 +138,27 @@ approve the PR.
 
 ## <a name="currentcodeowners"></a>Current Code Owners
 
-There are currently no Code Owners identified for oneDPL.
+| Component             | Code Owner(s)       | Github ID | Affiliation |
+| --------------------- | ------------------- | --------- | ----------- |
+| C++ standard policies and CPU backends | Dan Hoeflinger | @danhoeflinger | Intel |
+| SYCL device policies and SYCL backends | Mikhail Dvorskiy<br>Adam Fidel | @MikeDvorskiy<br>@adamfidel |  Intel |
+| Tested Standard C++ APIs & Utility Function Object Classes | Sergey Kopienko | @SergeyKopeinko | Intel |
+| C++17 standard algorithms | Mikhail Dvorskiy<br>Adam Fidel<br>SergeyKopienko<br>Julian Miller<br>Dmitriy Sobolev | @MikeDvorskiy<br>@adamfidel<br>@SergeyKopienko<br>@julianmi<br>@dmitriy-sobolev | Intel<br>Intel<br>Intel<br>Independent<br>Intel<br>Intel |
+| Range-Based Algorithms | Mikhail Dvorskiy | @MikeDvorskiy | Intel |
+| Asynchronous API Algorithms | Pablo Reble | @reble | Intel |
+| Additional Algorithms | Dan Hoeflinger<br>Matt Michel | @danhoeflinger<br>@mmichel11 | Intel<br>Intel |
+| Iterators | Dan Hoeflinger | @danhoeflinger | Intel |
+| Random Number Generators | Pavel Dyakov | @paveldyakov | Intel |
+| Dynamic Selection API | Anuya Welling | @AnuyaWelling2801 | AMD |
+| Kernel Templates API | Sergey Kopienko<br>Dmitriy Sobolev | @SergeyKopienko<br>@dmitriy-sobolev | Intel<br>Intel |
 
 ## <a name="currentmaintainers"></a>Current Maintainers
 
-| Feature               | Maintainer          | Github ID |
-| --------------------- | ------------------- | -------- |
-| C++ standard policies and CPU backends | Dan Hoeflinger | @danhoeflinger |
-| SYCL device policies and SYCL backends | Mikhail Dvorskiy<br>Adam Fidel | @MikeDvorskiy<br>@adamfidel | 
-| Tested Standard C++ APIs & Utility Function Object Classes | Sergey Kopienko | @SergeyKopeinko |
-| C++17 standard algorithms | Mikhail Dvorskiy<br>Adam Fidel<br>SergeyKopienko<br>Julian Miller<br>Dmitriy Sobolev | @MikeDvorskiy<br>@adamfidel<br>@SergeyKopienko<br>@julianmi<br>@dmitriy-sobolev |
-| Range-Based Algorithms | Mikhail Dvorskiy | @MikeDvorskiy |
-| Asynchronous API Algorithms | Pablo Reble | @reble |
-| Additional Algorithms | Dan Hoeflinger<br>Matt Michel | @danhoeflinger<br>@mmichel11 |
-| Iterators | Dan Hoeflinger | @danhoeflinger |
-| Random Number Generators | Pavel Dyakov | @paveldyakov |
-| Dynamic Selection API | Anuya Welling | @AnuyaWelling2801 |
-| Kernel Templates API | Sergey Kopienko<br>Dmitriy Sobolev | @SergeyKopienko<br>@dmitriy-sobolev |
+| Maintainer          | Github ID | Affiliation |
+| ------------------- | --------- | ----------- |
+| Mikhail Dvorskiy | @MikeDvorskiy | Intel |
+| Dan Hoeflinger   | @danhoeflinger | Intel |
+| Sergey Kopienko  | @SergeyKopeinko | Intel |
+| Alexey Kukanov   | @akukanov | Intel |
+| Timmie Smith     | @timmiesmith | Intel |
+| Dmitriy Sobolev  | @dmitriy-sobolev | Intel |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -25,7 +25,7 @@ The oneDPL project defines three primary roles, each with their own responsibili
 | Co-own the project as a whole,<br> including determining strategy and policy for the project                                                |            ✗            |            ✗           |            ✓            |
 |                     |                         |                        |                         |
 |                                                                                                                         **_Privileges_**    |     **Contributor**     |     **Code Owner**      |     **Maintainer**      |
-|                                                                                                                         Permission granted  |   [Write][permissions]   |   [Write][permissions]  | [Maintain][permissions] |
+|                                                                                                                         Permission granted  |   [Read][permissions]/[Write][permissions]   |   [Write][permissions]  | [Maintain][permissions] |
 | Can Approve PRs     |            ✗             |             ✓           |            ✓            |
 | Eligible to become                                                                                                                          |       Code Owner        |       Maintainer        |            ✗            |
 | Can recommend Contributors<br> to become Code Owner                                                                                         |            ✗            |            ✓           |            ✓            |
@@ -59,7 +59,7 @@ Responsibilities:
 Privileges:
 * Code contributions recognized in the oneDPL [credits](CREDITS.txt)
 * Eligible to become a Code Owner
-* Write permissions granted to the repository
+* May request write permissions to the repository from the oneDPL Maintainers.
 * Can suggest PRs and issues to be included in Milestones during planning
 
 ## <a name="codeowner"></a>Code Owner

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,8 +1,8 @@
 # Introduction
 
 This document defines the roles available in the oneDPL project and provides a list of the
-[Current Maintainers](#currentmaintainers) for each area of development in oneDPL. The document also defines the
-process for maintainers to [Leave A Role](#leavearole) in the project.
+[Current Code Owners](#currentcodeowners) and [Current Maintainers](#currentmaintainers) for each area of development
+in oneDPL. The document also defines the process for maintainers to [Leave A Role](#leavearole) in the project.
 
 # Roles and Responsibilities
 
@@ -123,7 +123,13 @@ The process of becoming a Maintainer is:
 1. A Code Owner is nominated by a current Maintainer by opening a PR modifying the MAINTAINERS.md file to move the code owner into the Current Maintainers section.
 2. A majority of the Current Maintainers must approve the PR.
 
-## Code Owners
+## Leave A Role
+
+Active code owners and maintainers of the oneDPL project may leave their current role by submitting a PR removing their
+name from the list of current maintainers or code owners and tagging two or more active maintainers to review and
+approve the PR.
+
+## Current Code Owners
 
 There are currently no Code Owners identified for oneDPL.
 
@@ -142,9 +148,3 @@ There are currently no Code Owners identified for oneDPL.
 | Random Number Generators | Pavel Dyakov | @paveldyakov |
 | Dynamic Selection API | Anuya Welling | @AnuyaWelling2801 |
 | Kernel Templates API | Sergey Kopienko<br>Dmitriy Sobolev | @SergeyKopienko<br>@dmitriy-sobolev |
-
-## Leave A Role
-
-Active code owners and maintainers of the oneDPL project may leave their current role by submitting a PR removing their
-name from the list of current maintainers or code owners and tagging two or more active maintainers to review and
-approve the PR.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -24,7 +24,7 @@ The oneDPL project defines three primary roles, each with their own responsibili
 | Co-own on technical direction of component or<br> aspect of the library                                                                     |            ✗            |            ✓           |            ✓            |
 | Co-own the project as a whole,<br> including determining strategy and policy for the project                                                |            ✗            |            ✗           |            ✓            |
 |                     |                         |                        |                         |
-|                                                                                                                         _Privileges_        |       Contributor       |       Code Owner        |       Maintainer        |
+|                                                                                                                         **Privileges**      |     **Contributor**     |     **Code Owner**      |     **Maintainer**      |
 |                                                                                                                         Permission granted  |   [Write][permissions]   |   [Write][permissions]  | [Maintain][permissions] |
 | Can Approve PRs     |            ✗             |             ✓           |            ✓            |
 | Eligible to become                                                                                                                          |       Code Owner        |       Maintainer        |            ✗            |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -43,7 +43,8 @@ requirements and the nomination process.
 
 ## <a name="contributor"></a>Contributor
 
-A Contributor can invest their time and resources in several different ways to improve oneDPL
+This role is open to anyone that would like to become actively involved in the oneDPL project. A Contributor can invest
+their time and resources in several different ways to improve oneDPL
 * Answering questions from community members in Discussions on Issues
 * Providing feedback on RFC pull requests and Discussions
 * Reviewing and/or testing pull requests

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,8 +1,8 @@
 # Introduction
 
 This document defines the roles available in the oneDPL project and provides a list of the
-[current maintainers](Current Maintainers) for each area of development in oneDPL. The document also defines the
-process for maintainers to [Leave the Role](leave the role) in the project.
+[current maintainers](#Current Maintainers) for each area of development in oneDPL. The document also defines the
+process for maintainers to [Leave the Role](#Leaving A Role) in the project.
 
 # Roles and Responsibilities
 
@@ -139,7 +139,7 @@ There are currently no Code Owners identified for oneDPL.
 | Dynamic Selection API | Anuya Welling | @AnuyaWelling2801 |
 | Kernel Templates API | Sergey Kopienko<br>Dmitriy Sobolev | @SergeyKopienko<br>@dmitriy-sobolev |
 
-## Leaving the Role of Code Owner or Maintainer
+## Leaving A Role
 
 Active code owners and maintainers of the oneDPL project may leave their current role by submitting a PR removing their
 name from the list of current maintainers or code owners and tagging two or more active maintainers to review and

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,8 +1,8 @@
 # Introduction
 
 This document defines the roles available in the oneDPL project and provides a list of the
-[current maintainers](#Current Maintainers) for each area of development in oneDPL. The document also defines the
-process for maintainers to [Leave the Role](#Leaving A Role) in the project.
+[Current Maintainers](#currentmaintainers) for each area of development in oneDPL. The document also defines the
+process for maintainers to [Leave A Role](#leavearole) in the project.
 
 # Roles and Responsibilities
 
@@ -139,7 +139,7 @@ There are currently no Code Owners identified for oneDPL.
 | Dynamic Selection API | Anuya Welling | @AnuyaWelling2801 |
 | Kernel Templates API | Sergey Kopienko<br>Dmitriy Sobolev | @SergeyKopienko<br>@dmitriy-sobolev |
 
-## Leaving A Role
+## Leave A Role
 
 Active code owners and maintainers of the oneDPL project may leave their current role by submitting a PR removing their
 name from the list of current maintainers or code owners and tagging two or more active maintainers to review and

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -59,7 +59,7 @@ Responsibilities:
 Privileges:
 * Code contributions recognized in the oneDPL [credits](CREDITS.txt)
 * Eligible to become a Code Owner
-* Read permissions granted to the repository
+* Write permissions granted to the repository
 * Can suggest PRs and issues to be included in Milestones during planning
 
 ## <a name="codeowner"></a>Code Owner
@@ -77,7 +77,6 @@ Requirements:
 * Demonstrated in-depth knowledge of the architecture of a specific project
   component.
 * Commits to being responsible for that specific area.
-* Can propose new RFC or participate in review of existing RFCs
 
 Responsibilities in addition to those of Contributors:
 * Ensure the Contribution Guidelines are followed in contributions impacting the Code Owner's component
@@ -142,11 +141,11 @@ approve the PR.
 
 | Component             | Code Owner(s)       | Github ID | Affiliation |
 | --------------------- | ------------------- | --------- | ----------- |
-| C++ standard policies and CPU backends | Dan Hoeflinger | @danhoeflinger | Intel |
+| C++ standard policies and CPU backends | Mikhail Dvorskiy<br>Dan Hoeflinger | @MikeDvorskiy<br>@danhoeflinger | Intel<br>Intel |
 | SYCL device policies and SYCL backends | Mikhail Dvorskiy<br>Adam Fidel | @MikeDvorskiy<br>@adamfidel |  Intel |
 | Tested Standard C++ APIs & Utility Function Object Classes | Sergey Kopienko | @SergeyKopeinko | Intel |
 | C++17 standard algorithms | Mikhail Dvorskiy<br>Adam Fidel<br>SergeyKopienko<br>Julian Miller<br>Dmitriy Sobolev | @MikeDvorskiy<br>@adamfidel<br>@SergeyKopienko<br>@julianmi<br>@dmitriy-sobolev | Intel<br>Intel<br>Intel<br>Independent<br>Intel |
-| Range-Based Algorithms | Mikhail Dvorskiy | @MikeDvorskiy | Intel |
+| Range-Based Algorithms | Mikhail Dvorskiy<br>Ruslan Arutyunyan | @MikeDvorskiy<br>@rarutyun | Intel<br>Intel |
 | Asynchronous API Algorithms | Pablo Reble | @reble | Intel |
 | Additional Algorithms | Dan Hoeflinger<br>Matt Michel | @danhoeflinger<br>@mmichel11 | Intel<br>Intel |
 | Iterators | Dan Hoeflinger | @danhoeflinger | Intel |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -119,6 +119,10 @@ Privileges:
 * Can manage release process of the project
 * Can represent the project in public as a Maintainer
 
+The process of becoming a Maintainer is:
+1. A Code Owner is nominated by a current Maintainer by opening a PR modifying the MAINTAINERS.md file to move the code owner into the Current Maintainers section.
+2. A majority of the Current Maintainers must approve the PR.
+
 ## Code Owners
 
 There are currently no Code Owners identified for oneDPL.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -84,7 +84,7 @@ Privileges:
 * Write permissions granted to the repository
 * Can recommend Contributors to become Code Owners
 * Can suggest Milestones during planning
-* Can chose Milestones for a specific component
+* Can choose Milestones for a specific component
 * Can propose new RFC or participate in review of existing RFCs
 
 The process of becoming a Code Owner is:
@@ -107,7 +107,7 @@ Requirements:
   * Is able to exercise judgment for the good of the project, independent of
     their employer, friends, or team.
 
-Responsibilities in additionto those of Code Owners:
+Responsibilities in addition to those of Code Owners:
 * Co-own the technical direction of a component or aspect of the library
 * Co-own the project as a whole, including determining strategy and policy for the project
 


### PR DESCRIPTION
As part of the process of adopting UXL governance this PR introduces the roles developers may fill in the project and the process of moving into roles with increased responsibility and privilege.  The work is based on the process defined by [oneDNN](https://github.com/oneapi-src/oneDNN/blob/main/MAINTAINERS.md) and what has been proposed for [oneTBB](https://github.com/oneapi-src/oneTBB/pull/1560).