### PR TITLE
Do not use deprecated sub-group load/store extension

### DIFF
--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -492,7 +492,7 @@ struct __parallel_transform_scan_static_single_group_submitter<_Inclusive, _Elem
                     const ::std::uint16_t __subgroup_id = __subgroup.get_group_id();
                     const ::std::uint16_t __subgroup_size = __subgroup.get_local_linear_range();
 
-#if _ONEDPL_SYCL_SUB_GROUP_LOAD_STORE_PRESENT
+#if _ONEDPL_LIBSYCL_SUB_GROUP_LOAD_STORE_PRESENT
                     constexpr bool __can_use_subgroup_load_store =
                         _IsFullGroup && oneapi::dpl::__internal::__range_has_raw_ptr_iterator_v<::std::decay_t<_InRng>>;
 #else
@@ -502,6 +502,7 @@ struct __parallel_transform_scan_static_single_group_submitter<_Inclusive, _Elem
                     auto __lacc_ptr = __dpl_sycl::__get_accessor_ptr(__lacc);
                     if constexpr (__can_use_subgroup_load_store)
                     {
+#if _ONEDPL_LIBSYCL_SUB_GROUP_LOAD_STORE_PRESENT
                         _ONEDPL_PRAGMA_UNROLL
                         for (::std::uint16_t __i = 0; __i < _ElemsPerItem; ++__i)
                         {
@@ -509,6 +510,7 @@ struct __parallel_transform_scan_static_single_group_submitter<_Inclusive, _Elem
                             auto __val = __unary_op(__subgroup.load(__in_rng.begin() + __idx));
                             __subgroup.store(__lacc_ptr + __idx, __val);
                         }
+#endif
                     }
                     else
                     {
@@ -523,6 +525,7 @@ struct __parallel_transform_scan_static_single_group_submitter<_Inclusive, _Elem
 
                     if constexpr (__can_use_subgroup_load_store)
                     {
+#if _ONEDPL_LIBSYCL_SUB_GROUP_LOAD_STORE_PRESENT
                         _ONEDPL_PRAGMA_UNROLL
                         for (::std::uint16_t __i = 0; __i < _ElemsPerItem; ++__i)
                         {
@@ -530,6 +533,7 @@ struct __parallel_transform_scan_static_single_group_submitter<_Inclusive, _Elem
                             auto __val = __subgroup.load(__lacc_ptr + __idx);
                             __subgroup.store(__out_rng.begin() + __idx, __val);
                         }
+#endif
                     }
                     else
                     {
@@ -598,7 +602,7 @@ struct __parallel_copy_if_static_single_group_submitter<_Size, _ElemsPerItem, _W
                     const ::std::uint16_t __subgroup_id = __subgroup.get_group_id();
                     const ::std::uint16_t __subgroup_size = __subgroup.get_local_linear_range();
 
-#if _ONEDPL_SYCL_SUB_GROUP_LOAD_STORE_PRESENT
+#if _ONEDPL_LIBSYCL_SUB_GROUP_LOAD_STORE_PRESENT
                     constexpr bool __can_use_subgroup_load_store =
                         _IsFullGroup && oneapi::dpl::__internal::__range_has_raw_ptr_iterator_v<::std::decay_t<_InRng>>;
 #else
@@ -607,6 +611,7 @@ struct __parallel_copy_if_static_single_group_submitter<_Size, _ElemsPerItem, _W
                     auto __lacc_ptr = __dpl_sycl::__get_accessor_ptr(__lacc);
                     if constexpr (__can_use_subgroup_load_store)
                     {
+#if _ONEDPL_LIBSYCL_SUB_GROUP_LOAD_STORE_PRESENT
                         _ONEDPL_PRAGMA_UNROLL
                         for (::std::uint16_t __i = 0; __i < _ElemsPerItem; ++__i)
                         {
@@ -614,6 +619,7 @@ struct __parallel_copy_if_static_single_group_submitter<_Size, _ElemsPerItem, _W
                             uint16_t __val = __unary_op(__subgroup.load(__in_rng.begin() + __idx));
                             __subgroup.store(__lacc_ptr + __idx, __val);
                         }
+#endif
                     }
                     else
                     {

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -493,7 +493,7 @@ struct __parallel_transform_scan_static_single_group_submitter<_Inclusive, _Elem
                     const ::std::uint16_t __subgroup_size = __subgroup.get_local_linear_range();
 
                     auto __lacc_ptr = __dpl_sycl::__get_accessor_ptr(__lacc);
-                    for (::std::uint16_t __idx = __item_id; __idx < __n; __idx += _WGSize)
+                    for (std::uint16_t __idx = __item_id; __idx < __n; __idx += _WGSize)
                     {
                         __lacc[__idx] = __unary_op(__in_rng[__idx]);
                     }
@@ -501,13 +501,13 @@ struct __parallel_transform_scan_static_single_group_submitter<_Inclusive, _Elem
                     __scan_work_group<_ValueType, _Inclusive>(__group, __lacc_ptr, __lacc_ptr + __n,
                                                               __lacc_ptr, __bin_op, __init);
 
-                    for (::std::uint16_t __idx = __item_id; __idx < __n; __idx += _WGSize)
+                    for (std::uint16_t __idx = __item_id; __idx < __n; __idx += _WGSize)
                     {
                         __out_rng[__idx] = __lacc[__idx];
                     }
 
-                    const ::std::uint16_t __residual = __n % _WGSize;
-                    const ::std::uint16_t __residual_start = __n - __residual;
+                    const std::uint16_t __residual = __n % _WGSize;
+                    const std::uint16_t __residual_start = __n - __residual;
                     if (__item_id < __residual)
                     {
                         auto __idx = __residual_start + __item_id;
@@ -565,7 +565,7 @@ struct __parallel_copy_if_static_single_group_submitter<_Size, _ElemsPerItem, _W
                     const ::std::uint16_t __subgroup_id = __subgroup.get_group_id();
                     const ::std::uint16_t __subgroup_size = __subgroup.get_local_linear_range();
                     auto __lacc_ptr = __dpl_sycl::__get_accessor_ptr(__lacc);
-                    for (::std::uint16_t __idx = __item_id; __idx < __n; __idx += _WGSize)
+                    for (std::uint16_t __idx = __item_id; __idx < __n; __idx += _WGSize)
                     {
                         __lacc[__idx] = __unary_op(__in_rng[__idx]);
                     }

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/parallel_backend_sycl.h
@@ -492,63 +492,26 @@ struct __parallel_transform_scan_static_single_group_submitter<_Inclusive, _Elem
                     const ::std::uint16_t __subgroup_id = __subgroup.get_group_id();
                     const ::std::uint16_t __subgroup_size = __subgroup.get_local_linear_range();
 
-#if _ONEDPL_LIBSYCL_SUB_GROUP_LOAD_STORE_PRESENT
-                    constexpr bool __can_use_subgroup_load_store =
-                        _IsFullGroup && oneapi::dpl::__internal::__range_has_raw_ptr_iterator_v<::std::decay_t<_InRng>>;
-#else
-                    constexpr bool __can_use_subgroup_load_store = false;
-#endif
-
                     auto __lacc_ptr = __dpl_sycl::__get_accessor_ptr(__lacc);
-                    if constexpr (__can_use_subgroup_load_store)
+                    for (::std::uint16_t __idx = __item_id; __idx < __n; __idx += _WGSize)
                     {
-#if _ONEDPL_LIBSYCL_SUB_GROUP_LOAD_STORE_PRESENT
-                        _ONEDPL_PRAGMA_UNROLL
-                        for (::std::uint16_t __i = 0; __i < _ElemsPerItem; ++__i)
-                        {
-                            auto __idx = __i * _WGSize + __subgroup_id * __subgroup_size;
-                            auto __val = __unary_op(__subgroup.load(__in_rng.begin() + __idx));
-                            __subgroup.store(__lacc_ptr + __idx, __val);
-                        }
-#endif
-                    }
-                    else
-                    {
-                        for (::std::uint16_t __idx = __item_id; __idx < __n; __idx += _WGSize)
-                        {
-                            __lacc[__idx] = __unary_op(__in_rng[__idx]);
-                        }
+                        __lacc[__idx] = __unary_op(__in_rng[__idx]);
                     }
 
                     __scan_work_group<_ValueType, _Inclusive>(__group, __lacc_ptr, __lacc_ptr + __n,
                                                               __lacc_ptr, __bin_op, __init);
 
-                    if constexpr (__can_use_subgroup_load_store)
+                    for (::std::uint16_t __idx = __item_id; __idx < __n; __idx += _WGSize)
                     {
-#if _ONEDPL_LIBSYCL_SUB_GROUP_LOAD_STORE_PRESENT
-                        _ONEDPL_PRAGMA_UNROLL
-                        for (::std::uint16_t __i = 0; __i < _ElemsPerItem; ++__i)
-                        {
-                            auto __idx = __i * _WGSize + __subgroup_id * __subgroup_size;
-                            auto __val = __subgroup.load(__lacc_ptr + __idx);
-                            __subgroup.store(__out_rng.begin() + __idx, __val);
-                        }
-#endif
+                        __out_rng[__idx] = __lacc[__idx];
                     }
-                    else
-                    {
-                        for (::std::uint16_t __idx = __item_id; __idx < __n; __idx += _WGSize)
-                        {
-                            __out_rng[__idx] = __lacc[__idx];
-                        }
 
-                        const ::std::uint16_t __residual = __n % _WGSize;
-                        const ::std::uint16_t __residual_start = __n - __residual;
-                        if (__item_id < __residual)
-                        {
-                            auto __idx = __residual_start + __item_id;
-                            __out_rng[__idx] = __lacc[__idx];
-                        }
+                    const ::std::uint16_t __residual = __n % _WGSize;
+                    const ::std::uint16_t __residual_start = __n - __residual;
+                    if (__item_id < __residual)
+                    {
+                        auto __idx = __residual_start + __item_id;
+                        __out_rng[__idx] = __lacc[__idx];
                     }
                 });
         });
@@ -601,32 +564,10 @@ struct __parallel_copy_if_static_single_group_submitter<_Size, _ElemsPerItem, _W
                     const ::std::uint16_t __item_id = __self_item.get_local_linear_id();
                     const ::std::uint16_t __subgroup_id = __subgroup.get_group_id();
                     const ::std::uint16_t __subgroup_size = __subgroup.get_local_linear_range();
-
-#if _ONEDPL_LIBSYCL_SUB_GROUP_LOAD_STORE_PRESENT
-                    constexpr bool __can_use_subgroup_load_store =
-                        _IsFullGroup && oneapi::dpl::__internal::__range_has_raw_ptr_iterator_v<::std::decay_t<_InRng>>;
-#else
-                    constexpr bool __can_use_subgroup_load_store = false;
-#endif
                     auto __lacc_ptr = __dpl_sycl::__get_accessor_ptr(__lacc);
-                    if constexpr (__can_use_subgroup_load_store)
+                    for (::std::uint16_t __idx = __item_id; __idx < __n; __idx += _WGSize)
                     {
-#if _ONEDPL_LIBSYCL_SUB_GROUP_LOAD_STORE_PRESENT
-                        _ONEDPL_PRAGMA_UNROLL
-                        for (::std::uint16_t __i = 0; __i < _ElemsPerItem; ++__i)
-                        {
-                            auto __idx = __i * _WGSize + __subgroup_id * __subgroup_size;
-                            uint16_t __val = __unary_op(__subgroup.load(__in_rng.begin() + __idx));
-                            __subgroup.store(__lacc_ptr + __idx, __val);
-                        }
-#endif
-                    }
-                    else
-                    {
-                        for (::std::uint16_t __idx = __item_id; __idx < __n; __idx += _WGSize)
-                        {
-                            __lacc[__idx] = __unary_op(__in_rng[__idx]);
-                        }
+                        __lacc[__idx] = __unary_op(__in_rng[__idx]);
                     }
 
                     __scan_work_group<_ValueType, /* _Inclusive */ false>(

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -86,9 +86,6 @@
 #define _ONEDPL_LIBSYCL_KNOWN_IDENTITY_PRESENT                (_ONEDPL_LIBSYCL_VERSION == 50200)
 #define _ONEDPL_LIBSYCL_SUB_GROUP_MASK_PRESENT                                                                         \
     (SYCL_EXT_ONEAPI_SUB_GROUP_MASK >= 1 && _ONEDPL_LIBSYCL_VERSION >= 50700)
-// TODO: consider replacing with SYCL_EXT_ONEAPI_GROUP_LOAD_STORE extension due to the deprecation with DPC++ 2025.1
-// or using a unified approach for loading and storing across the patterns
-#define _ONEDPL_LIBSYCL_SUB_GROUP_LOAD_STORE_PRESENT 0
 
 #define _ONEDPL_SYCL_DEVICE_COPYABLE_SPECIALIZATION_BROKEN (_ONEDPL_LIBSYCL_VERSION_LESS_THAN(70100))
 

--- a/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
+++ b/include/oneapi/dpl/pstl/hetero/dpcpp/sycl_defs.h
@@ -86,11 +86,11 @@
 #define _ONEDPL_LIBSYCL_KNOWN_IDENTITY_PRESENT                (_ONEDPL_LIBSYCL_VERSION == 50200)
 #define _ONEDPL_LIBSYCL_SUB_GROUP_MASK_PRESENT                                                                         \
     (SYCL_EXT_ONEAPI_SUB_GROUP_MASK >= 1 && _ONEDPL_LIBSYCL_VERSION >= 50700)
+// TODO: consider replacing with SYCL_EXT_ONEAPI_GROUP_LOAD_STORE extension due to the deprecation with DPC++ 2025.1
+// or using a unified approach for loading and storing across the patterns
+#define _ONEDPL_LIBSYCL_SUB_GROUP_LOAD_STORE_PRESENT 0
 
 #define _ONEDPL_SYCL_DEVICE_COPYABLE_SPECIALIZATION_BROKEN (_ONEDPL_LIBSYCL_VERSION_LESS_THAN(70100))
-
-// TODO: determine which compiler configurations provide subgroup load/store
-#define _ONEDPL_SYCL_SUB_GROUP_LOAD_STORE_PRESENT false
 
 // Macro to check if we are compiling for SPIR-V devices. This macro must only be used within
 // SYCL kernels for determining SPIR-V compilation. Using this macro on the host may lead to incorrect behavior.


### PR DESCRIPTION
Code sections which use `sycl::sub_group::<load()|store()>` DPC++ extension are not entirely disabled. Non-template expressions are still checked by a compiler even if they are within a discarded `if constexpr` branch. 

This makes the code non-compatible with compilers other than DPC++, and it results in a deprecation warning with the most recent DPC++ builds.

A mock-up example: https://godbolt.org/z/svhnY14r5