### PR TITLE
Update version to 2022.7.1

### DIFF
--- a/include/oneapi/dpl/internal/version_impl.h
+++ b/include/oneapi/dpl/internal/version_impl.h
@@ -13,7 +13,7 @@
 // The library version
 #define ONEDPL_VERSION_MAJOR 2022
 #define ONEDPL_VERSION_MINOR 7
-#define ONEDPL_VERSION_PATCH 0
+#define ONEDPL_VERSION_PATCH 1
 
 #if _ONEDPL___cplusplus >= 202002L && __has_include(<version>)
 #    include <version> // The standard C++20 header

--- a/test/general/version.pass.cpp
+++ b/test/general/version.pass.cpp
@@ -26,7 +26,7 @@ static_assert(_PSTL_VERSION_PATCH == 0);
 
 static_assert(ONEDPL_VERSION_MAJOR == 2022);
 static_assert(ONEDPL_VERSION_MINOR == 7);
-static_assert(ONEDPL_VERSION_PATCH == 0);
+static_assert(ONEDPL_VERSION_PATCH == 1);
 
 #include "support/utils.h"
 


### PR DESCRIPTION
`main` still shows 2022.7.0 and the same holds for the 2022.7.1 release tag, see https://github.com/oneapi-src/oneDPL/blob/oneDPL-2022.7.1-release/include/oneapi/dpl/internal/version_impl.h. In particular, this hinders me from testing the changes related to the fixes in  https://github.com/oneapi-src/oneDPL/pull/1927 and https://github.com/oneapi-src/oneDPL/pull/1932 (easily).