### PR TITLE
Adding information on how to use oneDPL on other vendor platforms

### DIFF
--- a/documentation/library_guide/onedpl_gsg.rst
+++ b/documentation/library_guide/onedpl_gsg.rst
@@ -35,8 +35,9 @@ page for:
 Install the `Intel® oneAPI Base Toolkit (Base Kit) <https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit.html>`_
 to use |onedpl_short|.
 
-Additionally, to use |onedpl_short| and other Base Kit components on NVIDIA® GPUs, install the
-`oneAPI for NVIDIA® GPUs plugin <https://developer.codeplay.com/products/oneapi/nvidia/home/>`_.
+Additionally, to use |onedpl_short| and other Base Kit components on non-Intel GPUs install either the
+`oneAPI for NVIDIA® GPUs plugin <https://developer.codeplay.com/products/oneapi/nvidia/home/>`_ or the
+`oneAPI for AMD GPUs plugin <https://developer.codeplay.com/products/oneapi/amd/home/>`_.
 
 See the |onedpl_short|
 `System Requirements <https://www.intel.com/content/www/us/en/docs/onedpl/developer-guide/2022-7/intel-oneapi-dpc-library-introduction.html>`_

--- a/documentation/library_guide/onedpl_gsg.rst
+++ b/documentation/library_guide/onedpl_gsg.rst
@@ -35,6 +35,14 @@ page for:
 Install the `Intel® oneAPI Base Toolkit (Base Kit) <https://www.intel.com/content/www/us/en/developer/tools/oneapi/base-toolkit.html>`_
 to use |onedpl_short|.
 
+Additionally, to use |onedpl_short| and other Base Kit components on NVIDIA® GPUs, install the
+`oneAPI for NVIDIA® GPUs plugin <https://developer.codeplay.com/products/oneapi/nvidia/home/>`_.
+
+See the |onedpl_short|
+`System Requirements <https://www.intel.com/content/www/us/en/docs/onedpl/developer-guide/2022-7/intel-oneapi-dpc-library-introduction.html>`_
+for details on the compiler support required to compile applications using |onedpl_short| on CPU using OpenMP* or Intel®
+oneAPI Threading Building Blocks (oneTBB).
+
 To use Parallel API, include the corresponding header files in your source code.
 
 All |onedpl_short| header files are in the ``oneapi/dpl`` directory. Use ``#include <oneapi/dpl/…>`` to include them.


### PR DESCRIPTION
The PR adds notes to the Getting Started Guide on installing the oneAPI for NVIDIA GPUs plugin as well as a reference to the System Requirements section of the Developer's guide for the installation requirements to run oneDPL on CPU.  This is meant to provide the documentation requested in https://github.com/uxlfoundation/open-source-working-group/issues/51 on how to use oneDPL on different vendor hardware platforms.