### PR TITLE
Avoid using release_oneDPL branch

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
   pull_request:
     branches:
-      - release_oneDPL
       - main
       - 'release/**'
 

--- a/.github/workflows/ci-testing.yml
+++ b/.github/workflows/ci-testing.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
   pull_request:
     branches:
-      - release_oneDPL
       - main
       - 'release/**'
     paths:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ We welcome community contributions to oneAPI DPC++ Library (oneDPL). You can:
 
 # License
 
-oneDPL is licensed under the terms in [LICENSE](https://github.com/oneapi-src/oneDPL/blob/release_oneDPL/licensing/LICENSE.txt).
+oneDPL is licensed under the terms in [LICENSE](https://github.com/oneapi-src/oneDPL/blob/main/LICENSE.txt).
 By contributing to the project, you agree to the license and copyright terms therein and
 release your contribution under these terms.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ for more information.
 Visit the latest [Release Notes](https://github.com/oneapi-src/oneDPL/blob/main/documentation/release_notes.rst).
 
 ## License
-oneDPL is licensed under [Apache License Version 2.0 with LLVM exceptions](https://github.com/oneapi-src/oneDPL/blob/release_oneDPL/licensing/LICENSE.txt).
+oneDPL is licensed under [Apache License Version 2.0 with LLVM exceptions](https://github.com/oneapi-src/oneDPL/blob/main/LICENSE.txt).
 Refer to the [LICENSE](licensing/LICENSE.txt) file for the full license text and copyright notice.
 
 ## Security
@@ -31,7 +31,7 @@ for information on how to report a potential security issue or vulnerability.
 You can also view the [Security Policy](SECURITY.md).
 
 ## Contributing
-See [CONTRIBUTING.md](https://github.com/oneapi-src/oneDPL/blob/release_oneDPL/CONTRIBUTING.md) for details.
+See [CONTRIBUTING.md](https://github.com/oneapi-src/oneDPL/blob/main/CONTRIBUTING.md) for details.
 
 ## Documentation
 

--- a/documentation/library_guide/notices_disclaimers.rst
+++ b/documentation/library_guide/notices_disclaimers.rst
@@ -20,7 +20,7 @@ License
 
 oneDPL is licensed under Apache License Version 2.0 with LLVM exceptions. 
 
-Refer to the `LICENSE <https://github.com/oneapi-src/oneDPL/blob/release_oneDPL/licensing/LICENSE.txt>`_ file for the full license text and copyright notice.
+Refer to the `LICENSE <https://github.com/oneapi-src/oneDPL/blob/main/LICENSE.txt>`_ file for the full license text and copyright notice.
 
 
 

--- a/examples/convex_hull/README.md
+++ b/examples/convex_hull/README.md
@@ -25,7 +25,7 @@ Correctness of the convex hull is checked by `std::any_of` algorithm using `coun
 
 ## License
 
-This code example is licensed under [Apache License Version 2.0 with LLVM exceptions](https://github.com/oneapi-src/oneDPL/blob/release_oneDPL/licensing/LICENSE.txt). Refer to the "[LICENSE](licensing/LICENSE.txt)" file for the full license text and copyright notice.
+This code example is licensed under [Apache License Version 2.0 with LLVM exceptions](https://github.com/oneapi-src/oneDPL/blob/main/LICENSE.txt). Refer to the "[LICENSE](licensing/LICENSE.txt)" file for the full license text and copyright notice.
 
 ## Building the 'Convex hull' Program
 

--- a/examples/dot_product/README.md
+++ b/examples/dot_product/README.md
@@ -11,7 +11,7 @@ This example contains the oneDPL-based implementation of dot product based on `s
 
 ## License
 
-This code example is licensed under [Apache License Version 2.0 with LLVM exceptions](https://github.com/oneapi-src/oneDPL/blob/release_oneDPL/licensing/LICENSE.txt). Refer to the "[LICENSE](licensing/LICENSE.txt)" file for the full license text and copyright notice.
+This code example is licensed under [Apache License Version 2.0 with LLVM exceptions](https://github.com/oneapi-src/oneDPL/blob/main/LICENSE.txt). Refer to the "[LICENSE](licensing/LICENSE.txt)" file for the full license text and copyright notice.
 
 ## Building the 'Dot product' Program
 

--- a/examples/random/README.md
+++ b/examples/random/README.md
@@ -11,7 +11,7 @@ This example demonstrates how to use scalar and vector random number generation 
 
 ## License
 
-This code example is licensed under [Apache License Version 2.0 with LLVM exceptions](https://github.com/oneapi-src/oneDPL/blob/release_oneDPL/licensing/LICENSE.txt). Refer to the "[LICENSE](licensing/LICENSE.txt)" file for the full license text and copyright notice.
+This code example is licensed under [Apache License Version 2.0 with LLVM exceptions](https://github.com/oneapi-src/oneDPL/blob/main/LICENSE.txt). Refer to the "[LICENSE](licensing/LICENSE.txt)" file for the full license text and copyright notice.
 
 ## Building the 'Random' Program for CPU and GPU
 


### PR DESCRIPTION
The reliance on the `release_oneDPL` branch for documentation appears to be a historical artifact. This PR removes its usage.